### PR TITLE
Fix regex in matrix_appservice_webhooks_registration_yaml

### DIFF
--- a/roles/matrix-bridge-appservice-webhooks/defaults/main.yml
+++ b/roles/matrix-bridge-appservice-webhooks/defaults/main.yml
@@ -94,7 +94,7 @@ matrix_appservice_webhooks_registration_yaml: |
   namespaces:
     users:
       - exclusive: true
-        regex: '@{{ matrix_appservice_webhooks_user_prefix }}*:{{ matrix_domain }}'
+        regex: '^@{{ matrix_appservice_webhooks_user_prefix | regex_escape }}.*:{{ matrix_domain | regex_escape }}$'
     aliases: []
     rooms: []
   url: "{{ matrix_appservice_webhooks_appservice_url }}:{{ matrix_appservice_webhooks_matrix_port }}"


### PR DESCRIPTION
Currently user registration for the webhook bridge is broken. See:

```
Jan-15-2020 17:36:41.639 +00:00 info [WebService [Hook 6x3q7FjQkQk4UJI69c2oVu3cRJPUK4KvdKdgRRZKgYOIA1W0MYoQr3BsD4zRIRPe]] Publishing webhook request for processing
Jan-15-2020 17:36:41.641 +00:00 info [WebhookBridge] Updating appearance of @_webhook__fDIN992hzJPf7kYP6p_matrix_Incoming_Webhook:matrix
Jan-15-2020 17:36:41.647 +00:00 error [matrix-appservice-bridge] [-] POST http://matrix-synapse:8008/_matrix/client/r0/register (AS) HTTP 400 Error: "{\"errcode\":\"M_EXCLUSIVE\",\"error\":\"Invalid user localpart for this application service.\"}"
Jan-15-2020 17:36:41.648 +00:00 error [WebhookReceiver] Invalid user localpart for this application service.
```

This pull request fixes the user registration regex for the webhook bridge.