### PR TITLE
fix slack bridge: salt too large, sha512_crypt requires <= 16 chars

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -108,9 +108,9 @@ matrix_appservice_slack_enabled: false
 # matrix-appservice-slack's client-server port to the local host.
 matrix_appservice_slack_container_http_host_bind_port: "{{ '' if matrix_nginx_proxy_enabled else '127.0.0.1:{{ matrix_appservice_slack_slack_port }}' }}"
 
-matrix_appservice_slack_appservice_token: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'slack.appservice.token') | to_uuid }}"
+matrix_appservice_slack_appservice_token: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'slack.as.token') | to_uuid }}"
 
-matrix_appservice_slack_homeserver_token: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'slack.homeserver.token') | to_uuid }}"
+matrix_appservice_slack_homeserver_token: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'slack.hs.token') | to_uuid }}"
 
 matrix_appservice_slack_id_token: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'slack.id.token') | to_uuid }}"
 


### PR DESCRIPTION
Hi and thank you for these great ansible roles!

Following https://github.com/spantaleev/matrix-docker-ansible-deploy/pull/357 and https://github.com/spantaleev/matrix-docker-ansible-deploy/pull/368 it seems the slack bridge needs some more fixing:

```
TASK [matrix-bridge-appservice-slack : Ensure appservice-slack registration.yaml installed]
fatal: [matrix.pub.solar]: FAILED! => {"msg": "An unhandled exception occurred while templating '{{ matrix_appservice_slack_registration_yaml|from_yaml }}'
Error was a <class 'ValueError'>, original message: salt too large (sha512_crypt requires <= 16 chars)"
```

```
$: ansible -i inventory/hosts -m setup 'matrix_servers' | grep -i ansible_python_version
        "ansible_python_version": "2.7.5",
```
This is on centOS 7.

This PR reduces the salt length to below 16 chars and thus makes `sha512_crypt` happy.