### PR TITLE
Facebook self build

### DIFF
--- a/roles/matrix-bridge-mautrix-facebook/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mautrix-facebook/tasks/setup_install.yml
@@ -36,17 +36,19 @@
     dest: "{{ matrix_mautrix_facebook_docker_src_files_path }}"
 #    version: "{{ matrix_coturn_docker_image.split(':')[1] }}"
     force: "yes"
+  register: matrix_mautrix_facebook_git_pull_results
   when: "matrix_mautrix_facebook_enabled|bool and matrix_mautrix_facebook_container_image_self_build"
 
 - name: Ensure Mautrix Facebook Docker image is built
   docker_image:
     name: "{{ matrix_mautrix_facebook_docker_image }}"
     source: build
+    force_source: yes
     build:
       dockerfile: Dockerfile
       path: "{{ matrix_mautrix_facebook_docker_src_files_path }}"
       pull: yes
-  when: "matrix_mautrix_facebook_enabled|bool and matrix_mautrix_facebook_container_image_self_build"
+  when: "matrix_mautrix_facebook_enabled|bool and matrix_mautrix_facebook_container_image_self_build and matrix_mautrix_facebook_git_pull_results.changed"
 
 - name: Check if an old database file already exists
   stat:

--- a/roles/matrix-bridge-mautrix-hangouts/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mautrix-hangouts/tasks/setup_install.yml
@@ -35,17 +35,19 @@
     repo: https://github.com/tulir/mautrix-hangouts.git
     dest: "{{ matrix_mautrix_hangouts_docker_src_files_path }}"
     force: "yes"
+  register: matrix_mautrix_hangouts_git_pull_results
   when: "matrix_mautrix_hangouts_enabled|bool and matrix_mautrix_hangouts_container_image_self_build"
 
 - name: Ensure Mautrix Hangouts Docker image is built
   docker_image:
     name: "{{ matrix_mautrix_hangouts_docker_image }}"
     source: build
+    force_source: yes
     build:
       dockerfile: Dockerfile
       path: "{{ matrix_mautrix_hangouts_docker_src_files_path }}"
       pull: yes
-  when: "matrix_mautrix_hangouts_enabled|bool and matrix_mautrix_hangouts_container_image_self_build"
+  when: "matrix_mautrix_hangouts_enabled|bool and matrix_mautrix_hangouts_container_image_self_build and matrix_mautrix_hangouts_git_pull_results.changed"
 
 - name: Check if an old database file already exists
   stat:


### PR DESCRIPTION
Slight modification to force self-build images when the git master branch has been modified, as currently the docker image xy:latest is always present.