### PR TITLE
Fix some bugs due to variables containing quotes/backticks

### DIFF
--- a/roles/matrix-server/templates/synapse/homeserver.yaml.j2
+++ b/roles/matrix-server/templates/synapse/homeserver.yaml.j2
@@ -216,7 +216,8 @@ database:
   name: "psycopg2"
   args:
     user: "{{ matrix_postgres_connection_username }}"
-    password: "{{ matrix_postgres_connection_password }}"
+    password: >-
+      {{ matrix_postgres_connection_password }}
     database: "{{ matrix_postgres_db_name }}"
     host: "{{ matrix_postgres_connection_hostname }}"
     cp_min: 5
@@ -411,7 +412,8 @@ recaptcha_siteverify_api: "https://www.google.com/recaptcha/api/siteverify"
 turn_uris: ["turn:{{ hostname_matrix }}:3478?transport=udp", "turn:{{ hostname_matrix }}:3478?transport=tcp"]
 
 # The shared secret used to compute passwords for the TURN server
-turn_shared_secret: "{{ matrix_coturn_turn_static_auth_secret }}"
+turn_shared_secret: >-
+  {{ matrix_coturn_turn_static_auth_secret }}
 
 # The Username and password if the TURN server needs them and
 # does not use a token
@@ -453,7 +455,8 @@ enable_registration: {{ matrix_synapse_enable_registration }}
 
 # If set, allows registration by anyone who also has the shared
 # secret, even if registration is otherwise disabled.
-registration_shared_secret: "{{ matrix_synapse_registration_shared_secret }}"
+registration_shared_secret: >-
+  {{ matrix_synapse_registration_shared_secret }}
 
 # Set the number of bcrypt rounds used to generate password hash.
 # Larger numbers increase the work factor needed to generate the hash.
@@ -513,14 +516,16 @@ room_invite_state_types:
 app_service_config_files: {{ matrix_synapse_app_service_config_files }}
 
 
-macaroon_secret_key: "{{ matrix_synapse_macaroon_secret_key }}"
+macaroon_secret_key: >-
+  {{ matrix_synapse_macaroon_secret_key }}
 
 # Used to enable access token expiration.
 expire_access_token: False
 
 # a secret which is used to calculate HMACs for form values, to stop
 # falsification of values
-form_secret: "{{ matrix_synapse_form_secret }}"
+form_secret: >-
+  {{ matrix_synapse_form_secret }}
 
 ## Signing Keys ##
 
@@ -584,10 +589,11 @@ perspectives:
 
 # Enable password for login.
 password_config:
-   enabled: true
-   # Uncomment and change to a secret random string for extra security.
-   # DO NOT CHANGE THIS AFTER INITIAL SETUP!
-   pepper: "{{ matrix_synapse_password_config_pepper }}"
+  enabled: true
+  # Uncomment and change to a secret random string for extra security.
+  # DO NOT CHANGE THIS AFTER INITIAL SETUP!
+  pepper: >-
+    {{ matrix_synapse_password_config_pepper }}
 
 
 
@@ -647,7 +653,8 @@ password_providers:
 {% if matrix_synapse_ext_password_provider_shared_secret_auth_enabled %}
   - module: "shared_secret_authenticator.SharedSecretAuthenticator"
     config:
-      sharedSecret: "{{ matrix_synapse_ext_password_provider_shared_secret_auth_shared_secret }}"
+      sharedSecret: >-
+        {{ matrix_synapse_ext_password_provider_shared_secret_auth_shared_secret }}
 {% endif %}
 {% if matrix_synapse_ext_password_provider_ldap_enabled %}
   - module: "ldap_auth_provider.LdapAuthProvider"
@@ -661,7 +668,8 @@ password_providers:
         mail: "{{ matrix_synapse_ext_password_provider_ldap_attributes_mail }}"
         name: "{{ matrix_synapse_ext_password_provider_ldap_attributes_name }}"
       bind_dn: "{{ matrix_synapse_ext_password_provider_ldap_bind_dn }}"
-      bind_password: "{{ matrix_synapse_ext_password_provider_ldap_bind_password }}"
+      bind_password: >-
+        {{ matrix_synapse_ext_password_provider_ldap_bind_password }}
       filter: "{{ matrix_synapse_ext_password_provider_ldap_filter }}"
 {% endif %}
 {% endif %}


### PR DESCRIPTION
**I only tested this by verifying that `matrix-synapse.service` starts successfully using the default configuration.**

Put variables that can contain arbitrary strings into a block scalar. This way,
no escaping of quotes or backticks is needed.

This fixes some bugs. For example, putting a backtick into the variable
`matrix_synapse_macaroon_secret_key` previously led to an error when starting
`matrix-synapse.service`, so the service couldn't start. The error message was:

```
[...]
[...] docker[19227]: yaml.scanner.ScannerError: while scanning a double-quoted scalar
[...] docker[19227]:   in /data/homeserver.yaml, line 451, column 29
[...] docker[19227]: found unknown escape character '`'
[...] docker[19227]:   in /data/homeserver.yaml, line 451, column 37
[...] docker[19227]: Traceback (most recent call last):
[...] docker[19227]:   File /start.py, line 66, in <module>
[...]
```