### PR TITLE
More Apache ProxyPass directives need 'nocanon'

### DIFF
--- a/examples/apache/matrix-synapse.conf
+++ b/examples/apache/matrix-synapse.conf
@@ -71,12 +71,12 @@
 
 	# Map /_matrix/identity to the identity server
 	<Location /_matrix/identity>
-		ProxyPass http://127.0.0.1:8090/_matrix/identity
+		ProxyPass http://127.0.0.1:8090/_matrix/identity nocanon
 	</Location>
 
 	# Map /_matrix/client/r0/user_directory/search to the identity server
 	<Location /_matrix/client/r0/user_directory/search>
-		ProxyPass http://127.0.0.1:8090/_matrix/client/r0/user_directory/search
+		ProxyPass http://127.0.0.1:8090/_matrix/client/r0/user_directory/search nocanon
 	</Location>
 
 	ErrorLog ${APACHE_LOG_DIR}/matrix.DOMAIN-error.log


### PR DESCRIPTION
Invitations weren't working for me until I added 'nocanon' to these additional places. Until then, invitations failed with "Invalid signature for server ..." errors, as in https://github.com/matrix-org/synapse/issues/3294 .

I didn't check whether the user_directory/search proxy line also needs it, I just assumed it should have it too.

The other two proxy lines in this example also include a 'retry=0' parameter. That's a separate issue; I haven't touched it here.