### PR TITLE
Update Riot Web from 1.0.5 to 1.0.6

### DIFF
--- a/roles/matrix-riot-web/defaults/main.yml
+++ b/roles/matrix-riot-web/defaults/main.yml
@@ -1,6 +1,6 @@
 matrix_riot_web_enabled: true
 
-matrix_riot_web_docker_image: "bubuntux/riot-web:v1.0.5"
+matrix_riot_web_docker_image: "bubuntux/riot-web:v1.0.6"
 
 matrix_riot_web_data_path: "{{ matrix_base_data_path }}/riot-web"
 


### PR DESCRIPTION
I have tested this version a bit and have found no noticeable errors.