### PR TITLE
matrix-nginx-proxy: adding additional configuration blocks

### DIFF
--- a/roles/matrix-nginx-proxy/defaults/main.yml
+++ b/roles/matrix-nginx-proxy/defaults/main.yml
@@ -152,8 +152,20 @@ matrix_nginx_proxy_proxy_matrix_federation_api_ssl_certificate_key: "{{ matrix_s
 # The tmpfs at /tmp needs to be large enough to handle multiple concurrent file uploads.
 matrix_nginx_proxy_tmp_directory_size_mb: "{{ (matrix_nginx_proxy_proxy_matrix_federation_api_client_max_body_size_mb | int) * 50 }}"
 
-# A list of strings containing additional configuration blocks to add to the matrix domain's server configuration.
+# A list of strings containing additional configuration blocks to add to the nginx http's server configuration.
+matrix_nginx_proxy_proxy_http_additional_server_configuration_blocks: []
+
+# A list of strings containing additional configuration blocks to add to the matrix synapse's server configuration.
 matrix_nginx_proxy_proxy_matrix_additional_server_configuration_blocks: []
+
+# A list of strings containing additional configuration blocks to add to the matrix riot's server configuration.
+matrix_nginx_proxy_proxy_riot_additional_server_configuration_blocks: []
+
+# A list of strings containing additional configuration blocks to add to the matrix dimension's server configuration.
+matrix_nginx_proxy_proxy_dimension_additional_server_configuration_blocks: []
+
+# A list of strings containing additional configuration blocks to add to the matrix domain server configuration.
+matrix_nginx_proxy_proxy_domain_additional_server_configuration_blocks: []
 
 # Specifies when to reload the matrix-nginx-proxy service so that
 # a new SSL certificate could go into effect.

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-dimension.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-dimension.conf.j2
@@ -3,6 +3,9 @@
 {% macro render_vhost_directives() %}
 	gzip on;
 	gzip_types text/plain application/json application/javascript text/css image/x-icon font/ttf image/gif;
+{% for configuration_block in matrix_nginx_proxy_proxy_dimension_additional_server_configuration_blocks %}
+	{{- configuration_block }}
+{% endfor %}
 
 	location / {
 		{% if matrix_nginx_proxy_enabled %}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
@@ -5,6 +5,9 @@
 
 	gzip on;
 	gzip_types text/plain application/json;
+	{% for configuration_block in matrix_nginx_proxy_proxy_domain_additional_server_configuration_blocks %}
+		{{- configuration_block }}
+	{% endfor %}
 
 	location /.well-known/matrix {
 		root {{ matrix_static_files_base_path }};

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-riot-web.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-riot-web.conf.j2
@@ -3,6 +3,9 @@
 {% macro render_vhost_directives() %}
 	gzip on;
 	gzip_types text/plain application/json application/javascript text/css image/x-icon font/ttf image/gif;
+	{% for configuration_block in matrix_nginx_proxy_proxy_riot_additional_server_configuration_blocks %}
+		{{- configuration_block }}
+	{% endfor %}
 
 	location / {
 		{% if matrix_nginx_proxy_enabled %}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/nginx-http.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/nginx-http.conf.j2
@@ -4,3 +4,6 @@
 #
 # Thus, we ensure a larger bucket size value is used.
 server_names_hash_bucket_size 64;
+{% for configuration_block in matrix_nginx_proxy_proxy_http_additional_server_configuration_blocks %}
+	{{- configuration_block }}
+{% endfor %}


### PR DESCRIPTION
Adding the ability to add additional configuration block not only the synapse vhost, but also to the nginx-http block, riot, dimension and domain vhost.

In my use case I needed to add additional arguments to import the real-ip (because my deployment is running behind a traefik reverse proxy).

Example usage:
```
# import real-ip from traefik reverse proxy
matrix_nginx_proxy_proxy_http_additional_server_configuration_blocks:
  - set_real_ip_from 172.16.0.0/12;
  - real_ip_header X-Real-Ip;
  - real_ip_recursive on;
```
