### PR TITLE
Fix apt message: docker doesn't support arch 'i386'

### DIFF
--- a/roles/matrix-base/tasks/setup_server_base.yml
+++ b/roles/matrix-base/tasks/setup_server_base.yml
@@ -49,7 +49,7 @@
 
 - name: Ensure Docker repository is enabled (Debian)
   apt_repository:
-    repo: "deb https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} stable"
+    repo: "deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} stable"
     state: present
     update_cache: yes
   when: ansible_os_family == 'Debian'


### PR DESCRIPTION
This fixes the apt/apt-get warning
`N: Skipping acquire of configured file 'stable/binary-i386/Packages' as repository 'https://download.docker.com/linux/<distro> <version> InRelease' doesn't support architecture 'i386'`
when updating your system.