### PR TITLE
Listen 8448 required for apache

### DIFF
--- a/examples/apache/matrix-synapse.conf
+++ b/examples/apache/matrix-synapse.conf
@@ -92,6 +92,7 @@
 #
 # In this example we use all services on the same machine (127.0.0.1) but you can do this with different machines.
 # If you do so be sure to reach the destinated IPADRESS and the correspondending port. Check this with netstat, nmap or your favourite tool.
+Listen 8448
 <VirtualHost *:8448>
 	ServerName matrix.DOMAIN
 


### PR DESCRIPTION
Listen 8448 directive makes apache listen on that port, without it federation does not work.