### PR TITLE
Add matrix_skip_setup variable to not run setup tasks

### DIFF
--- a/roles/matrix-base/tasks/main.yml
+++ b/roles/matrix-base/tasks/main.yml
@@ -13,7 +13,9 @@
     - setup-all
 
 - import_tasks: "{{ role_path }}/tasks/server_base/setup.yml"
-  when: run_setup|bool
+  when:
+    - run_setup|bool
+    - not matrix_skip_setup_server_base|bool
   tags:
     - setup-all
 


### PR DESCRIPTION
On Debian, even though the `matrix_docker_installation_enabled` allows to skip activation of the docker.com repository and installation of its packages, `roles/matrix-base/tasks/server_base/setup_debian.yml` triggers other actions that might not be wanted. For example, the various
```
  apt:
    update_cache: yes
```
will trigger an `apt update` action to refresh all apt repositories, which will only succeed when no apt interface is running. Furthermore, `apt-transport-https` has been included in `apt` since a while:

>    This is a dummy transitional package - https support has been moved into 
>    the apt package in 1.5. It can be safely removed.

https://pkgs.org/search/?q=apt shows that `stretch` was the last distro to need that package, but maybe someone is still running this on such a system, so m'eh.
Then the last package unconditionally installed is `fuse`, which in turn causes `fuse3` from unstable to be uninstalled, as well as its dependencies. Might create another patch for these issues..
For now, define a variable to allow completely skipping server-base setup on all platforms.