### PR TITLE
Quote docker args in case inputs contain spaces

### DIFF
--- a/roles/matrix-synapse/templates/synapse/usr-local-bin/matrix-synapse-register-user.j2
+++ b/roles/matrix-synapse/templates/synapse/usr-local-bin/matrix-synapse-register-user.j2
@@ -11,7 +11,7 @@ password=$2
 admin=$3
 
 if [ "$admin" -eq "1" ]; then
-	docker exec matrix-synapse register_new_matrix_user -u $user -p $password -c /data/homeserver.yaml --admin http://localhost:8008
+	docker exec matrix-synapse register_new_matrix_user -u "$user" -p "$password" -c /data/homeserver.yaml --admin http://localhost:8008
 else
-	docker exec matrix-synapse register_new_matrix_user -u $user -p $password -c /data/homeserver.yaml --no-admin http://localhost:8008
+	docker exec matrix-synapse register_new_matrix_user -u "$user" -p "$password" -c /data/homeserver.yaml --no-admin http://localhost:8008
 fi


### PR DESCRIPTION
Prompted by conversation between @elsatch:matrix.org and @aaronraimist about non-alphanumeric characters in password.