### PR TITLE
Use common path for systemctl in lets encrypt cron

### DIFF
--- a/roles/matrix-nginx-proxy/tasks/ssl/setup_ssl_lets_encrypt.yml
+++ b/roles/matrix-nginx-proxy/tasks/ssl/setup_ssl_lets_encrypt.yml
@@ -92,7 +92,7 @@
       hour: 4
       minute: 20
       day: "*/5"
-      job: /usr/bin/systemctl reload matrix-nginx-proxy.service
+      job: /bin/systemctl reload matrix-nginx-proxy.service
     when: matrix_nginx_proxy_enabled
   when: "matrix_ssl_retrieval_method == 'lets-encrypt'"
 


### PR DESCRIPTION
Currently the nginx reload cron fails on Debian 9 because the path to systemctl is /bin/systemctl rather than /usr/bin/systemctl.

CentOS 7 places systemctl in both /bin and /usr/bin, so we can just use /bin/systemctl as the full path.