### PR TITLE
Replace constructs appending elements with variables to matrix_synapse_container_extra_arguments

### DIFF
--- a/roles/matrix-bridge-appservice-discord/tasks/init.yml
+++ b/roles/matrix-bridge-appservice-discord/tasks/init.yml
@@ -15,7 +15,7 @@
     matrix_synapse_container_extra_arguments: >
       {{ matrix_synapse_container_extra_arguments|default([]) }}
       +
-      {{ ["--mount type=bind,src={{ matrix_appservice_discord_config_path }}/registration.yaml,dst=/matrix-appservice-discord-registration.yaml,ro"] }}
+      ["--mount type=bind,src={{ matrix_appservice_discord_config_path }}/registration.yaml,dst=/matrix-appservice-discord-registration.yaml,ro"]
 
     matrix_synapse_app_service_config_files: >
       {{ matrix_synapse_app_service_config_files|default([]) }}

--- a/roles/matrix-bridge-appservice-irc/tasks/init.yml
+++ b/roles/matrix-bridge-appservice-irc/tasks/init.yml
@@ -15,7 +15,7 @@
     matrix_synapse_container_extra_arguments: >
       {{ matrix_synapse_container_extra_arguments|default([]) }}
       +
-      {{ ["--mount type=bind,src={{ matrix_appservice_irc_config_path }}/registration.yaml,dst=/matrix-appservice-irc-registration.yaml,ro"] }}
+      ["--mount type=bind,src={{ matrix_appservice_irc_config_path }}/registration.yaml,dst=/matrix-appservice-irc-registration.yaml,ro"]
 
     matrix_synapse_app_service_config_files: >
       {{ matrix_synapse_app_service_config_files|default([]) }}

--- a/roles/matrix-bridge-appservice-slack/tasks/init.yml
+++ b/roles/matrix-bridge-appservice-slack/tasks/init.yml
@@ -15,7 +15,7 @@
     matrix_synapse_container_extra_arguments: >
       {{ matrix_synapse_container_extra_arguments|default([]) }}
       +
-      {{ ["--mount type=bind,src={{ matrix_appservice_slack_config_path }}/slack-registration.yaml,dst=/matrix-appservice-slack-registration.yaml,ro"] }}
+      ["--mount type=bind,src={{ matrix_appservice_slack_config_path }}/slack-registration.yaml,dst=/matrix-appservice-slack-registration.yaml,ro"]
 
     matrix_synapse_app_service_config_files: >
       {{ matrix_synapse_app_service_config_files|default([]) }}

--- a/roles/matrix-bridge-mautrix-facebook/tasks/init.yml
+++ b/roles/matrix-bridge-mautrix-facebook/tasks/init.yml
@@ -7,7 +7,7 @@
     matrix_synapse_container_extra_arguments: >
       {{ matrix_synapse_container_extra_arguments|default([]) }}
       +
-      {{ ["--mount type=bind,src={{ matrix_mautrix_facebook_config_path }}/registration.yaml,dst=/matrix-mautrix-facebook-registration.yaml,ro"] }}
+      ["--mount type=bind,src={{ matrix_mautrix_facebook_config_path }}/registration.yaml,dst=/matrix-mautrix-facebook-registration.yaml,ro"]
 
     matrix_synapse_app_service_config_files: >
       {{ matrix_synapse_app_service_config_files|default([]) }}

--- a/roles/matrix-bridge-mautrix-hangouts/tasks/init.yml
+++ b/roles/matrix-bridge-mautrix-hangouts/tasks/init.yml
@@ -7,7 +7,7 @@
     matrix_synapse_container_extra_arguments: >
       {{ matrix_synapse_container_extra_arguments|default([]) }}
       +
-      {{ ["--mount type=bind,src={{ matrix_mautrix_hangouts_config_path }}/registration.yaml,dst=/matrix-mautrix-hangouts-registration.yaml,ro"] }}
+      ["--mount type=bind,src={{ matrix_mautrix_hangouts_config_path }}/registration.yaml,dst=/matrix-mautrix-hangouts-registration.yaml,ro"]
 
     matrix_synapse_app_service_config_files: >
       {{ matrix_synapse_app_service_config_files|default([]) }}

--- a/roles/matrix-bridge-mautrix-telegram/tasks/init.yml
+++ b/roles/matrix-bridge-mautrix-telegram/tasks/init.yml
@@ -7,7 +7,7 @@
     matrix_synapse_container_extra_arguments: >
       {{ matrix_synapse_container_extra_arguments|default([]) }}
       +
-      {{ ["--mount type=bind,src={{ matrix_mautrix_telegram_config_path }}/registration.yaml,dst=/matrix-mautrix-telegram-registration.yaml,ro"] }}
+      ["--mount type=bind,src={{ matrix_mautrix_telegram_config_path }}/registration.yaml,dst=/matrix-mautrix-telegram-registration.yaml,ro"]
 
     matrix_synapse_app_service_config_files: >
       {{ matrix_synapse_app_service_config_files|default([]) }}

--- a/roles/matrix-bridge-mautrix-whatsapp/tasks/init.yml
+++ b/roles/matrix-bridge-mautrix-whatsapp/tasks/init.yml
@@ -2,12 +2,16 @@
     matrix_systemd_services_list: "{{ matrix_systemd_services_list + ['matrix-mautrix-whatsapp'] }}"
   when: matrix_mautrix_whatsapp_enabled|bool
 
+- set_fact:
+    matrix_synapse_mautrix_extra_arguments: "--mount type=bind,src={{ matrix_mautrix_whatsapp_config_path }}/registration.yaml,dst=/matrix-mautrix-whatsapp-registration.yaml,ro"
+  when: matrix_mautrix_whatsapp_enabled|bool
+
 # If the matrix-synapse role is not used, these variables may not exist.
 - set_fact:
     matrix_synapse_container_extra_arguments: >
       {{ matrix_synapse_container_extra_arguments|default([]) }}
       +
-      {{ ["--mount type=bind,src={{ matrix_mautrix_whatsapp_config_path }}/registration.yaml,dst=/matrix-mautrix-whatsapp-registration.yaml,ro"] }}
+      ["--mount type=bind,src={{ matrix_mautrix_whatsapp_config_path }}/registration.yaml,dst=/matrix-mautrix-whatsapp-registration.yaml,ro"]
 
     matrix_synapse_app_service_config_files: >
       {{ matrix_synapse_app_service_config_files|default([]) }}

--- a/roles/matrix-bridge-mautrix-whatsapp/tasks/init.yml
+++ b/roles/matrix-bridge-mautrix-whatsapp/tasks/init.yml
@@ -2,10 +2,6 @@
     matrix_systemd_services_list: "{{ matrix_systemd_services_list + ['matrix-mautrix-whatsapp'] }}"
   when: matrix_mautrix_whatsapp_enabled|bool
 
-- set_fact:
-    matrix_synapse_mautrix_extra_arguments: "--mount type=bind,src={{ matrix_mautrix_whatsapp_config_path }}/registration.yaml,dst=/matrix-mautrix-whatsapp-registration.yaml,ro"
-  when: matrix_mautrix_whatsapp_enabled|bool
-
 # If the matrix-synapse role is not used, these variables may not exist.
 - set_fact:
     matrix_synapse_container_extra_arguments: >

--- a/roles/matrix-synapse/tasks/ext/rest-auth/setup_install.yml
+++ b/roles/matrix-synapse/tasks/ext/rest-auth/setup_install.yml
@@ -20,7 +20,7 @@
     matrix_synapse_container_extra_arguments: >
       {{ matrix_synapse_container_extra_arguments|default([]) }}
       +
-      {{ ["--mount type=bind,src={{ matrix_synapse_ext_path }}/rest_auth_provider.py,dst={{ matrix_synapse_in_container_python_packages_path }}/rest_auth_provider.py,ro"] }}
+      ["--mount type=bind,src={{ matrix_synapse_ext_path }}/rest_auth_provider.py,dst={{ matrix_synapse_in_container_python_packages_path }}/rest_auth_provider.py,ro"]
 
     matrix_synapse_additional_loggers: >
       {{ matrix_synapse_additional_loggers }}

--- a/roles/matrix-synapse/tasks/ext/shared-secret-auth/setup_install.yml
+++ b/roles/matrix-synapse/tasks/ext/shared-secret-auth/setup_install.yml
@@ -20,7 +20,7 @@
     matrix_synapse_container_extra_arguments: >
       {{ matrix_synapse_container_extra_arguments|default([]) }}
       +
-      {{ ["--mount type=bind,src={{ matrix_synapse_ext_path }}/shared_secret_authenticator.py,dst={{ matrix_synapse_in_container_python_packages_path }}/shared_secret_authenticator.py,ro"] }}
+      ["--mount type=bind,src={{ matrix_synapse_ext_path }}/shared_secret_authenticator.py,dst={{ matrix_synapse_in_container_python_packages_path }}/shared_secret_authenticator.py,ro"]
 
     matrix_synapse_additional_loggers: >
       {{ matrix_synapse_additional_loggers }}

--- a/roles/matrix-synapse/tasks/ext/synapse-simple-antispam/setup_install.yml
+++ b/roles/matrix-synapse/tasks/ext/synapse-simple-antispam/setup_install.yml
@@ -38,4 +38,4 @@
     matrix_synapse_container_extra_arguments: >
       {{ matrix_synapse_container_extra_arguments|default([]) }}
       +
-      {{ ["--mount type=bind,src={{ matrix_synapse_ext_path }}/synapse-simple-antispam/synapse_simple_antispam,dst={{ matrix_synapse_in_container_python_packages_path }}/synapse_simple_antispam,ro"] }}
+      ["--mount type=bind,src={{ matrix_synapse_ext_path }}/synapse-simple-antispam/synapse_simple_antispam,dst={{ matrix_synapse_in_container_python_packages_path }}/synapse_simple_antispam,ro"]


### PR DESCRIPTION
Replace constructs appending elements with variables to matrix_synapse_container_extra_arguments. Fixes issue https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/304

The only bridge I have activated is mautrix-whatsapp. Can anyone test these changes with other/more bridges activated?