### PR TITLE
Default matrix-synapse-rest-auth endpoint to matrix-mxisd

### DIFF
--- a/roles/matrix-server/defaults/main.yml
+++ b/roles/matrix-server/defaults/main.yml
@@ -141,7 +141,7 @@ matrix_synapse_password_providers_enabled: false
 # See: https://github.com/kamax-io/matrix-synapse-rest-auth
 matrix_synapse_ext_password_provider_rest_auth_enabled: false
 matrix_synapse_ext_password_provider_rest_auth_download_url: "https://raw.githubusercontent.com/kamax-io/matrix-synapse-rest-auth/v0.1.1/rest_auth_provider.py"
-matrix_synapse_ext_password_provider_rest_auth_endpoint: ""
+matrix_synapse_ext_password_provider_rest_auth_endpoint: http://matrix-mxisd:8090
 matrix_synapse_ext_password_provider_rest_auth_registration_enforce_lowercase: false
 matrix_synapse_ext_password_provider_rest_auth_registration_profile_name_autofill: true
 matrix_synapse_ext_password_provider_rest_auth_login_profile_name_autofill: false


### PR DESCRIPTION
matrix-synapse-rest-auth is commonly used together with mxisd. The uninformed might either

* not know that `matrix_synapse_ext_password_provider_rest_auth_endpoint` has to be set or
* set it wrongly to `http://localhost:8090` which doesn't work because matrix-synapse doesn't run on the localhost, but inside a docker container.

The correct value for that common use case is `http://matrix-mxisd:8090` and is a better default than the empty string.