### PR TITLE
Flip around Jitsi port format to match other ports

### DIFF
--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -13,8 +13,8 @@ Before installing Jitsi, make sure you've created the `jitsi.DOMAIN` DNS record.
 
 You may also need to open the following ports to your server:
 
-- `udp/10000` - RTP media over UDP
-- `tcp/4443` - RTP media fallback over TCP
+- `10000/udp` - RTP media over UDP
+- `4443/tcp` - RTP media fallback over TCP
 
 
 ## Installation


### PR DESCRIPTION
This matches the way the ports are written in prerequisites.md and is the format that UFW likes.