### PR TITLE
Fix scalar widgets

### DIFF
--- a/roles/matrix-riot-web/defaults/main.yml
+++ b/roles/matrix-riot-web/defaults/main.yml
@@ -12,7 +12,7 @@ matrix_riot_web_disable_custom_urls: true
 matrix_riot_web_disable_guests: true
 matrix_riot_web_integrations_ui_url: "https://scalar.vector.im/"
 matrix_riot_web_integrations_rest_url: "https://scalar.vector.im/api"
-matrix_riot_web_integrations_widgets_urls: "https://scalar.vector.im/api"
+matrix_riot_web_integrations_widgets_urls: ["https://scalar.vector.im/api"]
 matrix_riot_web_integrations_jitsi_widget_url: "https://scalar.vector.im/api/widgets/jitsi.html"
 # Riot public room directory server(s)
 matrix_riot_web_roomdir_servers: ['matrix.org']

--- a/roles/matrix-riot-web/templates/config.json.j2
+++ b/roles/matrix-riot-web/templates/config.json.j2
@@ -6,7 +6,7 @@
     "brand": "Riot",
     "integrations_ui_url": "{{ matrix_riot_web_integrations_ui_url }}",
     "integrations_rest_url": "{{ matrix_riot_web_integrations_rest_url }}",
-    "integrations_widgets_urls": "{{ matrix_riot_web_integrations_widgets_urls }}",
+    "integrations_widgets_urls": {{ matrix_riot_web_integrations_widgets_urls|to_json }},
     "integrations_jitsi_widget_url": "{{ matrix_riot_web_integrations_jitsi_widget_url }}",
     "bug_report_endpoint_url": "https://riot.im/bugreports/submit",
     "enableLabs": true,


### PR DESCRIPTION
Riot-web parses integrations_widgets_urls as a list, thus causing it to incorrectly think Scalar widgets are non-Scalar and not passing the scalar token