### PR TITLE
Render vhost directives in https server block

### DIFF
--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
@@ -58,5 +58,7 @@ server {
 	ssl_protocols {{ matrix_nginx_proxy_ssl_protocols }};
 	ssl_prefer_server_ciphers on;
 	ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
+
+	{{ render_vhost_directives() }}
 }
 {% endif %}


### PR DESCRIPTION
Vhost directives were not being rendered in the https server block which made .well-known urls not work.