### PR TITLE
Update synapse-janitor to support current synapse database schema

### DIFF
--- a/roles/matrix-postgres/defaults/main.yml
+++ b/roles/matrix-postgres/defaults/main.yml
@@ -30,4 +30,4 @@ matrix_postgres_container_extra_arguments: []
 # Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:5432"), or empty string to not expose.
 matrix_postgres_container_postgres_bind_port: ""
 
-matrix_postgres_tool_synapse_janitor: "https://raw.githubusercontent.com/xwiki-labs/synapse_scripts/0b3f035951932ceb396631de3fc701043b9723bc/synapse_janitor.sql"
+matrix_postgres_tool_synapse_janitor: "https://raw.githubusercontent.com/xwiki-labs/synapse_scripts/a9188ff175ae581610f92d58ea6eac9a114d854b/synapse_janitor.sql"


### PR DESCRIPTION
Update synapse-janitor to reflect changes in synapse database schema.

Old version failed with the following error:
```
psql:/synapse_janitor.sql:91: NOTICE:  synapse_clean_unused_rooms() Cleaning up 22 unused rooms
psql:/synapse_janitor.sql:91: ERROR:  relation "topics" does not exist
LINE 1: DELETE FROM topics AS x WHERE x.room_id IN (SELECT y.room_id...
                    ^
QUERY:  DELETE FROM topics AS x WHERE x.room_id IN (SELECT y.room_id FROM synapse_clean_unused_rooms__tmp AS y)
CONTEXT:  PL/pgSQL function synapse_clean_unused_rooms() line 21 at SQL statement
```