### PR TITLE
string before to_json when string value is expected

### DIFF
--- a/roles/matrix-riot-web/templates/config.json.j2
+++ b/roles/matrix-riot-web/templates/config.json.j2
@@ -1,23 +1,23 @@
 {
-	"default_hs_url": {{ matrix_riot_web_default_hs_url|to_json }},
-	"default_is_url": {{ matrix_riot_web_default_is_url|to_json }},
+	"default_hs_url": {{ matrix_riot_web_default_hs_url|string|to_json }},
+	"default_is_url": {{ matrix_riot_web_default_is_url|string|to_json }},
 	"disable_custom_urls": {{ matrix_riot_web_disable_custom_urls|to_json }},
 	"disable_guests": {{ matrix_riot_web_disable_guests|to_json }},
 	"brand": "Riot",
-	"integrations_ui_url": {{ matrix_riot_web_integrations_ui_url|to_json }},
-	"integrations_rest_url": {{ matrix_riot_web_integrations_rest_url|to_json }},
+	"integrations_ui_url": {{ matrix_riot_web_integrations_ui_url|string|to_json }},
+	"integrations_rest_url": {{ matrix_riot_web_integrations_rest_url|string|to_json }},
 	"integrations_widgets_urls": {{ matrix_riot_web_integrations_widgets_urls|to_json }},
-	"integrations_jitsi_widget_url": {{ matrix_riot_web_integrations_jitsi_widget_url|to_json }},
+	"integrations_jitsi_widget_url": {{ matrix_riot_web_integrations_jitsi_widget_url|string|to_json }},
 	"bug_report_endpoint_url": "https://riot.im/bugreports/submit",
 	"enableLabs": true,
 	"roomDirectory": {
 		"servers": {{ matrix_riot_web_roomdir_servers|to_json }}
 	},
-	"welcomeUserId": {{ matrix_riot_web_welcome_user_id|to_json }},
+	"welcomeUserId": {{ matrix_riot_web_welcome_user_id|string|to_json }},
 	{% if matrix_riot_web_enable_presence_by_hs_url is not none %}
-		"enable_presence_by_hs_url": {{ matrix_riot_web_enable_presence_by_hs_url|to_json }},
+		"enable_presence_by_hs_url": {{ matrix_riot_web_enable_presence_by_hs_url|string|to_json }},
 	{% endif %}
 	"embeddedPages": {
-		"homeUrl": {{ matrix_riot_web_embedded_pages_home_url|to_json }}
+		"homeUrl": {{ matrix_riot_web_embedded_pages_home_url|string}to_json }}
 	}
 }

--- a/roles/matrix-riot-web/templates/config.json.j2
+++ b/roles/matrix-riot-web/templates/config.json.j2
@@ -15,9 +15,9 @@
 	},
 	"welcomeUserId": {{ matrix_riot_web_welcome_user_id|string|to_json }},
 	{% if matrix_riot_web_enable_presence_by_hs_url is not none %}
-		"enable_presence_by_hs_url": {{ matrix_riot_web_enable_presence_by_hs_url|string|to_json }},
+		"enable_presence_by_hs_url": {{ matrix_riot_web_enable_presence_by_hs_url|to_json }},
 	{% endif %}
 	"embeddedPages": {
-		"homeUrl": {{ matrix_riot_web_embedded_pages_home_url|string}to_json }}
+		"homeUrl": {{ matrix_riot_web_embedded_pages_home_url|string|to_json }}
 	}
 }

--- a/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -255,11 +255,11 @@ listeners:
 # instance, if using certbot, use `fullchain.pem` as your certificate,
 # not `cert.pem`).
 #
-tls_certificate_path: {{ matrix_synapse_tls_certificate_path|string|to_json }}
+tls_certificate_path: {{ matrix_synapse_tls_certificate_path|to_json }}
 
 # PEM-encoded private key for TLS
 #
-tls_private_key_path: {{ matrix_synapse_tls_private_key_path|string|to_json }}
+tls_private_key_path: {{ matrix_synapse_tls_private_key_path|to_json }}
 
 # ACME support: This will configure Synapse to request a valid TLS certificate
 # for your configured `server_name` via Let's Encrypt.
@@ -915,7 +915,7 @@ password_config:
 email:
    enable_notifs: true
    smtp_host: {{ matrix_synapse_email_smtp_host|string|to_json }}
-   smtp_port: {{ matrix_synapse_email_smtp_port|string|to_json }}
+   smtp_port: {{ matrix_synapse_email_smtp_port|to_json }}
    require_transport_security: {{ matrix_synapse_email_smtp_require_transport_security|to_json }}
    notif_from: {{ matrix_synapse_email_notif_from|string|to_json }}
    app_name: Matrix

--- a/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -255,11 +255,11 @@ listeners:
 # instance, if using certbot, use `fullchain.pem` as your certificate,
 # not `cert.pem`).
 #
-tls_certificate_path: {{ matrix_synapse_tls_certificate_path|to_json }}
+tls_certificate_path: {{ matrix_synapse_tls_certificate_path|string|to_json }}
 
 # PEM-encoded private key for TLS
 #
-tls_private_key_path: {{ matrix_synapse_tls_private_key_path|to_json }}
+tls_private_key_path: {{ matrix_synapse_tls_private_key_path|string|to_json }}
 
 # ACME support: This will configure Synapse to request a valid TLS certificate
 # for your configured `server_name` via Let's Encrypt.
@@ -358,8 +358,8 @@ database:
   # The database engine name
   name: "psycopg2"
   args:
-    user: {{ matrix_synapse_database_user|to_json }}
-    password: {{ matrix_synapse_database_password|to_json }}
+    user: {{ matrix_synapse_database_user|string|to_json }}
+    password: {{ matrix_synapse_database_password|string|to_json }}
     database: "{{ matrix_synapse_database_database }}"
     host: "{{ matrix_synapse_database_host }}"
     cp_min: 5
@@ -628,7 +628,7 @@ turn_uris: {{ matrix_synapse_turn_uris|to_json }}
 
 # The shared secret used to compute passwords for the TURN server
 #
-turn_shared_secret: {{ matrix_synapse_turn_shared_secret|to_json }}
+turn_shared_secret: {{ matrix_synapse_turn_shared_secret|string|to_json }}
 
 # The Username and password if the TURN server needs them and
 # does not use a token
@@ -683,7 +683,7 @@ enable_registration: {{ matrix_synapse_enable_registration|to_json }}
 # If set, allows registration of standard or admin accounts by anyone who
 # has the shared secret, even if registration is otherwise disabled.
 #
-registration_shared_secret: {{ matrix_synapse_registration_shared_secret|to_json }}
+registration_shared_secret: {{ matrix_synapse_registration_shared_secret|string|to_json }}
 
 # Set the number of bcrypt rounds used to generate password hash.
 # Larger numbers increase the work factor needed to generate the hash.
@@ -784,7 +784,7 @@ app_service_config_files: {{ matrix_synapse_app_service_config_files }}
 # the registration_shared_secret is used, if one is given; otherwise,
 # a secret key is derived from the signing key.
 #
-macaroon_secret_key: {{ matrix_synapse_macaroon_secret_key|to_json }}
+macaroon_secret_key: {{ matrix_synapse_macaroon_secret_key|string|to_json }}
 
 # Used to enable access token expiration.
 #
@@ -794,7 +794,7 @@ macaroon_secret_key: {{ matrix_synapse_macaroon_secret_key|to_json }}
 # falsification of values. Must be specified for the User Consent
 # forms to work.
 #
-form_secret: {{ matrix_synapse_form_secret|to_json }}
+form_secret: {{ matrix_synapse_form_secret|string|to_json }}
 
 ## Signing Keys ##
 
@@ -899,7 +899,7 @@ password_config:
    # Uncomment and change to a secret random string for extra security.
    # DO NOT CHANGE THIS AFTER INITIAL SETUP!
    #
-   pepper: {{ matrix_synapse_password_config_pepper|to_json }}
+   pepper: {{ matrix_synapse_password_config_pepper|string|to_json }}
 
 
 
@@ -914,15 +914,15 @@ password_config:
 {% if matrix_synapse_email_enabled %}
 email:
    enable_notifs: true
-   smtp_host: {{ matrix_synapse_email_smtp_host|to_json }}
-   smtp_port: {{ matrix_synapse_email_smtp_port|to_json }}
+   smtp_host: {{ matrix_synapse_email_smtp_host|string|to_json }}
+   smtp_port: {{ matrix_synapse_email_smtp_port|string|to_json }}
    require_transport_security: {{ matrix_synapse_email_smtp_require_transport_security|to_json }}
-   notif_from: {{ matrix_synapse_email_notif_from|to_json }}
+   notif_from: {{ matrix_synapse_email_notif_from|string|to_json }}
    app_name: Matrix
    notif_template_html: notif_mail.html
    notif_template_text: notif_mail.txt
    notif_for_new_users: True
-   riot_base_url: {{ matrix_synapse_email_riot_base_url|to_json }}
+   riot_base_url: {{ matrix_synapse_email_riot_base_url|string|to_json }}
 {% endif %}
 
 
@@ -945,12 +945,12 @@ password_providers:
 {% if matrix_synapse_ext_password_provider_shared_secret_auth_enabled %}
   - module: "shared_secret_authenticator.SharedSecretAuthenticator"
     config:
-      sharedSecret: {{ matrix_synapse_ext_password_provider_shared_secret_auth_shared_secret|to_json }}
+      sharedSecret: {{ matrix_synapse_ext_password_provider_shared_secret_auth_shared_secret|string|to_json }}
 {% endif %}
 {% if matrix_synapse_ext_password_provider_rest_auth_enabled %}
   - module: "rest_auth_provider.RestAuthProvider"
     config:
-      endpoint: {{ matrix_synapse_ext_password_provider_rest_auth_endpoint|to_json }}
+      endpoint: {{ matrix_synapse_ext_password_provider_rest_auth_endpoint|string|to_json }}
       policy:
         registration:
           username:
@@ -965,16 +965,16 @@ password_providers:
   - module: "ldap_auth_provider.LdapAuthProvider"
     config:
       enabled: true
-      uri: {{ matrix_synapse_ext_password_provider_ldap_uri|to_json }}
-      start_tls: {{ matrix_synapse_ext_password_provider_ldap_start_tls|to_json }}
-      base: {{ matrix_synapse_ext_password_provider_ldap_base|to_json }}
+      uri: {{ matrix_synapse_ext_password_provider_ldap_uri|string|to_json }}
+      start_tls: {{ matrix_synapse_ext_password_provider_ldap_start_tls|string|to_json }}
+      base: {{ matrix_synapse_ext_password_provider_ldap_base|string|to_json }}
       attributes:
-        uid: {{ matrix_synapse_ext_password_provider_ldap_attributes_uid|to_json }}
-        mail: {{ matrix_synapse_ext_password_provider_ldap_attributes_mail|to_json }}
-        name: {{ matrix_synapse_ext_password_provider_ldap_attributes_name|to_json }}
-      bind_dn: {{ matrix_synapse_ext_password_provider_ldap_bind_dn|to_json }}
-      bind_password: {{ matrix_synapse_ext_password_provider_ldap_bind_password|to_json }}
-      filter: {{ matrix_synapse_ext_password_provider_ldap_filter|to_json }}
+        uid: {{ matrix_synapse_ext_password_provider_ldap_attributes_uid|string|to_json }}
+        mail: {{ matrix_synapse_ext_password_provider_ldap_attributes_mail|string|to_json }}
+        name: {{ matrix_synapse_ext_password_provider_ldap_attributes_name|string|to_json }}
+      bind_dn: {{ matrix_synapse_ext_password_provider_ldap_bind_dn|string|to_json }}
+      bind_password: {{ matrix_synapse_ext_password_provider_ldap_bind_password|string|to_json }}
+      filter: {{ matrix_synapse_ext_password_provider_ldap_filter|string|to_json }}
 {% endif %}
 {% endif %}
 


### PR DESCRIPTION
This prevents Ansible from sometimes failing to decrypt vault variables.

I've tried to be careful and only cast string values to string before to_json, not lists or booleans, yet also as much as possible so people can use vault variables as much as possible (who knows, usernames may be vault-worthy for some). Please double check if I didn't accidentally cast too much. Proper fix for #102.