### PR TITLE
enable by default v2 api prefix for ma1sd

### DIFF
--- a/roles/matrix-ma1sd/defaults/main.yml
+++ b/roles/matrix-ma1sd/defaults/main.yml
@@ -76,6 +76,10 @@ matrix_ma1sd_self_check_validate_certificates: true
 # According to: https://github.com/ma1uta/ma1sd/blob/master/docs/troubleshooting.md#increase-verbosity
 matrix_ma1sd_verbose_logging: false
 
+# Setting up support for API prefixes
+matrix_ma1sd_v1_enabled: true
+matrix_ma1sd_v2_enabled: true
+
 # Default ma1sd configuration template which covers the generic use case.
 # You can customize it by controlling the various variables inside it.
 #
@@ -85,6 +89,8 @@ matrix_ma1sd_configuration_yaml: |
   #jinja2: lstrip_blocks: True
   matrix:
     domain: {{ matrix_domain }}
+    v1: {{ matrix_ma1sd_v1_enabled }}
+    v2: {{ matrix_ma1sd_v2_enabled }}
 
   server:
     name: {{ matrix_server_fqn_matrix }}

--- a/roles/matrix-ma1sd/defaults/main.yml
+++ b/roles/matrix-ma1sd/defaults/main.yml
@@ -89,8 +89,8 @@ matrix_ma1sd_configuration_yaml: |
   #jinja2: lstrip_blocks: True
   matrix:
     domain: {{ matrix_domain }}
-    v1: {{ matrix_ma1sd_v1_enabled }}
-    v2: {{ matrix_ma1sd_v2_enabled }}
+    v1: {{ matrix_ma1sd_v1_enabled|to_json }}
+    v2: {{ matrix_ma1sd_v2_enabled|to_json }}
 
   server:
     name: {{ matrix_server_fqn_matrix }}


### PR DESCRIPTION
I stumpled upon this while installing and configuring Matrix. The client (Riot) was not able to use the configured Identity Server. Riot returned

```
Access to XMLHttpRequest at 'https://matrix.example.com/_matrix/identity/v2/account/register' from origin 'vector://vector' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

First it looks like a CORS problem but with a deeper look in ma1sd I noticed that `v2` is not enabled by default at the moment. They will change that in a upcoming release. So I think it is a useful change to enable that by default or have it configurable anyways.