### PR TITLE
Added condition if ansible is not running on python3

### DIFF
--- a/roles/matrix-base/tasks/server_base/setup_debian.yml
+++ b/roles/matrix-base/tasks/server_base/setup_debian.yml
@@ -28,7 +28,7 @@
   apt:
     name:
       - bash-completion
-      - "python{{'3' if ansible_python.version.major == 3}}-docker"
+      - "python{{'3' if ansible_python.version.major == 3 else ''}}-docker"
       - ntp
       - fuse
     state: latest


### PR DESCRIPTION
"'3' if ansible_python.version.major == 3" fatally exits on systems with Python versions less than 3.  Adding the "else" statement corrects the fatal error.