### PR TITLE
Reduce journal logging

### DIFF
--- a/roles/matrix-nginx-proxy/defaults/main.yml
+++ b/roles/matrix-nginx-proxy/defaults/main.yml
@@ -25,6 +25,9 @@ matrix_nginx_proxy_container_additional_volumes: []
 # A list of extra arguments to pass to the container
 matrix_nginx_proxy_container_extra_arguments: []
 
+# Controls whether nginx logs access to stdout of the container (and so to journald) or to the file /matrix/nginx-proxy/access.log
+matrix_nginx_access_log_to_file: false
+
 # Controls whether matrix-nginx-proxy should serve the base domain.
 #
 # This is useful for when you only have your Matrix server, but you need to serve

--- a/roles/matrix-nginx-proxy/tasks/setup_nginx_proxy.yml
+++ b/roles/matrix-nginx-proxy/tasks/setup_nginx_proxy.yml
@@ -195,7 +195,7 @@
     state: absent
   when: "not matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_enabled|bool or not matrix_nginx_proxy_proxy_synapse_metrics|bool"
 
-- name: Ensure Matrix nginx-proxy configuration for base domain deleted
+- name: Ensure Matrix nginx-proxy access log deleted
   file:
     path: "{{ matrix_nginx_proxy_base_path }}/access.log"
     state: absent

--- a/roles/matrix-nginx-proxy/tasks/setup_nginx_proxy.yml
+++ b/roles/matrix-nginx-proxy/tasks/setup_nginx_proxy.yml
@@ -115,6 +115,14 @@
     daemon_reload: yes
   when: "matrix_nginx_proxy_enabled and matrix_nginx_proxy_systemd_service_result.changed"
 
+- name: Ensure Matrix nginx-proxy access.log file exist
+  file:
+    path: "{{ matrix_nginx_proxy_base_path }}/access.log"
+    state: touch
+    mode: 0644
+    owner: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_username }}"
+  when: matrix_nginx_access_log_to_file|bool
 
 #
 # Tasks related to getting rid of matrix-nginx-proxy (if it was previously enabled)
@@ -186,3 +194,9 @@
     path: "{{ matrix_nginx_proxy_data_path }}/matrix-synapse-metrics-htpasswd"
     state: absent
   when: "not matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_enabled|bool or not matrix_nginx_proxy_proxy_synapse_metrics|bool"
+
+- name: Ensure Matrix nginx-proxy configuration for base domain deleted
+  file:
+    path: "{{ matrix_nginx_proxy_base_path }}/access.log"
+    state: absent
+  when: "not matrix_nginx_proxy_enabled|bool"

--- a/roles/matrix-nginx-proxy/templates/nginx/nginx.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/nginx.conf.j2
@@ -33,7 +33,11 @@ http {
 					'$status $body_bytes_sent "$http_referer" '
 					'"$http_user_agent" "$http_x_forwarded_for"';
 
+	{% if matrix_nginx_access_log_to_file %}
+	access_log /var/log/nginx/access_file.log main;
+	{% else %}
 	access_log /var/log/nginx/access.log main;
+	{% endif %}
 
 	sendfile on;
 	#tcp_nopush on;

--- a/roles/matrix-nginx-proxy/templates/systemd/matrix-nginx-proxy.service.j2
+++ b/roles/matrix-nginx-proxy/templates/systemd/matrix-nginx-proxy.service.j2
@@ -31,6 +31,9 @@ ExecStart=/usr/bin/docker run --rm --name matrix-nginx-proxy \
 			-v {{ matrix_nginx_proxy_confd_path }}:/etc/nginx/conf.d:ro \
 			-v {{ matrix_ssl_config_dir_path }}:{{ matrix_ssl_config_dir_path }}:ro \
 			-v {{ matrix_static_files_base_path }}:{{ matrix_static_files_base_path }}:ro \
+			{% if matrix_nginx_access_log_to_file %}
+			-v {{ matrix_nginx_proxy_base_path }}/access.log:/var/log/nginx/access_file.log:rw \
+			{% endif %}
 			{% for volume in matrix_nginx_proxy_container_additional_volumes %}
 			-v {{ volume.src }}:{{ volume.dst }}:{{ volume.options }} \
 			{% endfor %}

--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -82,6 +82,7 @@ matrix_synapse_tmp_directory_size_mb: "{{ matrix_synapse_max_upload_size_mb * 50
 matrix_synapse_log_level: "INFO"
 matrix_synapse_storage_sql_log_level: "INFO"
 matrix_synapse_root_log_level: "INFO"
+matrix_synapse_console_log_level: "INFO"
 
 # Rate limits
 matrix_synapse_rc_message:

--- a/roles/matrix-synapse/templates/synapse/synapse.log.config.j2
+++ b/roles/matrix-synapse/templates/synapse/synapse.log.config.j2
@@ -23,6 +23,7 @@ handlers:
     console:
         class: logging.StreamHandler
         formatter: precise
+        level   : {{ matrix_synapse_console_log_level }}
         filters: [context]
 
 loggers:


### PR DESCRIPTION
Hey,
I used some local changes to reduce the logging to the systemd journal and thought I might upstream them. I basically added two options, one for setting an extra console logging level for synapse and one option to log the nginx access to a file instead of the console. With the synapse console level changed its still logs with the default level to the homeserver.log file (so you can have warning to the console and debug to the file). The nginx option is a bool and stops the access log to the journal completely.

Are those interesting for other playbook users?  

