### PR TITLE
Update Jitsi docker images to stable 4416

### DIFF
--- a/roles/matrix-jitsi/defaults/main.yml
+++ b/roles/matrix-jitsi/defaults/main.yml
@@ -28,7 +28,7 @@ matrix_jitsi_jibri_recorder_user: recorder
 matrix_jitsi_jibri_recorder_password: ''
 
 
-matrix_jitsi_web_docker_image: "jitsi/web:4384"
+matrix_jitsi_web_docker_image: "jitsi/web:4416"
 matrix_jitsi_web_docker_image_force_pull: "{{ matrix_jitsi_web_docker_image.endswith(':latest') }}"
 
 matrix_jitsi_web_base_path: "{{ matrix_base_data_path }}/jitsi/web"
@@ -74,7 +74,7 @@ matrix_jitsi_web_interface_config_show_powered_by: false
 matrix_jitsi_web_interface_config_disable_transcription_subtitles: false
 matrix_jisti_web_interface_config_show_deep_linking_image: false
 
-matrix_jitsi_prosody_docker_image: "jitsi/prosody:4384"
+matrix_jitsi_prosody_docker_image: "jitsi/prosody:4416"
 matrix_jitsi_prosody_docker_image_force_pull: "{{ matrix_jitsi_prosody_docker_image.endswith(':latest') }}"
 
 matrix_jitsi_prosody_base_path: "{{ matrix_base_data_path }}/jitsi/prosody"
@@ -87,7 +87,7 @@ matrix_jitsi_prosody_container_extra_arguments: []
 matrix_jitsi_prosody_systemd_required_services_list: ['docker.service']
 
 
-matrix_jitsi_jicofo_docker_image: "jitsi/jicofo:4384"
+matrix_jitsi_jicofo_docker_image: "jitsi/jicofo:4416"
 matrix_jitsi_jicofo_docker_image_force_pull: "{{ matrix_jitsi_jicofo_docker_image.endswith(':latest') }}"
 
 matrix_jitsi_jicofo_base_path: "{{ matrix_base_data_path }}/jitsi/jicofo"
@@ -104,7 +104,7 @@ matrix_jitsi_jicofo_auth_user: focus
 matrix_jitsi_jicofo_auth_password: ''
 
 
-matrix_jitsi_jvb_docker_image: "jitsi/jvb:4384"
+matrix_jitsi_jvb_docker_image: "jitsi/jvb:4416"
 matrix_jitsi_jvb_docker_image_force_pull: "{{ matrix_jitsi_jvb_docker_image.endswith(':latest') }}"
 
 matrix_jitsi_jvb_base_path: "{{ matrix_base_data_path }}/jitsi/jvb"


### PR DESCRIPTION
As far as I can see, there should be no further changes needed to our special ansible setup.

https://github.com/jitsi/docker-jitsi-meet/compare/stable-4384-1...stable-4416