### PR TITLE
Add support for running dimension in an unfederated environment

### DIFF
--- a/docs/configuring-playbook-dimension.md
+++ b/docs/configuring-playbook-dimension.md
@@ -4,7 +4,7 @@
 If you're just installing Matrix services for the first time, please continue with the [Configuration](configuring-playbook.md) / [Installation](installing.md) flow and come back here later.
 
 ## Prerequisites
-For an Integration Manager like [Dimension](https://dimension.t2bot.io) to work, your server needs to have federation enabled (`matrix_synapse_federation_enabled: true`). This is the default for this playbook, so unless you've explicitly disabled federation, you're okay.
+This playbook now supports running [Dimension](https://dimension.t2bot.io) in both a federated and an [unfederated](https://github.com/turt2live/matrix-dimension/blob/master/docs/unfederated.md) environment. This is handled automatically based on the value of `matrix_synapse_federation_enabled`.
 
 Other important prerequisite is the `dimension.<your-domain>` DNS record being set up correctly. See [Configuring your DNS server](configuring-dns.md) on how to set up DNS record correctly.
 

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -402,6 +402,8 @@ matrix_dimension_container_http_host_bind_port: "{{ '' if matrix_nginx_proxy_ena
 matrix_integration_manager_rest_url: "{{ matrix_dimension_integrations_rest_url if matrix_dimension_enabled else None }}"
 matrix_integration_manager_ui_url: "{{ matrix_dimension_integrations_ui_url if matrix_dimension_enabled else None }}"
 
+matrix_dimension_homeserver_federationUrl: "http://matrix-synapse:{{ 8048 if matrix_synapse_federation_enabled|bool else 8008 }}"
+
 ######################################################################
 #
 # /matrix-dimension
@@ -722,6 +724,13 @@ matrix_synapse_database_database: "{{ matrix_postgres_db_name }}"
 matrix_synapse_tls_federation_listener_enabled: false
 matrix_synapse_tls_certificate_path: ~
 matrix_synapse_tls_private_key_path: ~
+
+matrix_synapse_http_listener_resource_names: |
+  {{
+    ["client"]
+    +
+    ( ["openid"] if matrix_dimension_enabled and not matrix_synapse_federation_enabled else [] )
+  }}
 
 matrix_synapse_email_enabled: "{{ matrix_mailer_enabled }}"
 matrix_synapse_email_smtp_host: "matrix-mailer"

--- a/roles/matrix-dimension/defaults/main.yml
+++ b/roles/matrix-dimension/defaults/main.yml
@@ -58,7 +58,7 @@ matrix_dimension_configuration_yaml: |
     # The URL that Dimension should use when trying to communicate with federated APIs on
     # the homeserver. If not supplied or left empty Dimension will try to resolve the address
     # through the normal federation process.
-    federationUrl: "http://matrix-synapse:8048"
+    federationUrl: "http://matrix-synapse:{{ 8048 if matrix_synapse_federation_enabled|bool else 8008 }}"
 
     # The URL that Dimension will redirect media requests to for downloading media such as
     # stickers. If not supplied or left empty Dimension will use the clientServerUrl.

--- a/roles/matrix-dimension/defaults/main.yml
+++ b/roles/matrix-dimension/defaults/main.yml
@@ -32,6 +32,8 @@ matrix_dimension_integrations_rest_url: "https://{{ matrix_server_fqn_dimension 
 matrix_dimension_integrations_widgets_urls: ["https://{{ matrix_server_fqn_dimension }}/widgets"]
 matrix_dimension_integrations_jitsi_widget_url: "https://{{ matrix_server_fqn_dimension }}/widgets/jitsi"
 
+matrix_dimension_homeserver_federationUrl: "http://matrix-synapse:8048"
+
 # Default Dimension configuration template which covers the generic use case.
 # You can customize it by controlling the various variables inside it.
 #
@@ -58,7 +60,7 @@ matrix_dimension_configuration_yaml: |
     # The URL that Dimension should use when trying to communicate with federated APIs on
     # the homeserver. If not supplied or left empty Dimension will try to resolve the address
     # through the normal federation process.
-    federationUrl: "http://matrix-synapse:{{ 8048 if matrix_synapse_federation_enabled|bool else 8008 }}"
+    federationUrl: "{{ matrix_dimension_homeserver_federationUrl }}"
 
     # The URL that Dimension will redirect media requests to for downloading media such as
     # stickers. If not supplied or left empty Dimension will use the clientServerUrl.

--- a/roles/matrix-dimension/tasks/validate_config.yml
+++ b/roles/matrix-dimension/tasks/validate_config.yml
@@ -6,14 +6,6 @@
     - "matrix_dimension_access_token"
   when: "matrix_dimension_enabled and vars[item] == ''"
 
-- name: Fail if Matrix Federation is disabled
-  fail:
-    msg: >-
-      You need to enable Matrix Federation to use Dimension. Set `{{ item }}` to 'true'.
-  with_items:
-    - "matrix_synapse_federation_enabled"
-  when: "matrix_dimension_enabled|bool and not matrix_synapse_federation_enabled|bool"
-
 - name: (Deprecation) Catch and report renamed Dimension variables
   fail:
     msg: >-

--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -137,6 +137,11 @@ matrix_synapse_tls_federation_listener_enabled: true
 matrix_synapse_tls_certificate_path: "/data/{{ matrix_server_fqn_matrix }}.tls.crt"
 matrix_synapse_tls_private_key_path: "/data/{{ matrix_server_fqn_matrix }}.tls.key"
 
+# Resource names used by the unsecure HTTP listener. Here only the Client API
+# is defined, see the homeserver config for a full list of valid resource
+# names.
+matrix_synapse_http_listener_resource_names: ["client"]
+
 # Enable this to allow Synapse to report utilization statistics about your server to matrix.org
 # (things like number of users, number of messages sent, uptime, load, etc.)
 matrix_synapse_report_stats: false

--- a/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -226,7 +226,11 @@ listeners:
     x_forwarded: true
 
     resources:
-      - names: [client]
+      - names:
+        - client
+{% if matrix_dimension_enabled and not matrix_synapse_federation_enabled %}
+        - openid
+{% endif %}
         compress: false
 
 {% if matrix_synapse_federation_enabled %}

--- a/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -226,11 +226,7 @@ listeners:
     x_forwarded: true
 
     resources:
-      - names:
-        - client
-{% if matrix_dimension_enabled and not matrix_synapse_federation_enabled %}
-        - openid
-{% endif %}
+      - names: {{ matrix_synapse_http_listener_resource_names|to_json }}
         compress: false
 
 {% if matrix_synapse_federation_enabled %}


### PR DESCRIPTION
This PR adds support for running dimension in an unfederated environment, following the upstream [documentation](https://github.com/turt2live/matrix-dimension/blob/master/docs/unfederated.md).

I'm not sure about the DNS requirements in an unfederated environment, so left that section of the [docs](https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/docs/configuring-playbook-dimension.md#prerequisites) alone.

Happy to hear any advice on a better/cleaner way to make the switch in the config.