### PR TITLE
Upstream set mx-puppet-skype default port to 8438

### DIFF
--- a/roles/matrix-bridge-mx-puppet-skype/defaults/main.yml
+++ b/roles/matrix-bridge-mx-puppet-skype/defaults/main.yml
@@ -13,7 +13,7 @@ matrix_mx_puppet_skype_config_path: "{{ matrix_mx_puppet_skype_base_path }}/conf
 matrix_mx_puppet_skype_data_path: "{{ matrix_mx_puppet_skype_base_path }}/data"
 matrix_mx_puppet_skype_docker_src_files_path: "{{ matrix_mx_puppet_skype_base_path }}/docker-src"
 
-matrix_mx_puppet_skype_appservice_port: "6000"
+matrix_mx_puppet_skype_appservice_port: "8438"
 
 matrix_mx_puppet_skype_homeserver_address: 'http://matrix-synapse:8008'
 matrix_mx_puppet_skype_homeserver_domain: '{{ matrix_domain }}'


### PR DESCRIPTION
Default port was set to 6000 and upstream developer updated to 8438 to avoid port clash.