### PR TITLE
Make Discord bridge configuration playbook-managed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This means that if you were making manual changes to the `/matrix/appservice-dis
 
 The bridge now stores configuration in a subdirectory (`/matrix/appservice-discord/config`).
 
-Likewise, data is now also stored in a subdirectory (`/matrix/mautrix-whatsapp/data`). When you run the playbook with an existing database file (`/matrix/appservice-discord/discord.db`), the playbook will stop the bridge and relocate the database file to the `./data` directory. There's no data-loss involved. You'll need to restart the bridge manually though (`--tags=start`).
+Likewise, data is now also stored in a subdirectory (`/matrix/appservice-discord/data`). When you run the playbook with an existing database file (`/matrix/appservice-discord/discord.db`), the playbook will stop the bridge and relocate the database file to the `./data` directory. There's no data-loss involved. You'll need to restart the bridge manually though (`--tags=start`).
 
 The main directory (`/matrix/appservice-discord`) may contain some leftover files (`user-store.db`, `room-store.db`, `config.yaml`, `discord-registration.yaml`, `invite_link`). These are no longer necessary and can be deleted manually.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 2019-06-26
+
+## (BC Break) Discord bridge configuration is now entirely managed by the playbook
+
+Until now, the `config.yaml` file for the [Discord bridge](docs/configuring-playbook-bridge-appservice-discord.md) was managed by the playbook, but the `registration.yaml` file was not.
+
+From now on, the playbook will keep both configuration files sync for you.
+
+This means that if you were making manual changes to the `/matrix/appservice-discord/discord-registration.yaml` configuration file, those would be lost the next time you run the playbook.
+
+The bridge now stores configuration in a subdirectory (`/matrix/appservice-discord/config`).
+
+Likewise, data is now also stored in a subdirectory (`/matrix/mautrix-whatsapp/data`). When you run the playbook with an existing database file (`/matrix/appservice-discord/discord.db`), the playbook will stop the bridge and relocate the database file to the `./data` directory. There's no data-loss involved. You'll need to restart the bridge manually though (`--tags=start`).
+
+The main directory (`/matrix/appservice-discord`) may contain some leftover files (`user-store.db`, `room-store.db`, `config.yaml`, `discord-registration.yaml`, `invite_link`). These are no longer necessary and can be deleted manually.
+
+We're now following the default sample configuration for the Discord bridge.
+If you need to override some values, define them in `matrix_appservice_discord_configuration_extension_yaml`.
+
+
 # 2019-06-24
 
 ## (BC Break) WhatsApp bridge configuration is now entirely managed by the playbook
@@ -14,6 +34,7 @@ You need to migrate any manual changes over to the new `matrix_mautrix_whatsapp_
 Likewise, data is now also stored in a subdirectory (`/matrix/mautrix-whatsapp/data`). When you run the playbook with an existing database file (`/matrix/mautrix-whatsapp/mautrix-whatsapp.db`), the playbook will stop the bridge and relocate the database file to the `./data` directory. There's no data-loss involved. You'll need to restart the bridge manually though (`--tags=start`).
 
 We're now following the default configuration for the WhatsApp bridge.
+
 
 # 2019-06-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2019-06-26
+# 2019-06-27
 
 ## (BC Break) Discord bridge configuration is now entirely managed by the playbook
 

--- a/docs/configuring-playbook-bridge-appservice-discord.md
+++ b/docs/configuring-playbook-bridge-appservice-discord.md
@@ -19,8 +19,8 @@ matrix_appservice_discord_bot_token: "YOUR DISCORD APP BOT TOKEN"
 ```
 
 4. If you've already installed Matrix services using the playbook before, you'll need to re-run it (`--tags=setup-all,start`). If not, proceed with [configuring other playbook services](configuring-playbook.md) and then with [Installing](installing.md). Get back to this guide once ready.
-5. Retrieve Discord invitelink from the `{{ matrix_appservice_discord_base_path }}/invite_link` file on the server (this defaults to `/matrix/appservice-discord/invite_link`)
+5. Retrieve Discord invite link from the `{{ matrix_appservice_discord_config_path }}/invite_link` file on the server (this defaults to `/matrix/appservice-discord/config/invite_link`)
 6. Invite the Bot to Discord servers you wish to bridge. Administrator permission is recommended.
-7. Join the rooms by following this syntax `#_discord_guildid_channelid` - can be easily retrieved by logging into Discord in a browser and opening the desired channel. URL will have this format: discordapp.com/channels/guild_id/channel_id
+7. Join the rooms by following this syntax `#_discord_guildid_channelid` - can be easily retrieved by logging into Discord in a browser and opening the desired channel. URL will have this format: `discordapp.com/channels/guild_id/channel_id`
 
 Other configuration options are available via the `matrix_appservice_discord_configuration_extension_yaml` variable.

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -39,12 +39,19 @@ matrix_appservice_discord_enabled: false
 # matrix-appservice-discord's client-server port to the local host.
 matrix_appservice_discord_container_http_host_bind_port: "{{ '' if matrix_nginx_proxy_enabled else '127.0.0.1:9005' }}"
 
+# If the homeserver disables presence, it's likely better (less wasteful) to also disable presence on the bridge side.
+matrix_appservice_discord_bridge_disablePresence: "{{ matrix_synapse_use_presence }}"
+
 matrix_appservice_discord_systemd_required_services_list: |
   {{
     ['docker.service']
     +
     (['matrix-synapse.service'] if matrix_synapse_enabled else [])
   }}
+
+matrix_appservice_discord_appservice_token: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'discord.as.token') | to_uuid }}"
+
+matrix_appservice_discord_homeserver_token: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'discord.hs.token') | to_uuid }}"
 
 ######################################################################
 #

--- a/roles/matrix-bridge-appservice-discord/defaults/main.yml
+++ b/roles/matrix-bridge-appservice-discord/defaults/main.yml
@@ -7,10 +7,15 @@ matrix_appservice_discord_docker_image: "halfshot/matrix-appservice-discord:late
 matrix_appservice_discord_docker_image_force_pull: "{{ matrix_appservice_discord_docker_image.endswith(':latest') }}"
 
 matrix_appservice_discord_base_path: "{{ matrix_base_data_path }}/appservice-discord"
+matrix_appservice_discord_config_path: "{{ matrix_base_data_path }}/appservice-discord/config"
+matrix_appservice_discord_data_path: "{{ matrix_base_data_path }}/appservice-discord/data"
 
 # Get your own keys at https://discordapp.com/developers/applications/me/create
 matrix_appservice_discord_client_id: ''
 matrix_appservice_discord_bot_token: ''
+
+matrix_appservice_discord_appservice_token: ''
+matrix_appservice_discord_homeserver_token: ''
 
 # Controls whether the matrix-appservice-discord container exposes its HTTP port (tcp/9005 in the container).
 #
@@ -26,109 +31,135 @@ matrix_appservice_discord_systemd_required_services_list: ['docker.service']
 # List of systemd services that matrix-appservice-discord.service wants
 matrix_appservice_discord_systemd_wanted_services_list: []
 
+matrix_appservice_discord_appservice_url: 'http://matrix-appservice-discord:9005'
+
+matrix_appservice_discord_bridge_domain: "{{ matrix_domain }}"
+# As of right now, the homeserver URL must be a public URL. See below.
+matrix_appservice_discord_bridge_homeserverUrl: "{{ matrix_homeserver_url }}"
+matrix_appservice_discord_bridge_disablePresence: false
+
 matrix_appservice_discord_configuration_yaml: |
-    bridge:
-        domain: "{{ matrix_domain }}"
-        homeserverUrl: "{{ matrix_homeserver_url }}"
-    auth:
-        clientID: "{{matrix_appservice_discord_client_id}}"
-        botToken: "{{matrix_appservice_discord_bot_token}}"
-    database:
-        filename: "/data/discord.db"
-        userStorePath: "/data/user-store.db"
-        roomStorePath: "/data/room-store.db"
+  #jinja2: lstrip_blocks: "True"
+  bridge:
+    # Domain part of the bridge, e.g. matrix.org
+    domain: {{ matrix_appservice_discord_bridge_domain }}
+    # This should be your publically facing URL because Discord may use it to
+    # fetch media from the media store.
+    homeserverUrl: {{ matrix_appservice_discord_bridge_homeserverUrl }}
+    # Interval at which to process users in the 'presence queue'. If you have
+    # 5 users, one user will be processed every 500 milliseconds according to the
+    # value below. This has a minimum value of 250.
+    # WARNING: This has a high chance of spamming the homeserver with presence
+    # updates since it will send one each time somebody changes state or is online.
+    presenceInterval: 500
+    # Disable setting presence for 'ghost users' which means Discord users on Matrix
+    # will not be shown as away or online.
+    disablePresence: {{ matrix_appservice_discord_bridge_disablePresence|to_json }}
+    # Disable sending typing notifications when somebody on Discord types.
+    disableTypingNotifications: false
+    # Disable deleting messages on Discord if a message is redacted on Matrix.
+    disableDeletionForwarding: false
+    # Enable users to bridge rooms using !discord commands. See
+    # https://t2bot.io/discord for instructions.
+    enableSelfServiceBridging: false
+    # Disable sending of read receipts for Matrix events which have been
+    # successfully bridged to Discord.
+    disableReadReceipts: false
+    # Disable Join Leave echos from matrix
+    disableJoinLeaveNotifications: false
+  # Authentication configuration for the discord bot.
+  auth:
+    clientID: {{ matrix_appservice_discord_client_id }}
+    botToken: {{ matrix_appservice_discord_bot_token }}
+  logging:
+    # What level should the logger output to the console at.
+    console: "warn" #silly, verbose, info, http, warn, error, silent
+    lineDateFormat: "MMM-D HH:mm:ss.SSS" # This is in moment.js format
+    # files:
+    #   - file: "debug.log"
+    #     disable:
+    #       - "PresenceHandler" # Will not capture presence logging
+    #   - file: "warn.log" # Will capture warnings
+    #     level: "warn"
+    #   - file: "botlogs.log" # Will capture logs from DiscordBot
+    #     level: "info"
+    #     enable:
+    #       - "DiscordBot"
+  database:
+    # You may either use SQLite or Postgresql for the bridge database, which contains
+    # important mappings for events and user puppeting configurations.
+    # Use the filename option for SQLite, or connString for Postgresql.
+    # If you are migrating, see https://github.com/Half-Shot/matrix-appservice-discord/blob/master/docs/howto.md#migrate-to-postgres-from-sqlite
+    # WARNING: You will almost certainly be fine with sqlite unless your bridge
+    # is in heavy demand and you suffer from IO slowness.
+    filename: "/data/discord.db"
+    # connString: "postgresql://user:password@localhost/database_name"
+  room:
+    # Set the default visibility of alias rooms, defaults to "public".
+    # One of: "public", "private"
+    defaultVisibility: "public"
+  channel:
+      # Pattern of the name given to bridged rooms.
+      # Can use :guild for the guild name and :name for the channel name.
+      namePattern: "[Discord] :guild :name"
+      # Changes made to rooms when a channel is deleted.
+      deleteOptions:
+        # Prefix the room name with a string.
+        #namePrefix: "[Deleted]"
+        # Prefix the room topic with a string.
+        #topicPrefix: "This room has been deleted"
+        # Disable people from talking in the room by raising the event PL to 50
+        disableMessaging: false
+        # Remove the discord alias from the room.
+        unsetRoomAlias: true
+        # Remove the room from the directory.
+        unlistFromDirectory: true
+        # Set the room to be unavaliable for joining without an invite.
+        setInviteOnly: true
+        # Make all the discord users leave the room.
+        ghostsLeave: true
+  limits:
+      # Delay in milliseconds between discord users joining a room.
+      roomGhostJoinDelay: 6000
+      # Delay in milliseconds before sending messages to discord to avoid echos.
+      # (Copies of a sent message may arrive from discord before we've
+      # fininished handling it, causing us to echo it back to the room)
+      discordSendDelay: 750
+  ghosts:
+      # Pattern for the ghosts nick, available is :nick, :username, :tag and :id
+      nickPattern: ":nick"
+      # Pattern for the ghosts username, available is :username, :tag and :id
+      usernamePattern: ":username#:tag"
 
 matrix_appservice_discord_configuration_extension_yaml: |
-    # This is a sample of the config file showing all avaliable options.
-    # Where possible we have documented what they do, and all values are the
-    # default values.
-    #
-    #bridge:
-    #  # Domain part of the bridge, e.g. matrix.org
-    #  domain: "localhost"
-    #  # This should be your publically facing URL because Discord may use it to
-    #  # fetch media from the media store.
-    #  homeserverUrl: "http://localhost:8008"
-    #  # Interval at which to process users in the 'presence queue'. If you have
-    #  # 5 users, one user will be processed every 500 milliseconds according to the
-    #  # value below. This has a minimum value of 250.
-    #  # WARNING: This has a high chance of spamming the homeserver with presence
-    #  # updates since it will send one each time somebody changes state or is online.
-    #  presenceInterval: 500
-    #  # Disable setting presence for 'ghost users' which means Discord users on Matrix
-    #  # will not be shown as away or online.
-    #  disablePresence: false
-    #  # Disable sending typing notifications when somebody on Discord types.
-    #  disableTypingNotifications: false
-    #  # Disable deleting messages on Discord if a message is redacted on Matrix.
-    #  disableDeletionForwarding: false
-    #  # Enable users to bridge rooms using !discord commands. See
-    #  # https://t2bot.io/discord for instructions.
-    #  enableSelfServiceBridging: false
-    #  # Disable sending of read receipts for Matrix events which have been
-    #  # successfully bridged to Discord.
-    #  disableReadReceipts: false
-    # Authentication configuration for the discord bot.
-    #auth:
-    #  clientID: "12345"
-    #  botToken: "foobar"
-    #logging:
-    #  # What level should the logger output to the console at.
-    #  console: "warn" #silly, verbose, info, http, warn, error, silent
-    #  lineDateFormat: "MMM-D HH:mm:ss.SSS" # This is in moment.js format
-    #  files:
-    #    - file: "debug.log"
-    #      disable:
-    #        - "PresenceHandler" # Will not capture presence logging
-    #    - file: "warn.log" # Will capture warnings
-    #      level: "warn"
-    #    - file: "botlogs.log" # Will capture logs from DiscordBot
-    #      level: "info"
-    #      enable:
-    #        - "DiscordBot"
-    #database:
-    #  userStorePath: "user-store.db"
-    #  roomStorePath: "room-store.db"
-    #  # You may either use SQLite or Postgresql for the bridge database, which contains
-    #  # important mappings for events and user puppeting configurations.
-    #  # Use the filename option for SQLite, or connString for Postgresql.
-    #  # If you are migrating, see https://github.com/Half-Shot/matrix-appservice-discord/blob/master/docs/howto.md#migrate-to-postgres-from-sqlite
-    #  # WARNING: You will almost certainly be fine with sqlite unless your bridge
-    #  # is in heavy demand and you suffer from IO slowness.
-    #  filename: "discord.db"
-    #  # connString: "postgresql://user:password@localhost/database_name"
-    #room:
-    #  # Set the default visibility of alias rooms, defaults to "public".
-    #  # One of: "public", "private"
-    #  defaultVisibility: "public"
-    #channel:
-    #    # Pattern of the name given to bridged rooms.
-    #    # Can use :guild for the guild name and :name for the channel name.
-    #    namePattern: "[Discord] :guild :name"
-    #    # Changes made to rooms when a channel is deleted.
-    #    deleteOptions:
-    #       # Prefix the room name with a string.
-    #       #namePrefix: "[Deleted]"
-    #       # Prefix the room topic with a string.
-    #       #topicPrefix: "This room has been deleted"
-    #       # Disable people from talking in the room by raising the event PL to 50
-    #       disableMessaging: false
-    #       # Remove the discord alias from the room.
-    #       unsetRoomAlias: true
-    #       # Remove the room from the directory.
-    #       unlistFromDirectory: true
-    #       # Set the room to be unavaliable for joining without an invite.
-    #       setInviteOnly: true
-    #       # Make all the discord users leave the room.
-    #       ghostsLeave: true
-    #limits:
-    #    # Delay in milliseconds between discord users joining a room.
-    #    roomGhostJoinDelay: 6000
-    #    # Delay in milliseconds before sending messages to discord to avoid echos.
-    #    # (Copies of a sent message may arrive from discord before we've
-    #    # fininished handling it, causing us to echo it back to the room)
-    #    discordSendDelay: 750
+  # Your custom YAML configuration goes here.
+  # This configuration extends the default starting configuration (`matrix_appservice_discord_configuration_yaml`).
+  #
+  # You can override individual variables from the default configuration, or introduce new ones.
+  #
+  # If you need something more special, you can take full control by
+  # completely redefining `matrix_appservice_discord_configuration_yaml`.
 
 matrix_appservice_discord_configuration_extension: "{{ matrix_appservice_discord_configuration_extension_yaml|from_yaml if matrix_appservice_discord_configuration_extension_yaml|from_yaml is mapping else {} }}"
 
 matrix_appservice_discord_configuration: "{{ matrix_appservice_discord_configuration_yaml|from_yaml|combine(matrix_appservice_discord_configuration_extension, recursive=True) }}"
+
+matrix_appservice_discord_registration_yaml: |
+  #jinja2: lstrip_blocks: "True"
+  id: appservice-discord
+  as_token: "{{ matrix_appservice_discord_appservice_token }}"
+  hs_token: "{{ matrix_appservice_discord_homeserver_token }}"
+  namespaces:
+    users:
+    - exclusive: true
+      regex: '^@_discord_.*'
+    aliases:
+    - exclusive: true
+      regex: '^#_discord_.*'
+  url: {{ matrix_appservice_discord_appservice_url }}
+  sender_localpart: _discord_bot
+  rate_limited: false
+  protocols:
+    - discord
+
+matrix_appservice_discord_registration: "{{ matrix_appservice_discord_registration_yaml|from_yaml }}"

--- a/roles/matrix-bridge-appservice-discord/tasks/init.yml
+++ b/roles/matrix-bridge-appservice-discord/tasks/init.yml
@@ -1,3 +1,11 @@
+# If the matrix-synapse role is not used, `matrix_synapse_role_executed` won't exist.
+# We don't want to fail in such cases.
+- name: Fail if matrix-synapse role already executed
+  fail:
+    msg: >-
+      The matrix-bridge-appservice-discord role needs to execute before the matrix-synapse role.
+  when: "matrix_appservice_discord_enabled and matrix_synapse_role_executed|default(False)"
+
 - set_fact:
     matrix_systemd_services_list: "{{ matrix_systemd_services_list + ['matrix-appservice-discord'] }}"
   when: matrix_appservice_discord_enabled|bool
@@ -7,7 +15,7 @@
     matrix_synapse_container_extra_arguments: >
       {{ matrix_synapse_container_extra_arguments|default([]) }}
       +
-      {{ ["--mount type=bind,src={{ matrix_appservice_discord_base_path }}/discord-registration.yaml,dst=/matrix-appservice-discord-registration.yaml,ro"] }}
+      {{ ["--mount type=bind,src={{ matrix_appservice_discord_config_path }}/registration.yaml,dst=/matrix-appservice-discord-registration.yaml,ro"] }}
 
     matrix_synapse_app_service_config_files: >
       {{ matrix_synapse_app_service_config_files|default([]) }}

--- a/roles/matrix-bridge-appservice-discord/tasks/setup_install.yml
+++ b/roles/matrix-bridge-appservice-discord/tasks/setup_install.yml
@@ -1,13 +1,5 @@
 ---
 
-# If the matrix-synapse role is not used, `matrix_synapse_role_executed` won't exist.
-# We don't want to fail in such cases.
-- name: Fail if matrix-synapse role already executed
-  fail:
-    msg: >-
-      The matrix-bridge-appservice-discord role needs to execute before the matrix-synapse role.
-  when: "matrix_synapse_role_executed|default(False)"
-
 - name: Ensure Appservice Discord image is pulled
   docker_image:
     name: "{{ matrix_appservice_discord_docker_image }}"
@@ -15,21 +7,65 @@
     force_source: "{{ matrix_appservice_discord_docker_image_force_pull if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
     force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_appservice_discord_docker_image_force_pull }}"
 
-- name: Ensure Appservice Discord base directory exists
+- name: Ensure AppService Discord paths exist
   file:
-    path: "{{ matrix_appservice_discord_base_path }}"
+    path: "{{ item }}"
     state: directory
     mode: 0750
     owner: "{{ matrix_user_username }}"
     group: "{{ matrix_user_username }}"
+  with_items:
+    - "{{ matrix_appservice_discord_base_path }}"
+    - "{{ matrix_appservice_discord_config_path }}"
+    - "{{ matrix_appservice_discord_data_path }}"
 
-- name: Ensure Matrix Appservice Discord config installed
+- name: Check if an old database file already exists
+  stat:
+    path: "{{ matrix_appservice_discord_base_path }}/discord.db"
+  register: matrix_appservice_discord_stat_db
+
+- name: (Data relocation) Ensure matrix-appservice-discord.service is stopped
+  service:
+    name: matrix-appservice-discord
+    state: stopped
+    daemon_reload: yes
+  failed_when: false
+  when: "matrix_appservice_discord_stat_db.stat.exists"
+
+# In addition to this, there used to be some `user-store-db` and `room-store.db` files.
+# They're no longer in use, so we're not relocating them in an effort to point them out as neither `./data`, nor `./config`.
+- name: (Data relocation) Move AppService Discord discord.db file to ./data directory
+  command: "mv {{ matrix_appservice_discord_base_path }}/discord.db {{ matrix_appservice_discord_data_path }}/discord.db"
+  when: "matrix_appservice_discord_stat_db.stat.exists"
+
+- name: Ensure AppService Discord config.yaml installed
   copy:
     content: "{{ matrix_appservice_discord_configuration|to_nice_yaml }}"
-    dest: "{{ matrix_appservice_discord_base_path }}/config.yaml"
+    dest: "{{ matrix_appservice_discord_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
     group: "{{ matrix_user_username }}"
+
+- name: Ensure AppService Discord registration.yaml installed
+  copy:
+    content: "{{ matrix_appservice_discord_registration|to_nice_yaml }}"
+    dest: "{{ matrix_appservice_discord_config_path }}/registration.yaml"
+    mode: 0644
+    owner: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_username }}"
+
+# If `matrix_appservice_discord_client_id` hasn't changed, the same invite link would be generated.
+# We intentionally suppress Ansible changes.
+- name: Generate AppService Discord invite link
+  shell: >-
+    /usr/bin/docker run --rm --name matrix-appservice-discord-link-gen
+    --user={{ matrix_user_uid }}:{{ matrix_user_gid }}
+    --cap-drop=ALL
+    -v {{ matrix_appservice_discord_config_path }}:/cfg
+    -w /cfg
+    {{ matrix_appservice_discord_docker_image }}
+    /bin/sh -c "node /build/tools/addbot.js > /cfg/invite_link"
+  changed_when: false
 
 - name: Ensure matrix-appservice-discord.service installed
   template:
@@ -42,39 +78,3 @@
   service:
     daemon_reload: yes
   when: "matrix_appservice_discord_systemd_service_result.changed"
-
-- name: Check if a matrix-appservice-discord registration file exists
-  stat:
-    path: "{{ matrix_appservice_discord_base_path }}/discord-registration.yaml"
-  register: appservice_discord_registration_file
-
-- name: Generate matrix-appservice-discord discord-registration.yaml if it doesn't exist
-  shell: >-
-    /usr/bin/docker run --rm --name matrix-appservice-discord-gen
-    --user={{ matrix_user_uid }}:{{ matrix_user_gid }}
-    --cap-drop=ALL
-    -v {{ matrix_appservice_discord_base_path }}:/data:z
-    {{ matrix_appservice_discord_docker_image }}
-    node build/src/discordas.js
-    -r
-    -u "http://matrix-appservice-discord:9005"
-    -c /data/config.yaml
-    -f /data/discord-registration.yaml
-    -l discord_bot
-  when: "not appservice_discord_registration_file.stat.exists"
-
-- name: Check if a matrix-appservice-discord invite_link file exists
-  stat:
-    path: "{{ matrix_appservice_discord_base_path }}/invite_link"
-  register: appservice_discord_link_generated
-
-- name: Generate your discord invite link
-  shell: >-
-    /usr/bin/docker run --rm --name matrix-appservice-discord-link-gen
-    --user={{ matrix_user_uid }}:{{ matrix_user_gid }}
-    --cap-drop=ALL
-    -v {{ matrix_appservice_discord_base_path }}:/data
-    -w /data
-    {{ matrix_appservice_discord_docker_image }}
-    /bin/sh -c "node .././build/tools/addbot.js > invite_link"
-  when: "not appservice_discord_link_generated.stat.exists"

--- a/roles/matrix-bridge-appservice-discord/tasks/validate_config.yml
+++ b/roles/matrix-bridge-appservice-discord/tasks/validate_config.yml
@@ -8,6 +8,8 @@
   with_items:
     - "matrix_appservice_discord_client_id"
     - "matrix_appservice_discord_bot_token"
+    - "matrix_appservice_discord_appservice_token"
+    - "matrix_appservice_discord_homeserver_token"
 
 - name: (Deprecation) Catch and report renamed appservice-discord variables
   fail:

--- a/roles/matrix-bridge-appservice-discord/templates/systemd/matrix-appservice-discord.service.j2
+++ b/roles/matrix-bridge-appservice-discord/templates/systemd/matrix-appservice-discord.service.j2
@@ -25,11 +25,13 @@ ExecStart=/usr/bin/docker run --rm --name matrix-appservice-discord \
 			{% if matrix_appservice_discord_container_http_host_bind_port %}
 			-p {{ matrix_appservice_discord_container_http_host_bind_port }}:9005 \
 			{% endif %}
-			-v {{ matrix_appservice_discord_base_path }}:/data \
+			-v {{ matrix_appservice_discord_config_path }}:/cfg \
+			-v {{ matrix_appservice_discord_data_path }}:/data \
 			{% for arg in matrix_appservice_discord_container_extra_arguments %}
 			{{ arg }} \
 			{% endfor %}
-			{{ matrix_appservice_discord_docker_image }}
+			{{ matrix_appservice_discord_docker_image }} \
+			node /build/src/discordas.js -p 9005 -c /cfg/config.yaml -f /cfg/registration.yaml
 
 ExecStop=-/usr/bin/docker kill matrix-appservice-discord
 ExecStop=-/usr/bin/docker rm matrix-appservice-discord

--- a/roles/matrix-bridge-appservice-irc/tasks/setup_install.yml
+++ b/roles/matrix-bridge-appservice-irc/tasks/setup_install.yml
@@ -36,7 +36,7 @@
   command: "mv {{ matrix_appservice_irc_base_path }}/passkey.pem {{ matrix_appservice_irc_data_path }}/passkey.pem"
   when: "matrix_appservice_irc_stat_passkey.stat.exists"
 
-- name: (Data relocation) Move AppService database files to ./data directory
+- name: (Data relocation) Move AppService IRC database files to ./data directory
   command: "mv {{ matrix_appservice_irc_base_path }}/{{ item }} {{ matrix_appservice_irc_data_path }}/{{ item }}"
   with_items:
     - rooms.db


### PR DESCRIPTION
Well, `config.yaml` has been playbook-managed for a long time.
It's now extended to match the default sample config of the Discord
bridge.

With this patch, we also make `registration.yaml` playbook-managed,
which leads us to consistency with all other bridges.

Along with that, we introduce `./config` and `./data` separation,
like we do for the other bridges.

--------

# Changelog entry

Until now, the `config.yaml` file for the Discord bridge was managed by the playbook, but the `registration.yaml` file was not.

From now on, the playbook will keep both configuration files sync for you.

This means that if you were making manual changes to the `/matrix/appservice-discord/discord-registration.yaml` configuration file, those would be lost the next time you run the playbook.

The bridge now stores configuration in a subdirectory (`/matrix/appservice-discord/config`).

Likewise, data is now also stored in a subdirectory (`/matrix/appservice-discord/data`). When you run the playbook with an existing database file (`/matrix/appservice-discord/discord.db`), the playbook will stop the bridge and relocate the database file to the `./data` directory. There's no data-loss involved. You'll need to restart the bridge manually though (`--tags=start`).

The main directory (`/matrix/appservice-discord`) may contain some leftover files (`user-store.db`, `room-store.db`, `config.yaml`, `discord-registration.yaml`, `invite_link`). These are no longer necessary and can be deleted manually.

We're now following the default sample configuration for the Discord bridge.
If you need to override some values, define them in `matrix_appservice_discord_configuration_extension_yaml`.