### PR TITLE
Add global var to control skype image self build

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -301,6 +301,8 @@ matrix_mautrix_whatsapp_login_shared_secret: "{{ matrix_synapse_ext_password_pro
 # We don't enable bridges by default.
 matrix_mx_puppet_skype_enabled: false
 
+matrix_mx_puppet_skype_container_image_self_build: "{{ matrix_container_images_self_build }}"
+
 matrix_mx_puppet_skype_systemd_required_services_list: |
   {{
     ['docker.service']


### PR DESCRIPTION
Gergely Horváth:
A single line is missing from group_vars/matrix_servers: matrix_mx_puppet_skype_container_image_self_build: "{{ matrix_container_images_self_build }}",
so if the global variable is set, everything is being self-built