### PR TITLE
Add support for Jitsi LDAP authentication

### DIFF
--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -4,7 +4,7 @@ The playbook can install the [Jitsi](https://jitsi.org/) video-conferencing plat
 
 Jitsi installation is **not enabled by default**, because it's not a core component of Matrix services.
 
-The setup done by the playbook is very similar to [docker-jitsi-meet](https://github.com/jitsi/docker-jitsi-meet).
+The setup done by the playbook is very similar to [docker-jitsi-meet](https://github.com/jitsi/docker-jitsi-meet). You can refer to the documentation there for many of the options here.
 
 
 ## Prerequisites
@@ -34,13 +34,13 @@ matrix_jitsi_jibri_xmpp_password: ""
 ```
 
 
-## (Optional) configure internal Jitsi authentication and guests mode
+## (Optional) Configure Jitsi authentication and guests mode
 
 By default the Jitsi Meet instance does not require any kind of login and is open to use for anyone without registration.
 
 If you're fine with such an open Jitsi instance, please skip to [Apply changes](#apply-changes).
 
-If you would like to control who is allowed to open meetings on your new Jitsi instance, then please follow this step to enable Jitsi's `internal` authentication and guests mode. With this optional configuration, all meeting rooms have to be opened by at least one registered user, after that guests are free to join. If a registered host is not present yet, guests are put on hold into a waiting room.
+If you would like to control who is allowed to open meetings on your new Jitsi instance, then please follow this step to enable Jitsi's authentication and guests mode. With authentication enabled, all meeting rooms have to be opened by a registered user, after which guests are free to join. If a registered host is not yet present, guests are put on hold in individual waiting rooms.
 
 Add these two lines to your `inventory/host_vars/matrix.DOMAIN/vars.yml` configuration:
 
@@ -49,11 +49,28 @@ matrix_jitsi_enable_auth: true
 matrix_jitsi_enable_guests: true
 ```
 
+### (Optional) LDAP authentication
+
+The default authentication mode of Jitsi is `internal`, however LDAP is also supported. An example LDAP configuration could be:
+
+```yaml
+matrix_jitsi_enable_auth: true
+matrix_jitsi_auth_type: ldap
+matrix_jitsi_ldap_url: ldap://ldap.DOMAIN  # or ldaps:// if using tls
+matrix_jitsi_ldap_base: "OU=People,DC=DOMAIN"
+matrix_jitsi_ldap_filter: "(&(uid=%u)(employeeType=active))"
+matrix_jitsi_ldap_use_tls: false
+matrix_jitsi_ldap_start_tls: true
+```
+
+For more information refer to the [docker-jitsi-meet](https://github.com/jitsi/docker-jitsi-meet#authentication-using-ldap) and the [saslauthd `LDAP_SASLAUTHD`](https://github.com/winlibs/cyrus-sasl/blob/master/saslauthd/LDAP_SASLAUTHD) documentation.
+
+
 ## (Optional) Making your Jitsi server work on a LAN
 
 By default the Jitsi Meet instance does not work with a client in LAN (Local Area Network), even if others are connected from WAN. There are no video and audio. In the case of WAN to WAN everything is ok.
 
-The reason is the Jitsi VideoBridge git to LAN client the IP address of the docker image instead of the host. The [documentation](https://github.com/jitsi/docker-jitsi-meet#running-behind-nat-or-on-a-lan-environment) of Jitsi in docker suggest to add DOCKER_HOST_ADDRESS in enviornment variable to make it work.
+The reason is the Jitsi VideoBridge git to LAN client the IP address of the docker image instead of the host. The [documentation](https://github.com/jitsi/docker-jitsi-meet#running-behind-nat-or-on-a-lan-environment) of Jitsi in docker suggest to add `DOCKER_HOST_ADDRESS` in enviornment variable to make it work.
 
 Here is how to do it in the playbook.
 
@@ -68,7 +85,7 @@ matrix_jitsi_jvb_container_extra_arguments:
 
 Then re-run the playbook: `ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start`
 
-## Required if configuring Jitsi with its internal authentication: register new users
+## Required if configuring Jitsi with internal authentication: register new users
 
 Until this gets integrated into the playbook, we need to register new users / meeting hosts for Jitsi manually.
 Please SSH into your matrix host machine and execute the following command targeting the `matrix-jitsi-prosody` container:

--- a/roles/matrix-jitsi/defaults/main.yml
+++ b/roles/matrix-jitsi/defaults/main.yml
@@ -7,6 +7,28 @@ matrix_jitsi_enable_guests: false
 matrix_jitsi_enable_recording: true
 matrix_jitsi_enable_transcriptions: true
 
+# Authentication type, must be one of internal, jwt or ldap. Currently only
+# internal and ldap are supported by this playbook.
+matrix_jitsi_auth_type: internal
+
+# Configuration options for LDAP authentication. For details see upstream:
+#   https://github.com/jitsi/docker-jitsi-meet#authentication-using-ldap.
+# Defaults are taken from:
+#   https://github.com/jitsi/docker-jitsi-meet/blob/master/prosody/rootfs/defaults/saslauthd.conf
+matrix_jitsi_ldap_url: ""
+matrix_jitsi_ldap_base: ""
+matrix_jitsi_ldap_binddn: ""
+matrix_jitsi_ldap_bindpw: ""
+matrix_jitsi_ldap_filter: "uid=%u"
+matrix_jitsi_ldap_auth_method: "bind"
+matrix_jitsi_ldap_version: "3"
+matrix_jitsi_ldap_use_tls: false
+matrix_jitsi_ldap_tls_ciphers: ""
+matrix_jitsi_ldap_tls_check_peer: false
+matrix_jitsi_ldap_tls_cacert_file: "/etc/ssl/certs/ca-certificates.crt"
+matrix_jitsi_ldap_tls_cacert_dir: "/etc/ssl/certs"
+matrix_jitsi_ldap_start_tls: false
+
 matrix_jitsi_timezone: UTC
 
 matrix_jitsi_xmpp_domain: matrix-jitsi-web

--- a/roles/matrix-jitsi/templates/prosody/env.j2
+++ b/roles/matrix-jitsi/templates/prosody/env.j2
@@ -1,7 +1,21 @@
-AUTH_TYPE=internal
+AUTH_TYPE={{ matrix_jitsi_auth_type }}
 
 ENABLE_AUTH={{ 1 if matrix_jitsi_enable_auth else 0 }}
 ENABLE_GUESTS={{ 1 if matrix_jitsi_enable_guests else 0 }}
+
+LDAP_URL={{ matrix_jitsi_ldap_url }}
+LDAP_BASE={{ matrix_jitsi_ldap_base }}
+LDAP_BINDDN={{ matrix_jitsi_ldap_binddn }}
+LDAP_BINDPW={{ matrix_jitsi_ldap_bindpw }}
+LDAP_FILTER={{ matrix_jitsi_ldap_filter }}
+LDAP_AUTH_METHOD={{ matrix_jitsi_ldap_auth_method }}
+LDAP_VERSION={{ matrix_jitsi_ldap_version }}
+LDAP_USE_TLS={{ 1 if matrix_jitsi_ldap_use_tls else 0 }}
+LDAP_TLS_CIPHERS={{ matrix_jitsi_ldap_tls_ciphers }}
+LDAP_TLS_CHECK_PEER={{ 1 if matrix_jitsi_ldap_tls_check_peer else 0 }}
+LDAP_TLS_CACERT_FILE={{ matrix_jitsi_ldap_tls_cacert_file }}
+LDAP_TLS_CACERT_DIR={{ matrix_jitsi_ldap_tls_cacert_dir }}
+LDAP_START_TLS={{ 1 if matrix_jitsi_ldap_start_tls else 0 }}
 
 XMPP_DOMAIN={{ matrix_jitsi_xmpp_domain }}
 XMPP_AUTH_DOMAIN={{ matrix_jitsi_xmpp_auth_domain }}


### PR DESCRIPTION
This PR adds support for the [saslauthd method](https://github.com/jitsi/jitsi-meet/wiki/LDAP-Authentication#ldap-authentication-for-jitsi-meet-via-cyrussaslauthd) of authenticating Jitsi users via LDAP (by following the [docker-jitsi-meet](https://github.com/jitsi/docker-jitsi-meet#authentication-using-ldap) docs).

I was considering trying to harmonise the Jitsi LDAP configuration added in this PR with the other LDAP auth methods we already support ([synapse ldap3](https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/docs/configuring-playbook-ldap-auth.md#setting-up-the-ldap-authentication-password-provider-module-optional-advanced) and [ma1sd ldap](https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/docs/configuring-playbook-ma1sd.md#authentication)) under the assumption that most users would be using the same LDAP server for all services, however I feel this will get quite messy. Suggestions welcome on how to do it in a clean way.

Note that there are three authentication methods available, [internal, ldap and jwt](https://github.com/jitsi/docker-jitsi-meet#authentication). I left JWT out because I am not able to test this method.