### PR TITLE
Add option to enable Dimension widgets serve sites with self signed certs

### DIFF
--- a/roles/matrix-dimension/defaults/main.yml
+++ b/roles/matrix-dimension/defaults/main.yml
@@ -7,6 +7,9 @@ matrix_dimension_access_token: ""
 # Users in form: ['@user1:domain.com', '@user2:domain.com']
 matrix_dimension_admins: []
 
+# Whether to allow Dimension widgets serve websites with invalid or self signed SSL certificates
+matrix_dimension_widgets_allow_self_signed_ssl_certificates: false
+
 matrix_dimension_base_path: "{{ matrix_base_data_path }}/dimension"
 
 matrix_dimension_docker_image: "turt2live/matrix-dimension:latest"

--- a/roles/matrix-dimension/templates/systemd/matrix-dimension.service.j2
+++ b/roles/matrix-dimension/templates/systemd/matrix-dimension.service.j2
@@ -12,6 +12,9 @@ ExecStart=/usr/bin/docker run --rm --name matrix-dimension \
 			--user={{ matrix_dimension_user_uid }}:{{ matrix_dimension_user_gid }} \
 			--cap-drop=ALL \
 			--network={{ matrix_docker_network }} \
+			{% if matrix_dimension_widgets_allow_self_signed_ssl_certificates %}
+			-e NODE_TLS_REJECT_UNAUTHORIZED=0 \
+			{% endif %}
 			{% if matrix_dimension_container_expose_port %}
 			-p 127.0.0.1:8184:8184 \
 			{% endif %}


### PR DESCRIPTION
I tried to add custom widget with website where SSL certificate was self signed. Dimension did not allow me to do that saying `error [DimensionWidgetService] unable to verify the first certificate`.
Found out that Node needs global parameter `NODE_TLS_REJECT_UNAUTHORIZED` set to `0` to stop checking SSL certificates validity. I know - it's a security issue, but if I really need to embed such websites, I can take this risk.