### PR TITLE
Set default mautrix-telegram image to 0.4.0

### DIFF
--- a/roles/matrix-server/defaults/main.yml
+++ b/roles/matrix-server/defaults/main.yml
@@ -295,7 +295,7 @@ matrix_riot_web_welcome_user_id: "@riot-bot:matrix.org"
 # Enable telegram bridge
 matrix_mautrix_telegram_enabled: false
 
-matrix_mautrix_telegram_docker_image: "tulir/mautrix-telegram:v0.3.0"
+matrix_mautrix_telegram_docker_image: "tulir/mautrix-telegram:v0.4.0"
 
 matrix_mautrix_telegram_base_path: "{{ matrix_base_data_path }}/mautrix-telegram"
 


### PR DESCRIPTION
tulir has released a new mautrix-telegram version !

Tested locally and it works correctly