### PR TITLE
Switch riot-web image (bubuntux/riot-web -> vectorim/riot-web)

### DIFF
--- a/roles/matrix-riot-web/defaults/main.yml
+++ b/roles/matrix-riot-web/defaults/main.yml
@@ -1,6 +1,6 @@
 matrix_riot_web_enabled: true
 
-matrix_riot_web_docker_image: "bubuntux/riot-web:v1.5.5"
+matrix_riot_web_docker_image: "vectorim/riot-web:v1.5.5"
 matrix_riot_web_docker_image_force_pull: "{{ matrix_riot_web_docker_image.endswith(':latest') }}"
 
 matrix_riot_web_data_path: "{{ matrix_base_data_path }}/riot-web"

--- a/roles/matrix-riot-web/templates/systemd/matrix-riot-web.service.j2
+++ b/roles/matrix-riot-web/templates/systemd/matrix-riot-web.service.j2
@@ -23,11 +23,11 @@ ExecStart=/usr/bin/docker run --rm --name matrix-riot-web \
 			--tmpfs=/tmp:rw,noexec,nosuid,size=10m \
 			-v {{ matrix_riot_web_data_path }}/nginx.conf:/etc/nginx/nginx.conf:ro \
 			-v /dev/null:/etc/nginx/conf.d/default.conf:ro \
-			-v {{ matrix_riot_web_data_path }}/config.json:/etc/riot-web/config.json:ro \
+			-v {{ matrix_riot_web_data_path }}/config.json:/app/config.json:ro \
 			{% if matrix_riot_web_embedded_pages_home_path is not none %}
-			-v {{ matrix_riot_web_data_path }}/home.html:/etc/riot-web/home.html:ro \
+			-v {{ matrix_riot_web_data_path }}/home.html:/app/home.html:ro \
 			{% endif %}
-			-v {{ matrix_riot_web_data_path }}/welcome.html:/etc/riot-web/welcome.html:ro \
+			-v {{ matrix_riot_web_data_path }}/welcome.html:/app/welcome.html:ro \
 			{% for arg in matrix_riot_web_container_extra_arguments %}
 			{{ arg }} \
 			{% endfor %}


### PR DESCRIPTION
Switching to the official image (vectorim/riot-web) should ensure:
- there's less breakage, as it's maintained by the same team as riot-web
- there's fewer actors we need to trust
- we can upgrade riot-web faster, as newer versions should be released
on Docker hub at the same time riot-web releases are made

-----

Looks like this works, but I'd rather we not regress in terms of Docker image sizes.
See: https://github.com/vector-im/riot-web/pull/9848

We can wait a while and switch later, if/when the above gets merged.