### PR TITLE
Bump riot and synapse versions

### DIFF
--- a/roles/matrix-riot-web/defaults/main.yml
+++ b/roles/matrix-riot-web/defaults/main.yml
@@ -1,6 +1,6 @@
 matrix_riot_web_enabled: true
 
-matrix_riot_web_docker_image: "bubuntux/riot-web:v1.1.1"
+matrix_riot_web_docker_image: "bubuntux/riot-web:v1.1.2"
 
 matrix_riot_web_data_path: "{{ matrix_base_data_path }}/riot-web"
 

--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -1,4 +1,4 @@
-matrix_synapse_docker_image: "matrixdotorg/synapse:v0.99.3.2"
+matrix_synapse_docker_image: "matrixdotorg/synapse:v0.99.4"
 
 matrix_synapse_base_path: "{{ matrix_base_data_path }}/synapse"
 matrix_synapse_config_dir_path: "{{ matrix_synapse_base_path }}/config"


### PR DESCRIPTION
PR doesn't change any configs; it only bumps the docker image versions