### PR TITLE
Goofys Custom Endpoint Support

### DIFF
--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -218,7 +218,9 @@ matrix_synapse_ext_password_provider_ldap_filter: ""
 
 
 matrix_s3_media_store_enabled: false
+matrix_s3_media_store_custom_endpoint_enabled: false
 matrix_s3_goofys_docker_image: "ewoutp/goofys:latest"
+matrix_s3_media_store_custom_endpoint: "your-custom-endpoint"
 matrix_s3_media_store_bucket_name: "your-bucket-name"
 matrix_s3_media_store_aws_access_key: "your-aws-access-key"
 matrix_s3_media_store_aws_secret_key: "your-aws-secret-key"

--- a/roles/matrix-synapse/templates/goofys/env-goofys.j2
+++ b/roles/matrix-synapse/templates/goofys/env-goofys.j2
@@ -1,2 +1,3 @@
 AWS_ACCESS_KEY={{ matrix_s3_media_store_aws_access_key }}
 AWS_SECRET_KEY={{ matrix_s3_media_store_aws_secret_key }}
+{% matrix_s3_media_store_custom_endpoint_enabled %}ENDPOINT={{ matrix_s3_media_store_custom_endpoint }}{% endif %}

--- a/roles/matrix-synapse/templates/goofys/env-goofys.j2
+++ b/roles/matrix-synapse/templates/goofys/env-goofys.j2
@@ -1,3 +1,2 @@
 AWS_ACCESS_KEY={{ matrix_s3_media_store_aws_access_key }}
 AWS_SECRET_KEY={{ matrix_s3_media_store_aws_secret_key }}
-{% matrix_s3_media_store_custom_endpoint_enabled %}ENDPOINT={{ matrix_s3_media_store_custom_endpoint }}{% endif %}

--- a/roles/matrix-synapse/templates/goofys/systemd/matrix-goofys.service.j2
+++ b/roles/matrix-synapse/templates/goofys/systemd/matrix-goofys.service.j2
@@ -20,7 +20,7 @@ ExecStart=/usr/bin/docker run --rm --name %n \
 			--env-file={{ matrix_synapse_config_dir_path }}/env-goofys \
 			--entrypoint /bin/sh \
 			{{ matrix_s3_goofys_docker_image }} \
-			-c 'goofys -f --storage-class=STANDARD_IA --region {{ matrix_s3_media_store_region }} --stat-cache-ttl 60m0s --type-cache-ttl 60m0s --dir-mode 0700 --file-mode 0700 {{ matrix_s3_media_store_bucket_name }} /s3'
+			-c 'goofys -f{% if matrix_s3_media_store_custom_endpoint_enabled is false %} --storage-class=STANDARD_IA{% endif %}{% matrix_s3_media_store_custom_endpoint_enabled %} --endpoint={{matrix_s3_media_store_custom_endpoint}}{% endif %} --region {{ matrix_s3_media_store_region }} --stat-cache-ttl 60m0s --type-cache-ttl 60m0s --dir-mode 0700 --file-mode 0700 {{ matrix_s3_media_store_bucket_name }} /s3'
 TimeoutStartSec=5min
 ExecStop=-/usr/bin/docker stop %n
 ExecStop=-/usr/bin/docker kill %n

--- a/roles/matrix-synapse/templates/goofys/systemd/matrix-goofys.service.j2
+++ b/roles/matrix-synapse/templates/goofys/systemd/matrix-goofys.service.j2
@@ -20,7 +20,7 @@ ExecStart=/usr/bin/docker run --rm --name %n \
 			--env-file={{ matrix_synapse_config_dir_path }}/env-goofys \
 			--entrypoint /bin/sh \
 			{{ matrix_s3_goofys_docker_image }} \
-			-c 'goofys -f{% if matrix_s3_media_store_custom_endpoint_enabled is false %} --storage-class=STANDARD_IA{% endif %}{% matrix_s3_media_store_custom_endpoint_enabled %} --endpoint={{matrix_s3_media_store_custom_endpoint}}{% endif %} --region {{ matrix_s3_media_store_region }} --stat-cache-ttl 60m0s --type-cache-ttl 60m0s --dir-mode 0700 --file-mode 0700 {{ matrix_s3_media_store_bucket_name }} /s3'
+			-c 'goofys -f{% if matrix_s3_media_store_custom_endpoint_enabled is false %} --storage-class=STANDARD_IA{% endif %}{% matrix_s3_media_store_custom_endpoint_enabled %} --endpoint={{ matrix_s3_media_store_custom_endpoint }}{% endif %} --region {{ matrix_s3_media_store_region }} --stat-cache-ttl 60m0s --type-cache-ttl 60m0s --dir-mode 0700 --file-mode 0700 {{ matrix_s3_media_store_bucket_name }} /s3'
 TimeoutStartSec=5min
 ExecStop=-/usr/bin/docker stop %n
 ExecStop=-/usr/bin/docker kill %n


### PR DESCRIPTION
Goofys can work with more than just Amazon S3. _Hopefully_ this is all it takes to enable configuring a custom endpoint for custom endpoints like Minio.