### PR TITLE
Fix missing conf for double puppeting in mx-puppet-slack

### DIFF
--- a/roles/matrix-bridge-mx-puppet-slack/defaults/main.yml
+++ b/roles/matrix-bridge-mx-puppet-slack/defaults/main.yml
@@ -52,6 +52,9 @@ matrix_mx_puppet_slack_systemd_wanted_services_list: []
 matrix_mx_puppet_slack_appservice_token: ''
 matrix_mx_puppet_slack_homeserver_token: ''
 
+# Can be set to enable automatic double-puppeting via Shared Secret Auth (https://github.com/devture/matrix-synapse-shared-secret-auth).
+matrix_mx_puppet_slack_login_shared_secret: ''
+
 # Default configuration template which covers the generic use case.
 # You can customize it by controlling the various variables inside it.
 #

--- a/roles/matrix-bridge-mx-puppet-slack/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mx-puppet-slack/templates/config.yaml.j2
@@ -9,6 +9,10 @@ bridge:
   domain: {{ matrix_mx_puppet_slack_homeserver_domain }}
   # Reachable URL of the Matrix homeserver
   homeserverUrl: {{ matrix_mx_puppet_slack_homeserver_address }}
+  {% if matrix_mx_puppet_slack_login_shared_secret != '' %}
+  loginSharedSecretMap:
+    {{ matrix_domain }}: {{ matrix_mx_puppet_slack_login_shared_secret }}
+  {% endif %}
 
 
 # Slack OAuth settings. Create a slack app at https://api.slack.com/apps


### PR DESCRIPTION
Simple PR that copy the conf for double puppeting from mx-puppet-skype to mx-puppet-slack 