### PR TITLE
Don't to_json the matrix_synapse_database_password

### DIFF
--- a/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -327,7 +327,7 @@ database:
   name: "psycopg2"
   args:
     user: {{ matrix_synapse_database_user|to_json }}
-    password: {{ matrix_synapse_database_password }}
+    password: {{ matrix_synapse_database_password|string|to_json }}
     database: "{{ matrix_synapse_database_database }}"
     host: "{{ matrix_synapse_database_host }}"
     cp_min: 5
@@ -522,7 +522,7 @@ recaptcha_siteverify_api: "https://www.google.com/recaptcha/api/siteverify"
 turn_uris: {{ matrix_synapse_turn_uris|to_json }}
 
 # The shared secret used to compute passwords for the TURN server
-turn_shared_secret: {{ matrix_synapse_turn_shared_secret|to_json }}
+turn_shared_secret: {{ matrix_synapse_turn_shared_secret|string|to_json }}
 
 # The Username and password if the TURN server needs them and
 # does not use a token
@@ -569,7 +569,7 @@ enable_registration: {{ matrix_synapse_enable_registration|to_json }}
 
 # If set, allows registration by anyone who also has the shared
 # secret, even if registration is otherwise disabled.
-registration_shared_secret: {{ matrix_synapse_registration_shared_secret|to_json }}
+registration_shared_secret: {{ matrix_synapse_registration_shared_secret|string|to_json }}
 
 # Set the number of bcrypt rounds used to generate password hash.
 # Larger numbers increase the work factor needed to generate the hash.
@@ -643,11 +643,10 @@ app_service_config_files: {{ matrix_synapse_app_service_config_files }}
 # enables MAU tracking for application service users.
 track_appservice_user_ips: False
 
-
 # a secret which is used to sign access tokens. If none is specified,
 # the registration_shared_secret is used, if one is given; otherwise,
 # a secret key is derived from the signing key.
-macaroon_secret_key: {{ matrix_synapse_macaroon_secret_key|to_json }}
+macaroon_secret_key: {{ matrix_synapse_macaroon_secret_key|string|to_json }}
 
 # Used to enable access token expiration.
 expire_access_token: False
@@ -655,7 +654,7 @@ expire_access_token: False
 # a secret which is used to calculate HMACs for form values, to stop
 # falsification of values. Must be specified for the User Consent
 # forms to work.
-form_secret: {{ matrix_synapse_form_secret|to_json }}
+form_secret: {{ matrix_synapse_form_secret|string|to_json }}
 
 ## Signing Keys ##
 
@@ -755,7 +754,7 @@ password_config:
    enabled: true
    # Uncomment and change to a secret random string for extra security.
    # DO NOT CHANGE THIS AFTER INITIAL SETUP!
-   pepper: {{ matrix_synapse_password_config_pepper|to_json }}
+   pepper: {{ matrix_synapse_password_config_pepper|string|to_json }}
 
 
 
@@ -801,12 +800,12 @@ password_providers:
 {% if matrix_synapse_ext_password_provider_shared_secret_auth_enabled %}
   - module: "shared_secret_authenticator.SharedSecretAuthenticator"
     config:
-      sharedSecret: {{ matrix_synapse_ext_password_provider_shared_secret_auth_shared_secret|to_json }}
+      sharedSecret: {{ matrix_synapse_ext_password_provider_shared_secret_auth_shared_secret|string|to_json }}
 {% endif %}
 {% if matrix_synapse_ext_password_provider_rest_auth_enabled %}
   - module: "rest_auth_provider.RestAuthProvider"
     config:
-      endpoint: {{ matrix_synapse_ext_password_provider_rest_auth_endpoint|to_json }}
+      endpoint: {{ matrix_synapse_ext_password_provider_rest_auth_endpoint|string|to_json }}
       policy:
         registration:
           username:
@@ -829,7 +828,7 @@ password_providers:
         mail: {{ matrix_synapse_ext_password_provider_ldap_attributes_mail|to_json }}
         name: {{ matrix_synapse_ext_password_provider_ldap_attributes_name|to_json }}
       bind_dn: {{ matrix_synapse_ext_password_provider_ldap_bind_dn|to_json }}
-      bind_password: {{ matrix_synapse_ext_password_provider_ldap_bind_password|to_json }}
+      bind_password: {{ matrix_synapse_ext_password_provider_ldap_bind_password|string|to_json }}
       filter: {{ matrix_synapse_ext_password_provider_ldap_filter|to_json }}
 {% endif %}
 {% endif %}

--- a/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -327,7 +327,7 @@ database:
   name: "psycopg2"
   args:
     user: {{ matrix_synapse_database_user|to_json }}
-    password: {{ matrix_synapse_database_password|to_json }}
+    password: {{ matrix_synapse_database_password }}
     database: "{{ matrix_synapse_database_database }}"
     host: "{{ matrix_synapse_database_host }}"
     cp_min: 5


### PR DESCRIPTION
It's good policy to use ansible vault to define passwords. However, due to an Ansible bug, to_json will not cause the password to be decrypted: https://github.com/ansible/ansible/issues/24425