### PR TITLE
allow exposing mautrix_telegram port

### DIFF
--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -210,7 +210,7 @@ matrix_mautrix_telegram_api_hash: YOUR_TELEGRAM_API_HASH
 # Use an uuid so it's not easily discoverable
 matrix_mautrix_telegram_public_endpoint: "/{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'telegram') | to_uuid }}"
 # Set this to a port number to expose on the host when not using the nginx proxy
-matrix_mautrix_telegram_container_expose_port: false
+matrix_mautrix_telegram_container_exposed_port_number: ~
 
 # Matrix mautrix is a Matrix <-> Whatsapp bridge
 # Enable whatsapp bridge

--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -209,7 +209,8 @@ matrix_mautrix_telegram_api_hash: YOUR_TELEGRAM_API_HASH
 # Mautrix telegram public endpoint to log in to telegram
 # Use an uuid so it's not easily discoverable
 matrix_mautrix_telegram_public_endpoint: "/{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'telegram') | to_uuid }}"
-
+# Set this to a port number to expose on the host when not using the nginx proxy
+matrix_mautrix_telegram_container_expose_port: false
 
 # Matrix mautrix is a Matrix <-> Whatsapp bridge
 # Enable whatsapp bridge

--- a/roles/matrix-synapse/templates/ext/mautrix-telegram/systemd/matrix-mautrix-telegram.service.j2
+++ b/roles/matrix-synapse/templates/ext/mautrix-telegram/systemd/matrix-mautrix-telegram.service.j2
@@ -21,8 +21,8 @@ ExecStart=/usr/bin/docker run --rm --name matrix-mautrix-telegram \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
 			--network={{ matrix_docker_network }} \
-			{% if matrix_mautrix_telegram_container_expose_port %}
-			-p 127.0.0.1:{{ matrix_mautrix_telegram_container_expose_port }}:8080 \
+			{% if matrix_mautrix_telegram_container_exposed_port_number is not none %}
+			-p 127.0.0.1:{{ matrix_mautrix_telegram_container_exposed_port_number }}:8080 \
 			{% endif %}
 			-v {{ matrix_mautrix_telegram_base_path }}:/data:z \
 			{{ matrix_mautrix_telegram_docker_image }} \

--- a/roles/matrix-synapse/templates/ext/mautrix-telegram/systemd/matrix-mautrix-telegram.service.j2
+++ b/roles/matrix-synapse/templates/ext/mautrix-telegram/systemd/matrix-mautrix-telegram.service.j2
@@ -21,6 +21,9 @@ ExecStart=/usr/bin/docker run --rm --name matrix-mautrix-telegram \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
 			--network={{ matrix_docker_network }} \
+			{% if matrix_mautrix_telegram_container_expose_port %}
+			-p 127.0.0.1:{{ matrix_mautrix_telegram_container_expose_port }}:8080 \
+			{% endif %}
 			-v {{ matrix_mautrix_telegram_base_path }}:/data:z \
 			{{ matrix_mautrix_telegram_docker_image }} \
 			python3 -m mautrix_telegram -c /data/config.yaml


### PR DESCRIPTION
This allows the out of matrix links to work when not using the built in nginx proxy