### PR TITLE
Fix group name gid

### DIFF
--- a/roles/matrix-base/defaults/main.yml
+++ b/roles/matrix-base/defaults/main.yml
@@ -22,6 +22,7 @@ matrix_server_fqn_dimension: "dimension.{{ matrix_domain }}"
 matrix_server_fqn_jitsi: "jitsi.{{ matrix_domain }}"
 
 matrix_user_username: "matrix"
+matrix_user_groupname: "matrix"
 matrix_user_uid: 991
 matrix_user_gid: 991
 

--- a/roles/matrix-base/tasks/setup_matrix_base.yml
+++ b/roles/matrix-base/tasks/setup_matrix_base.yml
@@ -2,7 +2,7 @@
 
 - name: Ensure Matrix group is created
   group:
-    name: "{{ matrix_user_username }}"
+    name: "{{ matrix_user_groupname }}"
     gid: "{{ matrix_user_gid }}"
     state: present
 
@@ -11,7 +11,7 @@
     name: "{{ matrix_user_username }}"
     uid: "{{ matrix_user_uid }}"
     state: present
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 - name: Ensure Matrix base path exists
   file:
@@ -19,7 +19,7 @@
     state: directory
     mode: "{{ matrix_base_data_path_mode }}"
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   with_items:
     - "{{ matrix_base_data_path }}"
 

--- a/roles/matrix-base/tasks/setup_well_known.yml
+++ b/roles/matrix-base/tasks/setup_well_known.yml
@@ -8,7 +8,7 @@
     state: directory
     mode: 0755
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   with_items:
     - "{{ matrix_static_files_base_path }}/.well-known/matrix"
 
@@ -18,7 +18,7 @@
     dest: "{{ matrix_static_files_base_path }}/.well-known/matrix/client"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 - name: Ensure Matrix /.well-known/matrix/server file configured
   template:
@@ -26,7 +26,7 @@
     dest: "{{ matrix_static_files_base_path }}/.well-known/matrix/server"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   when: matrix_well_known_matrix_server_enabled|bool
 
 - name: Ensure Matrix /.well-known/matrix/server file deleted

--- a/roles/matrix-bridge-appservice-discord/tasks/setup_install.yml
+++ b/roles/matrix-bridge-appservice-discord/tasks/setup_install.yml
@@ -13,7 +13,7 @@
     state: directory
     mode: 0750
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   with_items:
     - "{{ matrix_appservice_discord_base_path }}"
     - "{{ matrix_appservice_discord_config_path }}"
@@ -46,7 +46,7 @@
     dest: "{{ matrix_appservice_discord_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 - name: Ensure AppService Discord registration.yaml installed
   copy:
@@ -54,7 +54,7 @@
     dest: "{{ matrix_appservice_discord_config_path }}/registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 # If `matrix_appservice_discord_client_id` hasn't changed, the same invite link would be generated.
 # We intentionally suppress Ansible changes.

--- a/roles/matrix-bridge-appservice-irc/tasks/setup_install.yml
+++ b/roles/matrix-bridge-appservice-irc/tasks/setup_install.yml
@@ -13,7 +13,7 @@
     state: directory
     mode: 0750
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   with_items:
     - "{{ matrix_appservice_irc_base_path }}"
     - "{{ matrix_appservice_irc_config_path }}"
@@ -50,7 +50,7 @@
     dest: "{{ matrix_appservice_irc_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 - name: Check if Appservice IRC passkey exists
   stat:
@@ -70,7 +70,7 @@
     path: "{{ matrix_appservice_irc_data_path }}/passkey.pem"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 # Ideally, we'd like to generate the final registration.yaml file by ourselves.
 #
@@ -134,7 +134,7 @@
     dest: "{{ matrix_appservice_irc_config_path }}/registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 - name: Ensure matrix-appservice-irc.service installed
   template:

--- a/roles/matrix-bridge-appservice-slack/tasks/setup_install.yml
+++ b/roles/matrix-bridge-appservice-slack/tasks/setup_install.yml
@@ -13,7 +13,7 @@
     state: directory
     mode: 0750
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   with_items:
     - "{{ matrix_appservice_slack_base_path }}"
     - "{{ matrix_appservice_slack_config_path }}"
@@ -25,7 +25,7 @@
     dest: "{{ matrix_appservice_slack_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 - name: Ensure appservice-slack registration.yaml installed
   copy:
@@ -33,7 +33,7 @@
     dest: "{{ matrix_appservice_slack_config_path }}/slack-registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 - name: Ensure matrix-appservice-slack.service installed
   template:

--- a/roles/matrix-bridge-appservice-webhooks/tasks/setup_install.yml
+++ b/roles/matrix-bridge-appservice-webhooks/tasks/setup_install.yml
@@ -13,7 +13,7 @@
     state: directory
     mode: 0750
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   with_items:
     - "{{ matrix_appservice_webhooks_base_path }}"
     - "{{ matrix_appservice_webhooks_config_path }}"
@@ -25,7 +25,7 @@
     dest: "{{ matrix_appservice_webhooks_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 - name: Ensure Matrix Appservice webhooks schema.yml template exists
   template:
@@ -33,7 +33,7 @@
     dest: "{{ matrix_appservice_webhooks_config_path }}/schema.yml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 - name: Ensure Matrix Appservice webhooks database.json template exists
   template:
@@ -41,7 +41,7 @@
     dest: "{{ matrix_appservice_webhooks_data_path }}/database.json"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 - name: Ensure appservice-webhooks registration.yaml installed
   copy:
@@ -49,7 +49,7 @@
     dest: "{{ matrix_appservice_webhooks_config_path }}/webhooks-registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 - name: Ensure matrix-appservice-webhooks.service installed
   template:

--- a/roles/matrix-bridge-mautrix-facebook/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mautrix-facebook/tasks/setup_install.yml
@@ -22,7 +22,7 @@
     state: directory
     mode: 0750
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   with_items:
     - { path: "{{ matrix_mautrix_facebook_base_path }}", when: true }
     - { path: "{{ matrix_mautrix_facebook_config_path }}", when: true }
@@ -73,7 +73,7 @@
     dest: "{{ matrix_mautrix_facebook_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 - name: Ensure mautrix-facebook registration.yaml installed
   copy:
@@ -81,7 +81,7 @@
     dest: "{{ matrix_mautrix_facebook_config_path }}/registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 - name: Ensure matrix-mautrix-facebook.service installed
   template:

--- a/roles/matrix-bridge-mautrix-hangouts/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mautrix-hangouts/tasks/setup_install.yml
@@ -22,7 +22,7 @@
     state: directory
     mode: 0750
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   with_items:
     - { path: "{{ matrix_mautrix_hangouts_base_path }}", when: true }
     - { path: "{{ matrix_mautrix_hangouts_config_path }}", when: true }
@@ -72,7 +72,7 @@
     dest: "{{ matrix_mautrix_hangouts_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 - name: Ensure mautrix-hangouts registration.yaml installed
   copy:
@@ -80,7 +80,7 @@
     dest: "{{ matrix_mautrix_hangouts_config_path }}/registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 - name: Ensure matrix-mautrix-hangouts.service installed
   template:

--- a/roles/matrix-bridge-mautrix-telegram/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mautrix-telegram/tasks/setup_install.yml
@@ -21,7 +21,7 @@
     state: directory
     mode: 0750
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   with_items:
     - "{{ matrix_mautrix_telegram_base_path }}"
     - "{{ matrix_mautrix_telegram_config_path }}"
@@ -50,7 +50,7 @@
     dest: "{{ matrix_mautrix_telegram_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 - name: Ensure mautrix-telegram registration.yaml installed
   copy:
@@ -58,7 +58,7 @@
     dest: "{{ matrix_mautrix_telegram_config_path }}/registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 - name: Ensure matrix-mautrix-telegram.service installed
   template:

--- a/roles/matrix-bridge-mautrix-whatsapp/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mautrix-whatsapp/tasks/setup_install.yml
@@ -21,7 +21,7 @@
     state: directory
     mode: 0750
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   with_items:
     - "{{ matrix_mautrix_whatsapp_base_path }}"
     - "{{ matrix_mautrix_whatsapp_config_path }}"
@@ -59,7 +59,7 @@
     dest: "{{ matrix_mautrix_whatsapp_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 - name: Ensure mautrix-whatsapp registration.yaml installed
   copy:
@@ -67,7 +67,7 @@
     dest: "{{ matrix_mautrix_whatsapp_config_path }}/registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 - name: Ensure matrix-mautrix-whatsapp.service installed
   template:

--- a/roles/matrix-bridge-mx-puppet-skype/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mx-puppet-skype/tasks/setup_install.yml
@@ -22,7 +22,7 @@
     state: directory
     mode: 0750
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   with_items:
     - { path: "{{ matrix_mx_puppet_skype_base_path }}", when: true }
     - { path: "{{ matrix_mx_puppet_skype_config_path }}", when: true }
@@ -71,7 +71,7 @@
     dest: "{{ matrix_mx_puppet_skype_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 - name: Ensure mx-puppet-skype skype-registration.yaml installed
   copy:
@@ -79,7 +79,7 @@
     dest: "{{ matrix_mx_puppet_skype_config_path }}/registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 - name: Ensure matrix-mx-puppet-skype.service installed
   template:

--- a/roles/matrix-bridge-mx-puppet-slack/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mx-puppet-slack/tasks/setup_install.yml
@@ -22,7 +22,7 @@
     state: directory
     mode: 0750
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   with_items:
     - { path: "{{ matrix_mx_puppet_slack_base_path }}", when: true }
     - { path: "{{ matrix_mx_puppet_slack_config_path }}", when: true }
@@ -70,7 +70,7 @@
     dest: "{{ matrix_mx_puppet_slack_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 - name: Ensure mx-puppet-slack slack-registration.yaml installed
   copy:
@@ -78,7 +78,7 @@
     dest: "{{ matrix_mx_puppet_slack_config_path }}/registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 - name: Ensure matrix-mx-puppet-slack.service installed
   template:

--- a/roles/matrix-corporal/tasks/setup_corporal.yml
+++ b/roles/matrix-corporal/tasks/setup_corporal.yml
@@ -10,7 +10,7 @@
     state: directory
     mode: 0750
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   with_items:
     - "{{ matrix_corporal_config_dir_path }}"
     - "{{ matrix_corporal_cache_dir_path }}"
@@ -31,7 +31,7 @@
     dest: "{{ matrix_corporal_config_dir_path }}/config.json"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   when: matrix_corporal_enabled|bool
 
 - name: Ensure matrix-corporal.service installed

--- a/roles/matrix-coturn/tasks/setup_coturn.yml
+++ b/roles/matrix-coturn/tasks/setup_coturn.yml
@@ -10,7 +10,7 @@
     state: directory
     mode: 0750
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   with_items:
     - { path: "{{ matrix_coturn_docker_src_files_path }}", when: "{{ matrix_coturn_container_image_self_build }}"}
   when: matrix_riot_web_enabled|bool and item.when
@@ -47,7 +47,7 @@
     state: directory
     mode: 0750
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   when: matrix_coturn_enabled|bool
 
 - name: Ensure turnserver.conf installed

--- a/roles/matrix-dimension/tasks/setup_dimension.yml
+++ b/roles/matrix-dimension/tasks/setup_dimension.yml
@@ -10,7 +10,7 @@
     state: directory
     mode: 0770
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_dimension_user_gid }}"
+    group: "{{ matrix_user_username }}"
   when: matrix_dimension_enabled|bool
 
 - name: Ensure Dimension config installed
@@ -19,7 +19,7 @@
     dest: "{{ matrix_dimension_base_path }}/config.yaml"
     mode: 0640
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_dimension_user_gid }}"
+    group: "{{ matrix_user_username }}"
   when: matrix_dimension_enabled|bool
 
 - name: Ensure Dimension image is pulled

--- a/roles/matrix-dimension/tasks/setup_dimension.yml
+++ b/roles/matrix-dimension/tasks/setup_dimension.yml
@@ -10,7 +10,7 @@
     state: directory
     mode: 0770
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   when: matrix_dimension_enabled|bool
 
 - name: Ensure Dimension config installed
@@ -19,7 +19,7 @@
     dest: "{{ matrix_dimension_base_path }}/config.yaml"
     mode: 0640
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   when: matrix_dimension_enabled|bool
 
 - name: Ensure Dimension image is pulled

--- a/roles/matrix-email2matrix/tasks/setup_email2matrix.yml
+++ b/roles/matrix-email2matrix/tasks/setup_email2matrix.yml
@@ -10,7 +10,7 @@
     state: directory
     mode: 0750
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   with_items:
     - "{{ matrix_email2matrix_base_path }}"
     - "{{ matrix_email2matrix_config_dir_path }}"
@@ -21,7 +21,7 @@
     src: "{{ role_path }}/templates/config.json.j2"
     dest: "{{ matrix_email2matrix_config_dir_path }}/config.json"
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
     mode: 0640
   when: matrix_email2matrix_enabled|bool
 

--- a/roles/matrix-jitsi/tasks/setup_jitsi_base.yml
+++ b/roles/matrix-jitsi/tasks/setup_jitsi_base.yml
@@ -10,7 +10,7 @@
     state: directory
     mode: 0750
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   with_items:
     - { path: "{{ matrix_jitsi_base_path }}", when: true }
   when: matrix_jitsi_enabled|bool and item.when

--- a/roles/matrix-jitsi/tasks/setup_jitsi_jicofo.yml
+++ b/roles/matrix-jitsi/tasks/setup_jitsi_jicofo.yml
@@ -10,7 +10,7 @@
     state: directory
     mode: 0777
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   with_items:
     - { path: "{{ matrix_jitsi_jicofo_base_path }}", when: true }
     - { path: "{{ matrix_jitsi_jicofo_config_path }}", when: true }

--- a/roles/matrix-jitsi/tasks/setup_jitsi_jvb.yml
+++ b/roles/matrix-jitsi/tasks/setup_jitsi_jvb.yml
@@ -10,7 +10,7 @@
     state: directory
     mode: 0777
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   with_items:
     - { path: "{{ matrix_jitsi_jvb_base_path }}", when: true }
     - { path: "{{ matrix_jitsi_jvb_config_path }}", when: true }

--- a/roles/matrix-jitsi/tasks/setup_jitsi_prosody.yml
+++ b/roles/matrix-jitsi/tasks/setup_jitsi_prosody.yml
@@ -10,7 +10,7 @@
     state: directory
     mode: 0777
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   with_items:
     - { path: "{{ matrix_jitsi_prosody_base_path }}", when: true }
     - { path: "{{ matrix_jitsi_prosody_config_path }}", when: true }

--- a/roles/matrix-jitsi/tasks/setup_jitsi_web.yml
+++ b/roles/matrix-jitsi/tasks/setup_jitsi_web.yml
@@ -10,7 +10,7 @@
     state: directory
     mode: 0777
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   with_items:
     - { path: "{{ matrix_jitsi_web_base_path }}", when: true }
     - { path: "{{ matrix_jitsi_web_config_path }}", when: true }

--- a/roles/matrix-ma1sd/tasks/setup_ma1sd.yml
+++ b/roles/matrix-ma1sd/tasks/setup_ma1sd.yml
@@ -10,7 +10,7 @@
     state: directory
     mode: 0750
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   with_items:
     - { path: "{{ matrix_ma1sd_config_path }}", when: true }
     - { path: "{{ matrix_ma1sd_data_path }}", when: true }
@@ -69,7 +69,7 @@
     dest: "{{ matrix_ma1sd_config_path }}/ma1sd.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   when: matrix_ma1sd_enabled|bool
 
 - name: Ensure custom templates are installed if any
@@ -78,7 +78,7 @@
     dest: "{{ matrix_ma1sd_data_path }}/{{ item.location }}"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   with_items:
     - {value: "{{ matrix_ma1sd_threepid_medium_email_custom_invite_template }}", location: 'invite-template.eml'}
     - {value: "{{ matrix_ma1sd_threepid_medium_email_custom_session_validation_template }}", location: 'validate-template.eml'}

--- a/roles/matrix-mailer/tasks/setup_mailer.yml
+++ b/roles/matrix-mailer/tasks/setup_mailer.yml
@@ -10,7 +10,7 @@
     state: directory
     mode: 0750
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   when: matrix_mailer_enabled|bool
 
 - name: Ensure mailer environment variables file created

--- a/roles/matrix-nginx-proxy/tasks/setup_nginx_proxy.yml
+++ b/roles/matrix-nginx-proxy/tasks/setup_nginx_proxy.yml
@@ -16,7 +16,7 @@
     state: directory
     mode: 0750
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   with_items:
     - "{{ matrix_nginx_proxy_base_path }}"
     - "{{ matrix_nginx_proxy_data_path }}"
@@ -34,7 +34,7 @@
     src: "{{ role_path }}/templates/nginx/matrix-synapse-metrics-htpasswd.j2"
     dest: "{{ matrix_nginx_proxy_data_path }}/matrix-synapse-metrics-htpasswd"
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
     mode: 0400
   when: "matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_enabled|bool and matrix_nginx_proxy_proxy_synapse_metrics|bool"
 
@@ -79,7 +79,7 @@
     state: directory
     mode: 0750
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   when: matrix_nginx_proxy_base_domain_serving_enabled|bool
 
 - name: Ensure Matrix nginx-proxy homepage for base domain exists
@@ -88,7 +88,7 @@
     dest: "{{ matrix_nginx_proxy_data_path }}/matrix-domain/index.html"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   when: matrix_nginx_proxy_base_domain_serving_enabled|bool and matrix_nginx_proxy_base_domain_homepage_enabled|bool
 
 - name: Ensure Matrix nginx-proxy configuration for base domain exists

--- a/roles/matrix-nginx-proxy/tasks/setup_well_known.yml
+++ b/roles/matrix-nginx-proxy/tasks/setup_well_known.yml
@@ -11,7 +11,7 @@
     state: directory
     mode: 0755
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   with_items:
     - "{{ matrix_static_files_base_path }}/.well-known/matrix"
 
@@ -21,4 +21,4 @@
     dest: "{{ matrix_static_files_base_path }}/.well-known/matrix"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"

--- a/roles/matrix-nginx-proxy/tasks/ssl/main.yml
+++ b/roles/matrix-nginx-proxy/tasks/ssl/main.yml
@@ -14,7 +14,7 @@
     state: directory
     mode: 0770
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
     recurse: true
   with_items:
     - "{{ matrix_ssl_log_dir_path }}"

--- a/roles/matrix-nginx-proxy/tasks/ssl/setup_ssl_self_signed_obtain_for_domain.yml
+++ b/roles/matrix-nginx-proxy/tasks/ssl/setup_ssl_self_signed_obtain_for_domain.yml
@@ -17,7 +17,7 @@
     state: directory
     mode: 0750
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   when: "not matrix_ssl_certificate_cert_path_stat_result.stat.exists"
 
 # The proper way to do this is by using a sequence of

--- a/roles/matrix-postgres/tasks/import_sqlite_db.yml
+++ b/roles/matrix-postgres/tasks/import_sqlite_db.yml
@@ -50,7 +50,7 @@
     state: directory
     mode: 0700
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 - name: Ensure matrix-postgres is started
   service:

--- a/roles/matrix-postgres/tasks/migrate_postgres_data_directory.yml
+++ b/roles/matrix-postgres/tasks/migrate_postgres_data_directory.yml
@@ -46,7 +46,7 @@
     state: directory
     mode: 0700
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   when: "result_pg_old_data_dir_stat.stat.exists"
 
 - block:

--- a/roles/matrix-postgres/tasks/run_synapse_janitor.yml
+++ b/roles/matrix-postgres/tasks/run_synapse_janitor.yml
@@ -42,7 +42,7 @@
     force: true
     mode: 0550
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 - name: Ensure matrix-postgres is started
   service:

--- a/roles/matrix-postgres/tasks/setup_postgres.yml
+++ b/roles/matrix-postgres/tasks/setup_postgres.yml
@@ -38,7 +38,7 @@
     state: directory
     mode: 0700
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   with_items:
     - "{{ matrix_postgres_base_path }}"
     - "{{ matrix_postgres_data_path }}"
@@ -52,7 +52,7 @@
     path: "{{ matrix_postgres_data_path }}"
     state: directory
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
     recurse: yes
   when: matrix_postgres_enabled|bool
 

--- a/roles/matrix-riot-web/tasks/setup_riot_web.yml
+++ b/roles/matrix-riot-web/tasks/setup_riot_web.yml
@@ -10,7 +10,7 @@
     state: directory
     mode: 0750
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   with_items:
     - { path: "{{ matrix_riot_web_data_path }}", when: true }
     - { path: "{{ matrix_riot_web_docker_src_files_path }}", when: "{{ matrix_riot_web_container_image_self_build }}" }
@@ -48,7 +48,7 @@
     dest: "{{ matrix_riot_web_data_path }}/config.json"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   when: matrix_riot_web_enabled|bool
 
 - name: Ensure Matrix riot-web config files installed
@@ -57,7 +57,7 @@
     dest: "{{ matrix_riot_web_data_path }}/{{ item.name }}"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   with_items:
     - {src: "{{ role_path }}/templates/nginx.conf.j2", name: "nginx.conf"}
     - {src: "{{ role_path }}/templates/welcome.html.j2", name: "welcome.html"}

--- a/roles/matrix-synapse/tasks/ext/rest-auth/setup_install.yml
+++ b/roles/matrix-synapse/tasks/ext/rest-auth/setup_install.yml
@@ -12,7 +12,7 @@
     force: true
     mode: 0440
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 - set_fact:
     matrix_synapse_password_providers_enabled: true

--- a/roles/matrix-synapse/tasks/ext/shared-secret-auth/setup_install.yml
+++ b/roles/matrix-synapse/tasks/ext/shared-secret-auth/setup_install.yml
@@ -12,7 +12,7 @@
     force: true
     mode: 0440
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 - set_fact:
     matrix_synapse_password_providers_enabled: true

--- a/roles/matrix-synapse/tasks/goofys/setup_install.yml
+++ b/roles/matrix-synapse/tasks/goofys/setup_install.yml
@@ -18,7 +18,7 @@
     state: directory
     mode: 0750
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   when: "not local_path_matrix_synapse_media_store_path_stat.failed and not local_path_matrix_synapse_media_store_path_stat.stat.exists"
 
 - name: Ensure goofys environment variables file created

--- a/roles/matrix-synapse/tasks/goofys/setup_install.yml
+++ b/roles/matrix-synapse/tasks/goofys/setup_install.yml
@@ -17,8 +17,8 @@
     path: "{{ matrix_synapse_media_store_path }}"
     state: directory
     mode: 0750
-    owner: "{{ matrix_user_uid }}"
-    group: "{{ matrix_user_gid }}"
+    owner: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_username }}"
   when: "not local_path_matrix_synapse_media_store_path_stat.failed and not local_path_matrix_synapse_media_store_path_stat.stat.exists"
 
 - name: Ensure goofys environment variables file created

--- a/roles/matrix-synapse/tasks/import_media_store.yml
+++ b/roles/matrix-synapse/tasks/import_media_store.yml
@@ -66,7 +66,7 @@
   file:
     path: "{{ matrix_synapse_media_store_path }}"
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
     recurse: yes
   when: "not matrix_s3_media_store_enabled|bool"
 

--- a/roles/matrix-synapse/tasks/setup_synapse.yml
+++ b/roles/matrix-synapse/tasks/setup_synapse.yml
@@ -6,7 +6,7 @@
     state: directory
     mode: 0750
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   with_items:
     - { path: "{{ matrix_synapse_config_dir_path }}", when: true }
     - { path: "{{ matrix_synapse_run_path }}", when: true }

--- a/roles/matrix-synapse/tasks/synapse/setup_install.yml
+++ b/roles/matrix-synapse/tasks/synapse/setup_install.yml
@@ -15,7 +15,7 @@
     state: directory
     mode: 0750
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
   when: "not local_path_media_store_stat.failed and not local_path_media_store_stat.stat.exists"
 
 - name: Ensure Synapse repository is present on self-build
@@ -79,7 +79,7 @@
     dest: "{{ matrix_synapse_config_dir_path }}/homeserver.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
 
 - name: Ensure Synapse log config installed
   template:


### PR DESCRIPTION
This PR addresses a few related issues i noticed regarding the ownership and permissions of files and directories managed by the playbook.

It should be highlighted that user intervention during migration is likely needed to fix the group ownership of `dimension.db`. I put the suggested commands in the commit message of 741064a, but it is basically just `chown -R`. How do we want to handle `CHANGELOG.md`? As far as I can tell there are no tags, just a date and a description of the action required, correct?

The migration worked for me, but it may warrant some more testing before merging into master.

The last commit 7585bcc is optional, I find it cleaner to use a separate variable for user and group but am open to discussion. I don't need it for my use case, it just felt like the right thing to do given the other changes in this PR.

On the topic of permissions, there is a mix used for both files and directories throughout the playbook. Even at the top level there is some variation:
```
drwxr-x--- matrix matrix coturn
drwxrwx--- matrix matrix dimension
drwxr-x--- matrix matrix jitsi
drwxr-x--- matrix matrix ma1sd
drwxr-x--- matrix matrix mailer
drwxr-x--- matrix matrix nginx-proxy
drwx------ matrix matrix postgres
drwxr-x--- matrix matrix riot-web
drwxrwx--- matrix matrix ssl
drwxr-xr-x matrix matrix static-files
drwxr-x--- matrix matrix synapse
```
Not sure if I am brave enough to tackle this though. At least in the subfolders I am sure there is a reason for some of the modes. Much of it could however be harmonised via a variable, like with `matrix_base_data_path_mode`.
