### PR TITLE
Provide a sample rest_auth_endpoint close to actual setup

### DIFF
--- a/docs/configuring-playbook-rest-auth.md
+++ b/docs/configuring-playbook-rest-auth.md
@@ -8,7 +8,7 @@ If you decide that you'd like to let this playbook install it for you, you need 
 
 ```yaml
 matrix_synapse_ext_password_provider_rest_auth_enabled: true
-matrix_synapse_ext_password_provider_rest_auth_endpoint: "http://change.me.example.com:12345"
+matrix_synapse_ext_password_provider_rest_auth_endpoint: "http://matrix-mxisd:8090"
 matrix_synapse_ext_password_provider_rest_auth_registration_enforce_lowercase: false
 matrix_synapse_ext_password_provider_rest_auth_registration_profile_name_autofill: true
 matrix_synapse_ext_password_provider_rest_auth_login_profile_name_autofill: false


### PR DESCRIPTION
Well this does set it up so that the mxisd endpoint is reachable from the synapse container.