### PR TITLE
Remove identity server section from .well-known/matrix/client if there is no identity server

### DIFF
--- a/roles/matrix-base/templates/static-files/well-known/matrix-client.j2
+++ b/roles/matrix-base/templates/static-files/well-known/matrix-client.j2
@@ -2,8 +2,10 @@
 {
 	"m.homeserver": {
 		"base_url": "{{ matrix_homeserver_url }}"
-	},
+	}
+	{% if matrix_identity_server_url %},
 	"m.identity_server": {
 		"base_url": "{{ matrix_identity_server_url }}"
 	}
+	{% endif %}
 }


### PR DESCRIPTION
Riot used to be fine with it being blank but now it complains. This creates an ugly looking comma when there is an identity server configured but I guess that's fine.