### PR TITLE
fix invalid password salt on slack bridge

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -108,11 +108,11 @@ matrix_appservice_slack_enabled: false
 # matrix-appservice-slack's client-server port to the local host.
 matrix_appservice_slack_container_http_host_bind_port: "{{ '' if matrix_nginx_proxy_enabled else '127.0.0.1:{{ matrix_appservice_slack_slack_port }}' }}"
 
-matrix_appservice_slack_appservice_token: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'slack-appservice-token') | to_uuid }}"
+matrix_appservice_slack_appservice_token: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'slack.appservice.token') | to_uuid }}"
 
-matrix_appservice_slack_homeserver_token: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'slack-homeserver-token') | to_uuid }}"
+matrix_appservice_slack_homeserver_token: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'slack.homeserver.token') | to_uuid }}"
 
-matrix_appservice_slack_id_token: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'slack-id-token') | to_uuid }}"
+matrix_appservice_slack_id_token: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'slack.id.token') | to_uuid }}"
 
 matrix_appservice_slack_systemd_required_services_list: |
   {{


### PR DESCRIPTION
Change usage of `-` on slack bridge configuration files (password hash) to `.`, following the same principle as in #357 for slack webhooks, fixing #365.