### PR TITLE
Fix case of the mxisd ldap.connection.baseDNs option in matrix_mxisd_configuration_extension_yaml comment

### DIFF
--- a/roles/matrix-mxisd/defaults/main.yml
+++ b/roles/matrix-mxisd/defaults/main.yml
@@ -152,7 +152,7 @@ matrix_mxisd_configuration_extension_yaml: |
   #     host: ldapHostnameOrIp
   #     tls: false
   #     port: 389
-  #     baseDns: ['OU=Users,DC=example,DC=org']
+  #     baseDNs: ['OU=Users,DC=example,DC=org']
   #     bindDn: CN=My Mxisd User,OU=Users,DC=example,DC=org
   #     bindPassword: TheUserPassword
 


### PR DESCRIPTION
Else,
```
May 14 22:35:04 base docker[25166]: [main] ERROR App - You must specify at least one Base DN via the singular or plural config option                         
May 14 22:35:04 base docker[25166]: [main] ERROR App - Invalid or empty value for configuration item: ldap.connection.baseDNs
May 14 22:35:05 base systemd[1]: matrix-mxisd.service: Main process exited, code=exited, status=2/INVALIDARGUMENT                                             
```