### PR TITLE
Fix Matrix homeserver name in Dimension configuration

### DIFF
--- a/roles/matrix-dimension/defaults/main.yml
+++ b/roles/matrix-dimension/defaults/main.yml
@@ -38,7 +38,7 @@ matrix_dimension_configuration_yaml: |
   homeserver:
     # The domain name of the homeserver. This is used in many places, such as with go-neb
     # setups, to identify the homeserver.
-    name: "{{ matrix_server_fqn_matrix }}"
+    name: "{{ matrix_domain }}"
 
     # The URL that Dimension, go-neb, and other services provisioned by Dimension should
     # use to access the homeserver with.


### PR DESCRIPTION
Today I lost few hours trying to figure out why my Dimension server does not connect to Matrix Federation server Docker container `matrix-synapse` as configured: `federationUrl: "http://matrix-synapse:8048"` The cause was `homeserver.name` in config: `matrix.HOSTNAME.COM`, but it needs to be just `HOSTNAME.COM`.
After changing name from `{{ matrix_server_fqn_matrix }}` to `{{ matrix_domain }}` Dimension started to work again for me.