### PR TITLE
Riot config server name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 2020-02-24
+
+## Customize the server name in Riot's login page
+
+You can now customize the server name string that Riot-web displays in its login page.
+
+These playbook variables, with these default values, have been added:
+
+```
+matrix_riot_web_default_server_name: "{{ matrix_domain }}"
+```
+
+The login page previously said "Sign in to your Matrix account on matrix.example.org" (the homeserver's domain name). It will now say "Sign in ... on example.org" (the server name) by default, or "Sign in ... on Our Server" if you set the variable to "Our Server".
+
+To support this, the config.json template is changed to use the configuration key `default_server_config` for setting the default HS/IS, and the new configuration key `server_name` is added in there.
+
+
 # 2020-01-30
 
 ## Disabling TLSv1.1

--- a/roles/matrix-riot-web/defaults/main.yml
+++ b/roles/matrix-riot-web/defaults/main.yml
@@ -17,6 +17,7 @@ matrix_riot_web_container_extra_arguments: []
 matrix_riot_web_systemd_required_services_list: ['docker.service']
 
 # Riot config.json customizations
+matrix_riot_web_default_server_name: "{{ matrix_domain }}"
 matrix_riot_web_default_hs_url: ""
 matrix_riot_web_default_is_url: ~
 matrix_riot_web_disable_custom_urls: true

--- a/roles/matrix-riot-web/templates/config.json.j2
+++ b/roles/matrix-riot-web/templates/config.json.j2
@@ -1,6 +1,12 @@
 {
-	"default_hs_url": {{ matrix_riot_web_default_hs_url|string|to_json }},
-	"default_is_url": {{ matrix_riot_web_default_is_url|string|to_json }},
+	"default_server_config": {
+		"m.homeserver": {
+			"base_url": {{ matrix_riot_web_default_hs_url|string|to_json }},
+		},
+		"m.identity_server": {
+			"base_url": {{ matrix_riot_web_default_is_url|string|to_json }}
+		}
+	},
 	"disable_custom_urls": {{ matrix_riot_web_disable_custom_urls|to_json }},
 	"disable_guests": {{ matrix_riot_web_disable_guests|to_json }},
 	"brand": {{ matrix_riot_web_brand|to_json }},

--- a/roles/matrix-riot-web/templates/config.json.j2
+++ b/roles/matrix-riot-web/templates/config.json.j2
@@ -2,6 +2,7 @@
 	"default_server_config": {
 		"m.homeserver": {
 			"base_url": {{ matrix_riot_web_default_hs_url|string|to_json }},
+			"server_name": {{ matrix_riot_web_default_server_name|string|to_json }}
 		},
 		"m.identity_server": {
 			"base_url": {{ matrix_riot_web_default_is_url|string|to_json }}


### PR DESCRIPTION
Support Riot config option to display a custom homeserver name on the Riot login page.