### PR TITLE
Fix hardcoded postgres template values

### DIFF
--- a/roles/matrix-nginx-proxy/templates/usr-local-bin/matrix-ssl-lets-encrypt-certificates-renew.j2
+++ b/roles/matrix-nginx-proxy/templates/usr-local-bin/matrix-ssl-lets-encrypt-certificates-renew.j2
@@ -11,7 +11,7 @@ docker run \
 	--rm \
 	--name=matrix-certbot \
 	--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
-    --cap-drop=ALL \
+	--cap-drop=ALL \
 	--network="{{ matrix_docker_network }}" \
 	-p 127.0.0.1:{{ matrix_ssl_lets_encrypt_certbot_standalone_http_port }}:8080 \
 	-v {{ matrix_ssl_config_dir_path }}:/etc/letsencrypt \

--- a/roles/matrix-postgres/templates/usr-local-bin/matrix-change-user-admin-status.j2
+++ b/roles/matrix-postgres/templates/usr-local-bin/matrix-change-user-admin-status.j2
@@ -11,9 +11,9 @@ fi
 docker run \
 	-it \
 	--rm \
-	--user=991:991 \
+	--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 	--cap-drop=ALL \
 	--env-file={{ matrix_postgres_base_path }}/env-postgres-psql \
 	--network {{ matrix_docker_network }} \
-	postgres:12.1-alpine \
-	psql -h matrix-postgres -c "UPDATE users set admin=$2 WHERE name like '@$1:{{ matrix_domain }}'"
+	{{ matrix_postgres_docker_image_to_use }} \
+	psql -h {{ matrix_postgres_connection_hostname }} -c "UPDATE users set admin=$2 WHERE name like '@$1:{{ matrix_domain }}'"

--- a/roles/matrix-postgres/templates/usr-local-bin/matrix-postgres-cli.j2
+++ b/roles/matrix-postgres/templates/usr-local-bin/matrix-postgres-cli.j2
@@ -5,7 +5,7 @@ docker run \
 	-it \
 	--rm \
 	--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
-    --cap-drop=ALL \
+	--cap-drop=ALL \
 	--env-file={{ matrix_postgres_base_path }}/env-postgres-psql \
 	--network {{ matrix_docker_network }} \
 	{{ matrix_postgres_docker_image_to_use }} \

--- a/roles/matrix-postgres/templates/usr-local-bin/matrix-postgres-update-user-password-hash.j2
+++ b/roles/matrix-postgres/templates/usr-local-bin/matrix-postgres-update-user-password-hash.j2
@@ -9,7 +9,7 @@ fi
 docker run \
 	--rm \
 	--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
-    --cap-drop=ALL \
+	--cap-drop=ALL \
 	--env-file={{ matrix_postgres_base_path }}/env-postgres-psql \
 	--network {{ matrix_docker_network }} \
 	{{ matrix_postgres_docker_image_to_use }} \


### PR DESCRIPTION
There was a few hardcoded values in the postgres script template `matrix-change-user-admin-status`, which are fixed by this PR to correctly used the templated variables. Additionally, some inconsistent whitespace usage I noticed in these scripts is fixed by this PR.