### PR TITLE
Allow Synapse manhole to be enabled

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -574,6 +574,9 @@ matrix_synapse_container_federation_api_tls_host_bind_port: "{{ '8448' if (matri
 #
 # For exposing the Synapse Metrics API's port (plain HTTP) to the local host.
 matrix_synapse_container_metrics_api_host_bind_port: "{{ '127.0.0.1:9100' if (matrix_synapse_metrics_enabled and not matrix_nginx_proxy_enabled) else '' }}"
+#
+# For exposing the Synapse Manhole port (plain HTTP) to the local host.
+matrix_synapse_container_manhole_api_host_bind_port: "{{ '127.0.0.1:9000' if matrix_synapse_manhole_enabled else '' }}"
 
 matrix_synapse_database_host: "{{ matrix_postgres_connection_hostname }}"
 matrix_synapse_database_user: "{{ matrix_postgres_connection_username }}"

--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -40,6 +40,13 @@ matrix_synapse_container_federation_api_tls_host_bind_port: ''
 # Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:9100"), or empty string to not expose.
 matrix_synapse_container_metrics_api_host_bind_port: ''
 
+# Controls whether the matrix-synapse container exposes the manhole port (tcp/9000 in the container).
+#
+# Takes effect only if the manhole is enabled (matrix_synapse_manhole_enabled).
+#
+# Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:9100"), or empty string to not expose.
+matrix_synapse_container_manhole_api_host_bind_port: ''
+
 # A list of extra arguments to pass to the container
 matrix_synapse_container_extra_arguments: []
 
@@ -222,9 +229,14 @@ matrix_synapse_push_include_content: true
 matrix_synapse_url_preview_enabled: true
 
 # Enable exposure of metrics to Prometheus
-# See https://github.com/matrix-org/synapse/blob/master/docs/metrics-howto.rst
+# See https://github.com/matrix-org/synapse/blob/master/docs/metrics-howto.md
 matrix_synapse_metrics_enabled: false
 matrix_synapse_metrics_port: 9100
+
+# Enable the Synapse manhole
+# See https://github.com/matrix-org/synapse/blob/master/docs/manhole.md
+matrix_synapse_manhole_enabled: false
+
 
 # Send ERROR logs to sentry.io for easier tracking
 # To set this up: go to sentry.io, create a python project, and set

--- a/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -229,11 +229,13 @@ listeners:
         compress: false
 {% endif %}
 
+{% if matrix_synapse_manhole_enabled %}
   # Turn on the twisted ssh manhole service on localhost on the given
   # port.
-  # - port: 9000
-  #   bind_addresses: ['::1', '127.0.0.1']
-  #   type: manhole
+  - port: 9000
+    bind_addresses: ['0.0.0.0']
+    type: manhole
+{% endif %}
 
 
 ## Homeserver blocking ##

--- a/roles/matrix-synapse/templates/synapse/systemd/matrix-synapse.service.j2
+++ b/roles/matrix-synapse/templates/synapse/systemd/matrix-synapse.service.j2
@@ -41,6 +41,9 @@ ExecStart=/usr/bin/docker run --rm --name matrix-synapse \
 			{% if matrix_synapse_metrics_enabled and matrix_synapse_container_metrics_api_host_bind_port %}
 			-p {{ matrix_synapse_container_metrics_api_host_bind_port }}:{{ matrix_synapse_metrics_port }} \
 			{% endif %}
+			{% if matrix_synapse_manhole_enabled and matrix_synapse_container_manhole_api_host_bind_port %}
+			-p {{ matrix_synapse_container_manhole_api_host_bind_port }}:9000 \
+			{% endif %}
 			-v {{ matrix_synapse_config_dir_path }}:/data:ro \
 			-v {{ matrix_synapse_run_path }}:/matrix-run:rw \
 			-v {{ matrix_synapse_storage_path }}:/matrix-media-store-parent:slave \


### PR DESCRIPTION
Can you double check that the way I have this set only exposes it locally? It is important that the manhole is not available to the outside world since it is quite powerful and the password is hard coded.