### PR TITLE
Expose mautrix-telegram public endpoint through nginx

### DIFF
--- a/roles/matrix-server/defaults/main.yml
+++ b/roles/matrix-server/defaults/main.yml
@@ -239,6 +239,9 @@ matrix_mautrix_telegram_enabled: false
 # Get your own API keys at https://my.telegram.org/apps
 matrix_mautrix_telegram_api_id: YOUR_TELEGRAM_APP_ID
 matrix_mautrix_telegram_api_hash: YOUR_TELEGRAM_API_HASH
+# Mautrix telegram public endpoint to log in to telegram
+# Use an uuid so it's not easily discoverable
+matrix_mautrix_telegram_public_endpoint: "/{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'telegram') | to_uuid }}"
 
 
 # By default, this playbook sets up its own nginx proxy server on port 80/443.

--- a/roles/matrix-server/templates/mautrix-telegram/config.yaml.j2
+++ b/roles/matrix-server/templates/mautrix-telegram/config.yaml.j2
@@ -35,10 +35,10 @@ appservice:
         # Whether or not the public-facing endpoints should be enabled.
         enabled: true
         # The prefix to use in the public-facing endpoints.
-        prefix: /public
+        prefix: {{ matrix_mautrix_telegram_public_endpoint }}
         # The base URL where the public-facing endpoints are available. The prefix is not added
         # implicitly.
-        external: https://{{ hostname_matrix }}/public
+        external: https://{{ hostname_matrix }}{{ matrix_mautrix_telegram_public_endpoint }}
 
     # Provisioning API part of the web server for automated portal creation and fetching information.
     # Used by things like Dimension (https://dimension.t2bot.io/).
@@ -206,8 +206,7 @@ bridge:
     #   domain - All users on that homeserver
     #     mxid - Specific user
     permissions:
-        '{{ hostname_identity }}': puppeting
-        '*': relaybot
+        '{{ hostname_identity }}': full
 
     # Options related to the message relay Telegram bot.
     relaybot:
@@ -219,8 +218,6 @@ bridge:
         ignore_own_incoming_events: true
         # List of usernames/user IDs who are also allowed to use the bot commands.
         whitelist:
-        - myusername
-        - 12345678
 
 # Telegram config
 telegram:

--- a/roles/matrix-server/templates/nginx-conf.d/matrix-synapse.conf.j2
+++ b/roles/matrix-server/templates/nginx-conf.d/matrix-synapse.conf.j2
@@ -73,6 +73,20 @@ server {
 	}
 	{% endif %}
 
+	{% if matrix_mautrix_telegram_enabled %}
+	location {{ matrix_mautrix_telegram_public_endpoint }} {
+		{% if matrix_nginx_proxy_enabled %}
+			{# Use the embedded DNS resolver in Docker containers to discover the service #}
+			resolver 127.0.0.11 valid=5s;
+			set $backend "matrix-mautrix-telegram:8080";
+			proxy_pass http://$backend;
+		{% else %}
+			{# Generic configuration for use outside of our container setup #}
+			proxy_pass http://localhost:8080;
+		{% endif %}
+	}
+	{% endif %}
+
 	location /_matrix {
 		{% if matrix_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}


### PR DESCRIPTION
It used to allow user to logging with their own account to the bot
see: https://github.com/tulir/mautrix-telegram/wiki/Authentication#replacing-telegram-accounts-matrix-puppet-with-matrix-account for more informations

The endpoint is an uuid hash generated from the matrix_synapse_macaroon_secret_key so it is not easily guessable by a third party