### PR TITLE
Allow changing Riot bug report URL

### DIFF
--- a/roles/matrix-riot-web/defaults/main.yml
+++ b/roles/matrix-riot-web/defaults/main.yml
@@ -21,6 +21,7 @@ matrix_riot_web_integrations_ui_url: "https://scalar.vector.im/"
 matrix_riot_web_integrations_rest_url: "https://scalar.vector.im/api"
 matrix_riot_web_integrations_widgets_urls: ["https://scalar.vector.im/api"]
 matrix_riot_web_integrations_jitsi_widget_url: "https://scalar.vector.im/api/widgets/jitsi.html"
+matrix_riot_web_bug_report_url: "https://riot.im/bugreports/submit"
 # Riot public room directory server(s)
 matrix_riot_web_roomdir_servers: ['matrix.org']
 matrix_riot_web_welcome_user_id: "@riot-bot:matrix.org"

--- a/roles/matrix-riot-web/templates/config.json.j2
+++ b/roles/matrix-riot-web/templates/config.json.j2
@@ -8,7 +8,7 @@
 	"integrations_rest_url": {{ matrix_riot_web_integrations_rest_url|to_json }},
 	"integrations_widgets_urls": {{ matrix_riot_web_integrations_widgets_urls|to_json }},
 	"integrations_jitsi_widget_url": {{ matrix_riot_web_integrations_jitsi_widget_url|to_json }},
-	"bug_report_endpoint_url": "https://riot.im/bugreports/submit",
+	"bug_report_endpoint_url": {{ matrix_riot_web_bug_report_url }},
 	"enableLabs": true,
 	"roomDirectory": {
 		"servers": {{ matrix_riot_web_roomdir_servers|to_json }}


### PR DESCRIPTION
Just want to make sure users of our hosted instance won't bug the Matrix team ;)