### PR TITLE
disable password change api, when password providers are used

### DIFF
--- a/roles/matrix-nginx-proxy/defaults/main.yml
+++ b/roles/matrix-nginx-proxy/defaults/main.yml
@@ -76,6 +76,9 @@ matrix_nginx_proxy_proxy_synapse_metrics: false
 matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_enabled: false
 matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_key: ""
 
+# if you want to disable password change (when using external password providers)
+matrix_nginx_proxy_proxy_matrix_password_change_disabled: false
+
 # The addresses where the Matrix Client API is.
 # Certain extensions (like matrix-corporal) may override this in order to capture all traffic.
 matrix_nginx_proxy_proxy_matrix_client_api_addr_with_container: "matrix-synapse:8008"

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-synapse.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-synapse.conf.j2
@@ -102,6 +102,12 @@ server {
 	}
 	{% endif %}
 
+	{% if matrix_nginx_proxy_proxy_matrix_password_change_disabled %}
+	location /_matrix/client/r0/account/password {
+		deny all;
+	}
+	{% endif %}
+
 	{% for configuration_block in matrix_nginx_proxy_proxy_matrix_additional_server_configuration_blocks %}
 		{{- configuration_block }}
 	{% endfor %}


### PR DESCRIPTION
This pull request is a workaround until https://github.com/matrix-org/synapse/pull/5092 lands upstream. It's really a problem when you use password_providers and users are allowed to change their password but it will only updated locally. It's not only confusing but also a security risk because you can login using 2 different passwords (local and the one from password_provider)