### PR TITLE
add missing keys 'permalinkPrefix' and 'default_theme' for configuring riot web

### DIFF
--- a/roles/matrix-riot-web/defaults/main.yml
+++ b/roles/matrix-riot-web/defaults/main.yml
@@ -29,6 +29,7 @@ matrix_riot_web_integrations_ui_url: "https://scalar.vector.im/"
 matrix_riot_web_integrations_rest_url: "https://scalar.vector.im/api"
 matrix_riot_web_integrations_widgets_urls: ["https://scalar.vector.im/api"]
 matrix_riot_web_integrations_jitsi_widget_url: "https://scalar.vector.im/api/widgets/jitsi.html"
+matrix_riot_web_permalinkPrefix: "https://matrix.to"
 # Riot public room directory server(s)
 matrix_riot_web_roomdir_servers: ['matrix.org']
 matrix_riot_web_welcome_user_id: "@riot-bot:matrix.org"

--- a/roles/matrix-riot-web/defaults/main.yml
+++ b/roles/matrix-riot-web/defaults/main.yml
@@ -76,11 +76,12 @@ matrix_riot_web_enable_presence_by_hs_url: ~
 matrix_riot_web_themes_enabled: false
 matrix_riot_web_themes_repository_url: https://github.com/aaronraimist/riot-web-themes
 
+# Controls the default riot-web theme
+matrix_riot_web_default_theme: 'light'
+
 # Controls the `settingsDefault.custom_themes` setting of the riot-web configuration.
 # You can use this setting to define custom themes.
-matrix_riot_web_change_default_theme: false
-matrix_riot_web_default_theme: ""
-
+#
 # Also, look at `matrix_riot_web_themes_enabled` for a way to pull in a bunch of custom themes automatically.
 # If you define your own themes here and set `matrix_riot_web_themes_enabled: true`, your themes will be preserved as well.
 #

--- a/roles/matrix-riot-web/defaults/main.yml
+++ b/roles/matrix-riot-web/defaults/main.yml
@@ -78,7 +78,9 @@ matrix_riot_web_themes_repository_url: https://github.com/aaronraimist/riot-web-
 
 # Controls the `settingsDefault.custom_themes` setting of the riot-web configuration.
 # You can use this setting to define custom themes.
-#
+matrix_riot_web_change_default_theme: false
+matrix_riot_web_default_theme: ""
+
 # Also, look at `matrix_riot_web_themes_enabled` for a way to pull in a bunch of custom themes automatically.
 # If you define your own themes here and set `matrix_riot_web_themes_enabled: true`, your themes will be preserved as well.
 #

--- a/roles/matrix-riot-web/templates/config.json.j2
+++ b/roles/matrix-riot-web/templates/config.json.j2
@@ -11,6 +11,7 @@
 	"settingDefaults": {
 		"custom_themes": {{ matrix_riot_web_settingDefaults_custom_themes|to_json }}
 	},
+	"permalinkPrefix": {{ matrix_riot_web_permalinkPrefix|string|to_json }},
 	"disable_custom_urls": {{ matrix_riot_web_disable_custom_urls|to_json }},
 	"disable_guests": {{ matrix_riot_web_disable_guests|to_json }},
 	"brand": {{ matrix_riot_web_brand|to_json }},

--- a/roles/matrix-riot-web/templates/config.json.j2
+++ b/roles/matrix-riot-web/templates/config.json.j2
@@ -11,9 +11,7 @@
 	"settingDefaults": {
 		"custom_themes": {{ matrix_riot_web_settingDefaults_custom_themes|to_json }}
 	},
-	{% if matrix_riot_web_change_default_theme %}
-		"default_theme": {{ matrix_riot_web_default_theme|string|to_json }},
-	{% endif %}
+	"default_theme": {{ matrix_riot_web_default_theme|string|to_json }},
 	"permalinkPrefix": {{ matrix_riot_web_permalinkPrefix|string|to_json }},
 	"disable_custom_urls": {{ matrix_riot_web_disable_custom_urls|to_json }},
 	"disable_guests": {{ matrix_riot_web_disable_guests|to_json }},

--- a/roles/matrix-riot-web/templates/config.json.j2
+++ b/roles/matrix-riot-web/templates/config.json.j2
@@ -11,6 +11,9 @@
 	"settingDefaults": {
 		"custom_themes": {{ matrix_riot_web_settingDefaults_custom_themes|to_json }}
 	},
+	{% if matrix_riot_web_change_default_theme %}
+		"default_theme": {{ matrix_riot_web_default_theme|string|to_json }},
+	{% endif %}
 	"permalinkPrefix": {{ matrix_riot_web_permalinkPrefix|string|to_json }},
 	"disable_custom_urls": {{ matrix_riot_web_disable_custom_urls|to_json }},
 	"disable_guests": {{ matrix_riot_web_disable_guests|to_json }},


### PR DESCRIPTION
### Description

Add two useful keys for configuring riot-web : `permalinkPrefix` and `default_theme`

### Why

Those two keys were missing and are useful to further configure Riot-Web, both being specifications of the [riot config file](https://github.com/vector-im/riot-web/blob/develop/docs/config.md)

- `permalinkPrefix` allows to redirect users to non-federated instance of Riot at `riot.DOMAIN` or `matrix.to.DOMAIN` instead of the default `matrix.to`
- `default_theme` allows to edit default_theme for Riot users

