### PR TITLE
Fix/mx puppet bridge

### DIFF
--- a/roles/matrix-bridge-mx-puppet-slack/defaults/main.yml
+++ b/roles/matrix-bridge-mx-puppet-slack/defaults/main.yml
@@ -68,7 +68,7 @@ matrix_mx_puppet_slack_configuration_yaml: |
 
   # Slack OAuth settings. Create a slack app at https://api.slack.com/apps
   oauth:
-    enabled: false
+    enabled: true
     # Slack app credentials.
     # N.B. This must be quoted so YAML wouldn't parse it as a float.
     clientId: "{{ matrix_mx_puppet_slack_client_id }}"

--- a/roles/matrix-bridge-mx-puppet-slack/tasks/init.yml
+++ b/roles/matrix-bridge-mx-puppet-slack/tasks/init.yml
@@ -50,7 +50,7 @@
         }}
   tags:
    - always
-  when: matrix_appservice_slack_enabled|bool
+  when: matrix_mx_puppet_slack_enabled|bool
 
 - name: Warn about reverse-proxying if matrix-nginx-proxy not used
   debug:
@@ -60,7 +60,7 @@
       Please make sure that you're proxying the `{{ something }}`
       URL endpoint to the matrix-appservice-slack container.
       You can expose the container's port using the `matrix_appservice_slack_container_http_host_bind_port` variable.
-  when: "matrix_appservice_slack_enabled|bool and matrix_nginx_proxy_enabled is not defined"
+  when: "matrix_mx_puppet_slack_enabled|bool and matrix_nginx_proxy_enabled is not defined"
 
 # ansible lower than 2.8, does not support docker_image build parameters
 # for self buildig it is explicitly needed, so we rather fail here


### PR DESCRIPTION
Small changes to fix the MX Puppet Bridge setup.

1. OAuth was not enabled by default
2. The wrong variable was being used in `/roles/matrix-bridge-mx-puppet-slack/tasks/init.yml`. It should be `matrix_mx_puppet_slack_enabled`, and not `matrix_appservice_slack_enabled` 