### PR TITLE
Set Riot's enable_presence_by_hs_url to false if presence is disabled

### DIFF
--- a/group_vars/matrix-servers
+++ b/group_vars/matrix-servers
@@ -321,6 +321,13 @@ matrix_riot_web_self_check_validate_certificates: "{{ false if matrix_ssl_retrie
 
 matrix_riot_web_registration_enabled: "{{ matrix_synapse_enable_registration }}"
 
+matrix_riot_web_enable_presence_by_hs_url: |
+  {{
+    none
+    if matrix_synapse_use_presence
+    else {matrix_riot_web_default_hs_url: false}
+  }}
+
 ######################################################################
 #
 # /matrix-riot-web

--- a/roles/matrix-riot-web/defaults/main.yml
+++ b/roles/matrix-riot-web/defaults/main.yml
@@ -31,3 +31,6 @@ matrix_riot_web_self_check_validate_certificates: true
 
 # don't show the registration button on welcome page
 matrix_riot_web_registration_enabled: false
+
+# Controls whether Riot shows the presence features
+matrix_riot_web_enable_presence_by_hs_url: ~

--- a/roles/matrix-riot-web/templates/config.json.j2
+++ b/roles/matrix-riot-web/templates/config.json.j2
@@ -14,10 +14,8 @@
 		"servers": {{ matrix_riot_web_roomdir_servers|to_json }}
 	},
 	"welcomeUserId": {{ matrix_riot_web_welcome_user_id|to_json }},
-	{% if matrix_synapse_use_presence|to_json %}
-	"enable_presence_by_hs_url": {
-		{{ matrix_riot_web_default_hs_url|to_json }}: false
-	},
+	{% if matrix_riot_web_enable_presence_by_hs_url is not none %}
+		"enable_presence_by_hs_url": {{ matrix_riot_web_enable_presence_by_hs_url|to_json }},
 	{% endif %}
 	"embeddedPages": {
 		"homeUrl": {{ matrix_riot_web_embedded_pages_home_url|to_json }}

--- a/roles/matrix-riot-web/templates/config.json.j2
+++ b/roles/matrix-riot-web/templates/config.json.j2
@@ -14,6 +14,11 @@
 		"servers": {{ matrix_riot_web_roomdir_servers|to_json }}
 	},
 	"welcomeUserId": {{ matrix_riot_web_welcome_user_id|to_json }},
+	{% if matrix_synapse_use_presence|to_json %}
+	"enable_presence_by_hs_url": {
+		{{ matrix_riot_web_default_hs_url|to_json }}: false
+	},
+	{% endif %}
 	"embeddedPages": {
 		"homeUrl": {{ matrix_riot_web_embedded_pages_home_url|to_json }}
 	}


### PR DESCRIPTION
This is kind of a hack put in place until homeservers have a way of advertising that they have disabled presence and makes Riot hide all the presence related info. 