### PR TITLE
Remove hardcoded values in matrix-remove-all

### DIFF
--- a/roles/matrix-base/templates/usr-local-bin/matrix-remove-all.j2
+++ b/roles/matrix-base/templates/usr-local-bin/matrix-remove-all.j2
@@ -26,9 +26,9 @@ else
 	echo "Remove every docker images"
 	docker rmi $(docker images -aq)
 	echo "Remove docker matrix network"
-	docker network rm matrix
-	echo "Remove /matrix directory"
-	rm -fr /matrix
+	docker network rm {{ matrix_docker_network }}
+	echo "Remove {{ matrix_base_data_path }} directory"
+	rm -fr "{{ matrix_base_data_path }}"
 	exit 0
 fi
 


### PR DESCRIPTION
Use `matrix_docker_network` and `matrix_base_data_path` in `matrix-remove-all`
instead of hardcoded default values.