### PR TITLE
Switch from kamax-matrix/matrix-synapse-rest-password-provider to ma1uta/matrix-synapse-rest-password-provider

### DIFF
--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -263,9 +263,9 @@ matrix_synapse_email_client_base_url: "https://{{ matrix_server_fqn_riot }}"
 
 
 # Enable this to activate the REST auth password provider module.
-# See: https://github.com/kamax-io/matrix-synapse-rest-auth
+# See: https://github.com/ma1uta/matrix-synapse-rest-password-provider
 matrix_synapse_ext_password_provider_rest_auth_enabled: false
-matrix_synapse_ext_password_provider_rest_auth_download_url: "https://raw.githubusercontent.com/kamax-io/matrix-synapse-rest-auth/v0.1.2/rest_auth_provider.py"
+matrix_synapse_ext_password_provider_rest_auth_download_url: "https://github.com/ma1uta/matrix-synapse-rest-password-provider/blob/ed377fb70513c2e51b42055eb364195af1ccaf33/rest_auth_provider.py"
 matrix_synapse_ext_password_provider_rest_auth_endpoint: ""
 matrix_synapse_ext_password_provider_rest_auth_registration_enforce_lowercase: false
 matrix_synapse_ext_password_provider_rest_auth_registration_profile_name_autofill: true


### PR DESCRIPTION
Synapse v1.9.0 changed some things which made the REST Auth Password
Provider break.

The ma1uta/matrix-synapse-rest-password-provider implements some
workarounds for now and will likely deliver a proper fix in the future.

Not much has changed between the 2 projects, so this should be a
painless transition.