### PR TITLE
Federation self-check respects matrix_synapse_federation_enabled

### DIFF
--- a/roles/matrix-synapse/tasks/self_check_federation_api.yml
+++ b/roles/matrix-synapse/tasks/self_check_federation_api.yml
@@ -11,8 +11,14 @@
 - name: Fail if Matrix Federation API not working
   fail:
     msg: "Failed checking Matrix Federation API is up at `{{ matrix_server_fqn_matrix }}` (checked endpoint: `{{ matrix_synapse_federation_api_url_endpoint_public }}`). Is Synapse running? Is port 8448 open in your firewall? Full error: {{ result_matrix_synapse_federation_api }}"
-  when: "result_matrix_synapse_federation_api.failed or 'json' not in result_matrix_synapse_federation_api"
+  when: "matrix_synapse_federation_enabled and (result_matrix_synapse_federation_api.failed or 'json' not in result_matrix_synapse_federation_api)"
+
+- name: Fail if Matrix Federation API unexpectedly enabled
+  fail:
+      msg: "Matrix Federation API is up at `{{ matrix_server_fqn_matrix }}` (checked endpoint: `{{ matrix_synapse_federation_api_url_endpoint_public }}`) despite being disabled."
+  when: "matrix_synapse_federation_enabled == false and not result_matrix_synapse_federation_api.failed"
 
 - name: Report working Matrix Federation API
   debug:
     msg: "The Matrix Federation API at `{{ matrix_server_fqn_matrix }}` (checked endpoint: `{{ matrix_synapse_federation_api_url_endpoint_public }}`) is working"
+  when: "matrix_synapse_federation_enabled"


### PR DESCRIPTION
When federation was intentionally disabled (via `matrix_synapse_federation_enabled: false`), self-check `ansible-playbook -i inventory/hosts setup.yml --tags=self-check` was failing when it got to the federation check. This PR modifies the self-check to test for working federation when `matrix_synapse_federation_enabled: true` and to test for no federation when `matrix_synapse_federation_enabled: false`.