### PR TITLE
Add support for custom MXISD templates

### DIFF
--- a/roles/matrix-mxisd/defaults/main.yml
+++ b/roles/matrix-mxisd/defaults/main.yml
@@ -43,6 +43,16 @@ matrix_mxisd_dns_overwrite_enabled: false
 matrix_mxisd_dns_overwrite_homeserver_client_name: "{{ matrix_server_fqn_matrix }}"
 matrix_mxisd_dns_overwrite_homeserver_client_value: "http://matrix-synapse:8008"
 
+# Override the default email templates
+# More info:
+# https://github.com/kamax-matrix/mxisd/blob/master/docs/threepids/notification/template-generator.md
+# https://github.com/kamax-matrix/mxisd/tree/master/src/main/resources/threepids/email
+matrix_mxisd_threepid_medium_email_custom_templates_enabled: false
+matrix_mxisd_threepid_medium_email_custom_invite_template: ""
+matrix_mxisd_threepid_medium_email_custom_session_validation_template: ""
+matrix_mxisd_threepid_medium_email_custom_unbind_fraudulent_template: ""
+matrix_mxisd_threepid_medium_email_custom_matrixid_template: ""
+
 # Default mxisd configuration template which covers the generic use case.
 # You can customize it by controlling the various variables inside it.
 #
@@ -89,6 +99,27 @@ matrix_mxisd_configuration_yaml: |
             tls: {{ matrix_mxisd_threepid_medium_email_connectors_smtp_tls }}
             login: {{ matrix_mxisd_threepid_medium_email_connectors_smtp_login }}
             password: {{ matrix_mxisd_threepid_medium_email_connectors_smtp_password }}
+        {% if matrix_mxisd_threepid_medium_email_custom_templates_enabled %}
+        generators:
+          template:
+            {% if matrix_mxisd_threepid_medium_email_custom_invite_template %}
+            invite: '/var/mxisd/invite-template.eml'
+            {% endif %}
+            {% if matrix_mxisd_threepid_medium_email_custom_session_validation_template or matrix_mxisd_threepid_medium_email_custom_unbind_fraudulent_template %}
+            session:
+              {% if matrix_mxisd_threepid_medium_email_custom_session_validation_template %}
+              validation: '/var/mxisd/validate-template.eml'
+              {% endif %}
+              {% if matrix_mxisd_threepid_medium_email_custom_unbind_fraudulent_template %}
+              unbind:
+                frandulent: '/var/mxisd/unbind-fraudulent.eml'
+              {% endif %}
+            {% endif %}
+            {% if matrix_mxisd_threepid_medium_email_custom_matrixid_template %}
+            generic:
+              matrixId: '/var/mxisd/mxid-template.eml'
+            {% endif %}
+        {% endif %}
 
   synapseSql:
     enabled: {{ matrix_mxisd_synapsesql_enabled }}

--- a/roles/matrix-mxisd/defaults/main.yml
+++ b/roles/matrix-mxisd/defaults/main.yml
@@ -44,6 +44,8 @@ matrix_mxisd_dns_overwrite_homeserver_client_name: "{{ matrix_server_fqn_matrix 
 matrix_mxisd_dns_overwrite_homeserver_client_value: "http://matrix-synapse:8008"
 
 # Override the default email templates
+# To use this, fill in the template variables with the full desired template as a multi-line YAML variable
+#
 # More info:
 # https://github.com/kamax-matrix/mxisd/blob/master/docs/threepids/notification/template-generator.md
 # https://github.com/kamax-matrix/mxisd/tree/master/src/main/resources/threepids/email

--- a/roles/matrix-mxisd/tasks/setup_mxisd.yml
+++ b/roles/matrix-mxisd/tasks/setup_mxisd.yml
@@ -30,6 +30,20 @@
     group: "{{ matrix_user_username }}"
   when: matrix_mxisd_enabled
 
+- name: Ensure custom templates are installed if any
+  copy:
+    content: "{{ item.value }}"
+    dest: "{{ matrix_mxisd_data_path }}/{{ item.location }}"
+    mode: 0644
+    owner: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_username }}"
+  with_items:
+    - {value: "{{ matrix_mxisd_threepid_medium_email_custom_invite_template }}", location: 'invite-template.eml'}
+    - {value: "{{ matrix_mxisd_threepid_medium_email_custom_session_validation_template }}", location: 'validate-template.eml'}
+    - {value: "{{ matrix_mxisd_threepid_medium_email_custom_unbind_fraudulent_template }}", location: 'unbind-fraudulent.eml'}
+    - {value: "{{ matrix_mxisd_threepid_medium_email_custom_matrixid_template }}", location: 'mxid-template.eml'}
+  when: matrix_mxisd_enabled and matrix_mxisd_threepid_medium_email_custom_templates_enabled and item.value
+
 - name: Ensure matrix-mxisd.service installed
   template:
     src: "{{ role_path }}/templates/systemd/matrix-mxisd.service.j2"


### PR DESCRIPTION
The template can be set straight in the variable:

```
matrix_mxisd_threepid_medium_email_custom_invite_template: |
  This is an
  example template
```