### PR TITLE
Add a variable to disable server base setup (f.e. docker repo/package)

### DIFF
--- a/roles/matrix-base/defaults/main.yml
+++ b/roles/matrix-base/defaults/main.yml
@@ -22,6 +22,9 @@ matrix_user_username: "matrix"
 matrix_user_uid: 991
 matrix_user_gid: 991
 
+# Wether to handle installation of docker and ntp.
+matrix_install_server_packages: true
+
 matrix_base_data_path: "/matrix"
 matrix_base_data_path_mode: "750"
 

--- a/roles/matrix-base/tasks/main.yml
+++ b/roles/matrix-base/tasks/main.yml
@@ -8,7 +8,7 @@
     - setup-all
 
 - import_tasks: "{{ role_path }}/tasks/setup_server_base.yml"
-  when: run_setup|bool
+  when: run_setup|bool and matrix_install_server_packages|bool
   tags:
     - setup-all
 


### PR DESCRIPTION
We use debops to set up the server, and don't want to add the docker-ce repo but try the debian builtin instead. This commit is just an easy way to achieve that - how about the semantics? Any proposals how to do this very welcome.