### PR TITLE
Fix matrix_synapse_ext_password_provider_ldap_start_tls (it's boolean)

### DIFF
--- a/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -977,7 +977,7 @@ password_providers:
     config:
       enabled: true
       uri: {{ matrix_synapse_ext_password_provider_ldap_uri|string|to_json }}
-      start_tls: {{ matrix_synapse_ext_password_provider_ldap_start_tls|string|to_json }}
+      start_tls: {{ matrix_synapse_ext_password_provider_ldap_start_tls|to_json }}
       base: {{ matrix_synapse_ext_password_provider_ldap_base|string|to_json }}
       attributes:
         uid: {{ matrix_synapse_ext_password_provider_ldap_attributes_uid|string|to_json }}


### PR DESCRIPTION
With the leftover `|string` it was ending up as `start_tls: "False"` in `homeserver.yaml` which evaluates to `true`, causing unexpected
```
ldap_auth_provider - 420 - WARNING -  - Error during LDAP authentication: startTLS failed - protocolError
```