### PR TITLE
Allow for ansible-galaxy command to be used to fetch this role.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,24 @@
+---
+galaxy_info:
+  role_name: matrix-docker-ansible-deploy
+  author: spantaleev
+  description: Installs and manages matrix homeserver.
+
+  issue_tracker_url: >-
+    https://github.com/spantaleev/matrix-docker-ansible-deploy
+
+  license: AGPL-3.0
+
+  min_ansible_version: 2.8
+
+  # platforms:
+  #   - name: EL
+  #     versions:
+  #       - 7
+
+  galaxy_tags:
+    - matrix
+    - synapse
+    - docker
+
+  dependencies: []


### PR DESCRIPTION
So something like this in `requirements.yml` should work now that we have this file:

```
- name: spantaleev.matrix-docker-ansible-deploy
  src: https://github.com/spantaleev/matrix-docker-ansible-deploy
  version: master
```

Fixes #226