### PR TITLE
Add utf8 encoding option to log config

### DIFF
--- a/roles/matrix-server/templates/synapse/synapse.log.config.j2
+++ b/roles/matrix-server/templates/synapse/synapse.log.config.j2
@@ -18,6 +18,7 @@ handlers:
         maxBytes: {{ matrix_synapse_max_log_file_size_mb * 1024 * 1024 }}
         backupCount: {{ matrix_synapse_max_log_files_count }}
         filters: [context]
+        encoding: utf8
     console:
         class: logging.StreamHandler
         formatter: precise


### PR DESCRIPTION
This is the now recommended practice as of v0.34.0rc1
https://github.com/matrix-org/synapse/blob/develop/UPGRADE.rst#upgrading-to-v0340

Should work on Python 2 and 3 although I've only tested on Python 3