### PR TITLE
Set MAILNAME env variable to FQDN hostname for matrix-mailer

### DIFF
--- a/roles/matrix-server/templates/env/env-mailer.j2
+++ b/roles/matrix-server/templates/env/env-mailer.j2
@@ -1,4 +1,4 @@
-MAILNAME=matrix-mailer
+MAILNAME={{ hostname_matrix }}
 {% if matrix_mailer_relay_use %}
 RELAYHOST={{ matrix_mailer_relay_host_name }}:{{ matrix_mailer_relay_host_port }}
 {% endif %}


### PR DESCRIPTION
The documentation for the Postfix mailer image at https://hub.docker.com/r/panubo/postfix specifies the pupose of the `MAILNAME` environment variable as follows: 

> MAILNAME - set this to a legitimate FQDN hostname for this service (required).

This pull request changes the variable's value to hold the `hostname_matrix` configuration variable, which is a FQDN. In addition to being compliant to the image specification, setting a proper hostname avoids problems with strictly configured SMTP servers that require a FQDN. If it isn't set, the SMTP server may raise an error

> HELO command rejected: need fully-qualified hostname

and refuse delivery of the message. That's what happened in my installation and applying the patch of this pull request fixed the problem.