### PR TITLE
Fixed error message to direct users to the right debug command

### DIFF
--- a/roles/matrix-common-after/tasks/start.yml
+++ b/roles/matrix-common-after/tasks/start.yml
@@ -36,6 +36,6 @@
     msg: >-
       {{ item }} was not detected to be running.
       It's possible that there's a configuration problem or another service on your server interferes with it (uses the same ports, etc.).
-      Try running `systemctl status {{ item }}` and `systemctl -fu {{ item }}` on the server to investigate.
+      Try running `systemctl status {{ item }}` and `journalctl -fu {{ item }}` on the server to investigate.
   with_items: "{{ matrix_systemd_services_list }}"
   when: "ansible_facts.services[item + '.service']|default(none) is none or ansible_facts.services[item + '.service'].state != 'running'"


### PR DESCRIPTION
When an error happens in starting the server, it tells users to ` Try running systemctl status {{ item }} and systemctl -fu {{ item }}`, even though systemctl -fu doesn't exist, and it was meant to be journalctl.

It's a small fix, but finding out it was meant to be journalctl saved me a lot of grief, and it may help others too.