### PR TITLE
Fix caddy .well-known config

### DIFF
--- a/docs/configuring-well-known.md
+++ b/docs/configuring-well-known.md
@@ -71,6 +71,7 @@ server {
 
 ```caddy
 proxy /.well-known/matrix https://matrix.DOMAIN
+header /.well-known/matrix Access-Control-Allow-Origin  *
 ```
 
 Make sure to:


### PR DESCRIPTION
I assume you'll also need to change this for nginx and apache. Without this, Riot (support has only landed on [riot.im/develop](https://riot.im/develop) so far) will tell you "Cannot find homeserver".

