### PR TITLE
Allow configuring push content for matrix-synapse

### DIFF
--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -140,6 +140,11 @@ matrix_synapse_app_service_config_files: []
 # any password providers have been enabled or not.
 matrix_synapse_password_providers_enabled: false
 
+# Whether clients can request to include message content in push notifications
+# sent through third party servers. Setting this to false requires mobile clients
+# to load message content directly from the homeserver.
+matrix_synapse_push_include_content: true
+
 # Enable exposure of metrics to Prometheus
 # See https://github.com/matrix-org/synapse/blob/master/docs/metrics-howto.rst
 matrix_synapse_metrics_enabled: false

--- a/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -847,9 +847,8 @@ password_providers:
 # For modern android devices the notification content will still appear
 # because it is loaded by the app. iPhone, however will send a
 # notification saying only that a message arrived and who it came from.
-#
-#push:
-#   include_content: true
+push:
+   include_content: {{ matrix_synapse_push_include_content }}
 
 
 # spam_checker:


### PR DESCRIPTION
This allows overriding the default value for `include_content`. Setting this to false allows homeserver admins to ensure that message content isn't sent in the clear through third party servers.