### PR TITLE
Fix: Restrict a Debian-specific task to Debian OS.

### DIFF
--- a/roles/matrix-base/tasks/setup_server_base.yml
+++ b/roles/matrix-base/tasks/setup_server_base.yml
@@ -75,7 +75,7 @@
       - docker-ce
     state: latest
     update_cache: yes
-  when: "'docker.io' not in ansible_facts.packages"
+  when: ansible_os_family == 'Debian' and 'docker.io' not in ansible_facts.packages
 
 - name: Ensure Docker is started and autoruns
   service:


### PR DESCRIPTION
Since commit b9753635 the task 'Ensure docker-ce is installed (Debian)' fails with an error on CentOS although it should not even run on this OS.