### PR TITLE
Make every mxisd configuration option accessible

### DIFF
--- a/roles/matrix-server/defaults/main.yml
+++ b/roles/matrix-server/defaults/main.yml
@@ -239,37 +239,19 @@ matrix_mxisd_data_path: "{{ matrix_mxisd_base_path }}/data"
 # Enabling this is discouraged. Learn more here: https://github.com/kamax-io/mxisd/blob/master/docs/features/identity.md#lookups
 matrix_mxisd_matrixorg_forwarding_enabled: false
 
-# mxisd has serveral supported identity stores.
-# One of them is storing identities directly in Synapse's database.
-# Learn more here: https://github.com/kamax-matrix/mxisd/blob/master/docs/stores/synapse.md
-matrix_mxisd_synapsesql_enabled: true
-matrix_mxisd_synapsesql_type: postgresql
-matrix_mxisd_synapsesql_connection: //{{ matrix_postgres_connection_hostname }}/{{ matrix_postgres_db_name }}?user={{ matrix_postgres_connection_username }}&password={{ matrix_postgres_connection_password }}
 
-# LDAP is another identity store that's supported by mxisd.
-# Learn more here: https://github.com/kamax-matrix/mxisd/blob/master/docs/stores/ldap.md
-matrix_mxisd_ldap_enabled: false
-matrix_mxisd_ldap_connection_host: ldapHostnameOrIp
-matrix_mxisd_ldap_connection_tls: false
-matrix_mxisd_ldap_connection_port: 389
-matrix_mxisd_ldap_connection_baseDns: ['OU=Users,DC=example,DC=org']
-matrix_mxisd_ldap_connection_bindDn: CN=My Mxisd User,OU=Users,DC=example,DC=org
-matrix_mxisd_ldap_connection_bindPassword: TheUserPassword
-# The following keys are optional:
-# matrix_mxisd_ldap_filter: ""
-# matrix_mxisd_ldap_attribute_uid_type: uid
-# matrix_mxisd_ldap_attribute_uid_value: sAMAccountName
-# matrix_mxisd_ldap_attribute_name: cn
-# matrix_mxisd_ldap_attribute_threepid_email:
-#   - mail
-#   - otherMailAttribute
-# matrix_mxisd_ldap_attribute_threepid_msisdn:
-#   - phone
-#   - otherPhoneAttribute
-# matrix_mxisd_ldap_identity_filter: ""
-# matrix_mxisd_ldap_identity_medium: ""
-# matrix_mxisd_ldap_auth_filter: ""
-# matrix_mxisd_ldap_directory_filter: ""
+# You can add arbirary mxisd config by specifying matrix_mxisd_extra_config.
+# Example:
+# matrix_mxisd_extra_config:
+#   synapseSql.enabled: false
+#   ldap.enabled: true
+#   ldap.connection.host: ldapHostnameOrIp
+#   ldap.connection.tls: false
+#   ldap.connection.port: 389
+#   ldap.connection.baseDn: OU=Users,DC=example,DC=org
+#   ldap.connection.bindDn: CN=My Mxisd User,OU=Users,DC=example,DC=org
+#   ldap.connection.bindPassword: TheUserPassword
+matrix_mxisd_extra_config:
 
 
 # Specifies which template files to use when configuring mxisd.

--- a/roles/matrix-server/templates/mxisd/mxisd.yaml.j2
+++ b/roles/matrix-server/templates/mxisd/mxisd.yaml.j2
@@ -1,69 +1,21 @@
-matrix.domain: {{ hostname_identity }}
-server.name: {{ hostname_matrix }}
-
-key.path: /var/mxisd/sign.key
-
-storage.provider.sqlite.database: /var/mxisd/mxisd.db
-
-threepid.medium.email.identity.from: {{ matrix_mailer_sender_address }}
-threepid.medium.email.connectors.smtp.host: matrix-mailer
-threepid.medium.email.connectors.smtp.port: 587
-threepid.medium.email.connectors.smtp.tls: 0
+{% set matrix_mxisd_default_config = {
+  "matrix.domain": hostname_identity,
+  "server.name": hostname_matrix,
+  "key.path": "/var/mxisd/sign.key",
+  "storage.provider.sqlite.database": "/var/mxisd/mxisd.db",
+  "threepid.medium.email.identity.from": matrix_mailer_sender_address,
+  "threepid.medium.email.connectors.smtp.host": "matrix-mailer",
+  "threepid.medium.email.connectors.smtp.port": 587,
+  "threepid.medium.email.connectors.smtp.tls": 0,
+  "synapseSql.enabled": true,
+  "synapseSql.type": "postgresql",
+  "synapseSql.connection": "//" + matrix_postgres_connection_hostname + "/" + matrix_postgres_db_name + "?user=" + matrix_postgres_connection_username + "&password=" + matrix_postgres_connection_password
+} %}
 
 {% if matrix_mxisd_matrixorg_forwarding_enabled %}
-forward.servers: ['matrix-org']
+  {% set matrix_mxisd_default_config = matrix_mxisd_default_config | combine(
+    { "forward.servers": [ "matrix-org" ] }
+  ) %}
 {% endif %}
 
-synapseSql.enabled: {{ matrix_mxisd_synapsesql_enabled }}
-synapseSql.type: {{ matrix_mxisd_synapsesql_type }}
-synapseSql.connection: {{ matrix_mxisd_synapsesql_connection }}
-
-ldap.enabled: {{ matrix_mxisd_ldap_enabled }}
-ldap.connection.host: {{ matrix_mxisd_ldap_connection_host }}
-ldap.connection.tls: {{ matrix_mxisd_ldap_connection_tls }}
-ldap.connection.port: {{ matrix_mxisd_ldap_connection_port }}
-ldap.connection.baseDns:
-{{ matrix_mxisd_ldap_connection_baseDns|to_nice_yaml }}
-ldap.connection.bindDn: {{ matrix_mxisd_ldap_connection_bindDn }}
-ldap.connection.bindPassword: {{ matrix_mxisd_ldap_connection_bindPassword }}
-
-{% if matrix_mxisd_ldap_filter is defined %}
-ldap.filter: {{ matrix_mxisd_ldap_filter }}
-{% endif %}
-
-{% if matrix_mxisd_ldap_attribute_uid_type is defined %}
-ldap.attribute.uid.type: {{ matrix_mxisd_ldap_attribute_uid_type }}
-{% endif %}
-
-{% if matrix_mxisd_ldap_attribute_uid_value is defined %}
-ldap.attribute.uid.value: {{ matrix_mxisd_ldap_attribute_uid_value }}
-{% endif %}
-
-{% if matrix_mxisd_ldap_attribute_name is defined %}
-ldap.attribute.name: {{ matrix_mxisd_ldap_attribute_name }}
-{% endif %}
-
-{% if matrix_mxisd_ldap_attribute_threepid_email is defined %}
-ldap.attribute.threepid.email: {{ matrix_mxisd_ldap_attribute_threepid_email|to_yaml }}
-{% endif %}
-
-{% if matrix_mxisd_ldap_attribute_threepid_msisdn is defined %}
-ldap.attribute.threepid.msisdn: {{ matrix_mxisd_ldap_attribute_threepid_msisdn|to_yaml }}
-{% endif %}
-
-{% if matrix_mxisd_ldap_identity_filter is defined %}
-ldap.identity.filter: {{ matrix_mxisd_ldap_identity_filter }}
-{% endif %}
-
-{% if matrix_mxisd_ldap_identity_medium is defined %}
-ldap.identity.medium: {{ matrix_mxisd_ldap_identity_medium }}
-{% endif %}
-
-{% if matrix_mxisd_ldap_auth_filter is defined %}
-ldap.auth.filter: {{ matrix_mxisd_ldap_auth_filter }}
-{% endif %}
-
-{% if matrix_mxisd_ldap_directory_filter is defined %}
-ldap.directory.filter: {{ matrix_mxisd_ldap_directory_filter }}
-{% endif %}
-
+{{ matrix_mxisd_default_config | combine(matrix_mxisd_extra_config, recursive=true) | to_nice_yaml }}


### PR DESCRIPTION
22523c0e42 added role variables that wrap certain mxisd configuration keys. This has the obvious drawback that not all keys are accessible but only the wrapped.

This change replaces the previously added wrapper role variables by a single dictionary variable `matrix_mxisd_extra_config` in which arbirary mxisd configuration keys can be added.

There's still the same default mxisd configuration. Keys of that default are overwritten individually when added to `matrix_mxisd_extra_config`.