### PR TITLE
Add additional room config options

### DIFF
--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -797,3 +797,19 @@ matrix_appservice_discord_configuration_extension: "{{ matrix_appservice_irc_con
 matrix_appservice_discord_configuration: "{{ matrix_appservice_discord_configuration_yaml|from_yaml|combine(matrix_appservice_discord_configuration_extension, recursive=True) }}"
 
 
+# Controls whether searching the public room list is enabled.
+matrix_enable_room_list_search: true
+
+# Controls who's allowed to create aliases on this server.
+matrix_alias_creation_rules:
+  - user_id: "*"
+    alias: "*"
+    room_id: "*"
+    action: allow
+
+# Controls who can publish and which rooms can be published in the public room list.
+matrix_room_list_publication_rules:
+  - user_id: "*"
+    alias: "*"
+    room_id: "*"
+    action: allow

--- a/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -1108,6 +1108,8 @@ push:
 #
 #enable_room_list_search: false
 
+enable_room_list_search: {{ matrix_enable_room_list_search|to_json }}
+
 # The `alias_creation` option controls who's allowed to create aliases
 # on this server.
 #
@@ -1135,6 +1137,8 @@ push:
 #    alias: "*"
 #    room_id: "*"
 #    action: allow
+
+alias_creation_rules: {{ matrix_alias_creation_rules|to_json }}
 
 # The `room_list_publication_rules` option controls who can publish and
 # which rooms can be published in the public room list.
@@ -1164,3 +1168,5 @@ push:
 #    alias: "*"
 #    room_id: "*"
 #    action: allow
+
+room_list_publication_rules: {{ matrix_room_list_publication_rules|to_json }}


### PR DESCRIPTION
 - matrix_enable_room_list_search - Controls whether searching the public room list is enabled.
 - matrix_alias_creation_rules - Controls who's allowed to create aliases on this server.
 - matrix_room_list_publication_rules - Controls who can publish and which rooms can be published in the public room list.