### PR TITLE
Add the possibility to pass extra flags to the docker container

### DIFF
--- a/roles/matrix-corporal/defaults/main.yml
+++ b/roles/matrix-corporal/defaults/main.yml
@@ -6,6 +6,9 @@ matrix_corporal_enabled: true
 # Controls whether the matrix-corporal web server's ports (`41080` and `41081`) are exposed outside of the container.
 matrix_corporal_container_expose_ports: false
 
+# A list of extra arguments to pass to the container
+matrix_corporal_container_extra_arguments: []
+
 # List of systemd services that matrix-corporal.service depends on
 matrix_corporal_systemd_required_services_list: ['docker.service']
 

--- a/roles/matrix-corporal/templates/systemd/matrix-corporal.service.j2
+++ b/roles/matrix-corporal/templates/systemd/matrix-corporal.service.j2
@@ -22,6 +22,9 @@ ExecStart=/usr/bin/docker run --rm --name matrix-corporal \
 			-v {{ matrix_corporal_config_dir_path }}:/etc/matrix-corporal:ro \
 			-v {{ matrix_corporal_cache_dir_path }}:/var/cache/matrix-corporal:rw \
 			-v {{ matrix_corporal_var_dir_path }}:/var/matrix-corporal:rw \
+			{% for arg in matrix_corporal_container_extra_arguments %}
+			{{ arg }} \
+			{% endfor %}
 			{{ matrix_corporal_docker_image }} \
 			/matrix-corporal -config=/etc/matrix-corporal/config.json
 ExecStop=-/usr/bin/docker kill matrix-corporal

--- a/roles/matrix-coturn/defaults/main.yml
+++ b/roles/matrix-coturn/defaults/main.yml
@@ -23,6 +23,9 @@ matrix_coturn_systemd_required_services_list: ['docker.service']
 # Contains definition objects like this: `{"src": "/outside", "dst": "/inside", "options": "rw|ro|slave|.."}
 matrix_coturn_container_additional_volumes: []
 
+# A list of extra arguments to pass to the container
+matrix_coturn_container_extra_arguments: []
+
 # A shared secret (between Synapse and Coturn) used for authentication.
 # You can put any string here, but generating a strong one is preferred (e.g. `pwgen -s 64 1`).
 matrix_coturn_turn_static_auth_secret: ""

--- a/roles/matrix-coturn/templates/systemd/matrix-coturn.service.j2
+++ b/roles/matrix-coturn/templates/systemd/matrix-coturn.service.j2
@@ -27,6 +27,9 @@ ExecStart=/usr/bin/docker run --rm --name matrix-coturn \
 			{% for volume in matrix_coturn_container_additional_volumes %}
 			-v {{ volume.src }}:{{ volume.dst }}:{{ volume.options }} \
 			{% endfor %}
+			{% for arg in matrix_coturn_container_extra_arguments %}
+			{{ arg }} \
+			{% endfor %}
 			{{ matrix_coturn_docker_image }} \
 			-c /turnserver.conf
 

--- a/roles/matrix-dimension/defaults/main.yml
+++ b/roles/matrix-dimension/defaults/main.yml
@@ -20,6 +20,9 @@ matrix_dimension_user_gid: 1000
 
 matrix_dimension_container_expose_port: false
 
+# A list of extra arguments to pass to the container
+matrix_dimension_container_extra_arguments: []
+
 matrix_dimension_integrations_ui_url: "https://{{ matrix_server_fqn_dimension }}/riot"
 matrix_dimension_integrations_rest_url: "https://{{ matrix_server_fqn_dimension }}/api/v1/scalar"
 matrix_dimension_integrations_widgets_urls: ["https://{{ matrix_server_fqn_dimension }}/widgets"]

--- a/roles/matrix-dimension/templates/systemd/matrix-dimension.service.j2
+++ b/roles/matrix-dimension/templates/systemd/matrix-dimension.service.j2
@@ -19,6 +19,9 @@ ExecStart=/usr/bin/docker run --rm --name matrix-dimension \
 			-p 127.0.0.1:8184:8184 \
 			{% endif %}
 			-v {{ matrix_dimension_base_path }}:/data:rw \
+			{% for arg in matrix_dimension_container_extra_arguments %}
+			{{ arg }} \
+			{% endfor %}
 			{{ matrix_dimension_docker_image }}
 ExecStop=-/usr/bin/docker kill matrix-dimension
 ExecStop=-/usr/bin/docker rm matrix-dimension

--- a/roles/matrix-mailer/defaults/main.yml
+++ b/roles/matrix-mailer/defaults/main.yml
@@ -9,6 +9,9 @@ matrix_mailer_docker_image: "devture/exim-relay:4.91-r3-0"
 matrix_mailer_container_user_uid: 100
 matrix_mailer_container_user_gid: 101
 
+# A list of extra arguments to pass to the container
+matrix_mailer_container_extra_arguments: []
+
 matrix_mailer_sender_address: "matrix@{{ matrix_domain }}"
 matrix_mailer_relay_use: false
 matrix_mailer_relay_host_name: "mail.example.com"

--- a/roles/matrix-mailer/templates/systemd/matrix-mailer.service.j2
+++ b/roles/matrix-mailer/templates/systemd/matrix-mailer.service.j2
@@ -16,6 +16,9 @@ ExecStart=/usr/bin/docker run --rm --name matrix-mailer \
 			--network={{ matrix_docker_network }} \
 			--env-file={{ matrix_mailer_base_path }}/env-mailer \
 			--hostname={{ matrix_server_fqn_matrix }} \
+			{% for arg in matrix_mailer_container_extra_arguments %}
+			{{ arg }} \
+			{% endfor %}
 			{{ matrix_mailer_docker_image }}
 ExecStop=-/usr/bin/docker kill matrix-mailer
 ExecStop=-/usr/bin/docker rm matrix-mailer

--- a/roles/matrix-mxisd/defaults/main.yml
+++ b/roles/matrix-mxisd/defaults/main.yml
@@ -8,6 +8,9 @@ matrix_mxisd_data_path: "{{ matrix_mxisd_base_path }}/data"
 # Controls whether the mxisd web server's port (`8090`) is exposed outside of the container.
 matrix_mxisd_container_expose_port: false
 
+# A list of extra arguments to pass to the container
+matrix_mxisd_container_extra_arguments: []
+
 # List of systemd services that matrix-mxisd.service depends on
 matrix_mxisd_systemd_required_services_list: ['docker.service']
 

--- a/roles/matrix-mxisd/templates/systemd/matrix-mxisd.service.j2
+++ b/roles/matrix-mxisd/templates/systemd/matrix-mxisd.service.j2
@@ -27,6 +27,9 @@ ExecStart=/usr/bin/docker run --rm --name matrix-mxisd \
 			{% endif %}
 			-v {{ matrix_mxisd_config_path }}:/etc/mxisd:ro \
 			-v {{ matrix_mxisd_data_path }}:/var/mxisd:rw \
+			{% for arg in matrix_mxisd_container_extra_arguments %}
+			{{ arg }} \
+			{% endfor %}
 			{{ matrix_mxisd_docker_image }}
 
 ExecStop=-/usr/bin/docker kill matrix-mxisd

--- a/roles/matrix-nginx-proxy/defaults/main.yml
+++ b/roles/matrix-nginx-proxy/defaults/main.yml
@@ -21,6 +21,9 @@ matrix_nginx_proxy_systemd_wanted_services_list: []
 # Contains definition objects like this: `{"src": "/outside", "dst": "/inside", "options": "rw|ro|slave|.."}
 matrix_nginx_proxy_container_additional_volumes: []
 
+# A list of extra arguments to pass to the container
+matrix_nginx_proxy_container_extra_arguments: []
+
 # Controls whether matrix-nginx-proxy should serve the base domain.
 #
 # This is useful for when you only have your Matrix server, but you need to serve

--- a/roles/matrix-nginx-proxy/templates/systemd/matrix-nginx-proxy.service.j2
+++ b/roles/matrix-nginx-proxy/templates/systemd/matrix-nginx-proxy.service.j2
@@ -33,6 +33,9 @@ ExecStart=/usr/bin/docker run --rm --name matrix-nginx-proxy \
 			{% for volume in matrix_nginx_proxy_container_additional_volumes %}
 			-v {{ volume.src }}:{{ volume.dst }}:{{ volume.options }} \
 			{% endfor %}
+			{% for arg in matrix_nginx_proxy_container_extra_arguments %}
+			{{ arg }} \
+			{% endfor %}
 			{{ matrix_nginx_proxy_docker_image }}
 
 ExecStop=-/usr/bin/docker kill matrix-nginx-proxy

--- a/roles/matrix-postgres/defaults/main.yml
+++ b/roles/matrix-postgres/defaults/main.yml
@@ -12,3 +12,6 @@ matrix_postgres_docker_image_v9: "postgres:9.6.12-alpine"
 matrix_postgres_docker_image_v10: "postgres:10.7-alpine"
 matrix_postgres_docker_image_v11: "postgres:11.2-alpine"
 matrix_postgres_docker_image_latest: "{{ matrix_postgres_docker_image_v11 }}"
+
+# A list of extra arguments to pass to the container
+matrix_postgres_container_extra_arguments: []

--- a/roles/matrix-postgres/templates/systemd/matrix-postgres.service.j2
+++ b/roles/matrix-postgres/templates/systemd/matrix-postgres.service.j2
@@ -18,6 +18,9 @@ ExecStart=/usr/bin/docker run --rm --name matrix-postgres \
 			--env-file={{ matrix_postgres_base_path }}/env-postgres-server \
 			-v {{ matrix_postgres_data_path }}:/var/lib/postgresql/data:rw \
 			-v /etc/passwd:/etc/passwd:ro \
+			{% for arg in matrix_postgres_container_extra_arguments %}
+			{{ arg }} \
+			{% endfor %}
 			{{ matrix_postgres_docker_image_to_use }}
 ExecStop=-/usr/bin/docker stop matrix-postgres
 ExecStop=-/usr/bin/docker rm matrix-postgres

--- a/roles/matrix-riot-web/defaults/main.yml
+++ b/roles/matrix-riot-web/defaults/main.yml
@@ -6,6 +6,9 @@ matrix_riot_web_data_path: "{{ matrix_base_data_path }}/riot-web"
 
 matrix_riot_web_container_expose_port: false
 
+# A list of extra arguments to pass to the container
+matrix_riot_web_container_extra_arguments: []
+
 # List of systemd services that matrix-riot-web.service depends on
 matrix_riot_web_systemd_required_services_list: ['docker.service']
 

--- a/roles/matrix-riot-web/templates/systemd/matrix-riot-web.service.j2
+++ b/roles/matrix-riot-web/templates/systemd/matrix-riot-web.service.j2
@@ -26,6 +26,9 @@ ExecStart=/usr/bin/docker run --rm --name matrix-riot-web \
 			-v {{ matrix_riot_web_data_path }}/home.html:/etc/riot-web/home.html:ro \
 			{% endif %}
 			-v {{ matrix_riot_web_data_path }}/welcome.html:/etc/riot-web/welcome.html:ro \
+			{% for arg in matrix_riot_web_container_extra_arguments %}
+			{{ arg }} \
+			{% endfor %}
 			{{ matrix_riot_web_docker_image }}
 ExecStop=-/usr/bin/docker kill matrix-riot-web
 ExecStop=-/usr/bin/docker rm matrix-riot-web

--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -24,6 +24,9 @@ matrix_appservice_discord_container_expose_client_server_api_port: false
 # Controls whether the matrix-synapse container exposes the metrics port (tcp/9100).
 matrix_synapse_container_expose_metrics_port: false
 
+# A list of extra arguments to pass to the container
+matrix_synapse_container_extra_arguments: []
+
 # List of systemd services that matrix-synapse.service depends on
 matrix_synapse_systemd_required_services_list: ['docker.service']
 

--- a/roles/matrix-synapse/templates/synapse/systemd/matrix-synapse.service.j2
+++ b/roles/matrix-synapse/templates/synapse/systemd/matrix-synapse.service.j2
@@ -46,6 +46,9 @@ ExecStart=/usr/bin/docker run --rm --name matrix-synapse \
 			{% for volume in matrix_synapse_container_additional_volumes %}
 			-v {{ volume.src }}:{{ volume.dst }}:{{ volume.options }} \
 			{% endfor %}
+			{% for arg in matrix_synapse_container_extra_arguments %}
+			{{ arg }} \
+			{% endfor %}
 			{{ matrix_synapse_docker_image }} \
 			-m synapse.app.homeserver -c /data/homeserver.yaml
 


### PR DESCRIPTION
Untested, but submitting it to get your two cents.

I've been having to deal with a network setup where the external domain names cannot be resolved internally. Thus, I've been adding --add-host flags to the systemd files.

`--add-host` however, seems very much a very specific edge case, so I figured I should instead make it possible to add support for any extra docker arguments, so that any weird edge case can be worked around by users.

How does this seem?