### PR TITLE
Expose allowed local 3pids as a configurable option

### DIFF
--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -164,6 +164,13 @@ matrix_synapse_enable_group_creation: false
 # A list of 3PID types which users must supply when registering (possible values: email, msisdn).
 matrix_synapse_registrations_require_3pid: []
 
+# A list of patterns 3pids must match in order to permit registration, e.g.:
+#  - medium: email
+#    pattern: '.*@example\.com'
+#  - medium: msisdn
+#    pattern: '\+44'
+matrix_synapse_allowed_local_3pids: []
+
 # The server to use for email threepid validation. When empty, Synapse does it by itself.
 # Otherwise, this should be pointed to an identity server.
 matrix_synapse_account_threepid_delegates_email: ''

--- a/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -986,6 +986,9 @@ registrations_require_3pid: {{ matrix_synapse_registrations_require_3pid|to_json
 #    pattern: '.*@vector\.im'
 #  - medium: msisdn
 #    pattern: '\+44'
+{% if matrix_synapse_allowed_local_3pids %}
+allowed_local_3pids: {{ matrix_synapse_allowed_local_3pids|to_json }}
+{% endif %}
 
 # Enable 3PIDs lookup requests to identity servers from this server.
 #


### PR DESCRIPTION
Trivial change to expose `allowed_local_3pids` (which allows you to restrict registration to users who provide a 3pid matching the specified pattern or patterns) as a configurable option.