### PR TITLE
Made directory variables for system files

### DIFF
--- a/roles/matrix-base/defaults/main.yml
+++ b/roles/matrix-base/defaults/main.yml
@@ -29,6 +29,9 @@ matrix_base_data_path: "/matrix"
 matrix_base_data_path_mode: "750"
 
 matrix_static_files_base_path: "{{ matrix_base_data_path }}/static-files"
+matrix_systemd_path: "/etc/systemd/system"
+matrix_cron_path: "/etc/cron.d"
+matrix_local_bin_path: "/usr/local/bin"
 
 matrix_homeserver_url: "https://{{ matrix_server_fqn_matrix }}"
 

--- a/roles/matrix-base/tasks/setup_matrix_base.yml
+++ b/roles/matrix-base/tasks/setup_matrix_base.yml
@@ -52,6 +52,6 @@
 - name: Ensure matrix-remove-all script created
   template:
     src: "{{ role_path }}/templates/usr-local-bin/matrix-remove-all.j2"
-    dest: "/usr/local/bin/matrix-remove-all"
+    dest: "{{ matrix_local_bin_path }}/matrix-remove-all"
     mode: 0750
 

--- a/roles/matrix-base/templates/usr-local-bin/matrix-remove-all.j2
+++ b/roles/matrix-base/templates/usr-local-bin/matrix-remove-all.j2
@@ -15,15 +15,15 @@ if [ "$sure" != "Yes, I really want to remove everything!" ]; then
 	exit 0
 else
 	echo "Stop and remove matrix services"
-	for s in $(find /etc/systemd/system/ -name "matrix-*" -printf "%f\n"); do
+	for s in $(find {{ matrix_systemd_path }}/ -name "matrix-*" -printf "%f\n"); do
 		systemctl stop $s
-		rm -f /etc/systemd/system/$s
+		rm -f {{ matrix_systemd_path }}/$s
 	done
 	systemctl daemon-reload
 	echo "Remove matrix cronjobs"
 	find /etc/cron.d/ -name "matrix-*" -delete
 	echo "Remove matrix scripts"
-	find /usr/local/bin/ -name "matrix-*" -delete
+	find {{ matrix_local_bin_path }}/ -name "matrix-*" -delete
 	echo "Remove every docker images"
 	docker rmi $(docker images -aq)
 	echo "Remove docker matrix network"

--- a/roles/matrix-bridge-appservice-discord/tasks/setup_install.yml
+++ b/roles/matrix-bridge-appservice-discord/tasks/setup_install.yml
@@ -72,7 +72,7 @@
 - name: Ensure matrix-appservice-discord.service installed
   template:
     src: "{{ role_path }}/templates/systemd/matrix-appservice-discord.service.j2"
-    dest: "/etc/systemd/system/matrix-appservice-discord.service"
+    dest: "{{ matrix_systemd_path }}/matrix-appservice-discord.service"
     mode: 0644
   register: matrix_appservice_discord_systemd_service_result
 

--- a/roles/matrix-bridge-appservice-discord/tasks/setup_uninstall.yml
+++ b/roles/matrix-bridge-appservice-discord/tasks/setup_uninstall.yml
@@ -2,7 +2,7 @@
 
 - name: Check existence of matrix-appservice-discord service
   stat:
-    path: "/etc/systemd/system/matrix-appservice-discord.service"
+    path: "{{ matrix_systemd_path }}/matrix-appservice-discord.service"
   register: matrix_appservice_discord_service_stat
 
 - name: Ensure matrix-appservice-discord is stopped
@@ -14,7 +14,7 @@
 
 - name: Ensure matrix-appservice-discord.service doesn't exist
   file:
-    path: "/etc/systemd/system/matrix-appservice-discord.service"
+    path: "{{ matrix_systemd_path }}/matrix-appservice-discord.service"
     state: absent
   when: "matrix_appservice_discord_service_stat.stat.exists"
 

--- a/roles/matrix-bridge-appservice-irc/tasks/setup_install.yml
+++ b/roles/matrix-bridge-appservice-irc/tasks/setup_install.yml
@@ -139,7 +139,7 @@
 - name: Ensure matrix-appservice-irc.service installed
   template:
     src: "{{ role_path }}/templates/systemd/matrix-appservice-irc.service.j2"
-    dest: "/etc/systemd/system/matrix-appservice-irc.service"
+    dest: "{{ matrix_systemd_path }}/matrix-appservice-irc.service"
     mode: 0644
   register: matrix_appservice_irc_systemd_service_result
 

--- a/roles/matrix-bridge-appservice-irc/tasks/setup_uninstall.yml
+++ b/roles/matrix-bridge-appservice-irc/tasks/setup_uninstall.yml
@@ -2,7 +2,7 @@
 
 - name: Check existence of matrix-appservice-irc service
   stat:
-    path: "/etc/systemd/system/matrix-appservice-irc.service"
+    path: "{{ matrix_systemd_path }}/matrix-appservice-irc.service"
   register: matrix_appservice_irc_service_stat
 
 - name: Ensure matrix-appservice-irc is stopped
@@ -14,7 +14,7 @@
 
 - name: Ensure matrix-appservice-irc.service doesn't exist
   file:
-    path: "/etc/systemd/system/matrix-appservice-irc.service"
+    path: "{{ matrix_systemd_path }}/matrix-appservice-irc.service"
     state: absent
   when: "matrix_appservice_irc_service_stat.stat.exists"
 

--- a/roles/matrix-bridge-appservice-slack/tasks/setup_install.yml
+++ b/roles/matrix-bridge-appservice-slack/tasks/setup_install.yml
@@ -38,7 +38,7 @@
 - name: Ensure matrix-appservice-slack.service installed
   template:
     src: "{{ role_path }}/templates/systemd/matrix-appservice-slack.service.j2"
-    dest: "/etc/systemd/system/matrix-appservice-slack.service"
+    dest: "{{ matrix_systemd_path }}/matrix-appservice-slack.service"
     mode: 0644
   register: matrix_appservice_slack_systemd_service_result
 

--- a/roles/matrix-bridge-appservice-slack/tasks/setup_uninstall.yml
+++ b/roles/matrix-bridge-appservice-slack/tasks/setup_uninstall.yml
@@ -2,7 +2,7 @@
 
 - name: Check existence of matrix-appservice-slack service
   stat:
-    path: "/etc/systemd/system/matrix-appservice-slack.service"
+    path: "{{ matrix_systemd_path }}/matrix-appservice-slack.service"
   register: matrix_appservice_slack_service_stat
 
 - name: Ensure matrix-appservice-slack is stopped
@@ -14,7 +14,7 @@
 
 - name: Ensure matrix-appservice-slack.service doesn't exist
   file:
-    path: "/etc/systemd/system/matrix-appservice-slack.service"
+    path: "{{ matrix_systemd_path }}/matrix-appservice-slack.service"
     state: absent
   when: "matrix_appservice_slack_service_stat.stat.exists"
 

--- a/roles/matrix-bridge-appservice-webhooks/tasks/setup_install.yml
+++ b/roles/matrix-bridge-appservice-webhooks/tasks/setup_install.yml
@@ -54,7 +54,7 @@
 - name: Ensure matrix-appservice-webhooks.service installed
   template:
     src: "{{ role_path }}/templates/systemd/matrix-appservice-webhooks.service.j2"
-    dest: "/etc/systemd/system/matrix-appservice-webhooks.service"
+    dest: "{{ matrix_systemd_path }}/matrix-appservice-webhooks.service"
     mode: 0644
   register: matrix_appservice_webhooks_systemd_service_result
 

--- a/roles/matrix-bridge-appservice-webhooks/tasks/setup_uninstall.yml
+++ b/roles/matrix-bridge-appservice-webhooks/tasks/setup_uninstall.yml
@@ -2,7 +2,7 @@
 
 - name: Check existence of matrix-appservice-webhooks service
   stat:
-    path: "/etc/systemd/system/matrix-appservice-webhooks.service"
+    path: "{{ matrix_systemd_path }}/matrix-appservice-webhooks.service"
   register: matrix_appservice_webhooks_service_stat
 
 - name: Ensure matrix-appservice-webhooks is stopped
@@ -14,7 +14,7 @@
 
 - name: Ensure matrix-appservice-webhooks.service doesn't exist
   file:
-    path: "/etc/systemd/system/matrix-appservice-webhooks.service"
+    path: "{{ matrix_systemd_path }}/matrix-appservice-webhooks.service"
     state: absent
   when: "matrix_appservice_webhooks_service_stat.stat.exists"
 

--- a/roles/matrix-bridge-mautrix-facebook/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mautrix-facebook/tasks/setup_install.yml
@@ -84,7 +84,7 @@
 - name: Ensure matrix-mautrix-facebook.service installed
   template:
     src: "{{ role_path }}/templates/systemd/matrix-mautrix-facebook.service.j2"
-    dest: "/etc/systemd/system/matrix-mautrix-facebook.service"
+    dest: "{{ matrix_systemd_path }}/matrix-mautrix-facebook.service"
     mode: 0644
   register: matrix_mautrix_facebook_systemd_service_result
 

--- a/roles/matrix-bridge-mautrix-facebook/tasks/setup_uninstall.yml
+++ b/roles/matrix-bridge-mautrix-facebook/tasks/setup_uninstall.yml
@@ -2,7 +2,7 @@
 
 - name: Check existence of matrix-mautrix-facebook service
   stat:
-    path: "/etc/systemd/system/matrix-mautrix-facebook.service"
+    path: "{{ matrix_systemd_path }}/matrix-mautrix-facebook.service"
   register: matrix_mautrix_facebook_service_stat
 
 - name: Ensure matrix-mautrix-facebook is stopped
@@ -14,7 +14,7 @@
 
 - name: Ensure matrix-mautrix-facebook.service doesn't exist
   file:
-    path: "/etc/systemd/system/matrix-mautrix-facebook.service"
+    path: "{{ matrix_systemd_path }}/matrix-mautrix-facebook.service"
     state: absent
   when: "matrix_mautrix_facebook_service_stat.stat.exists"
 

--- a/roles/matrix-bridge-mautrix-hangouts/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mautrix-hangouts/tasks/setup_install.yml
@@ -83,7 +83,7 @@
 - name: Ensure matrix-mautrix-hangouts.service installed
   template:
     src: "{{ role_path }}/templates/systemd/matrix-mautrix-hangouts.service.j2"
-    dest: "/etc/systemd/system/matrix-mautrix-hangouts.service"
+    dest: "{{ matrix_systemd_path }}/matrix-mautrix-hangouts.service"
     mode: 0644
   register: matrix_mautrix_hangouts_systemd_service_result
 

--- a/roles/matrix-bridge-mautrix-hangouts/tasks/setup_uninstall.yml
+++ b/roles/matrix-bridge-mautrix-hangouts/tasks/setup_uninstall.yml
@@ -2,7 +2,7 @@
 
 - name: Check existence of matrix-mautrix-hangouts service
   stat:
-    path: "/etc/systemd/system/matrix-mautrix-hangouts.service"
+    path: "{{ matrix_systemd_path }}/matrix-mautrix-hangouts.service"
   register: matrix_mautrix_hangouts_service_stat
 
 - name: Ensure matrix-mautrix-hangouts is stopped
@@ -14,7 +14,7 @@
 
 - name: Ensure matrix-mautrix-hangouts.service doesn't exist
   file:
-    path: "/etc/systemd/system/matrix-mautrix-hangouts.service"
+    path: "{{ matrix_systemd_path }}/matrix-mautrix-hangouts.service"
     state: absent
   when: "matrix_mautrix_hangouts_service_stat.stat.exists"
 

--- a/roles/matrix-bridge-mautrix-telegram/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mautrix-telegram/tasks/setup_install.yml
@@ -63,7 +63,7 @@
 - name: Ensure matrix-mautrix-telegram.service installed
   template:
     src: "{{ role_path }}/templates/systemd/matrix-mautrix-telegram.service.j2"
-    dest: "/etc/systemd/system/matrix-mautrix-telegram.service"
+    dest: "{{ matrix_systemd_path }}/matrix-mautrix-telegram.service"
     mode: 0644
   register: matrix_mautrix_telegram_systemd_service_result
 

--- a/roles/matrix-bridge-mautrix-telegram/tasks/setup_uninstall.yml
+++ b/roles/matrix-bridge-mautrix-telegram/tasks/setup_uninstall.yml
@@ -2,7 +2,7 @@
 
 - name: Check existence of matrix-mautrix-telegram service
   stat:
-    path: "/etc/systemd/system/matrix-mautrix-telegram.service"
+    path: "{{ matrix_systemd_path }}/matrix-mautrix-telegram.service"
   register: matrix_mautrix_telegram_service_stat
 
 - name: Ensure matrix-mautrix-telegram is stopped
@@ -14,7 +14,7 @@
 
 - name: Ensure matrix-mautrix-telegram.service doesn't exist
   file:
-    path: "/etc/systemd/system/matrix-mautrix-telegram.service"
+    path: "{{ matrix_systemd_path }}/matrix-mautrix-telegram.service"
     state: absent
   when: "matrix_mautrix_telegram_service_stat.stat.exists"
 

--- a/roles/matrix-bridge-mautrix-whatsapp/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mautrix-whatsapp/tasks/setup_install.yml
@@ -72,7 +72,7 @@
 - name: Ensure matrix-mautrix-whatsapp.service installed
   template:
     src: "{{ role_path }}/templates/systemd/matrix-mautrix-whatsapp.service.j2"
-    dest: "/etc/systemd/system/matrix-mautrix-whatsapp.service"
+    dest: "{{ matrix_systemd_path }}/matrix-mautrix-whatsapp.service"
     mode: 0644
   register: matrix_mautrix_whatsapp_systemd_service_result
 

--- a/roles/matrix-bridge-mautrix-whatsapp/tasks/setup_uninstall.yml
+++ b/roles/matrix-bridge-mautrix-whatsapp/tasks/setup_uninstall.yml
@@ -2,7 +2,7 @@
 
 - name: Check existence of matrix-mautrix-whatsapp service
   stat:
-    path: "/etc/systemd/system/matrix-mautrix-whatsapp.service"
+    path: "{{ matrix_systemd_path }}/matrix-mautrix-whatsapp.service"
   register: matrix_mautrix_whatsapp_service_stat
 
 - name: Ensure matrix-mautrix-whatsapp is stopped
@@ -14,7 +14,7 @@
 
 - name: Ensure matrix-mautrix-whatsapp.service doesn't exist
   file:
-    path: "/etc/systemd/system/matrix-mautrix-whatsapp.service"
+    path: "{{ matrix_systemd_path }}/matrix-mautrix-whatsapp.service"
     state: absent
   when: "matrix_mautrix_whatsapp_service_stat.stat.exists"
 

--- a/roles/matrix-corporal/tasks/setup_corporal.yml
+++ b/roles/matrix-corporal/tasks/setup_corporal.yml
@@ -37,7 +37,7 @@
 - name: Ensure matrix-corporal.service installed
   template:
     src: "{{ role_path }}/templates/systemd/matrix-corporal.service.j2"
-    dest: "/etc/systemd/system/matrix-corporal.service"
+    dest: "{{ matrix_systemd_path }}/matrix-corporal.service"
     mode: 0644
   register: matrix_corporal_systemd_service_result
   when: matrix_corporal_enabled|bool
@@ -54,7 +54,7 @@
 
 - name: Check existence of matrix-corporal service
   stat:
-    path: "/etc/systemd/system/matrix-corporal.service"
+    path: "{{ matrix_systemd_path }}/matrix-corporal.service"
   register: matrix_corporal_service_stat
   when: "not matrix_corporal_enabled|bool"
 
@@ -68,7 +68,7 @@
 
 - name: Ensure matrix-corporal.service doesn't exist
   file:
-    path: "/etc/systemd/system/matrix-corporal.service"
+    path: "{{ matrix_systemd_path }}/matrix-corporal.service"
     state: absent
   when: "not matrix_corporal_enabled|bool and matrix_corporal_service_stat.stat.exists"
 
@@ -82,7 +82,7 @@
     path: "{{ item }}"
     state: absent
   with_items:
-    - /etc/systemd/system/matrix-corporal.service
+    - "{{ matrix_systemd_path }}/matrix-corporal.service"
     - "{{ matrix_corporal_config_dir_path }}/config.json"
   when: "not matrix_corporal_enabled|bool"
 

--- a/roles/matrix-coturn/tasks/setup_coturn.yml
+++ b/roles/matrix-coturn/tasks/setup_coturn.yml
@@ -77,7 +77,7 @@
 - name: Ensure matrix-coturn.service installed
   template:
     src: "{{ role_path }}/templates/systemd/matrix-coturn.service.j2"
-    dest: "/etc/systemd/system/matrix-coturn.service"
+    dest: "{{ matrix_systemd_path }}/matrix-coturn.service"
     mode: 0644
   register: matrix_coturn_systemd_service_result
   when: matrix_coturn_enabled|bool
@@ -116,7 +116,7 @@
 
 - name: Check existence of matrix-coturn service
   stat:
-    path: "/etc/systemd/system/matrix-coturn.service"
+    path: "{{ matrix_systemd_path }}/matrix-coturn.service"
   register: matrix_coturn_service_stat
   when: "not matrix_coturn_enabled|bool"
 
@@ -130,7 +130,7 @@
 
 - name: Ensure matrix-coturn.service doesn't exist
   file:
-    path: "/etc/systemd/system/matrix-coturn.service"
+    path: "{{ matrix_systemd_path }}/matrix-coturn.service"
     state: absent
   when: "not matrix_coturn_enabled|bool and matrix_coturn_service_stat.stat.exists"
 

--- a/roles/matrix-dimension/tasks/setup_dimension.yml
+++ b/roles/matrix-dimension/tasks/setup_dimension.yml
@@ -33,7 +33,7 @@
 - name: Ensure matrix-dimension.service installed
   template:
     src: "{{ role_path }}/templates/systemd/matrix-dimension.service.j2"
-    dest: "/etc/systemd/system/matrix-dimension.service"
+    dest: "{{ matrix_systemd_path }}/matrix-dimension.service"
     mode: 0644
   register: matrix_dimension_systemd_service_result
   when: matrix_dimension_enabled|bool
@@ -49,7 +49,7 @@
 
 - name: Check existence of matrix-dimension service
   stat:
-    path: "/etc/systemd/system/matrix-dimension.service"
+    path: "{{ matrix_systemd_path }}/matrix-dimension.service"
   register: matrix_dimension_service_stat
   when: "not matrix_dimension_enabled|bool"
 
@@ -63,7 +63,7 @@
 
 - name: Ensure matrix-dimension.service doesn't exist
   file:
-    path: "/etc/systemd/system/matrix-dimension.service"
+    path: "{{ matrix_systemd_path }}/matrix-dimension.service"
     state: absent
   when: "not matrix_dimension_enabled|bool and matrix_dimension_service_stat.stat.exists"
 

--- a/roles/matrix-email2matrix/tasks/setup_email2matrix.yml
+++ b/roles/matrix-email2matrix/tasks/setup_email2matrix.yml
@@ -36,7 +36,7 @@
 - name: Ensure matrix-email2matrix.service installed
   template:
     src: "{{ role_path }}/templates/systemd/matrix-email2matrix.service.j2"
-    dest: "/etc/systemd/system/matrix-email2matrix.service"
+    dest: "{{ matrix_systemd_path }}/matrix-email2matrix.service"
     mode: 0644
   register: matrix_email2matrix_systemd_service_result
   when: matrix_email2matrix_enabled|bool
@@ -52,7 +52,7 @@
 
 - name: Check existence of matrix-email2matrix service
   stat:
-    path: "/etc/systemd/system/matrix-email2matrix.service"
+    path: "{{ matrix_systemd_path }}/matrix-email2matrix.service"
   register: matrix_email2matrix_service_stat
   when: "not matrix_email2matrix_enabled|bool"
 
@@ -66,7 +66,7 @@
 
 - name: Ensure matrix-email2matrix.service doesn't exist
   file:
-    path: "/etc/systemd/system/matrix-email2matrix.service"
+    path: "{{ matrix_systemd_path }}/matrix-email2matrix.service"
     state: absent
   when: "not matrix_email2matrix_enabled|bool and matrix_email2matrix_service_stat.stat.exists"
 

--- a/roles/matrix-jitsi/tasks/setup_jitsi_jicofo.yml
+++ b/roles/matrix-jitsi/tasks/setup_jitsi_jicofo.yml
@@ -44,7 +44,7 @@
 - name: Ensure matrix-jitsi-jicofo.service installed
   template:
     src: "{{ role_path }}/templates/jicofo/matrix-jitsi-jicofo.service.j2"
-    dest: "/etc/systemd/system/matrix-jitsi-jicofo.service"
+    dest: "{{ matrix_systemd_path }}/matrix-jitsi-jicofo.service"
     mode: 0644
   register: matrix_jitsi_jicofo_systemd_service_result
   when: matrix_jitsi_enabled|bool
@@ -60,7 +60,7 @@
 
 - name: Check existence of matrix-jitsi-jicofo service
   stat:
-    path: "/etc/systemd/system/matrix-jitsi-jicofo.service"
+    path: "{{ matrix_systemd_path }}/matrix-jitsi-jicofo.service"
   register: matrix_jitsi_jicofo_service_stat
   when: "not matrix_jitsi_enabled|bool"
 
@@ -74,7 +74,7 @@
 
 - name: Ensure matrix-jitsi-jicofo.service doesn't exist
   file:
-    path: "/etc/systemd/system/matrix-jitsi-jicofo.service"
+    path: "{{ matrix_systemd_path }}/matrix-jitsi-jicofo.service"
     state: absent
   when: "not matrix_jitsi_enabled|bool and matrix_jitsi_jicofo_service_stat.stat.exists"
 

--- a/roles/matrix-jitsi/tasks/setup_jitsi_jvb.yml
+++ b/roles/matrix-jitsi/tasks/setup_jitsi_jvb.yml
@@ -37,7 +37,7 @@
 - name: Ensure matrix-jitsi-jvb.service installed
   template:
     src: "{{ role_path }}/templates/jvb/matrix-jitsi-jvb.service.j2"
-    dest: "/etc/systemd/system/matrix-jitsi-jvb.service"
+    dest: "{{ matrix_systemd_path }}/matrix-jitsi-jvb.service"
     mode: 0644
   register: matrix_jitsi_jvb_systemd_service_result
   when: matrix_jitsi_enabled|bool
@@ -53,7 +53,7 @@
 
 - name: Check existence of matrix-jitsi-jvb service
   stat:
-    path: "/etc/systemd/system/matrix-jitsi-jvb.service"
+    path: "{{ matrix_systemd_path }}/matrix-jitsi-jvb.service"
   register: matrix_jitsi_jvb_service_stat
   when: "not matrix_jitsi_enabled|bool"
 
@@ -67,7 +67,7 @@
 
 - name: Ensure matrix-jitsi-jvb.service doesn't exist
   file:
-    path: "/etc/systemd/system/matrix-jitsi-jvb.service"
+    path: "{{ matrix_systemd_path }}/matrix-jitsi-jvb.service"
     state: absent
   when: "not matrix_jitsi_enabled|bool and matrix_jitsi_jvb_service_stat.stat.exists"
 

--- a/roles/matrix-jitsi/tasks/setup_jitsi_prosody.yml
+++ b/roles/matrix-jitsi/tasks/setup_jitsi_prosody.yml
@@ -34,7 +34,7 @@
 - name: Ensure matrix-jitsi-prosody.service installed
   template:
     src: "{{ role_path }}/templates/prosody/matrix-jitsi-prosody.service.j2"
-    dest: "/etc/systemd/system/matrix-jitsi-prosody.service"
+    dest: "{{ matrix_systemd_path }}/matrix-jitsi-prosody.service"
     mode: 0644
   register: matrix_jitsi_prosody_systemd_service_result
   when: matrix_jitsi_enabled|bool
@@ -50,7 +50,7 @@
 
 - name: Check existence of matrix-jitsi-prosody service
   stat:
-    path: "/etc/systemd/system/matrix-jitsi-prosody.service"
+    path: "{{ matrix_systemd_path }}/matrix-jitsi-prosody.service"
   register: matrix_jitsi_prosody_service_stat
   when: "not matrix_jitsi_enabled|bool"
 
@@ -64,7 +64,7 @@
 
 - name: Ensure matrix-jitsi-prosody.service doesn't exist
   file:
-    path: "/etc/systemd/system/matrix-jitsi-prosody.service"
+    path: "{{ matrix_systemd_path }}/matrix-jitsi-prosody.service"
     state: absent
   when: "not matrix_jitsi_enabled|bool and matrix_jitsi_prosody_service_stat.stat.exists"
 

--- a/roles/matrix-jitsi/tasks/setup_jitsi_web.yml
+++ b/roles/matrix-jitsi/tasks/setup_jitsi_web.yml
@@ -45,7 +45,7 @@
 - name: Ensure matrix-jitsi-web.service installed
   template:
     src: "{{ role_path }}/templates/web/matrix-jitsi-web.service.j2"
-    dest: "/etc/systemd/system/matrix-jitsi-web.service"
+    dest: "{{ matrix_systemd_path }}/matrix-jitsi-web.service"
     mode: 0644
   register: matrix_jitsi_web_systemd_service_result
   when: matrix_jitsi_enabled|bool
@@ -61,7 +61,7 @@
 
 - name: Check existence of matrix-jitsi-web service
   stat:
-    path: "/etc/systemd/system/matrix-jitsi-web.service"
+    path: "{{ matrix_systemd_path }}/matrix-jitsi-web.service"
   register: matrix_jitsi_web_service_stat
   when: "not matrix_jitsi_enabled|bool"
 
@@ -75,7 +75,7 @@
 
 - name: Ensure matrix-jitsi-web.service doesn't exist
   file:
-    path: "/etc/systemd/system/matrix-jitsi-web.service"
+    path: "{{ matrix_systemd_path }}/matrix-jitsi-web.service"
     state: absent
   when: "not matrix_jitsi_enabled|bool and matrix_jitsi_web_service_stat.stat.exists"
 

--- a/roles/matrix-mailer/tasks/setup_mailer.yml
+++ b/roles/matrix-mailer/tasks/setup_mailer.yml
@@ -31,7 +31,7 @@
 - name: Ensure matrix-mailer.service installed
   template:
     src: "{{ role_path }}/templates/systemd/matrix-mailer.service.j2"
-    dest: "/etc/systemd/system/matrix-mailer.service"
+    dest: "{{ matrix_systemd_path }}/matrix-mailer.service"
     mode: 0644
   register: matrix_mailer_systemd_service_result
   when: matrix_mailer_enabled|bool
@@ -47,7 +47,7 @@
 
 - name: Check existence of matrix-mailer service
   stat:
-    path: "/etc/systemd/system/matrix-mailer.service"
+    path: "{{ matrix_systemd_path }}/matrix-mailer.service"
   register: matrix_mailer_service_stat
   when: "not matrix_mailer_enabled|bool"
 
@@ -61,7 +61,7 @@
 
 - name: Ensure matrix-mailer.service doesn't exist
   file:
-    path: "/etc/systemd/system/matrix-mailer.service"
+    path: "{{ matrix_systemd_path }}/matrix-mailer.service"
     state: absent
   when: "not matrix_mailer_enabled|bool and matrix_mailer_service_stat.stat.exists"
 

--- a/roles/matrix-mxisd/tasks/setup_mxisd.yml
+++ b/roles/matrix-mxisd/tasks/setup_mxisd.yml
@@ -78,7 +78,7 @@
 - name: Ensure matrix-mxisd.service installed
   template:
     src: "{{ role_path }}/templates/systemd/matrix-mxisd.service.j2"
-    dest: "/etc/systemd/system/matrix-mxisd.service"
+    dest: "{{ matrix_systemd_path }}/matrix-mxisd.service"
     mode: 0644
   register: matrix_mxisd_systemd_service_result
   when: matrix_mxisd_enabled|bool
@@ -94,7 +94,7 @@
 
 - name: Check existence of matrix-mxisd service
   stat:
-    path: "/etc/systemd/system/matrix-mxisd.service"
+    path: "{{ matrix_systemd_path }}/matrix-mxisd.service"
   register: matrix_mxisd_service_stat
 
 - name: Ensure matrix-mxisd is stopped
@@ -107,7 +107,7 @@
 
 - name: Ensure matrix-mxisd.service doesn't exist
   file:
-    path: "/etc/systemd/system/matrix-mxisd.service"
+    path: "{{ matrix_systemd_path }}/matrix-mxisd.service"
     state: absent
   when: "not matrix_mxisd_enabled|bool and matrix_mxisd_service_stat.stat.exists"
 

--- a/roles/matrix-nginx-proxy/tasks/setup_nginx_proxy.yml
+++ b/roles/matrix-nginx-proxy/tasks/setup_nginx_proxy.yml
@@ -112,7 +112,7 @@
 - name: Ensure matrix-nginx-proxy.service installed
   template:
     src: "{{ role_path }}/templates/systemd/matrix-nginx-proxy.service.j2"
-    dest: "/etc/systemd/system/matrix-nginx-proxy.service"
+    dest: "{{ matrix_systemd_path }}/matrix-nginx-proxy.service"
     mode: 0644
   register: matrix_nginx_proxy_systemd_service_result
   when: matrix_nginx_proxy_enabled|bool
@@ -129,7 +129,7 @@
 
 - name: Check existence of matrix-nginx-proxy service
   stat:
-    path: "/etc/systemd/system/matrix-nginx-proxy.service"
+    path: "{{ matrix_systemd_path }}/matrix-nginx-proxy.service"
   register: matrix_nginx_proxy_service_stat
   when: "not matrix_nginx_proxy_enabled|bool"
 
@@ -143,7 +143,7 @@
 
 - name: Ensure matrix-nginx-proxy.service doesn't exist
   file:
-    path: "/etc/systemd/system/matrix-nginx-proxy.service"
+    path: "{{ matrix_systemd_path }}/matrix-nginx-proxy.service"
     state: absent
   when: "not matrix_nginx_proxy_enabled|bool and matrix_nginx_proxy_service_stat.stat.exists"
 

--- a/roles/matrix-nginx-proxy/tasks/ssl/setup_ssl_lets_encrypt.yml
+++ b/roles/matrix-nginx-proxy/tasks/ssl/setup_ssl_lets_encrypt.yml
@@ -7,9 +7,9 @@
     path: "{{ item }}"
     state: absent
   with_items:
-    - /usr/local/bin/matrix-ssl-certificates-renew
-    - /etc/cron.d/matrix-ssl-certificate-renewal
-    - /etc/cron.d/matrix-nginx-proxy-periodic-restarter
+    - "{{ matrix_local_bin_path }}/matrix-ssl-certificates-renew"
+    - "{{ matrix_cron_path }}/matrix-ssl-certificate-renewal"
+    - "{{ matrix_cron_path }}/matrix-nginx-proxy-periodic-restarter"
 
 
 #
@@ -51,7 +51,7 @@
 - name: Ensure Let's Encrypt SSL renewal script installed
   template:
     src: "{{ role_path }}/templates/usr-local-bin/matrix-ssl-lets-encrypt-certificates-renew.j2"
-    dest: /usr/local/bin/matrix-ssl-lets-encrypt-certificates-renew
+    dest: "{{ matrix_local_bin_path }}/matrix-ssl-lets-encrypt-certificates-renew"
     mode: 0750
   when: "matrix_ssl_retrieval_method == 'lets-encrypt'"
 
@@ -73,7 +73,7 @@
       hour: "4"
       minute: "15"
       day: "*"
-      job: /usr/local/bin/matrix-ssl-lets-encrypt-certificates-renew
+      job: "{{ matrix_local_bin_path }}/matrix-ssl-lets-encrypt-certificates-renew"
 
   - name: Ensure periodic reloading of matrix-nginx-proxy is configured for SSL renewal (matrix-nginx-proxy-reload)
     cron:
@@ -113,6 +113,6 @@
 
 - name: Ensure Let's Encrypt SSL renewal script removed
   file:
-    path: /usr/local/bin/matrix-ssl-lets-encrypt-certificates-renew
+    path: "{{ matrix_local_bin_path }}/matrix-ssl-lets-encrypt-certificates-renew"
     state: absent
   when: "matrix_ssl_retrieval_method != 'lets-encrypt'"

--- a/roles/matrix-postgres/tasks/migrate_postgres_data_directory.yml
+++ b/roles/matrix-postgres/tasks/migrate_postgres_data_directory.yml
@@ -62,7 +62,7 @@
 
 - name: Ensure outdated matrix-postgres.service doesn't exist
   file:
-    path: "/etc/systemd/system/matrix-postgres.service"
+    path: "{{ matrix_systemd_path }}/matrix-postgres.service"
     state: absent
   when: "result_pg_old_data_dir_stat.stat.exists"
 

--- a/roles/matrix-postgres/tasks/setup_postgres.yml
+++ b/roles/matrix-postgres/tasks/setup_postgres.yml
@@ -69,34 +69,34 @@
 - name: Ensure matrix-postgres-cli script created
   template:
     src: "{{ role_path }}/templates/usr-local-bin/matrix-postgres-cli.j2"
-    dest: "/usr/local/bin/matrix-postgres-cli"
+    dest: "{{ matrix_local_bin_path }}/matrix-postgres-cli"
     mode: 0750
   when: matrix_postgres_enabled|bool
 
 - name: Ensure matrix-change-user-admin-status script created
   template:
     src: "{{ role_path }}/templates/usr-local-bin/matrix-change-user-admin-status.j2"
-    dest: "/usr/local/bin/matrix-change-user-admin-status"
+    dest: "{{ matrix_local_bin_path }}/matrix-change-user-admin-status"
     mode: 0750
   when: matrix_postgres_enabled|bool
 
 - name: (Migration) Ensure old matrix-make-user-admin script deleted
   file:
-    path: "/usr/local/bin/matrix-make-user-admin"
+    path: "{{ matrix_local_bin_path }}/matrix-make-user-admin"
     state: absent
   when: matrix_postgres_enabled|bool
 
 - name: Ensure matrix-postgres-update-user-password-hash script created
   template:
     src: "{{ role_path }}/templates/usr-local-bin/matrix-postgres-update-user-password-hash.j2"
-    dest: "/usr/local/bin/matrix-postgres-update-user-password-hash"
+    dest: "{{ matrix_local_bin_path }}/matrix-postgres-update-user-password-hash"
     mode: 0750
   when: matrix_postgres_enabled|bool
 
 - name: Ensure matrix-postgres.service installed
   template:
     src: "{{ role_path }}/templates/systemd/matrix-postgres.service.j2"
-    dest: "/etc/systemd/system/matrix-postgres.service"
+    dest: "{{ matrix_systemd_path }}/matrix-postgres.service"
     mode: 0644
   register: matrix_postgres_systemd_service_result
   when: matrix_postgres_enabled|bool
@@ -112,7 +112,7 @@
 
 - name: Check existence of matrix-postgres service
   stat:
-    path: "/etc/systemd/system/matrix-postgres.service"
+    path: "{{ matrix_systemd_path }}/matrix-postgres.service"
   register: matrix_postgres_service_stat
   when: "not matrix_postgres_enabled|bool"
 
@@ -125,7 +125,7 @@
 
 - name: Ensure matrix-postgres.service doesn't exist
   file:
-    path: "/etc/systemd/system/matrix-postgres.service"
+    path: "{{ matrix_systemd_path }}/matrix-postgres.service"
     state: absent
   when: "not matrix_postgres_enabled|bool and matrix_postgres_service_stat.stat.exists"
 
@@ -148,7 +148,7 @@
 
 - name: Remove Postgres scripts
   file:
-    path: "/usr/local/bin/{{ item }}"
+    path: "{{ matrix_local_bin_path }}/{{ item }}"
     state: absent
   with_items:
     - matrix-postgres-cli

--- a/roles/matrix-riot-web/tasks/setup_riot_web.yml
+++ b/roles/matrix-riot-web/tasks/setup_riot_web.yml
@@ -75,7 +75,7 @@
 - name: Ensure matrix-riot-web.service installed
   template:
     src: "{{ role_path }}/templates/systemd/matrix-riot-web.service.j2"
-    dest: "/etc/systemd/system/matrix-riot-web.service"
+    dest: "{{ matrix_systemd_path }}/matrix-riot-web.service"
     mode: 0644
   register: matrix_riot_web_systemd_service_result
   when: matrix_riot_web_enabled|bool
@@ -91,7 +91,7 @@
 
 - name: Check existence of matrix-riot-web service
   stat:
-    path: "/etc/systemd/system/matrix-riot-web.service"
+    path: "{{ matrix_systemd_path }}/matrix-riot-web.service"
   register: matrix_riot_web_service_stat
   when: "not matrix_riot_web_enabled|bool"
 
@@ -105,7 +105,7 @@
 
 - name: Ensure matrix-riot-web.service doesn't exist
   file:
-    path: "/etc/systemd/system/matrix-riot-web.service"
+    path: "{{ matrix_systemd_path }}/matrix-riot-web.service"
     state: absent
   when: "not matrix_riot_web_enabled|bool and matrix_riot_web_service_stat.stat.exists"
 

--- a/roles/matrix-synapse/tasks/goofys/setup_install.yml
+++ b/roles/matrix-synapse/tasks/goofys/setup_install.yml
@@ -31,7 +31,7 @@
 - name: Ensure matrix-goofys.service installed
   template:
     src: "{{ role_path }}/templates/goofys/systemd/matrix-goofys.service.j2"
-    dest: "/etc/systemd/system/matrix-goofys.service"
+    dest: "{{ matrix_systemd_path }}/matrix-goofys.service"
     mode: 0644
   register: matrix_goofys_systemd_service_result
 

--- a/roles/matrix-synapse/tasks/goofys/setup_uninstall.yml
+++ b/roles/matrix-synapse/tasks/goofys/setup_uninstall.yml
@@ -1,6 +1,6 @@
 - name: Check existence of matrix-goofys service
   stat:
-    path: "/etc/systemd/system/matrix-goofys.service"
+    path: "{{ matrix_systemd_path }}/matrix-goofys.service"
   register: matrix_goofys_service_stat
 
 - name: Ensure matrix-goofys is stopped
@@ -13,7 +13,7 @@
 
 - name: Ensure matrix-goofys.service doesn't exist
   file:
-    path: "/etc/systemd/system/matrix-goofys.service"
+    path: "{{ matrix_systemd_path }}/matrix-goofys.service"
     state: absent
   when: "matrix_goofys_service_stat.stat.exists"
 

--- a/roles/matrix-synapse/tasks/register_user.yml
+++ b/roles/matrix-synapse/tasks/register_user.yml
@@ -28,4 +28,4 @@
   when: "start_result.changed"
 
 - name: Register user
-  shell: "/usr/local/bin/matrix-synapse-register-user {{ username }} {{ password }} {{ '1' if admin == 'yes' else '0' }}"
+  shell: "{{ matrix_local_bin_path }}/matrix-synapse-register-user {{ username }} {{ password }} {{ '1' if admin == 'yes' else '0' }}"

--- a/roles/matrix-synapse/tasks/synapse/setup_install.yml
+++ b/roles/matrix-synapse/tasks/synapse/setup_install.yml
@@ -90,7 +90,7 @@
 - name: Ensure matrix-synapse.service installed
   template:
     src: "{{ role_path }}/templates/synapse/systemd/matrix-synapse.service.j2"
-    dest: "/etc/systemd/system/matrix-synapse.service"
+    dest: "{{ matrix_systemd_path }}/matrix-synapse.service"
     mode: 0644
   register: matrix_synapse_systemd_service_result
 
@@ -102,5 +102,5 @@
 - name: Ensure matrix-synapse-register-user script created
   template:
     src: "{{ role_path }}/templates/synapse/usr-local-bin/matrix-synapse-register-user.j2"
-    dest: "/usr/local/bin/matrix-synapse-register-user"
+    dest: "{{ matrix_local_bin_path }}/matrix-synapse-register-user"
     mode: 0750

--- a/roles/matrix-synapse/tasks/synapse/setup_uninstall.yml
+++ b/roles/matrix-synapse/tasks/synapse/setup_uninstall.yml
@@ -1,6 +1,6 @@
 - name: Check existence of matrix-synapse service
   stat:
-    path: "/etc/systemd/system/matrix-synapse.service"
+    path: "{{ matrix_systemd_path }}/matrix-synapse.service"
   register: matrix_synapse_service_stat
 
 - name: Ensure matrix-synapse is stopped
@@ -13,7 +13,7 @@
 
 - name: Ensure matrix-synapse.service doesn't exist
   file:
-    path: "/etc/systemd/system/matrix-synapse.service"
+    path: "{{ matrix_systemd_path }}/matrix-synapse.service"
     state: absent
   when: "matrix_synapse_service_stat.stat.exists"
 

--- a/roles/matrix-synapse/tasks/update_user_password.yml
+++ b/roles/matrix-synapse/tasks/update_user_password.yml
@@ -45,4 +45,4 @@
   register: password_hash
 
 - name: Update user password hash
-  shell: "/usr/local/bin/matrix-postgres-update-user-password-hash {{ username }} '{{ password_hash.stdout }}'"
+  shell: "{{ matrix_local_bin_path }}/matrix-postgres-update-user-password-hash {{ username }} '{{ password_hash.stdout }}'"


### PR DESCRIPTION
Wrap system paths in vars:

matrix_systemd_path: "/etc/systemd/system"
matrix_cron_path: "/etc/cron.d"
matrix_local_bin_path: "/usr/local/bin"

which can then be overridden in inventory/host_vars if you want to use some other container management system.  This helps with #64 

N.B. These paths must already exist on your system.  Tasks can certainly be added to the playbook to ensure they exist, but I wanted to make the minimum change first. 