### PR TITLE
Notes when not using a ssh key for authentication

### DIFF
--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -65,7 +65,7 @@ You can execute `ansible-playbook` commands as per normal now.
 ### If you don't use SSH keys for authentication 
 
 If you don't use SSH keys for authentication, simply remove that whole line (`-v $HOME/.ssh/id_rsa:/root/.ssh/id_rsa:ro`).
-To authenticate at your server using a password, you need to add a package. So, when you are in the shell of the ansible docker container (previous used `docker run -it ...`), run:
+To authenticate at your server using a password, you need to add a package. So, when you are in the shell of the ansible docker container (the previously used `docker run -it ...` command), run:
 ```bash
 apk add sshpass
 ```

--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -1,3 +1,4 @@
+
 # Running this playbook
 
 This playbook is meant to be run using [Ansible](https://www.ansible.com/).
@@ -18,7 +19,7 @@ If you're on Ansible 2.5.x, due to bugs in Ansible 2.5.0 and 2.5.1, at least Ans
 In most cases, you won't need to worry about the Ansible version.
 The playbook will try to detect it and tell you if you're on an unsupported version.
 
-To manually check which verison of Ansible you're on, run: `ansible --version`.
+To manually check which version of Ansible you're on, run: `ansible --version`.
 
 If you're on an old version of Ansible, you should [upgrade Ansible to a newer version](#upgrading-ansible) or [use Ansible via Docker](#using-ansible-via-docker).
 
@@ -55,9 +56,18 @@ devture/ansible:2.8.1-r0
 
 The above command tries to mount an SSH key (`$HOME/.ssh/id_rsa`) into the container (at `/root/.ssh/id_rsa`).
 If your SSH key is at a different path (not in `$HOME/.ssh/id_rsa`), adjust that part.
-If you don't use SSH keys for authentication, simply remove that whole line (`-v $HOME/.ssh/id_rsa:/root/.ssh/id_rsa:ro`).
 
 Once you execute the above command, you'll be dropped into a `/work` directory inside a Docker container.
 The `/work` directory contains the playbook's code.
 
 You can execute `ansible-playbook` commands as per normal now.
+
+### If you don't use SSH keys for authentication 
+
+If you don't use SSH keys for authentication, simply remove that whole line (`-v $HOME/.ssh/id_rsa:/root/.ssh/id_rsa:ro`).
+To authenticate at your server using a password, you need to add a package. So, when you are in the shell of the ansible docker container (previous used `docker run -it ...`), run:
+```bash
+apk add sshpass
+```
+Then, to be asked for the password whenever running an  `ansible-playbook` command add `--ask-pass` to the arguments of the command.
+


### PR DESCRIPTION
Fixed small typo, added an extra note on how to use the ansible docker image when not using a ssh key for authentication