### PR TITLE
Remove spurious 'mxisd' string from mautrix bridge templates comment

### DIFF
--- a/roles/matrix-bridge-mautrix-facebook/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-facebook/defaults/main.yml
@@ -27,7 +27,7 @@ matrix_mautrix_facebook_systemd_wanted_services_list: []
 matrix_mautrix_facebook_appservice_token: ''
 matrix_mautrix_facebook_homeserver_token: ''
 
-# Default mxisd configuration template which covers the generic use case.
+# Default configuration template which covers the generic use case.
 # You can customize it by controlling the various variables inside it.
 #
 # For a more advanced customization, you can extend the default (see `matrix_mautrix_facebook_configuration_extension_yaml`)

--- a/roles/matrix-bridge-mautrix-hangouts/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-hangouts/defaults/main.yml
@@ -29,7 +29,7 @@ matrix_mautrix_hangouts_systemd_wanted_services_list: []
 matrix_mautrix_hangouts_appservice_token: ''
 matrix_mautrix_hangouts_homeserver_token: ''
 
-# Default mxisd configuration template which covers the generic use case.
+# Default configuration template which covers the generic use case.
 # You can customize it by controlling the various variables inside it.
 #
 # For a more advanced customization, you can extend the default (see `matrix_mautrix_hangouts_configuration_extension_yaml`)

--- a/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
@@ -43,7 +43,7 @@ matrix_mautrix_telegram_systemd_wanted_services_list: []
 matrix_mautrix_telegram_appservice_token: ''
 matrix_mautrix_telegram_homeserver_token: ''
 
-# Default mxisd configuration template which covers the generic use case.
+# Default configuration template which covers the generic use case.
 # You can customize it by controlling the various variables inside it.
 #
 # For a more advanced customization, you can extend the default (see `matrix_mautrix_telegram_configuration_extension_yaml`)


### PR DESCRIPTION
These templates seemingly were copied originally from the mxisd one.. so remove the stray strings.