### PR TITLE
Remove riot.im from list of trusted identity servers

### DIFF
--- a/roles/matrix-server/defaults/main.yml
+++ b/roles/matrix-server/defaults/main.yml
@@ -50,7 +50,7 @@ matrix_synapse_registration_shared_secret: "{{ matrix_synapse_macaroon_secret_ke
 matrix_synapse_form_secret: "{{ matrix_synapse_macaroon_secret_key }}"
 
 # These are the identity servers that would be trusted by Synapse if mxisd is NOT enabled
-matrix_synapse_id_servers_public: ['vector.im', 'riot.im', 'matrix.org']
+matrix_synapse_id_servers_public: ['vector.im', 'matrix.org']
 
 # These are the identity servers that would be trusted by Synapse if mxisd IS enabled
 matrix_synapse_id_servers_own: "['{{ hostname_matrix }}']"


### PR DESCRIPTION
This brings the list in line with the new default as of https://github.com/matrix-org/synapse/pull/4207, otherwise 
https://github.com/vector-im/riot-web/issues/7717 can happen