### PR TITLE
Fix Dimension documentation

### DIFF
--- a/docs/configuring-dns.md
+++ b/docs/configuring-dns.md
@@ -41,7 +41,7 @@ As the table above illustrates, you need to create 2 subdomains (`matrix.<your-d
 The `riot.<your-domain>` subdomain is necessary, because this playbook installs the Riot web client for you.
 If you'd rather instruct the playbook not to install Riot (`matrix_riot_web_enabled: false` when [Configuring the playbook](configuring-playbook.md) later), feel free to skip the `riot.<your-domain>` DNS record.
 
-The `dimension.<your-domain>` subdomain may be necessary, because this playbook could install the [Dimension integrations manager](http://dimension.t2bot.io/) for you. Dimension installation is disabled by default, because it's only possible to install it after the other Matrix services are working (see [Setting up Dimension](docs/configuring-playbook-dimension.md) later). If you do not wish to set up Dimension, feel free to skip the `dimension.<your-domain>` DNS record.
+The `dimension.<your-domain>` subdomain may be necessary, because this playbook could install the [Dimension integrations manager](http://dimension.t2bot.io/) for you. Dimension installation is disabled by default, because it's only possible to install it after the other Matrix services are working (see [Setting up Dimension](configuring-playbook-dimension.md) later). If you do not wish to set up Dimension, feel free to skip the `dimension.<your-domain>` DNS record.
 
 
 ## `_matrix._tcp` SRV record setup (temporary requirement)

--- a/docs/configuring-playbook-dimension.md
+++ b/docs/configuring-playbook-dimension.md
@@ -31,7 +31,7 @@ To get an access token, follow these steps:
 1. In a private browsing session (incognito window), open Riot.
 2. It's better to you use dedicated user for getting access token, so log in with this user's username and password.
 3. Set the display name and avatar, if required.
-4. In the settings page, scroll down to the bottom and click `Access Token: <click to reveal>`.
+4. In the settings page choose "Help & About", scroll down to the bottom and click `Access Token: <click to reveal>`.
 5. Copy the highlighted text to your configuration.
 6. Close the private browsing session. **Do not log out**. Logging out will invalidate the token, making it not work.
 


### PR DESCRIPTION
1. Fix incorrect link in DNS configuration page
2. Make "Getting access token" in Dimension documentation more descriptive