### PR TITLE
Fix indenting of generators value

### DIFF
--- a/roles/matrix-mxisd/defaults/main.yml
+++ b/roles/matrix-mxisd/defaults/main.yml
@@ -101,7 +101,7 @@ matrix_mxisd_configuration_yaml: |
             tls: {{ matrix_mxisd_threepid_medium_email_connectors_smtp_tls }}
             login: {{ matrix_mxisd_threepid_medium_email_connectors_smtp_login }}
             password: {{ matrix_mxisd_threepid_medium_email_connectors_smtp_password }}
-        {% if matrix_mxisd_threepid_medium_email_custom_templates_enabled %}
+  {% if matrix_mxisd_threepid_medium_email_custom_templates_enabled %}
         generators:
           template:
             {% if matrix_mxisd_threepid_medium_email_custom_invite_template %}
@@ -121,7 +121,7 @@ matrix_mxisd_configuration_yaml: |
             generic:
               matrixId: '/var/mxisd/mxid-template.eml'
             {% endif %}
-        {% endif %}
+  {% endif %}
 
   synapseSql:
     enabled: {{ matrix_mxisd_synapsesql_enabled }}


### PR DESCRIPTION
I made an indenting mistake in https://github.com/spantaleev/matrix-docker-ansible-deploy/pull/108, causing generators to be put as a subkey of password. Oops.