### PR TITLE
Jitsi 4548-1 update

### DIFF
--- a/roles/matrix-jitsi/defaults/main.yml
+++ b/roles/matrix-jitsi/defaults/main.yml
@@ -50,7 +50,7 @@ matrix_jitsi_jibri_recorder_user: recorder
 matrix_jitsi_jibri_recorder_password: ''
 
 
-matrix_jitsi_web_docker_image: "jitsi/web:4416"
+matrix_jitsi_web_docker_image: "jitsi/web:4548-1"
 matrix_jitsi_web_docker_image_force_pull: "{{ matrix_jitsi_web_docker_image.endswith(':latest') }}"
 
 matrix_jitsi_web_base_path: "{{ matrix_base_data_path }}/jitsi/web"
@@ -96,7 +96,7 @@ matrix_jitsi_web_interface_config_show_powered_by: false
 matrix_jitsi_web_interface_config_disable_transcription_subtitles: false
 matrix_jisti_web_interface_config_show_deep_linking_image: false
 
-matrix_jitsi_prosody_docker_image: "jitsi/prosody:4416"
+matrix_jitsi_prosody_docker_image: "jitsi/prosody:4548-1"
 matrix_jitsi_prosody_docker_image_force_pull: "{{ matrix_jitsi_prosody_docker_image.endswith(':latest') }}"
 
 matrix_jitsi_prosody_base_path: "{{ matrix_base_data_path }}/jitsi/prosody"
@@ -109,7 +109,7 @@ matrix_jitsi_prosody_container_extra_arguments: []
 matrix_jitsi_prosody_systemd_required_services_list: ['docker.service']
 
 
-matrix_jitsi_jicofo_docker_image: "jitsi/jicofo:4416"
+matrix_jitsi_jicofo_docker_image: "jitsi/jicofo:4548-1"
 matrix_jitsi_jicofo_docker_image_force_pull: "{{ matrix_jitsi_jicofo_docker_image.endswith(':latest') }}"
 
 matrix_jitsi_jicofo_base_path: "{{ matrix_base_data_path }}/jitsi/jicofo"
@@ -126,7 +126,7 @@ matrix_jitsi_jicofo_auth_user: focus
 matrix_jitsi_jicofo_auth_password: ''
 
 
-matrix_jitsi_jvb_docker_image: "jitsi/jvb:4416"
+matrix_jitsi_jvb_docker_image: "jitsi/jvb:4548-1"
 matrix_jitsi_jvb_docker_image_force_pull: "{{ matrix_jitsi_jvb_docker_image.endswith(':latest') }}"
 
 matrix_jitsi_jvb_base_path: "{{ matrix_base_data_path }}/jitsi/jvb"

--- a/roles/matrix-jitsi/defaults/main.yml
+++ b/roles/matrix-jitsi/defaults/main.yml
@@ -101,6 +101,7 @@ matrix_jitsi_prosody_docker_image_force_pull: "{{ matrix_jitsi_prosody_docker_im
 
 matrix_jitsi_prosody_base_path: "{{ matrix_base_data_path }}/jitsi/prosody"
 matrix_jitsi_prosody_config_path: "{{ matrix_jitsi_prosody_base_path }}/config"
+matrix_jitsi_prosody_plugins_path: "{{ matrix_jitsi_prosody_base_path }}/prosody-plugins-custom"
 
 # A list of extra arguments to pass to the container
 matrix_jitsi_prosody_container_extra_arguments: []

--- a/roles/matrix-jitsi/tasks/setup_jitsi_prosody.yml
+++ b/roles/matrix-jitsi/tasks/setup_jitsi_prosody.yml
@@ -14,6 +14,7 @@
   with_items:
     - { path: "{{ matrix_jitsi_prosody_base_path }}", when: true }
     - { path: "{{ matrix_jitsi_prosody_config_path }}", when: true }
+    - { path: "{{ matrix_jitsi_prosody_plugins_path }}", when: true }
   when: matrix_jitsi_enabled|bool and item.when
 
 - name: Ensure jitsi-prosody Docker image is pulled

--- a/roles/matrix-jitsi/templates/prosody/matrix-jitsi-prosody.service.j2
+++ b/roles/matrix-jitsi/templates/prosody/matrix-jitsi-prosody.service.j2
@@ -16,6 +16,7 @@ ExecStart=/usr/bin/docker run --rm --name matrix-jitsi-prosody \
 			--network={{ matrix_docker_network }} \
 			--env-file={{ matrix_jitsi_prosody_base_path }}/env \
 			-v {{ matrix_jitsi_prosody_config_path }}:/config \
+			-v {{ matrix_jitsi_prosody_plugins_path }}:/prosody-plugins-custom \
 			{% for arg in matrix_jitsi_prosody_container_extra_arguments %}
 			{{ arg }} \
 			{% endfor %}


### PR DESCRIPTION
This PR updates the Jitsi containers to the latest version which is 4548-1 atm.
Also a new volume for plugins is added to the prosody container.

Possible breaking upstream changes:
- Prosody auth method changed default from `internal_plain` to `internal_hashed`. I guess people using auth need to reconfigure all passwords. Will report back after more testing. See https://github.com/jitsi/docker-jitsi-meet/commit/d44230e2b121e72542a60b6dfbce9b07e84ed706#diff-af6bb4ab6f170892599e22f681468018

Open question:
- How closely do we want to follow the Jitsi docker upstream repo? E.g. [this commit](https://github.com/jitsi/docker-jitsi-meet/commit/0177765f2dfb7c54afa33158d5e25e8f3bcefe4d#diff-4e5e90c6228fd48698d074241c2ba760) adds compatibility for SElinux `enforcing` mode, do we want that, too? Or do we wait with the implementation until the need arises?