### PR TITLE
Comment that secrets mustn't contain quotes/backticks

### DIFF
--- a/examples/host-vars.yml
+++ b/examples/host-vars.yml
@@ -20,8 +20,10 @@ host_specific_hostname_identity: YOUR_BARE_DOMAIN_NAME_HERE
 
 # A shared secret (between Synapse and Coturn) used for authentication.
 # You can put any string here, but generating a strong one is preferred (e.g. `pwgen -s 64 1`).
+# It must NOT contain any quotes or backticks.
 matrix_coturn_turn_static_auth_secret: ""
 
 # A secret used to protect access keys issued by the server.
 # You can put any string here, but generating a strong one is preferred (e.g. `pwgen -s 64 1`).
+# It must NOT contain any quotes or backticks.
 matrix_synapse_macaroon_secret_key: ""


### PR DESCRIPTION
Putting a backtick into the variable `matrix_synapse_macaroon_secret_key`
leads to an error when starting `matrix-synapse.service`, so the service
can't start. Error Message:

```
[...]
[...] docker[19227]: yaml.scanner.ScannerError: while scanning a double-quoted scalar
[...] docker[19227]:   in /data/homeserver.yaml, line 451, column 29
[...] docker[19227]: found unknown escape character '`'
[...] docker[19227]:   in /data/homeserver.yaml, line 451, column 37
[...] docker[19227]: Traceback (most recent call last):
[...] docker[19227]:   File /start.py, line 66, in <module>
[...]
```

Therefore, added comments that the secrets mustn't contain quotes or
backticks.