### PR TITLE
fix for importing sqllite database

### DIFF
--- a/roles/matrix-postgres/tasks/import_sqlite_db.yml
+++ b/roles/matrix-postgres/tasks/import_sqlite_db.yml
@@ -79,6 +79,7 @@
     --network={{ matrix_docker_network }}
     --entrypoint=python
     -v {{ matrix_synapse_config_dir_path }}:/data
+    -v {{ matrix_synapse_config_dir_path }}:/matrix-media-store-parent/media-store
     -v {{ server_path_homeserver_db }}:/{{ server_path_homeserver_db|basename }}:ro
     {{ matrix_synapse_docker_image }}
     /usr/local/bin/synapse_port_db --sqlite-database /{{ server_path_homeserver_db|basename }} --postgres-config /data/homeserver.yaml


### PR DESCRIPTION
the current version fails the import, because the volume for the media is missing. It still fails if you have the optional shared secret password provider is enabled, so that might need another mount. Commenting out the password provider in the hoimeserver.yaml during the run works as well.