### PR TITLE
Fix for when if case evaluates to false

### DIFF
--- a/roles/matrix-base/tasks/server_base/setup_debian.yml
+++ b/roles/matrix-base/tasks/server_base/setup_debian.yml
@@ -28,7 +28,7 @@
   apt:
     name:
       - bash-completion
-      - "python{{'3' if ansible_python.version.major == 3}}-docker"
+      - "python{{'3' if ansible_python.version.major == 3 else ''}}-docker"
       - ntp
       - fuse
     state: latest


### PR DESCRIPTION
I got this error when the if case evalutes to false, so I added an else statement to fix the error.

```
FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: the inline if-expression on line 1 evaluated to false and no else section was defined.
```