### PR TITLE
Customization welcome

### DIFF
--- a/roles/matrix-riot-web/defaults/main.yml
+++ b/roles/matrix-riot-web/defaults/main.yml
@@ -43,13 +43,13 @@ matrix_riot_web_welcome_text: "_t('Decentralised, encrypted chat &amp; collabora
 
 # Links, shown in footer of welcome page:
 # [{"text": "Link text", "url": "https://link.target"}, {"text": "Other link"}]
-matrix_riot_web_welcome_footerlinks: false
+matrix_riot_web_branding_authFooterLinks: ~
 
 # URL to image, shown during Login
-matrix_riot_web_welcome_authlogo: "{{ matrix_riot_web_welcome_logo }}"
+matrix_riot_web_branding_authHeaderLogoUrl: "{{ matrix_riot_web_welcome_logo }}"
 
 # URL to Wallpaper, shown in background of welcome page
-matrix_riot_web_welcome_background: false
+matrix_riot_web_branding_welcomeBackgroundUrl: ~
 
 # By default, there's no Riot homepage (when logged in). If you wish to have one,
 # point this to a `home.html` template file on your local filesystem.

--- a/roles/matrix-riot-web/defaults/main.yml
+++ b/roles/matrix-riot-web/defaults/main.yml
@@ -32,7 +32,20 @@ matrix_riot_web_welcome_user_id: "@riot-bot:matrix.org"
 # Branding of riot web
 matrix_riot_web_brand: "Riot"
 
+# Links, shown in footer of welcome page:
+# [{"text": "Link text", "url": "https://link.target"}, {"text": "Other link"}]
+matrix_riot_web_welcome_footerlinks: false
+
+# URL to image, shown during Login
+matrix_riot_web_welcome_authlogo: false
+
+# URL to Wallpaper, shown in background of welcome page
+matrix_riot_web_welcome_background: false
+
+# URL to Logo on welcome page
 matrix_riot_web_welcome_logo: "welcome/images/logo.svg"
+
+# URL of link on welcome image
 matrix_riot_web_welcome_logo_link: "https://riot.im"
 
 matrix_riot_web_welcome_headline: "_t('Welcome to Riot.im')"

--- a/roles/matrix-riot-web/defaults/main.yml
+++ b/roles/matrix-riot-web/defaults/main.yml
@@ -32,6 +32,12 @@ matrix_riot_web_welcome_user_id: "@riot-bot:matrix.org"
 # Branding of riot web
 matrix_riot_web_brand: "Riot"
 
+matrix_riot_web_welcome_logo: "welcome/images/logo.svg"
+matrix_riot_web_welcome_logo_link: "https://riot.im"
+
+matrix_riot_web_welcome_headline: "_t('Welcome to Riot.im')"
+matrix_riot_web_welcome_text: "_t('Decentralised, encrypted chat &amp; collaboration powered by [matrix]')"
+
 # By default, there's no Riot homepage (when logged in). If you wish to have one,
 # point this to a `home.html` template file on your local filesystem.
 matrix_riot_web_embedded_pages_home_path: ~

--- a/roles/matrix-riot-web/defaults/main.yml
+++ b/roles/matrix-riot-web/defaults/main.yml
@@ -32,16 +32,6 @@ matrix_riot_web_welcome_user_id: "@riot-bot:matrix.org"
 # Branding of riot web
 matrix_riot_web_brand: "Riot"
 
-# Links, shown in footer of welcome page:
-# [{"text": "Link text", "url": "https://link.target"}, {"text": "Other link"}]
-matrix_riot_web_welcome_footerlinks: false
-
-# URL to image, shown during Login
-matrix_riot_web_welcome_authlogo: false
-
-# URL to Wallpaper, shown in background of welcome page
-matrix_riot_web_welcome_background: false
-
 # URL to Logo on welcome page
 matrix_riot_web_welcome_logo: "welcome/images/logo.svg"
 
@@ -50,6 +40,16 @@ matrix_riot_web_welcome_logo_link: "https://riot.im"
 
 matrix_riot_web_welcome_headline: "_t('Welcome to Riot.im')"
 matrix_riot_web_welcome_text: "_t('Decentralised, encrypted chat &amp; collaboration powered by [matrix]')"
+
+# Links, shown in footer of welcome page:
+# [{"text": "Link text", "url": "https://link.target"}, {"text": "Other link"}]
+matrix_riot_web_welcome_footerlinks: false
+
+# URL to image, shown during Login
+matrix_riot_web_welcome_authlogo: "{{ matrix_riot_web_welcome_logo }}"
+
+# URL to Wallpaper, shown in background of welcome page
+matrix_riot_web_welcome_background: false
 
 # By default, there's no Riot homepage (when logged in). If you wish to have one,
 # point this to a `home.html` template file on your local filesystem.

--- a/roles/matrix-riot-web/templates/config.json.j2
+++ b/roles/matrix-riot-web/templates/config.json.j2
@@ -29,5 +29,10 @@
 	{% endif %}
 	"embeddedPages": {
 		"homeUrl": {{ matrix_riot_web_embedded_pages_home_url|string|to_json }}
+	},
+	"branding": {
+		"authFooterLinks": {{ matrix_riot_web_welcome_footerlinks|to_json }},
+		"authHeaderLogoUrl": {{ matrix_riot_web_welcome_authlogo|to_json }},
+		"welcomeBackgroundUrl": {{ matrix_riot_web_welcome_background|to_json }}
 	}
 }

--- a/roles/matrix-riot-web/templates/config.json.j2
+++ b/roles/matrix-riot-web/templates/config.json.j2
@@ -31,8 +31,8 @@
 		"homeUrl": {{ matrix_riot_web_embedded_pages_home_url|string|to_json }}
 	},
 	"branding": {
-		"authFooterLinks": {{ matrix_riot_web_welcome_footerlinks|to_json }},
-		"authHeaderLogoUrl": {{ matrix_riot_web_welcome_authlogo|to_json }},
-		"welcomeBackgroundUrl": {{ matrix_riot_web_welcome_background|to_json }}
+		"authFooterLinks": {{ matrix_riot_web_branding_authFooterLinks|to_json }},
+		"authHeaderLogoUrl": {{ matrix_riot_web_branding_authHeaderLogoUrl|to_json }},
+		"welcomeBackgroundUrl": {{ matrix_riot_web_branding_welcomeBackgroundUrl|to_json }}
 	}
 }

--- a/roles/matrix-riot-web/templates/welcome.html.j2
+++ b/roles/matrix-riot-web/templates/welcome.html.j2
@@ -153,11 +153,11 @@ h1::after {
 </style>
 
 <div class="mx_Parent">
-    <a href="https://riot.im" target="_blank" rel="noopener">
-        <img src="welcome/images/logo.svg" alt="" class="mx_Logo"/>
+    <a href="{{ matrix_riot_web_welcome_logo_link }}" target="_blank" rel="noopener">
+        <img src="{{ matrix_riot_web_welcome_logo }}" alt="" class="mx_Logo"/>
     </a>
-    <h1 class="mx_Header_title">_t("Welcome to Riot.im")</h1>
-    <h4 class="mx_Header_subtitle">_t("Decentralised, encrypted chat &amp; collaboration powered by [matrix]")</h4>
+    <h1 class="mx_Header_title">{{ matrix_riot_web_welcome_headline }}</h1>
+    <h4 class="mx_Header_subtitle">{{ matrix_riot_web_welcome_text }}</h4>
     <div class="mx_ButtonGroup">
         <div class="mx_ButtonRow">
             <a href="#/login" class="mx_ButtonParent mx_ButtonSignIn mx_Button_iconSignIn">


### PR DESCRIPTION
Because we are starting using Matrix/Riot productive, I checked Riot-Web README for new configurations and found some I'm searching for some time time, because both logos on welcome page are handled different and wallpaper cannot changed.

Now customization of logo during login and wallpaper is also able to configure.

Pay attention: 
The way I choose will change default behavior of UI, because in past the second "Login Logo" cannot configured. 
Now it is set to same logo as on welcome startpage. So this logo maybe changed from riot logo to branding.
When default of "matrix_riot_web_welcome_authlogo" is set to "false", the old behavior will used.

About "matrix_riot_web_welcome_headline", this isn't always my preferred method to insert "_t(..)", too, but I think the translation cannot modified by config. So this can also overwritten.
