### PR TITLE
Fix value of nginx-proxy tmpfs size

### DIFF
--- a/roles/matrix-nginx-proxy/defaults/main.yml
+++ b/roles/matrix-nginx-proxy/defaults/main.yml
@@ -92,7 +92,7 @@ matrix_nginx_proxy_proxy_matrix_federation_api_ssl_certificate: "{{ matrix_ssl_c
 matrix_nginx_proxy_proxy_matrix_federation_api_ssl_certificate_key: "{{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_proxy_matrix_hostname }}/privkey.pem"
 
 # The tmpfs at /tmp needs to be large enough to handle multiple concurrent file uploads.
-matrix_nginx_proxy_tmp_directory_size_mb: "{{ matrix_nginx_proxy_proxy_matrix_federation_api_client_max_body_size_mb * 50 }}"
+matrix_nginx_proxy_tmp_directory_size_mb: "{{ (matrix_nginx_proxy_proxy_matrix_federation_api_client_max_body_size_mb | int) * 50 }}"
 
 # A list of strings containing additional configuration blocks to add to the matrix domain's server configuration.
 matrix_nginx_proxy_proxy_matrix_additional_server_configuration_blocks: []


### PR DESCRIPTION
Use an int conversion in the computation of the value of
`matrix_nginx_proxy_tmp_directory_size_mb`, to have the integer value
multiplied by 50 instead of having the string repeated 50 times.