### PR TITLE
Fix invalid password salts for slack webhooks

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -74,11 +74,11 @@ matrix_appservice_webhooks_enabled: false
 # matrix-appservice-webhooks' client-server port to the local host.
 matrix_appservice_webhooks_container_http_host_bind_port: "{{ '' if matrix_nginx_proxy_enabled else '127.0.0.1:{{ matrix_appservice_webhooks_webhooks_port }}' }}"
 
-matrix_appservice_webhooks_appservice_token: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'webhooks-appservice-token') | to_uuid }}"
+matrix_appservice_webhooks_appservice_token: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'webhook.as.token') | to_uuid }}"
 
-matrix_appservice_webhooks_homeserver_token: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'webhooks-homeserver-token') | to_uuid }}"
+matrix_appservice_webhooks_homeserver_token: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'webhook.hs.token') | to_uuid }}"
 
-matrix_appservice_webhooks_id_token: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'webhooks-id-token') | to_uuid }}"
+matrix_appservice_webhooks_id_token: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'webhook.id.token') | to_uuid }}"
 
 matrix_appservice_webhooks_systemd_required_services_list: |
   {{


### PR DESCRIPTION
Under the previous salts, this resulted in the incredibly cryptic error of:

```
original message: An unhandled exception occurred while templating '{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'webhooks-id-token') | to_uuid }}'.
Error was a <class 'ValueError'>, original message: invalid characters in sha512_crypt salt
```

Ansible password salts must be <= 16 characters and have a variety of restrictions on the contents, namely no `-` characters.