### PR TITLE
Enable exposure of Prometheus metrics.

### DIFF
--- a/group_vars/matrix-servers
+++ b/group_vars/matrix-servers
@@ -181,6 +181,10 @@ matrix_nginx_proxy_proxy_matrix_identity_api_enabled: "{{ matrix_mxisd_enabled }
 matrix_nginx_proxy_proxy_matrix_identity_api_addr_with_container: "matrix-mxisd:8090"
 matrix_nginx_proxy_proxy_matrix_identity_api_addr_sans_container: "localhost:8090"
 
+matrix_nginx_proxy_proxy_synapse_metrics: "{{ matrix_synapse_metrics_enabled }}"
+matrix_nginx_proxy_proxy_synapse_metrics_addr_with_container: "matrix-synapse:{{ matrix_synapse_metrics_port }}"
+matrix_nginx_proxy_proxy_synapse_metrics_addr_sans_container: "localhost:{{ matrix_synapse_metrics_port }}"
+
 matrix_nginx_proxy_proxy_matrix_user_directory_search_enabled: "{{ matrix_mxisd_enabled }}"
 matrix_nginx_proxy_proxy_matrix_user_directory_search_addr_with_container: "{{ matrix_nginx_proxy_proxy_matrix_identity_api_addr_with_container }}"
 matrix_nginx_proxy_proxy_matrix_user_directory_search_addr_sans_container: "{{ matrix_nginx_proxy_proxy_matrix_identity_api_addr_sans_container }}"
@@ -271,6 +275,8 @@ matrix_synapse_trusted_third_party_id_servers: "{{ [hostname_matrix] if matrix_m
 # If matrix-nginx-proxy is not enabled, or you otherwise have a need for it, you can expose
 # the Client/Server API's port to the local host (`127.0.0.1:8008`).
 matrix_synapse_container_expose_client_server_api_port: "{{ not matrix_nginx_proxy_enabled }}"
+
+matrix_synapse_container_expose_metrics_port: "{{ not matrix_nginx_proxy_enabled }}"
 
 matrix_synapse_database_host: "{{ matrix_postgres_connection_hostname }}"
 matrix_synapse_database_user: "{{ matrix_postgres_connection_username }}"

--- a/roles/matrix-nginx-proxy/defaults/main.yml
+++ b/roles/matrix-nginx-proxy/defaults/main.yml
@@ -39,6 +39,11 @@ matrix_nginx_proxy_proxy_matrix_identity_api_enabled: false
 matrix_nginx_proxy_proxy_matrix_identity_api_addr_with_container: "matrix-mxisd:8090"
 matrix_nginx_proxy_proxy_matrix_identity_api_addr_sans_container: "localhost:8090"
 
+# Controls whether proxying for metrics (`/_synapse/metrics`) should be done (on the matrix domain)
+matrix_nginx_proxy_proxy_synapse_metrics: false
+matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_enabled: false
+matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_key: ""
+
 # The addresses where the Matrix Client API is.
 # Certain extensions (like matrix-corporal) may override this in order to capture all traffic.
 matrix_nginx_proxy_proxy_matrix_client_api_addr_with_container: "matrix-synapse:8008"

--- a/roles/matrix-nginx-proxy/tasks/setup_nginx_proxy.yml
+++ b/roles/matrix-nginx-proxy/tasks/setup_nginx_proxy.yml
@@ -28,6 +28,15 @@
     mode: 0644
   when: "matrix_nginx_proxy_enabled"
 
+- name: Ensure matrix-synapse-metrics-htpasswd is present (protecting /_synapse/metrics URI)
+  template:
+    src: "{{ role_path }}/templates/nginx/matrix-synapse-metrics-htpasswd.j2"
+    dest: "{{ matrix_nginx_proxy_data_path }}/matrix-synapse-metrics-htpasswd"
+    owner: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_username }}"
+    mode: 0400
+  when: "matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_enabled and matrix_nginx_proxy_proxy_synapse_metrics"
+
 - name: Ensure Matrix nginx-proxy configured (generic)
   template:
     src: "{{ role_path }}/templates/nginx/conf.d/nginx-http.conf.j2"
@@ -116,3 +125,9 @@
     path: "{{ matrix_nginx_proxy_data_path }}/nginx.conf"
     state: absent
   when: "not matrix_nginx_proxy_enabled"
+
+- name: Ensure Matrix nginx-proxy htpasswd is deleted (protecting /_synapse/metrics URI)
+  file:
+    path: "{{ matrix_nginx_proxy_data_path }}/matrix-synapse-metrics-htpasswd"
+    state: absent
+  when: "not matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_enabled or not matrix_nginx_proxy_proxy_synapse_metrics"

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-synapse.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-synapse.conf.j2
@@ -120,6 +120,28 @@ server {
 		proxy_max_temp_file_size 0;
 	}
 
+	{% if matrix_nginx_proxy_proxy_synapse_metrics %}
+	location /_synapse/metrics {
+		{% if matrix_nginx_proxy_enabled %}
+			{# Use the embedded DNS resolver in Docker containers to discover the service #}
+			resolver 127.0.0.11 valid=5s;
+			set $backend "{{ matrix_nginx_proxy_proxy_synapse_metrics_addr_with_container }}";
+			proxy_pass http://$backend;
+		{% else %}
+			{# Generic configuration for use outside of our container setup #}
+			proxy_pass http://{{ matrix_nginx_proxy_proxy_synapse_metrics_addr_sans_container }};
+		{% endif %}
+
+		proxy_set_header Host $host;
+		proxy_set_header X-Forwarded-For $remote_addr;
+
+		{% if matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_enabled %}
+			auth_basic "protected";
+			auth_basic_user_file .matrix-synapse-metrics-htpasswd;
+		{% endif %}
+	}
+	{% endif %}
+
 	location / {
 		rewrite ^/$ /_matrix/static/ last;
 	}

--- a/roles/matrix-nginx-proxy/templates/nginx/matrix-synapse-metrics-htpasswd.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/matrix-synapse-metrics-htpasswd.j2
@@ -1,0 +1,2 @@
+# User and password for protecting /_synapse/metrics URI
+prometheus:{{ matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_key }}

--- a/roles/matrix-nginx-proxy/templates/systemd/matrix-nginx-proxy.service.j2
+++ b/roles/matrix-nginx-proxy/templates/systemd/matrix-nginx-proxy.service.j2
@@ -26,6 +26,9 @@ ExecStart=/usr/bin/docker run --rm --name matrix-nginx-proxy \
 			-v {{ matrix_nginx_proxy_confd_path }}:/etc/nginx/conf.d:ro \
 			-v {{ matrix_ssl_config_dir_path }}:{{ matrix_ssl_config_dir_path }}:ro \
 			-v {{ matrix_static_files_base_path }}:{{ matrix_static_files_base_path }}:ro \
+			{% if (matrix_nginx_proxy_proxy_synapse_metrics and matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_enabled) %}
+			-v {{ matrix_nginx_proxy_data_path }}/matrix-synapse-metrics-htpasswd:/etc/nginx/.matrix-synapse-metrics-htpasswd:ro \
+			{% endif %}
 			{{ matrix_nginx_proxy_docker_image }}
 
 ExecStop=-/usr/bin/docker kill matrix-nginx-proxy

--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -13,6 +13,9 @@ matrix_synapse_container_expose_client_server_api_port: false
 # Controls whether the Appservice IRC container exposes the Client/Server API port (tcp/9999).
 matrix_appservice_irc_container_expose_client_server_api_port: false
 
+# Controls whether the matrix-synapse container exposes the metrics port (tcp/9100).
+matrix_synapse_container_expose_metrics_port: false
+
 # List of systemd services that matrix-synapse.service depends on
 matrix_synapse_systemd_required_services_list: ['docker.service']
 
@@ -117,6 +120,11 @@ matrix_synapse_app_service_config_files: []
 # This is set dynamically during execution depending on whether
 # any password providers have been enabled or not.
 matrix_synapse_password_providers_enabled: false
+
+# Enable exposure of metrics to Prometheus
+# See https://github.com/matrix-org/synapse/blob/master/docs/metrics-howto.rst
+matrix_synapse_metrics_enabled: false
+matrix_synapse_metrics_port: 9100
 
 # Postgres database information
 matrix_synapse_database_host: ""

--- a/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -127,6 +127,12 @@ federation_domain_whitelist: {{ matrix_synapse_federation_domain_whitelist|to_js
 # List of ports that Synapse should listen on, their purpose and their
 # configuration.
 listeners:
+{% if matrix_synapse_metrics_enabled %}
+  - type: metrics
+    port: {{ matrix_synapse_metrics_port }}
+    bind_addresses:
+      - '0.0.0.0'
+{% endif %}
 {% if matrix_synapse_federation_enabled %}
   # Main HTTPS listener
   # For when matrix traffic is sent directly to synapse.
@@ -496,7 +502,7 @@ autocreate_auto_join_rooms: {{ matrix_synapse_autocreate_auto_join_rooms }}
 ## Metrics ###
 
 # Enable collection and rendering of performance metrics
-enable_metrics: False
+enable_metrics: {{ matrix_synapse_metrics_enabled }}
 report_stats: {{ matrix_synapse_report_stats|to_json }}
 
 

--- a/roles/matrix-synapse/templates/synapse/systemd/matrix-synapse.service.j2
+++ b/roles/matrix-synapse/templates/synapse/systemd/matrix-synapse.service.j2
@@ -34,6 +34,9 @@ ExecStart=/usr/bin/docker run --rm --name matrix-synapse \
 			{% if matrix_synapse_container_expose_client_server_api_port %}
 			-p 127.0.0.1:8008:8008 \
 			{% endif %}
+			{% if matrix_synapse_container_expose_metrics_port %}
+			-p 127.0.0.1:{{ matrix_synapse_metrics_port }}:{{ matrix_synapse_metrics_port }} \
+			{% endif %}
 			-v {{ matrix_synapse_config_dir_path }}:/data:ro \
 			-v {{ matrix_synapse_run_path }}:/matrix-run:rw \
 			-v {{ matrix_synapse_base_path }}/storage:/matrix-media-store-parent:slave \


### PR DESCRIPTION
Added the option to enable exposure of Prometheus metrics. Still a work in progress and needs some more testing, refinement and documentation. I have tested the different options on my installation and as far as I can tell they work as intended. 

I have used the second method from https://github.com/matrix-org/synapse/blob/master/docs/metrics-howto.rst. 

I have basically added three default variables:

```
matrix_synapse_enable_metrics: false
matrix_synapse_metrics_port: 9100
matrix_synapse_metrics_enable_basic_auth: false
```

If `matrix_synapse_enable_metrics` is enabled the metrics are exposed using URI `/_synapse/metrics`. I also added the option to enable basic auth for `/_synapse/metrics` if scraping is done over Internet for example. If `matrix_synapse_metrics_enable_basic_auth` is enabled a variable called `matrix_synapse_metrics_basic_auth_key` must be defined with the htpasswd-hash. 
