### PR TITLE
Make Dimension communicate to Synapse through Docker network

### DIFF
--- a/roles/matrix-dimension/defaults/main.yml
+++ b/roles/matrix-dimension/defaults/main.yml
@@ -45,7 +45,7 @@ matrix_dimension_configuration_yaml: |
 
     # The URL that Dimension, go-neb, and other services provisioned by Dimension should
     # use to access the homeserver with.
-    clientServerUrl: "https://{{ matrix_server_fqn_matrix }}"
+    clientServerUrl: "http://matrix-synapse:8008"
 
     # The URL that Dimension should use when trying to communicate with federated APIs on
     # the homeserver. If not supplied or left empty Dimension will try to resolve the address
@@ -54,7 +54,7 @@ matrix_dimension_configuration_yaml: |
 
     # The URL that Dimension will redirect media requests to for downloading media such as
     # stickers. If not supplied or left empty Dimension will use the clientServerUrl.
-    #mediaUrl: "https://t2bot.io"
+    mediaUrl: "https://{{ matrix_server_fqn_matrix }}"
 
     # The access token Dimension should use for miscellaneous access to the homeserver. This
     # should be for a user on the configured homeserver: any user will do, however it is


### PR DESCRIPTION
Media is pulled from client side, so we specify external Matrix DNS name as mediaUrl