### PR TITLE
Fix matrix-synapse example for Caddy

### DIFF
--- a/examples/caddy/matrix-dimension
+++ b/examples/caddy/matrix-dimension
@@ -1,4 +1,6 @@
 https://dimension.DOMAIN {
+	# These might differ if you are supplying your own certificates
+	# If you wish to use Caddy's built-in Let's Encrypt support, you can also supply an email address here
 	tls /matrix/ssl/config/live/dimension.DOMAIN/fullchain.pem /matrix/ssl/config/live/dimension.DOMAIN/privkey.pem
 
 	proxy / http://127.0.0.1:8134/ {

--- a/examples/caddy/matrix-synapse
+++ b/examples/caddy/matrix-synapse
@@ -22,7 +22,7 @@ https://matrix.DOMAIN {
 	# Synapse Client<>Server API
 	proxy / matrix-synapse:8008 {
 		transparent
-		without /.well-known/ /_matrix/identity/ /_matrix/client/r0/user_directory/search
+		except /.well-known/ /_matrix/identity/ /_matrix/client/r0/user_directory/search
 	}
 
 }

--- a/examples/caddy/matrix-synapse
+++ b/examples/caddy/matrix-synapse
@@ -1,5 +1,6 @@
 https://matrix.DOMAIN {
 	# If you use your own certificates, your path may differ
+	# If you wish to use Caddy's built-in Let's Encrypt support, you can also supply an email address here
 	tls /matrix/ssl/config/live/matrix.DOMAIN/fullchain.pem /matrix/ssl/config/live/matrix.DOMAIN/privkey.pem
 
 	root /matrix/static-files


### PR DESCRIPTION
The instruction that tells Caddy to make exceptions when proxying is `except`, instead of `without`, which trims the given prefix from the proxied URIs, as per https://caddyserver.com/docs/proxy

I also took the liberty to expand the examples' comments about TLS, including instructions about Caddy's built-in LE support.