### PR TITLE
Fix matrix-appservice-irc database specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Using this playbook, you can get the following services configured on your serve
 
 - (optional) the [mautrix-hangouts](https://github.com/tulir/mautrix-hangouts) bridge for bridging your Matrix server to [Google Hangouts](https://en.wikipedia.org/wiki/Google_Hangouts)
 
-- (optional) the [matrix-appservice-irc](https://github.com/TeDomum/matrix-appservice-irc) bridge for bridging your Matrix server to [IRC](https://wikipedia.org/wiki/Internet_Relay_Chat)
+- (optional) the [matrix-appservice-irc](https://github.com/matrix-org/matrix-appservice-irc) bridge for bridging your Matrix server to [IRC](https://wikipedia.org/wiki/Internet_Relay_Chat)
 
 - (optional) the [matrix-appservice-discord](https://github.com/Half-Shot/matrix-appservice-discord) bridge for bridging your Matrix server to [Discord](https://discordapp.com/)
 
@@ -134,7 +134,7 @@ This playbook sets up your server using the following Docker images:
 
 - [tulir/mautrix-hangouts](https://hub.docker.com/r/tulir/mautrix-hangouts/) - the [mautrix-hangouts](https://github.com/tulir/mautrix-hangouts) bridge to [Google Hangouts](https://en.wikipedia.org/wiki/Google_Hangouts) (optional)
 
-- [tedomum/matrix-appservice-irc](https://hub.docker.com/r/tedomum/matrix-appservice-irc/) - the [matrix-appservice-irc](https://github.com/TeDomum/matrix-appservice-irc) bridge to [IRC](https://wikipedia.org/wiki/Internet_Relay_Chat) (optional)
+- [matrixdotorg/matrix-appservice-irc](https://hub.docker.com/r/matrixdotorg/matrix-appservice-irc) - the [matrix-appservice-irc](https://github.com/matrix-org/matrix-appservice-irc) bridge to [IRC](https://wikipedia.org/wiki/Internet_Relay_Chat) (optional)
 
 - [halfshot/matrix-appservice-discord](https://hub.docker.com/r/halfshot/matrix-appservice-discord) - the [matrix-appservice-discord](https://github.com/Half-Shot/matrix-appservice-discord) bridge to [Discord](https://discordapp.com/) (optional)
 

--- a/docs/configuring-playbook-bridge-appservice-irc.md
+++ b/docs/configuring-playbook-bridge-appservice-irc.md
@@ -1,8 +1,8 @@
 # Setting up Appservice IRC (optional)
 
-The playbook can install and configure [matrix-appservice-irc](https://github.com/TeDomum/matrix-appservice-irc) for you.
+The playbook can install and configure [matrix-appservice-irc](https://github.com/matrix-org/matrix-appservice-irc) for you.
 
-See the project's [documentation](https://github.com/TeDomum/matrix-appservice-irc/blob/master/HOWTO.md) to learn what it does and why it might be useful to you.
+See the project's [documentation](https://github.com/matrix-org/matrix-appservice-irc/blob/master/HOWTO.md) to learn what it does and why it might be useful to you.
 
 You'll need to use the following playbook configuration:
 

--- a/roles/matrix-bridge-appservice-irc/defaults/main.yml
+++ b/roles/matrix-bridge-appservice-irc/defaults/main.yml
@@ -469,14 +469,14 @@ matrix_appservice_irc_configuration_yaml: |
     # enough for the vast majority of use cases.
     maxHttpSockets: 1000
 
-    # Use an external database to store bridge state.
-    database:
-      # database engine (must be 'postgres' or 'nedb'). Default: nedb
-      engine: "nedb"
-        # Either a PostgreSQL connection string, or a path to the NeDB storage directory.
-        # For postgres, it must start with postgres://
-        # For NeDB, it must start with nedb://. The path is relative to the project directory.
-      connectionString: "nedb:///data"
+  # Use an external database to store bridge state.
+  database:
+    # database engine (must be 'postgres' or 'nedb'). Default: nedb
+    engine: "nedb"
+    # Either a PostgreSQL connection string, or a path to the NeDB storage directory.
+    # For postgres, it must start with postgres://
+    # For NeDB, it must start with nedb://. The path is relative to the project directory.
+    connectionString: "nedb:///data"
 
 matrix_appservice_irc_configuration_extension_yaml: |
   # Your custom YAML configuration for Appservice IRC servers goes here.


### PR DESCRIPTION
This fixes an incorrect indentation in the database specification for appservice-irc which caused matrix-appservice-irc to refuse to start with the remarkably unhelpful error message:

```
ERROR:CLI Failed to run bridge.
```

This also updates doc links to the new upstream repo because the tedomum repo contains out-of-date documentation.