### PR TITLE
Add missing tag to task

### DIFF
--- a/roles/matrix-server/tasks/main.yml
+++ b/roles/matrix-server/tasks/main.yml
@@ -64,6 +64,7 @@
 
 - include: tasks/setup_well_known.yml
   tags:
+    - setup-all
     - setup-mxisd
     - setup-synapse
     - setup-nginx-proxy


### PR DESCRIPTION
The setup-all should include the setup_well_known task as well