### PR TITLE
Move pipelining configuration to ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,3 +1,5 @@
 [defaults]
 retry_files_enabled = False
+
+[connection]
 pipelining = True

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,3 @@
 [defaults]
 retry_files_enabled = False
+pipelining = True

--- a/examples/hosts
+++ b/examples/hosts
@@ -11,4 +11,4 @@
 # consider adding an additional `ansible_connection=local` argument below.
 
 [matrix_servers]
-matrix.<your-domain> ansible_host=<your-server's external IP address> ansible_ssh_user=root ansible_ssh_pipelining=yes
+matrix.<your-domain> ansible_host=<your-server's external IP address> ansible_ssh_user=root

--- a/examples/hosts
+++ b/examples/hosts
@@ -4,8 +4,9 @@
 # To connect using a non-root user (and elevate to root with sudo later),
 # replace `ansible_ssh_user=root` with something like this: `ansible_ssh_user=username become=true become_user=root`
 #
-# For improved Ansible performance, SSH pipelining is enabled by default (`ansible_ssh_pipelining=yes`).
-# If this causes SSH connection troubles, feel free to disable it.
+# For improved Ansible performance, SSH pipelining is enabled by default in `ansible.cfg`.
+# If this causes SSH connection troubles, disable it by adding `ansible_ssh_pipelining=False`
+# to the host line below or by adding `ansible_ssh_pipelining: False` to your variables file.
 #
 # If you're running this Ansible playbook on the same server as the one you're installing to,
 # consider adding an additional `ansible_connection=local` argument below.


### PR DESCRIPTION
This is a rather small change that moves the pipelining option from `examples/hosts` to `ansible.cfg`.

# Reasoning

In my understanding the example section tries to be as simple and as easy to understand as possible. Most users however will not be able to understand what pipelining actually means and thus not change the option. Moving it away will hide it and makes the example host file 25% easier to read ;)

Also, while that option can be triggered via an environment variable like in the example hosts file, moving it to the config file enables users (and developers of this playbooks) to define it as a default value, and change it via `-e` on the fly if needed without worrying about the precedence of the environment variables.