### PR TITLE
Disable appservice-irc log files

### DIFF
--- a/roles/matrix-bridge-appservice-irc/defaults/main.yml
+++ b/roles/matrix-bridge-appservice-irc/defaults/main.yml
@@ -427,10 +427,10 @@ matrix_appservice_irc_configuration_yaml: |
       # Level to log on console/logfile. One of error|warn|info|debug
       level: "debug"
       # The file location to log to. This is relative to the project directory.
-      logfile: "debug.log"
+      #logfile: "debug.log"
       # The file location to log errors to. This is relative to the project
       # directory.
-      errfile: "errors.log"
+      #errfile: "errors.log"
       # Whether to log to the console or not.
       toConsole: true
       # The max number of files to keep. Files will be overwritten eventually due


### PR DESCRIPTION
appservice-irc doesn't have permission to create files in its project directory, so the default config results in the following error message:
```
Jun 22 07:56:33 matrix matrix-appservice-irc[4517]: Loading config file /config/config.yaml
Jun 22 07:56:33 matrix matrix-appservice-irc[4517]: 2019-06-22T05:56:33.809Z '[FileStreamRotator] Failed to store log audit at:' '.0cf66abdbd2fe32c05e614547bf32513986ab836-audit
Jun 22 07:56:33 matrix matrix-appservice-irc[4517]:     at Error (native)
Jun 22 07:56:33 matrix matrix-appservice-irc[4517]:     at Object.fs.openSync (fs.js:642:18)
Jun 22 07:56:33 matrix matrix-appservice-irc[4517]:     at Object.fs.writeFileSync (fs.js:1356:33)
Jun 22 07:56:33 matrix matrix-appservice-irc[4517]:     at Object.FileStreamRotator.writeAuditLog (/app/node_modules/file-stream-rotator/FileStreamRotator.js:246:12)
Jun 22 07:56:33 matrix matrix-appservice-irc[4517]:     at Object.FileStreamRotator.addLogToAudit (/app/node_modules/file-stream-rotator/FileStreamRotator.js:320:27)
Jun 22 07:56:33 matrix matrix-appservice-irc[4517]:     at EventEmitter.<anonymous> (/app/node_modules/file-stream-rotator/FileStreamRotator.js:437:36)
Jun 22 07:56:33 matrix matrix-appservice-irc[4517]:     at emitOne (events.js:96:13)
Jun 22 07:56:33 matrix matrix-appservice-irc[4517]:     at EventEmitter.emit (events.js:188:7)
Jun 22 07:56:33 matrix matrix-appservice-irc[4517]:     at /app/node_modules/file-stream-rotator/FileStreamRotator.js:483:20
Jun 22 07:56:33 matrix matrix-appservice-irc[4517]:     at _combinedTickCallback (internal/process/next_tick.js:73:7)
Jun 22 07:56:33 matrix matrix-appservice-irc[4517]:     at process._tickCallback (internal/process/next_tick.js:104:9)
Jun 22 07:56:33 matrix matrix-appservice-irc[4517]:     at Module.runMain (module.js:613:11)
Jun 22 07:56:33 matrix matrix-appservice-irc[4517]:     at run (bootstrap_node.js:394:7)
Jun 22 07:56:33 matrix matrix-appservice-irc[4517]:     at startup (bootstrap_node.js:160:9)
Jun 22 07:56:33 matrix matrix-appservice-irc[4517]:     at bootstrap_node.js:507:3
Jun 22 07:56:33 matrix matrix-appservice-irc[4517]:   errno: -13,
Jun 22 07:56:33 matrix matrix-appservice-irc[4517]:   code: 'EACCES',
Jun 22 07:56:33 matrix matrix-appservice-irc[4517]:   syscall: 'open',
```

I think the intention is to log to the console, anyway. By commenting out the file names, appservice-irc won't attempt to open the files.