### PR TITLE
Remove hardcoded paths to commands on the host machine

### DIFF
--- a/roles/matrix-base/defaults/main.yml
+++ b/roles/matrix-base/defaults/main.yml
@@ -36,6 +36,7 @@ matrix_host_command_docker: "/usr/bin/env docker"
 matrix_host_command_sleep: "/usr/bin/env sleep"
 matrix_host_command_chown: "/usr/bin/env chown"
 matrix_host_command_fusermount: "/usr/bin/env fusermount"
+matrix_host_command_openssl: "/usr/bin/env openssl"
 
 matrix_ntpd_package: "ntp"
 matrix_ntpd_service: "{{ 'ntpd' if ansible_os_family == 'RedHat' or ansible_distribution == 'Archlinux' else 'ntp' }}"

--- a/roles/matrix-base/defaults/main.yml
+++ b/roles/matrix-base/defaults/main.yml
@@ -37,6 +37,7 @@ matrix_host_command_sleep: "/usr/bin/env sleep"
 matrix_host_command_chown: "/usr/bin/env chown"
 matrix_host_command_fusermount: "/usr/bin/env fusermount"
 matrix_host_command_openssl: "/usr/bin/env openssl"
+matrix_host_command_systemctl: "/usr/bin/env systemctl"
 
 matrix_ntpd_package: "ntp"
 matrix_ntpd_service: "{{ 'ntpd' if ansible_os_family == 'RedHat' or ansible_distribution == 'Archlinux' else 'ntp' }}"

--- a/roles/matrix-base/defaults/main.yml
+++ b/roles/matrix-base/defaults/main.yml
@@ -32,6 +32,11 @@ matrix_systemd_path: "/etc/systemd/system"
 matrix_cron_path: "/etc/cron.d"
 matrix_local_bin_path: "/usr/local/bin"
 
+matrix_host_command_docker: "/usr/bin/env docker"
+matrix_host_command_sleep: "/usr/bin/env sleep"
+matrix_host_command_chown: "/usr/bin/env chown"
+matrix_host_command_fusermount: "/usr/bin/env fusermount"
+
 matrix_ntpd_package: "ntp"
 matrix_ntpd_service: "{{ 'ntpd' if ansible_os_family == 'RedHat' or ansible_distribution == 'Archlinux' else 'ntp' }}"
 

--- a/roles/matrix-bridge-appservice-discord/tasks/setup_install.yml
+++ b/roles/matrix-bridge-appservice-discord/tasks/setup_install.yml
@@ -60,7 +60,7 @@
 # We intentionally suppress Ansible changes.
 - name: Generate AppService Discord invite link
   shell: >-
-    /usr/bin/docker run --rm --name matrix-appservice-discord-link-gen
+    {{ matrix_host_command_docker }} run --rm --name matrix-appservice-discord-link-gen
     --user={{ matrix_user_uid }}:{{ matrix_user_gid }}
     --cap-drop=ALL
     -v {{ matrix_appservice_discord_config_path }}:/cfg

--- a/roles/matrix-bridge-appservice-discord/templates/systemd/matrix-appservice-discord.service.j2
+++ b/roles/matrix-bridge-appservice-discord/templates/systemd/matrix-appservice-discord.service.j2
@@ -11,13 +11,13 @@ Wants={{ service }}
 
 [Service]
 Type=simple
-ExecStartPre=-/usr/bin/docker kill matrix-appservice-discord
-ExecStartPre=-/usr/bin/docker rm matrix-appservice-discord
+ExecStartPre=-{{ matrix_host_command_docker }} kill matrix-appservice-discord
+ExecStartPre=-{{ matrix_host_command_docker }} rm matrix-appservice-discord
 
 # Intentional delay, so that the homeserver (we likely depend on) can manage to start.
-ExecStartPre=/bin/sleep 5
+ExecStartPre={{ matrix_host_command_sleep }} 5
 
-ExecStart=/usr/bin/docker run --rm --name matrix-appservice-discord \
+ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-appservice-discord \
 			--log-driver=none \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
@@ -33,8 +33,8 @@ ExecStart=/usr/bin/docker run --rm --name matrix-appservice-discord \
 			{{ matrix_appservice_discord_docker_image }} \
 			node /build/src/discordas.js -p 9005 -c /cfg/config.yaml -f /cfg/registration.yaml
 
-ExecStop=-/usr/bin/docker kill matrix-appservice-discord
-ExecStop=-/usr/bin/docker rm matrix-appservice-discord
+ExecStop=-{{ matrix_host_command_docker }} kill matrix-appservice-discord
+ExecStop=-{{ matrix_host_command_docker }} rm matrix-appservice-discord
 Restart=always
 RestartSec=30
 SyslogIdentifier=matrix-appservice-discord

--- a/roles/matrix-bridge-appservice-irc/tasks/setup_install.yml
+++ b/roles/matrix-bridge-appservice-irc/tasks/setup_install.yml
@@ -58,7 +58,7 @@
   register: irc_passkey_file
 
 - name: Generate Appservice IRC passkey if it doesn't exist
-  shell: /usr/bin/openssl genpkey -out {{ matrix_appservice_irc_data_path }}/passkey.pem -outform PEM -algorithm RSA -pkeyopt rsa_keygen_bits:2048
+  shell: "{{ matrix_host_command_openssl }} genpkey -out {{ matrix_appservice_irc_data_path }}/passkey.pem -outform PEM -algorithm RSA -pkeyopt rsa_keygen_bits:2048"
   become: true
   become_user: "{{ matrix_user_username }}"
   when: "not irc_passkey_file.stat.exists"
@@ -93,7 +93,7 @@
 # to produce a final registration.yaml file, as we desire.
 - name: Generate Appservice IRC registration-template.yaml
   shell: >-
-    /usr/bin/docker run --rm --name matrix-appservice-irc-gen
+    {{ matrix_host_command_docker }} run --rm --name matrix-appservice-irc-gen
     --user={{ matrix_user_uid }}:{{ matrix_user_gid }}
     --cap-drop=ALL
     -v {{ matrix_appservice_irc_config_path }}:/config:z

--- a/roles/matrix-bridge-appservice-irc/templates/systemd/matrix-appservice-irc.service.j2
+++ b/roles/matrix-bridge-appservice-irc/templates/systemd/matrix-appservice-irc.service.j2
@@ -11,13 +11,13 @@ Wants={{ service }}
 
 [Service]
 Type=simple
-ExecStartPre=-/usr/bin/docker kill matrix-appservice-irc
-ExecStartPre=-/usr/bin/docker rm matrix-appservice-irc
+ExecStartPre=-{{ matrix_host_command_docker }} kill matrix-appservice-irc
+ExecStartPre=-{{ matrix_host_command_docker }} rm matrix-appservice-irc
 
 # Intentional delay, so that the homeserver (we likely depend on) can manage to start.
-ExecStartPre=/bin/sleep 5
+ExecStartPre={{ matrix_host_command_sleep }} 5
 
-ExecStart=/usr/bin/docker run --rm --name matrix-appservice-irc \
+ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-appservice-irc \
 			--log-driver=none \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
@@ -34,8 +34,8 @@ ExecStart=/usr/bin/docker run --rm --name matrix-appservice-irc \
 			{{ matrix_appservice_irc_docker_image }} \
 			-c 'node app.js -c /config/config.yaml -f /config/registration.yaml -p 9999'
 
-ExecStop=-/usr/bin/docker kill matrix-appservice-irc
-ExecStop=-/usr/bin/docker rm matrix-appservice-irc
+ExecStop=-{{ matrix_host_command_docker }} kill matrix-appservice-irc
+ExecStop=-{{ matrix_host_command_docker }} rm matrix-appservice-irc
 Restart=always
 RestartSec=30
 SyslogIdentifier=matrix-appservice-irc

--- a/roles/matrix-bridge-appservice-slack/templates/systemd/matrix-appservice-slack.service.j2
+++ b/roles/matrix-bridge-appservice-slack/templates/systemd/matrix-appservice-slack.service.j2
@@ -11,13 +11,13 @@ Wants={{ service }}
 
 [Service]
 Type=simple
-ExecStartPre=-/usr/bin/docker kill matrix-appservice-slack
-ExecStartPre=-/usr/bin/docker rm matrix-appservice-slack
+ExecStartPre=-{{ matrix_host_command_docker }} kill matrix-appservice-slack
+ExecStartPre=-{{ matrix_host_command_docker }} rm matrix-appservice-slack
 
 # Intentional delay, so that the homeserver (we likely depend on) can manage to start.
-ExecStartPre=/bin/sleep 5
+ExecStartPre={{ matrix_host_command_sleep }} 5
 
-ExecStart=/usr/bin/docker run --rm --name matrix-appservice-slack \
+ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-appservice-slack \
 			--log-driver=none \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
@@ -33,8 +33,8 @@ ExecStart=/usr/bin/docker run --rm --name matrix-appservice-slack \
 			{{ matrix_appservice_slack_docker_image }} \
 			node app.js -p {{matrix_appservice_slack_matrix_port}} -c /config/config.yaml -f /config/slack-registration.yaml
 
-ExecStop=-/usr/bin/docker kill matrix-appservice-slack
-ExecStop=-/usr/bin/docker rm matrix-appservice-slack
+ExecStop=-{{ matrix_host_command_docker }} kill matrix-appservice-slack
+ExecStop=-{{ matrix_host_command_docker }} rm matrix-appservice-slack
 Restart=always
 RestartSec=30
 SyslogIdentifier=matrix-appservice-slack

--- a/roles/matrix-bridge-appservice-webhooks/templates/systemd/matrix-appservice-webhooks.service.j2
+++ b/roles/matrix-bridge-appservice-webhooks/templates/systemd/matrix-appservice-webhooks.service.j2
@@ -11,13 +11,13 @@ Wants={{ service }}
 
 [Service]
 Type=simple
-ExecStartPre=-/usr/bin/docker kill matrix-appservice-webhooks
-ExecStartPre=-/usr/bin/docker rm matrix-appservice-webhooks
+ExecStartPre=-{{ matrix_host_command_docker }} kill matrix-appservice-webhooks
+ExecStartPre=-{{ matrix_host_command_docker }} rm matrix-appservice-webhooks
 
 # Intentional delay, so that the homeserver (we likely depend on) can manage to start.
-ExecStartPre=/bin/sleep 5
+ExecStartPre={{ matrix_host_command_sleep }} 5
 
-ExecStart=/usr/bin/docker run --rm --name matrix-appservice-webhooks \
+ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-appservice-webhooks \
 			--log-driver=none \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
@@ -33,8 +33,8 @@ ExecStart=/usr/bin/docker run --rm --name matrix-appservice-webhooks \
 			{{ matrix_appservice_webhooks_docker_image }} \
 			node index.js -p {{ matrix_appservice_webhooks_matrix_port }} -c /config/config.yaml -f /config/webhooks-registration.yaml
 
-ExecStop=-/usr/bin/docker kill matrix-appservice-webhooks
-ExecStop=-/usr/bin/docker rm matrix-appservice-webhooks
+ExecStop=-{{ matrix_host_command_docker }} kill matrix-appservice-webhooks
+ExecStop=-{{ matrix_host_command_docker }} rm matrix-appservice-webhooks
 Restart=always
 RestartSec=30
 SyslogIdentifier=matrix-appservice-webhooks

--- a/roles/matrix-bridge-mautrix-facebook/templates/systemd/matrix-mautrix-facebook.service.j2
+++ b/roles/matrix-bridge-mautrix-facebook/templates/systemd/matrix-mautrix-facebook.service.j2
@@ -11,9 +11,9 @@ Wants={{ service }}
 
 [Service]
 Type=simple
-ExecStartPre=-/usr/bin/docker kill matrix-mautrix-facebook
-ExecStartPre=-/usr/bin/docker rm matrix-mautrix-facebook
-ExecStartPre=/usr/bin/docker run --rm --name matrix-mautrix-facebook-db \
+ExecStartPre=-{{ matrix_host_command_docker }} kill matrix-mautrix-facebook
+ExecStartPre=-{{ matrix_host_command_docker }} rm matrix-mautrix-facebook
+ExecStartPre={{ matrix_host_command_docker }} run --rm --name matrix-mautrix-facebook-db \
 			--log-driver=none \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
@@ -23,9 +23,9 @@ ExecStartPre=/usr/bin/docker run --rm --name matrix-mautrix-facebook-db \
 			alembic -x config=/config/config.yaml upgrade head
 
 # Intentional delay, so that the homeserver (we likely depend on) can manage to start.
-ExecStartPre=/bin/sleep 5
+ExecStartPre={{ matrix_host_command_sleep }} 5
 
-ExecStart=/usr/bin/docker run --rm --name matrix-mautrix-facebook \
+ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-mautrix-facebook \
 			--log-driver=none \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
@@ -38,8 +38,8 @@ ExecStart=/usr/bin/docker run --rm --name matrix-mautrix-facebook \
 			{{ matrix_mautrix_facebook_docker_image }} \
 			python3 -m mautrix_facebook -c /config/config.yaml
 
-ExecStop=-/usr/bin/docker kill matrix-mautrix-facebook
-ExecStop=-/usr/bin/docker rm matrix-mautrix-facebook
+ExecStop=-{{ matrix_host_command_docker }} kill matrix-mautrix-facebook
+ExecStop=-{{ matrix_host_command_docker }} rm matrix-mautrix-facebook
 Restart=always
 RestartSec=30
 SyslogIdentifier=matrix-mautrix-facebook

--- a/roles/matrix-bridge-mautrix-hangouts/templates/systemd/matrix-mautrix-hangouts.service.j2
+++ b/roles/matrix-bridge-mautrix-hangouts/templates/systemd/matrix-mautrix-hangouts.service.j2
@@ -11,9 +11,9 @@ Wants={{ service }}
 
 [Service]
 Type=simple
-ExecStartPre=-/usr/bin/docker kill matrix-mautrix-hangouts matrix-mautrix-hangouts-db
-ExecStartPre=-/usr/bin/docker rm matrix-mautrix-hangouts matrix-mautrix-hangouts-db
-ExecStartPre=/usr/bin/docker run --rm --name matrix-mautrix-hangouts-db \
+ExecStartPre=-{{ matrix_host_command_docker }} kill matrix-mautrix-hangouts matrix-mautrix-hangouts-db
+ExecStartPre=-{{ matrix_host_command_docker }} rm matrix-mautrix-hangouts matrix-mautrix-hangouts-db
+ExecStartPre={{ matrix_host_command_docker }} run --rm --name matrix-mautrix-hangouts-db \
 			--log-driver=none \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
@@ -23,9 +23,9 @@ ExecStartPre=/usr/bin/docker run --rm --name matrix-mautrix-hangouts-db \
 			alembic -x config=/config/config.yaml upgrade head
 
 # Intentional delay, so that the homeserver (we likely depend on) can manage to start.
-ExecStartPre=/bin/sleep 5
+ExecStartPre={{ matrix_host_command_sleep }} 5
 
-ExecStart=/usr/bin/docker run --rm --name matrix-mautrix-hangouts \
+ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-mautrix-hangouts \
 			--log-driver=none \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
@@ -38,8 +38,8 @@ ExecStart=/usr/bin/docker run --rm --name matrix-mautrix-hangouts \
 			{{ matrix_mautrix_hangouts_docker_image }} \
 			python3 -m mautrix_hangouts -c /config/config.yaml
 
-ExecStop=-/usr/bin/docker kill matrix-mautrix-hangouts
-ExecStop=-/usr/bin/docker rm matrix-mautrix-hangouts
+ExecStop=-{{ matrix_host_command_docker }} kill matrix-mautrix-hangouts
+ExecStop=-{{ matrix_host_command_docker }} rm matrix-mautrix-hangouts
 Restart=always
 RestartSec=30
 SyslogIdentifier=matrix-mautrix-hangouts

--- a/roles/matrix-bridge-mautrix-telegram/templates/systemd/matrix-mautrix-telegram.service.j2
+++ b/roles/matrix-bridge-mautrix-telegram/templates/systemd/matrix-mautrix-telegram.service.j2
@@ -11,9 +11,9 @@ Wants={{ service }}
 
 [Service]
 Type=simple
-ExecStartPre=-/usr/bin/docker kill matrix-mautrix-telegram
-ExecStartPre=-/usr/bin/docker rm matrix-mautrix-telegram
-ExecStartPre=/usr/bin/docker run --rm --name matrix-mautrix-telegram-db \
+ExecStartPre=-{{ matrix_host_command_docker }} kill matrix-mautrix-telegram
+ExecStartPre=-{{ matrix_host_command_docker }} rm matrix-mautrix-telegram
+ExecStartPre={{ matrix_host_command_docker }} run --rm --name matrix-mautrix-telegram-db \
 			--log-driver=none \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
@@ -23,9 +23,9 @@ ExecStartPre=/usr/bin/docker run --rm --name matrix-mautrix-telegram-db \
 			alembic -x config=/config/config.yaml upgrade head
 
 # Intentional delay, so that the homeserver (we likely depend on) can manage to start.
-ExecStartPre=/bin/sleep 5
+ExecStartPre={{ matrix_host_command_sleep }} 5
 
-ExecStart=/usr/bin/docker run --rm --name matrix-mautrix-telegram \
+ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-mautrix-telegram \
 			--log-driver=none \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
@@ -41,8 +41,8 @@ ExecStart=/usr/bin/docker run --rm --name matrix-mautrix-telegram \
 			{{ matrix_mautrix_telegram_docker_image }} \
 			python3 -m mautrix_telegram -c /config/config.yaml
 
-ExecStop=-/usr/bin/docker kill matrix-mautrix-telegram
-ExecStop=-/usr/bin/docker rm matrix-mautrix-telegram
+ExecStop=-{{ matrix_host_command_docker }} kill matrix-mautrix-telegram
+ExecStop=-{{ matrix_host_command_docker }} rm matrix-mautrix-telegram
 Restart=always
 RestartSec=30
 SyslogIdentifier=matrix-mautrix-telegram

--- a/roles/matrix-bridge-mautrix-whatsapp/templates/systemd/matrix-mautrix-whatsapp.service.j2
+++ b/roles/matrix-bridge-mautrix-whatsapp/templates/systemd/matrix-mautrix-whatsapp.service.j2
@@ -11,13 +11,13 @@ Wants={{ service }}
 
 [Service]
 Type=simple
-ExecStartPre=-/usr/bin/docker kill matrix-mautrix-whatsapp
-ExecStartPre=-/usr/bin/docker rm matrix-mautrix-whatsapp
+ExecStartPre=-{{ matrix_host_command_docker }} kill matrix-mautrix-whatsapp
+ExecStartPre=-{{ matrix_host_command_docker }} rm matrix-mautrix-whatsapp
 
 # Intentional delay, so that the homeserver (we likely depend on) can manage to start.
-ExecStartPre=/bin/sleep 5
+ExecStartPre={{ matrix_host_command_sleep }} 5
 
-ExecStart=/usr/bin/docker run --rm --name matrix-mautrix-whatsapp \
+ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-mautrix-whatsapp \
 			--log-driver=none \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
@@ -31,8 +31,8 @@ ExecStart=/usr/bin/docker run --rm --name matrix-mautrix-whatsapp \
 			{{ matrix_mautrix_whatsapp_docker_image }} \
 			/usr/bin/mautrix-whatsapp -c /config/config.yaml -r /config/registration.yaml
 
-ExecStop=-/usr/bin/docker kill matrix-mautrix-whatsapp
-ExecStop=-/usr/bin/docker rm matrix-mautrix-whatsapp
+ExecStop=-{{ matrix_host_command_docker }} kill matrix-mautrix-whatsapp
+ExecStop=-{{ matrix_host_command_docker }} rm matrix-mautrix-whatsapp
 Restart=always
 RestartSec=30
 SyslogIdentifier=matrix-mautrix-whatsapp

--- a/roles/matrix-bridge-mx-puppet-skype/templates/systemd/matrix-mx-puppet-skype.service.j2
+++ b/roles/matrix-bridge-mx-puppet-skype/templates/systemd/matrix-mx-puppet-skype.service.j2
@@ -11,13 +11,13 @@ Wants={{ service }}
 
 [Service]
 Type=simple
-ExecStartPre=-/usr/bin/docker kill matrix-mx-puppet-skype
-ExecStartPre=-/usr/bin/docker rm matrix-mx-puppet-skype
+ExecStartPre=-{{ matrix_host_command_docker }} kill matrix-mx-puppet-skype
+ExecStartPre=-{{ matrix_host_command_docker }} rm matrix-mx-puppet-skype
 
 # Intentional delay, so that the homeserver (we likely depend on) can manage to start.
-ExecStartPre=/bin/sleep 5
+ExecStartPre={{ matrix_host_command_sleep }} 5
 
-ExecStart=/usr/bin/docker run --rm --name matrix-mx-puppet-skype \
+ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-mx-puppet-skype \
 			--log-driver=none \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
@@ -31,8 +31,8 @@ ExecStart=/usr/bin/docker run --rm --name matrix-mx-puppet-skype \
 			{% endfor %}
 			{{ matrix_mx_puppet_skype_docker_image }}
 
-ExecStop=-/usr/bin/docker kill matrix-mx-puppet-skype
-ExecStop=-/usr/bin/docker rm matrix-mx-puppet-skype
+ExecStop=-{{ matrix_host_command_docker }} kill matrix-mx-puppet-skype
+ExecStop=-{{ matrix_host_command_docker }} rm matrix-mx-puppet-skype
 Restart=always
 RestartSec=30
 SyslogIdentifier=matrix-mx-puppet-skype

--- a/roles/matrix-bridge-mx-puppet-slack/templates/systemd/matrix-mx-puppet-slack.service.j2
+++ b/roles/matrix-bridge-mx-puppet-slack/templates/systemd/matrix-mx-puppet-slack.service.j2
@@ -11,13 +11,13 @@ Wants={{ service }}
 
 [Service]
 Type=simple
-ExecStartPre=-/usr/bin/docker kill matrix-mx-puppet-slack
-ExecStartPre=-/usr/bin/docker rm matrix-mx-puppet-slack
+ExecStartPre=-{{ matrix_host_command_docker }} kill matrix-mx-puppet-slack
+ExecStartPre=-{{ matrix_host_command_docker }} rm matrix-mx-puppet-slack
 
 # Intentional delay, so that the homeserver (we likely depend on) can manage to start.
-ExecStartPre=/bin/sleep 5
+ExecStartPre={{ matrix_host_command_sleep }} 5
 
-ExecStart=/usr/bin/docker run --rm --name matrix-mx-puppet-slack \
+ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-mx-puppet-slack \
 			--log-driver=none \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
@@ -34,8 +34,8 @@ ExecStart=/usr/bin/docker run --rm --name matrix-mx-puppet-slack \
 			{% endfor %}
 			{{ matrix_mx_puppet_slack_docker_image }}
 
-ExecStop=-/usr/bin/docker kill matrix-mx-puppet-slack
-ExecStop=-/usr/bin/docker rm matrix-mx-puppet-slack
+ExecStop=-{{ matrix_host_command_docker }} kill matrix-mx-puppet-slack
+ExecStop=-{{ matrix_host_command_docker }} rm matrix-mx-puppet-slack
 Restart=always
 RestartSec=30
 SyslogIdentifier=matrix-mx-puppet-slack

--- a/roles/matrix-corporal/templates/systemd/matrix-corporal.service.j2
+++ b/roles/matrix-corporal/templates/systemd/matrix-corporal.service.j2
@@ -8,10 +8,10 @@ After={{ service }}
 
 [Service]
 Type=simple
-ExecStartPre=-/usr/bin/docker kill matrix-corporal
-ExecStartPre=-/usr/bin/docker rm matrix-corporal
+ExecStartPre=-{{ matrix_host_command_docker }} kill matrix-corporal
+ExecStartPre=-{{ matrix_host_command_docker }} rm matrix-corporal
 
-ExecStart=/usr/bin/docker run --rm --name matrix-corporal \
+ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-corporal \
 			--log-driver=none \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
@@ -32,8 +32,8 @@ ExecStart=/usr/bin/docker run --rm --name matrix-corporal \
 			{{ matrix_corporal_docker_image }} \
 			/matrix-corporal -config=/etc/matrix-corporal/config.json
 
-ExecStop=-/usr/bin/docker kill matrix-corporal
-ExecStop=-/usr/bin/docker rm matrix-corporal
+ExecStop=-{{ matrix_host_command_docker }} kill matrix-corporal
+ExecStop=-{{ matrix_host_command_docker }} rm matrix-corporal
 Restart=always
 RestartSec=30
 SyslogIdentifier=matrix-corporal

--- a/roles/matrix-coturn/tasks/setup_coturn.yml
+++ b/roles/matrix-coturn/tasks/setup_coturn.yml
@@ -99,7 +99,7 @@
     hour: "4"
     minute: "20"
     day: "*/5"
-    job: /bin/systemctl reload matrix-coturn.service
+    job: "{{ matrix_host_command_systemctl }} reload matrix-coturn.service"
   when: "matrix_coturn_enabled|bool and matrix_coturn_tls_enabled|bool"
 
 

--- a/roles/matrix-coturn/templates/systemd/matrix-coturn.service.j2
+++ b/roles/matrix-coturn/templates/systemd/matrix-coturn.service.j2
@@ -8,10 +8,10 @@ After={{ service }}
 
 [Service]
 Type=simple
-ExecStartPre=-/usr/bin/docker kill matrix-coturn
-ExecStartPre=-/usr/bin/docker rm matrix-coturn
+ExecStartPre=-{{ matrix_host_command_docker }} kill matrix-coturn
+ExecStartPre=-{{ matrix_host_command_docker }} rm matrix-coturn
 
-ExecStart=/usr/bin/docker run --rm --name matrix-coturn \
+ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-coturn \
 			--log-driver=none \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
@@ -40,12 +40,12 @@ ExecStart=/usr/bin/docker run --rm --name matrix-coturn \
 			{{ matrix_coturn_docker_image }} \
 			-c /turnserver.conf
 
-ExecStop=-/usr/bin/docker kill matrix-coturn
-ExecStop=-/usr/bin/docker rm matrix-coturn
+ExecStop=-{{ matrix_host_command_docker }} kill matrix-coturn
+ExecStop=-{{ matrix_host_command_docker }} rm matrix-coturn
 
 # This only reloads certificates (not other configuration).
 # See: https://github.com/coturn/coturn/pull/236
-ExecReload=/usr/bin/docker exec matrix-coturn kill -USR2 1
+ExecReload={{ matrix_host_command_docker }} exec matrix-coturn kill -USR2 1
 
 Restart=always
 RestartSec=30

--- a/roles/matrix-dimension/templates/systemd/matrix-dimension.service.j2
+++ b/roles/matrix-dimension/templates/systemd/matrix-dimension.service.j2
@@ -6,13 +6,13 @@ Requires=docker.service
 
 [Service]
 Type=simple
-ExecStartPre=-/usr/bin/docker kill matrix-dimension
-ExecStartPre=-/usr/bin/docker rm matrix-dimension
+ExecStartPre=-{{ matrix_host_command_docker }} kill matrix-dimension
+ExecStartPre=-{{ matrix_host_command_docker }} rm matrix-dimension
 
 # Fixup database ownership if it got changed somehow (during a server migration, etc.)
-ExecStartPre=-/usr/bin/chown {{ matrix_dimension_user_uid }}:{{ matrix_dimension_user_gid }} {{ matrix_dimension_base_path }}/dimension.db
+ExecStartPre=-{{ matrix_host_command_chown }} {{ matrix_dimension_user_uid }}:{{ matrix_dimension_user_gid }} {{ matrix_dimension_base_path }}/dimension.db
 
-ExecStart=/usr/bin/docker run --rm --name matrix-dimension \
+ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-dimension \
 			--log-driver=none \
 			--user={{ matrix_dimension_user_uid }}:{{ matrix_dimension_user_gid }} \
 			--cap-drop=ALL \
@@ -29,8 +29,8 @@ ExecStart=/usr/bin/docker run --rm --name matrix-dimension \
 			{% endfor %}
 			{{ matrix_dimension_docker_image }}
 
-ExecStop=-/usr/bin/docker kill matrix-dimension
-ExecStop=-/usr/bin/docker rm matrix-dimension
+ExecStop=-{{ matrix_host_command_docker }} kill matrix-dimension
+ExecStop=-{{ matrix_host_command_docker }} rm matrix-dimension
 Restart=always
 RestartSec=30
 SyslogIdentifier=matrix-dimension

--- a/roles/matrix-email2matrix/templates/systemd/matrix-email2matrix.service.j2
+++ b/roles/matrix-email2matrix/templates/systemd/matrix-email2matrix.service.j2
@@ -6,10 +6,10 @@ Requires=docker.service
 
 [Service]
 Type=simple
-ExecStartPre=-/usr/bin/docker kill matrix-email2matrix
-ExecStartPre=-/usr/bin/docker rm matrix-email2matrix
+ExecStartPre=-{{ matrix_host_command_docker }} kill matrix-email2matrix
+ExecStartPre=-{{ matrix_host_command_docker }} rm matrix-email2matrix
 
-ExecStart=/usr/bin/docker run --rm --name matrix-email2matrix \
+ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-email2matrix \
 			--log-driver=none \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
@@ -22,8 +22,8 @@ ExecStart=/usr/bin/docker run --rm --name matrix-email2matrix \
 			{% endfor %}
 			{{ matrix_email2matrix_docker_image }}
 
-ExecStop=-/usr/bin/docker kill matrix-email2matrix
-ExecStop=-/usr/bin/docker rm matrix-email2matrix
+ExecStop=-{{ matrix_host_command_docker }} kill matrix-email2matrix
+ExecStop=-{{ matrix_host_command_docker }} rm matrix-email2matrix
 Restart=always
 RestartSec=30
 SyslogIdentifier=matrix-email2matrix

--- a/roles/matrix-jitsi/templates/jicofo/matrix-jitsi-jicofo.service.j2
+++ b/roles/matrix-jitsi/templates/jicofo/matrix-jitsi-jicofo.service.j2
@@ -8,10 +8,10 @@ After={{ service }}
 
 [Service]
 Type=simple
-ExecStartPre=-/usr/bin/docker kill matrix-jitsi-jicofo
-ExecStartPre=-/usr/bin/docker rm matrix-jitsi-jicofo
+ExecStartPre=-{{ matrix_host_command_docker }} kill matrix-jitsi-jicofo
+ExecStartPre=-{{ matrix_host_command_docker }} rm matrix-jitsi-jicofo
 
-ExecStart=/usr/bin/docker run --rm --name matrix-jitsi-jicofo \
+ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-jitsi-jicofo \
 			--log-driver=none \
 			--network={{ matrix_docker_network }} \
 			--env-file={{ matrix_jitsi_jicofo_base_path }}/env \
@@ -21,8 +21,8 @@ ExecStart=/usr/bin/docker run --rm --name matrix-jitsi-jicofo \
 			{% endfor %}
 			{{ matrix_jitsi_jicofo_docker_image }}
 
-ExecStop=-/usr/bin/docker kill matrix-jitsi-jicofo
-ExecStop=-/usr/bin/docker rm matrix-jitsi-jicofo
+ExecStop=-{{ matrix_host_command_docker }} kill matrix-jitsi-jicofo
+ExecStop=-{{ matrix_host_command_docker }} rm matrix-jitsi-jicofo
 Restart=always
 RestartSec=30
 SyslogIdentifier=matrix-jitsi-jicofo

--- a/roles/matrix-jitsi/templates/jvb/matrix-jitsi-jvb.service.j2
+++ b/roles/matrix-jitsi/templates/jvb/matrix-jitsi-jvb.service.j2
@@ -8,10 +8,10 @@ After={{ service }}
 
 [Service]
 Type=simple
-ExecStartPre=-/usr/bin/docker kill matrix-jitsi-jvb
-ExecStartPre=-/usr/bin/docker rm matrix-jitsi-jvb
+ExecStartPre=-{{ matrix_host_command_docker }} kill matrix-jitsi-jvb
+ExecStartPre=-{{ matrix_host_command_docker }} rm matrix-jitsi-jvb
 
-ExecStart=/usr/bin/docker run --rm --name matrix-jitsi-jvb \
+ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-jitsi-jvb \
 			--log-driver=none \
 			--network={{ matrix_docker_network }} \
 			--env-file={{ matrix_jitsi_jvb_base_path }}/env \
@@ -27,8 +27,8 @@ ExecStart=/usr/bin/docker run --rm --name matrix-jitsi-jvb \
 			{% endfor %}
 			{{ matrix_jitsi_jvb_docker_image }}
 
-ExecStop=-/usr/bin/docker kill matrix-jitsi-jvb
-ExecStop=-/usr/bin/docker rm matrix-jitsi-jvb
+ExecStop=-{{ matrix_host_command_docker }} kill matrix-jitsi-jvb
+ExecStop=-{{ matrix_host_command_docker }} rm matrix-jitsi-jvb
 Restart=always
 RestartSec=30
 SyslogIdentifier=matrix-jitsi-jvb

--- a/roles/matrix-jitsi/templates/prosody/matrix-jitsi-prosody.service.j2
+++ b/roles/matrix-jitsi/templates/prosody/matrix-jitsi-prosody.service.j2
@@ -8,10 +8,10 @@ After={{ service }}
 
 [Service]
 Type=simple
-ExecStartPre=-/usr/bin/docker kill matrix-jitsi-prosody
-ExecStartPre=-/usr/bin/docker rm matrix-jitsi-prosody
+ExecStartPre=-{{ matrix_host_command_docker }} kill matrix-jitsi-prosody
+ExecStartPre=-{{ matrix_host_command_docker }} rm matrix-jitsi-prosody
 
-ExecStart=/usr/bin/docker run --rm --name matrix-jitsi-prosody \
+ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-jitsi-prosody \
 			--log-driver=none \
 			--network={{ matrix_docker_network }} \
 			--env-file={{ matrix_jitsi_prosody_base_path }}/env \
@@ -22,8 +22,8 @@ ExecStart=/usr/bin/docker run --rm --name matrix-jitsi-prosody \
 			{% endfor %}
 			{{ matrix_jitsi_prosody_docker_image }}
 
-ExecStop=-/usr/bin/docker kill matrix-jitsi-prosody
-ExecStop=-/usr/bin/docker rm matrix-jitsi-prosody
+ExecStop=-{{ matrix_host_command_docker }} kill matrix-jitsi-prosody
+ExecStop=-{{ matrix_host_command_docker }} rm matrix-jitsi-prosody
 Restart=always
 RestartSec=30
 SyslogIdentifier=matrix-jitsi-prosody

--- a/roles/matrix-jitsi/templates/web/matrix-jitsi-web.service.j2
+++ b/roles/matrix-jitsi/templates/web/matrix-jitsi-web.service.j2
@@ -8,10 +8,10 @@ After={{ service }}
 
 [Service]
 Type=simple
-ExecStartPre=-/usr/bin/docker kill matrix-jitsi-web
-ExecStartPre=-/usr/bin/docker rm matrix-jitsi-web
+ExecStartPre=-{{ matrix_host_command_docker }} kill matrix-jitsi-web
+ExecStartPre=-{{ matrix_host_command_docker }} rm matrix-jitsi-web
 
-ExecStart=/usr/bin/docker run --rm --name matrix-jitsi-web \
+ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-jitsi-web \
 			--log-driver=none \
 			--network={{ matrix_docker_network }} \
 			--env-file={{ matrix_jitsi_web_base_path }}/env \
@@ -25,8 +25,8 @@ ExecStart=/usr/bin/docker run --rm --name matrix-jitsi-web \
 			{% endfor %}
 			{{ matrix_jitsi_web_docker_image }}
 
-ExecStop=-/usr/bin/docker kill matrix-jitsi-web
-ExecStop=-/usr/bin/docker rm matrix-jitsi-web
+ExecStop=-{{ matrix_host_command_docker }} kill matrix-jitsi-web
+ExecStop=-{{ matrix_host_command_docker }} rm matrix-jitsi-web
 Restart=always
 RestartSec=30
 SyslogIdentifier=matrix-jitsi-web

--- a/roles/matrix-ma1sd/templates/systemd/matrix-ma1sd.service.j2
+++ b/roles/matrix-ma1sd/templates/systemd/matrix-ma1sd.service.j2
@@ -11,12 +11,12 @@ Wants={{ service }}
 
 [Service]
 Type=simple
-ExecStartPre=-/usr/bin/docker kill matrix-ma1sd
-ExecStartPre=-/usr/bin/docker rm matrix-ma1sd
+ExecStartPre=-{{ matrix_host_command_docker }} kill matrix-ma1sd
+ExecStartPre=-{{ matrix_host_command_docker }} rm matrix-ma1sd
 
 # ma1sd writes an SQLite shared library (libsqlitejdbc.so) to /tmp and executes it from there,
 # so /tmp needs to be mounted with an exec option.
-ExecStart=/usr/bin/docker run --rm --name matrix-ma1sd \
+ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-ma1sd \
 			--log-driver=none \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
@@ -36,8 +36,8 @@ ExecStart=/usr/bin/docker run --rm --name matrix-ma1sd \
 			{% endfor %}
 			{{ matrix_ma1sd_docker_image }}
 
-ExecStop=-/usr/bin/docker kill matrix-ma1sd
-ExecStop=-/usr/bin/docker rm matrix-ma1sd
+ExecStop=-{{ matrix_host_command_docker }} kill matrix-ma1sd
+ExecStop=-{{ matrix_host_command_docker }} rm matrix-ma1sd
 Restart=always
 RestartSec=30
 SyslogIdentifier=matrix-ma1sd

--- a/roles/matrix-mailer/templates/systemd/matrix-mailer.service.j2
+++ b/roles/matrix-mailer/templates/systemd/matrix-mailer.service.j2
@@ -6,10 +6,10 @@ Requires=docker.service
 
 [Service]
 Type=simple
-ExecStartPre=-/usr/bin/docker kill matrix-mailer
-ExecStartPre=-/usr/bin/docker rm matrix-mailer
+ExecStartPre=-{{ matrix_host_command_docker }} kill matrix-mailer
+ExecStartPre=-{{ matrix_host_command_docker }} rm matrix-mailer
 
-ExecStart=/usr/bin/docker run --rm --name matrix-mailer \
+ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-mailer \
 			--log-driver=none \
 			--user={{ matrix_mailer_container_user_uid }}:{{ matrix_mailer_container_user_gid }} \
 			--cap-drop=ALL \
@@ -24,8 +24,8 @@ ExecStart=/usr/bin/docker run --rm --name matrix-mailer \
 			{% endfor %}
 			{{ matrix_mailer_docker_image }}
 
-ExecStop=-/usr/bin/docker kill matrix-mailer
-ExecStop=-/usr/bin/docker rm matrix-mailer
+ExecStop=-{{ matrix_host_command_docker }} kill matrix-mailer
+ExecStop=-{{ matrix_host_command_docker }} rm matrix-mailer
 Restart=always
 RestartSec=30
 SyslogIdentifier=matrix-mailer

--- a/roles/matrix-nginx-proxy/tasks/ssl/setup_ssl_lets_encrypt.yml
+++ b/roles/matrix-nginx-proxy/tasks/ssl/setup_ssl_lets_encrypt.yml
@@ -84,7 +84,7 @@
       hour: "5"
       minute: "20"
       day: "*"
-      job: /bin/systemctl reload matrix-nginx-proxy.service
+      job: "{{ matrix_host_command_systemctl }} reload matrix-nginx-proxy.service"
     when: matrix_nginx_proxy_enabled|bool
   when: "matrix_ssl_retrieval_method == 'lets-encrypt'"
 

--- a/roles/matrix-nginx-proxy/tasks/ssl/setup_ssl_lets_encrypt_obtain_for_domain.yml
+++ b/roles/matrix-nginx-proxy/tasks/ssl/setup_ssl_lets_encrypt_obtain_for_domain.yml
@@ -16,7 +16,7 @@
 # We suppress the error, as we'll try another method below.
 - name: Attempt initial SSL certificate retrieval with standalone authenticator (directly)
   shell: >-
-    /usr/bin/docker run
+    {{ matrix_host_command_docker }} run
     --rm
     --name=matrix-certbot
     --user={{ matrix_user_uid }}:{{ matrix_user_gid }}
@@ -43,7 +43,7 @@
 # and it's running now, it may be able to proxy requests to `matrix_ssl_lets_encrypt_certbot_standalone_http_port`.
 - name: Attempt initial SSL certificate retrieval with standalone authenticator (via proxy)
   shell: >-
-    /usr/bin/docker run
+    {{ matrix_host_command_docker }} run
     --rm
     --name=matrix-certbot
     --user={{ matrix_user_uid }}:{{ matrix_user_gid }}

--- a/roles/matrix-nginx-proxy/templates/systemd/matrix-nginx-proxy.service.j2
+++ b/roles/matrix-nginx-proxy/templates/systemd/matrix-nginx-proxy.service.j2
@@ -11,10 +11,10 @@ Wants={{ service }}
 
 [Service]
 Type=simple
-ExecStartPre=-/usr/bin/docker kill matrix-nginx-proxy
-ExecStartPre=-/usr/bin/docker rm matrix-nginx-proxy
+ExecStartPre=-{{ matrix_host_command_docker }} kill matrix-nginx-proxy
+ExecStartPre=-{{ matrix_host_command_docker }} rm matrix-nginx-proxy
 
-ExecStart=/usr/bin/docker run --rm --name matrix-nginx-proxy \
+ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-nginx-proxy \
 			--log-driver=none \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
@@ -43,9 +43,9 @@ ExecStart=/usr/bin/docker run --rm --name matrix-nginx-proxy \
 			{% endfor %}
 			{{ matrix_nginx_proxy_docker_image }}
 
-ExecStop=-/usr/bin/docker kill matrix-nginx-proxy
-ExecStop=-/usr/bin/docker rm matrix-nginx-proxy
-ExecReload=/usr/bin/docker exec matrix-nginx-proxy /usr/sbin/nginx -s reload
+ExecStop=-{{ matrix_host_command_docker }} kill matrix-nginx-proxy
+ExecStop=-{{ matrix_host_command_docker }} rm matrix-nginx-proxy
+ExecReload={{ matrix_host_command_docker }} exec matrix-nginx-proxy /usr/sbin/nginx -s reload
 Restart=always
 RestartSec=30
 SyslogIdentifier=matrix-nginx-proxy

--- a/roles/matrix-postgres/tasks/import_postgres.yml
+++ b/roles/matrix-postgres/tasks/import_postgres.yml
@@ -63,7 +63,7 @@
 - name: Generate Postgres database import command
   set_fact:
     matrix_postgres_import_command: >-
-      /usr/bin/docker run --rm --name matrix-postgres-import
+      {{ matrix_host_command_docker }} run --rm --name matrix-postgres-import
       --user={{ matrix_user_uid }}:{{ matrix_user_gid }}
       --cap-drop=ALL
       --network={{ matrix_docker_network }}

--- a/roles/matrix-postgres/tasks/run_synapse_janitor.yml
+++ b/roles/matrix-postgres/tasks/run_synapse_janitor.yml
@@ -66,7 +66,7 @@
 - name: Generate Postgres database synapse-janitor command
   set_fact:
     matrix_postgres_synapse_janitor_command: >-
-      /usr/bin/docker run --rm --name matrix-postgres-synapse-janitor
+      {{ matrix_host_command_docker }} run --rm --name matrix-postgres-synapse-janitor
       --user={{ matrix_user_uid }}:{{ matrix_user_gid }}
       --cap-drop=ALL
       --network={{ matrix_docker_network }}

--- a/roles/matrix-postgres/tasks/run_vacuum.yml
+++ b/roles/matrix-postgres/tasks/run_vacuum.yml
@@ -45,7 +45,7 @@
 - name: Generate Postgres database vacuum command
   set_fact:
     matrix_postgres_vacuum_command: >-
-      /usr/bin/docker run --rm --name matrix-postgres-synapse-vacuum
+      {{ matrix_host_command_docker }} run --rm --name matrix-postgres-synapse-vacuum
       --user={{ matrix_user_uid }}:{{ matrix_user_gid }}
       --cap-drop=ALL
       --network={{ matrix_docker_network }}

--- a/roles/matrix-postgres/tasks/upgrade_postgres.yml
+++ b/roles/matrix-postgres/tasks/upgrade_postgres.yml
@@ -79,7 +79,7 @@
 # we need to remove these from the dump, or we'll get errors saying these already exist.
 - name: Perform Postgres database dump
   command: >-
-    /usr/bin/docker run --rm --name matrix-postgres-dump
+    {{ matrix_host_command_docker }} run --rm --name matrix-postgres-dump
     --user={{ matrix_user_uid }}:{{ matrix_user_gid }}
     --network={{ matrix_docker_network }}
     --env-file={{ matrix_postgres_base_path }}/env-postgres-psql
@@ -123,7 +123,7 @@
 - name: Generate Postgres database import command
   set_fact:
     matrix_postgres_import_command: >-
-      /usr/bin/docker run --rm --name matrix-postgres-import
+      {{ matrix_host_command_docker }} run --rm --name matrix-postgres-import
       --user={{ matrix_user_uid }}:{{ matrix_user_gid }}
       --cap-drop=ALL
       --network={{ matrix_docker_network }}

--- a/roles/matrix-postgres/templates/systemd/matrix-postgres.service.j2
+++ b/roles/matrix-postgres/templates/systemd/matrix-postgres.service.j2
@@ -6,10 +6,10 @@ Requires=docker.service
 
 [Service]
 Type=simple
-ExecStartPre=-/usr/bin/docker stop matrix-postgres
-ExecStartPre=-/usr/bin/docker rm matrix-postgres
+ExecStartPre=-{{ matrix_host_command_docker }} stop matrix-postgres
+ExecStartPre=-{{ matrix_host_command_docker }} rm matrix-postgres
 
-ExecStart=/usr/bin/docker run --rm --name matrix-postgres \
+ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-postgres \
 			--log-driver=none \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
@@ -28,8 +28,8 @@ ExecStart=/usr/bin/docker run --rm --name matrix-postgres \
 			{% endfor %}
 			{{ matrix_postgres_docker_image_to_use }}
 
-ExecStop=-/usr/bin/docker stop matrix-postgres
-ExecStop=-/usr/bin/docker rm matrix-postgres
+ExecStop=-{{ matrix_host_command_docker }} stop matrix-postgres
+ExecStop=-{{ matrix_host_command_docker }} rm matrix-postgres
 Restart=always
 RestartSec=30
 SyslogIdentifier=matrix-postgres

--- a/roles/matrix-riot-web/templates/systemd/matrix-riot-web.service.j2
+++ b/roles/matrix-riot-web/templates/systemd/matrix-riot-web.service.j2
@@ -8,10 +8,10 @@ After={{ service }}
 
 [Service]
 Type=simple
-ExecStartPre=-/usr/bin/docker kill matrix-riot-web
-ExecStartPre=-/usr/bin/docker rm matrix-riot-web
+ExecStartPre=-{{ matrix_host_command_docker }} kill matrix-riot-web
+ExecStartPre=-{{ matrix_host_command_docker }} rm matrix-riot-web
 
-ExecStart=/usr/bin/docker run --rm --name matrix-riot-web \
+ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-riot-web \
 			--log-driver=none \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
@@ -34,8 +34,8 @@ ExecStart=/usr/bin/docker run --rm --name matrix-riot-web \
 			{% endfor %}
 			{{ matrix_riot_web_docker_image }}
 
-ExecStop=-/usr/bin/docker kill matrix-riot-web
-ExecStop=-/usr/bin/docker rm matrix-riot-web
+ExecStop=-{{ matrix_host_command_docker }} kill matrix-riot-web
+ExecStop=-{{ matrix_host_command_docker }} rm matrix-riot-web
 Restart=always
 RestartSec=30
 SyslogIdentifier=matrix-riot-web

--- a/roles/matrix-synapse/tasks/update_user_password.yml
+++ b/roles/matrix-synapse/tasks/update_user_password.yml
@@ -36,7 +36,7 @@
   when: "start_result.changed or postgres_start_result.changed"
 
 - name: Generate password hash
-  shell: "/usr/bin/docker exec matrix-synapse /usr/local/bin/hash_password -c /data/homeserver.yaml -p {{ password|quote }}"
+  shell: "{{ matrix_host_command_docker }} exec matrix-synapse /usr/local/bin/hash_password -c /data/homeserver.yaml -p {{ password|quote }}"
   register: password_hash
 
 - name: Update user password hash

--- a/roles/matrix-synapse/templates/goofys/systemd/matrix-goofys.service.j2
+++ b/roles/matrix-synapse/templates/goofys/systemd/matrix-goofys.service.j2
@@ -6,10 +6,10 @@ Requires=docker.service
 
 [Service]
 Type=simple
-ExecStartPre=-/usr/bin/docker kill %n
-ExecStartPre=-/usr/bin/docker rm %n
+ExecStartPre=-{{ matrix_host_command_docker }} kill %n
+ExecStartPre=-{{ matrix_host_command_docker }} rm %n
 
-ExecStart=/usr/bin/docker run --rm --name %n \
+ExecStart={{ matrix_host_command_docker }} run --rm --name %n \
 			--log-driver=none \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			-v /etc/passwd:/etc/passwd:ro \
@@ -25,10 +25,10 @@ ExecStart=/usr/bin/docker run --rm --name %n \
 			-c 'goofys -f{% if not matrix_s3_media_store_custom_endpoint_enabled %} --storage-class=STANDARD_IA{% endif %}{% if matrix_s3_media_store_custom_endpoint_enabled %} --endpoint={{ matrix_s3_media_store_custom_endpoint }}{% endif %} --region {{ matrix_s3_media_store_region }} --stat-cache-ttl 60m0s --type-cache-ttl 60m0s --dir-mode 0700 --file-mode 0700 {{ matrix_s3_media_store_bucket_name }} /s3'
 
 TimeoutStartSec=5min
-ExecStop=-/usr/bin/docker stop %n
-ExecStop=-/usr/bin/docker kill %n
-ExecStop=-/usr/bin/docker rm %n
-ExecStop=-/bin/fusermount -u {{ matrix_synapse_media_store_path }}
+ExecStop=-{{ matrix_host_command_docker }} stop %n
+ExecStop=-{{ matrix_host_command_docker }} kill %n
+ExecStop=-{{ matrix_host_command_docker }} rm %n
+ExecStop=-{{ matrix_host_command_fusermount }} -u {{ matrix_synapse_media_store_path }}
 Restart=always
 RestartSec=5
 SyslogIdentifier=matrix-goofys

--- a/roles/matrix-synapse/templates/synapse/systemd/matrix-synapse.service.j2
+++ b/roles/matrix-synapse/templates/synapse/systemd/matrix-synapse.service.j2
@@ -11,16 +11,16 @@ Wants={{ service }}
 
 [Service]
 Type=simple
-ExecStartPre=-/usr/bin/docker kill matrix-synapse
-ExecStartPre=-/usr/bin/docker rm matrix-synapse
+ExecStartPre=-{{ matrix_host_command_docker }} kill matrix-synapse
+ExecStartPre=-{{ matrix_host_command_docker }} rm matrix-synapse
 {% if matrix_s3_media_store_enabled %}
 # Allow for some time before starting, so that media store can mount.
 # Mounting can happen later too, but if we start writing,
 # we'd write files to the local filesystem and fusermount will complain.
-ExecStartPre=/bin/sleep 3
+ExecStartPre={{ matrix_host_command_sleep }} 3
 {% endif %}
 
-ExecStart=/usr/bin/docker run --rm --name matrix-synapse \
+ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-synapse \
 			--log-driver=none \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
@@ -55,9 +55,9 @@ ExecStart=/usr/bin/docker run --rm --name matrix-synapse \
 			{{ matrix_synapse_docker_image }} \
 			-m synapse.app.homeserver -c /data/homeserver.yaml
 
-ExecStop=-/usr/bin/docker kill matrix-synapse
-ExecStop=-/usr/bin/docker rm matrix-synapse
-ExecReload=/usr/bin/docker exec matrix-synapse kill -HUP 1
+ExecStop=-{{ matrix_host_command_docker }} kill matrix-synapse
+ExecStop=-{{ matrix_host_command_docker }} rm matrix-synapse
+ExecReload={{ matrix_host_command_docker }} exec matrix-synapse kill -HUP 1
 Restart=always
 RestartSec=30
 SyslogIdentifier=matrix-synapse


### PR DESCRIPTION
The `ExecStartPre` command shown below does not work on Ubuntu 18.04 LTS, as `chown` is located in `/bin` and not `/usr/bin` ([file link](https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/f8157a94ef70c2eb0bb317dbccd84b78301be493/roles/matrix-dimension/templates/systemd/matrix-dimension.service.j2#L13)):
```
ExecStartPre=-/usr/bin/chown {{ matrix_dimension_user_uid }}:{{ matrix_dimension_user_gid }} {{ matrix_dimension_base_path }}/dimension.db
```
We need the full path here since systemd added path lookup to `ExecStart*` in v239, but Ubuntu 18.04 LTS is still on v237.

This PR replaces the hardcoded path with `/usr/bin/env chown`, as the location will vary between distros.

I may have gotten carried away, but I replaced all usage of hardcoded paths on the host machine with ansible variables pointing to `/usr/bin/env` by default (including `docker`). This may have been a bit excessive as in many cases (e.g. the ansible `shell` module) path lookup is anyway performed, but I felt it was better to use the same `matrix_host_command_*` variable. It would be great to get some feedback on what people think here.