### PR TITLE
Support configuring mxisd's identity stores (two of them)

### DIFF
--- a/roles/matrix-server/defaults/main.yml
+++ b/roles/matrix-server/defaults/main.yml
@@ -237,6 +237,39 @@ matrix_mxisd_data_path: "{{ matrix_mxisd_base_path }}/data"
 # Enabling this is discouraged. Learn more here: https://github.com/kamax-io/mxisd/blob/master/docs/features/identity.md#lookups
 matrix_mxisd_matrixorg_forwarding_enabled: false
 
+# mxisd has serveral supported identity stores.
+# One of them is storing identities directly in Synapse's database.
+# Learn more here: https://github.com/kamax-matrix/mxisd/blob/master/docs/stores/synapse.md
+matrix_mxisd_synapsesql_enabled: true
+matrix_mxisd_synapsesql_type: postgresql
+matrix_mxisd_synapsesql_connection: //{{ matrix_postgres_connection_hostname }}/{{ matrix_postgres_db_name }}?user={{ matrix_postgres_connection_username }}&password={{ matrix_postgres_connection_password }}
+
+# LDAP is another identity store that's supported by mxisd.
+# Learn more here: https://github.com/kamax-matrix/mxisd/blob/master/docs/stores/ldap.md
+matrix_mxisd_ldap_enabled: false
+matrix_mxisd_ldap_connection_host: ldapHostnameOrIp
+matrix_mxisd_ldap_connection_tls: false
+matrix_mxisd_ldap_connection_port: 389
+matrix_mxisd_ldap_connection_baseDn: OU=Users,DC=example,DC=org
+matrix_mxisd_ldap_connection_bindDn: CN=My Mxisd User,OU=Users,DC=example,DC=org
+matrix_mxisd_ldap_connection_bindPassword: TheUserPassword
+# The following keys are optional:
+# matrix_mxisd_ldap_filter: ""
+# matrix_mxisd_ldap_attribute_uid_type: uid
+# matrix_mxisd_ldap_attribute_uid_value: sAMAccountName
+# matrix_mxisd_ldap_attribute_name: cn
+# matrix_mxisd_ldap_attribute_threepid_email:
+#   - mail
+#   - otherMailAttribute
+# matrix_mxisd_ldap_attribute_threepid_msisdn:
+#   - phone
+#   - otherPhoneAttribute
+# matrix_mxisd_ldap_identity_filter: ""
+# matrix_mxisd_ldap_identity_medium: ""
+# matrix_mxisd_ldap_auth_filter: ""
+# matrix_mxisd_ldap_directory_filter: ""
+
+
 # Specifies which template files to use when configuring mxisd.
 # If you'd like to have your own different configuration, feel free to copy and paste
 # the original files into your inventory (e.g. in `inventory/host_vars/<host>/`)

--- a/roles/matrix-server/templates/mxisd/mxisd.yaml.j2
+++ b/roles/matrix-server/templates/mxisd/mxisd.yaml.j2
@@ -10,10 +10,59 @@ threepid.medium.email.connectors.smtp.host: matrix-mailer
 threepid.medium.email.connectors.smtp.port: 587
 threepid.medium.email.connectors.smtp.tls: 0
 
-synapseSql.enabled: true
-synapseSql.type: postgresql
-synapseSql.connection: //{{ matrix_postgres_connection_hostname }}/{{ matrix_postgres_db_name }}?user={{ matrix_postgres_connection_username }}&password={{ matrix_postgres_connection_password }}
-
 {% if matrix_mxisd_matrixorg_forwarding_enabled %}
 forward.servers: ['matrix-org']
 {% endif %}
+
+synapseSql.enabled: {{ matrix_mxisd_synapsesql_enabled }}
+synapseSql.type: {{ matrix_mxisd_synapsesql_type }}
+synapseSql.connection: {{ matrix_mxisd_synapsesql_connection }}
+
+ldap.enabled: {{ matrix_mxisd_ldap_enabled }}
+ldap.connection.host: {{ matrix_mxisd_ldap_connection_host }}
+ldap.connection.tls: {{ matrix_mxisd_ldap_connection_tls }}
+ldap.connection.port: {{ matrix_mxisd_ldap_connection_port }}
+ldap.connection.baseDn: {{ matrix_mxisd_ldap_connection_baseDn }}
+ldap.connection.bindDn: {{ matrix_mxisd_ldap_connection_bindDn }}
+ldap.connection.bindPassword: {{ matrix_mxisd_ldap_connection_bindPassword }}
+
+{% if matrix_mxisd_ldap_filter is defined %}
+ldap.filter: {{ matrix_mxisd_ldap_filter }}
+{% endif %}
+
+{% if matrix_mxisd_ldap_attribute_uid_type is defined %}
+ldap.attribute.uid.type: {{ matrix_mxisd_ldap_attribute_uid_type }}
+{% endif %}
+
+{% if matrix_mxisd_ldap_attribute_uid_value is defined %}
+ldap.attribute.uid.value: {{ matrix_mxisd_ldap_attribute_uid_value }}
+{% endif %}
+
+{% if matrix_mxisd_ldap_attribute_name is defined %}
+ldap.attribute.name: {{ matrix_mxisd_ldap_attribute_name }}
+{% endif %}
+
+{% if matrix_mxisd_ldap_attribute_threepid_email is defined %}
+ldap.attribute.threepid.email: {{ matrix_mxisd_ldap_attribute_threepid_email|to_yaml }}
+{% endif %}
+
+{% if matrix_mxisd_ldap_attribute_threepid_msisdn is defined %}
+ldap.attribute.threepid.msisdn: {{ matrix_mxisd_ldap_attribute_threepid_msisdn|to_yaml }}
+{% endif %}
+
+{% if matrix_mxisd_ldap_identity_filter is defined %}
+ldap.identity.filter: {{ matrix_mxisd_ldap_identity_filter }}
+{% endif %}
+
+{% if matrix_mxisd_ldap_identity_medium is defined %}
+ldap.identity.medium: {{ matrix_mxisd_ldap_identity_medium }}
+{% endif %}
+
+{% if matrix_mxisd_ldap_auth_filter is defined %}
+ldap.auth.filter: {{ matrix_mxisd_ldap_auth_filter }}
+{% endif %}
+
+{% if matrix_mxisd_ldap_directory_filter is defined %}
+ldap.directory.filter: {{ matrix_mxisd_ldap_directory_filter }}
+{% endif %}
+


### PR DESCRIPTION
_mxisd_ supports several identity stores. Add support to configure two of them through role variables:

* synapseSql (storing identities directly in Synapse's database)
* LDAP

This removed the need to copy `mxisd.yaml.j2` to the inventory in case one wants to use LDAP as identity store. Note that the previous solution (copying `mxisd.yaml.j2`) was poor because of two reasons:

* The copy remains outdated in case the original is updated in future versions of this repo.
* The role's configuration should be in one place (configured only through role variables) instead of in multiple.

Configuring more identity stores through role variables can be supported in the future.