### PR TITLE
add missing jitsi auth URL conditional

### DIFF
--- a/roles/matrix-jitsi/templates/jicofo/sip-communicator.properties.j2
+++ b/roles/matrix-jitsi/templates/jicofo/sip-communicator.properties.j2
@@ -3,3 +3,7 @@ org.jitsi.jicofo.BRIDGE_MUC={{ matrix_jitsi_jvb_brewery_muc }}@{{ matrix_jitsi_x
 
 org.jitsi.jicofo.jibri.BREWERY={{ matrix_jitsi_jibri_brewery_muc }}@{{ matrix_jitsi_xmpp_internal_muc_domain }}
 org.jitsi.jicofo.jibri.PENDING_TIMEOUT=90
+
+{% if matrix_jitsi_enable_auth %}
+org.jitsi.jicofo.auth.URL=XMPP:{{ matrix_jitsi_xmpp_domain }}
+{% endif %}

--- a/roles/matrix-jitsi/templates/web/config.js.j2
+++ b/roles/matrix-jitsi/templates/web/config.js.j2
@@ -21,7 +21,7 @@ var config = {
         {% if matrix_jitsi_enable_auth %}
         {% if matrix_jitsi_enable_guests %}
         // When using authentication, domain for guest users.
-		anonymousdomain: '{{ matrix_jitsi_xmpp_guest_domain }}',
+        anonymousdomain: '{{ matrix_jitsi_xmpp_guest_domain }}',
         {% endif %}
 
         // Domain for authenticated users. Defaults to <domain>.


### PR DESCRIPTION
While double checking on the `internal` authentication in [docker-jitsi-meet](https://github.com/jitsi/docker-jitsi-meet) I noticed a missing conditional, that this PR adds.

For reference, see [sip-communicator.properties](https://github.com/jitsi/docker-jitsi-meet/blob/7c0c795fa7d29d04248ec6201ef7b879f4dc537f/jicofo/rootfs/defaults/sip-communicator.properties#L13-L15) in that repo.