### PR TITLE
Add variables to fine tune jitsi

### DIFF
--- a/roles/matrix-jitsi/defaults/main.yml
+++ b/roles/matrix-jitsi/defaults/main.yml
@@ -96,6 +96,18 @@ matrix_jitsi_web_interface_config_show_powered_by: false
 matrix_jitsi_web_interface_config_disable_transcription_subtitles: false
 matrix_jisti_web_interface_config_show_deep_linking_image: false
 
+# Jitsi Fine Tune
+matrix_jitsi_web_config_disable_AudioLevels: False
+matrix_jitsi_web_config_enable_LayerSuspension: False
+matrix_jitsi_web_config_channelLastN: -1
+matrix_jitsi_web_config_enable_Video_Constraints: False
+
+# This settings work if matrix_jitsi_web_config_enable_Video_Constraints: true
+matrix_jitsi_web_config_aspectRatio: 16 / 9
+matrix_jitsi_web_config_height_ideal: 720
+matrix_jitsi_web_config_height_max: 720
+matrix_jitsi_web_config_height_min: 240
+
 matrix_jitsi_prosody_docker_image: "jitsi/prosody:stable-4548-1"
 matrix_jitsi_prosody_docker_image_force_pull: "{{ matrix_jitsi_prosody_docker_image.endswith(':latest') }}"
 

--- a/roles/matrix-jitsi/defaults/main.yml
+++ b/roles/matrix-jitsi/defaults/main.yml
@@ -96,17 +96,20 @@ matrix_jitsi_web_interface_config_show_powered_by: false
 matrix_jitsi_web_interface_config_disable_transcription_subtitles: false
 matrix_jisti_web_interface_config_show_deep_linking_image: false
 
-# Jitsi Fine Tune
-matrix_jitsi_web_config_disable_AudioLevels: False
-matrix_jitsi_web_config_enable_LayerSuspension: False
+# Jitsi_web Fine Tune default values.
+# Useful to manage bandwidth and CPU consumption in server and client side
+matrix_jitsi_web_config_disableAudioLevels: false
+matrix_jitsi_web_config_enableLayerSuspension: false
 matrix_jitsi_web_config_channelLastN: -1
-matrix_jitsi_web_config_enable_Video_Constraints: False
-
-# This settings work if matrix_jitsi_web_config_enable_Video_Constraints: true
-matrix_jitsi_web_config_aspectRatio: 16 / 9
-matrix_jitsi_web_config_height_ideal: 720
-matrix_jitsi_web_config_height_max: 720
-matrix_jitsi_web_config_height_min: 240
+# If 'matrix_jitsi_web_config_constraints_enabled: false'
+# the video constraints will be disabled and will take the default values of jitsi
+matrix_jitsi_web_config_constraints_enabled: false
+# This settings work if matrix_jitsi_web_config_constraints_enabled: true
+# See their definitions in config.js.j2 (templates / web)
+matrix_jitsi_web_config_constraints_video_aspectRatio: 16 / 9
+matrix_jitsi_web_config_constraints_video_height_ideal: 720
+matrix_jitsi_web_config_constraints_video_height_max: 720
+matrix_jitsi_web_config_constraints_video_height_min: 240
 
 matrix_jitsi_prosody_docker_image: "jitsi/prosody:stable-4548-1"
 matrix_jitsi_prosody_docker_image_force_pull: "{{ matrix_jitsi_prosody_docker_image.endswith(':latest') }}"

--- a/roles/matrix-jitsi/templates/web/config.js.j2
+++ b/roles/matrix-jitsi/templates/web/config.js.j2
@@ -81,7 +81,7 @@ var config = {
     // Audio
 
     // Disable measuring of audio levels.
-    // disableAudioLevels: false,
+    disableAudioLevels: {{ matrix_jitsi_web_config_disable_AudioLevels|to_json }},
 
     // Start the conference in audio only mode (no video is being received nor
     // sent).
@@ -109,24 +109,25 @@ var config = {
     // util#browser#usesNewGumFlow. The constraints are independency from
     // this config's resolution value. Defaults to requesting an ideal aspect
     // ratio of 16:9 with an ideal resolution of 720.
-    // constraints: {
-    //     video: {
-    //         aspectRatio: 16 / 9,
-    //         height: {
-    //             ideal: 720,
-    //             max: 720,
-    //             min: 240
-    //         }
-    //     }
-    // },
-
+    {% if matrix_jitsi_web_config_enable_Video_Constraints %}
+    constraints: {
+        video: {
+            aspectRatio: {{ matrix_jitsi_web_config_aspectRatio }},
+            height: {
+                ideal: {{ matrix_jitsi_web_config_height_ideal|to_json }},
+                max: {{ matrix_jitsi_web_config_height_max|to_json }},
+                min: {{ matrix_jitsi_web_config_height_min|to_json }}
+            }
+        }
+    },
+    {% endif %}
     // Enable / disable simulcast support.
     // disableSimulcast: false,
 
     // Enable / disable layer suspension.  If enabled, endpoints whose HD
     // layers are not in use will be suspended (no longer sent) until they
     // are requested again.
-    // enableLayerSuspension: false,
+    enableLayerSuspension: {{ matrix_jitsi_web_config_enable_LayerSuspension|to_json }},
 
     // Suspend sending video if bandwidth estimation is too low. This may cause
     // problems with audio playback. Disabled until these are fixed.
@@ -211,7 +212,7 @@ hiddenDomain: {{ matrix_jitsi_recorder_domain|to_json }},
     // Misc
 
     // Default value for the channel "last N" attribute. -1 for unlimited.
-    channelLastN: -1,
+    channelLastN: {{ matrix_jitsi_web_config_channelLastN|to_json }},
 
     // Disables or enables RTX (RFC 4588) (defaults to false).
     // disableRtx: false,
@@ -488,3 +489,4 @@ hiddenDomain: {{ matrix_jitsi_recorder_domain|to_json }},
 };
 
 /* eslint-enable no-unused-vars, no-var */
+

--- a/roles/matrix-jitsi/templates/web/config.js.j2
+++ b/roles/matrix-jitsi/templates/web/config.js.j2
@@ -81,7 +81,7 @@ var config = {
     // Audio
 
     // Disable measuring of audio levels.
-    disableAudioLevels: {{ matrix_jitsi_web_config_disable_AudioLevels|to_json }},
+    disableAudioLevels: {{ matrix_jitsi_web_config_disableAudioLevels|to_json }},
 
     // Start the conference in audio only mode (no video is being received nor
     // sent).
@@ -109,14 +109,14 @@ var config = {
     // util#browser#usesNewGumFlow. The constraints are independency from
     // this config's resolution value. Defaults to requesting an ideal aspect
     // ratio of 16:9 with an ideal resolution of 720.
-    {% if matrix_jitsi_web_config_enable_Video_Constraints %}
+    {% if matrix_jitsi_web_config_constraints_enabled %}
     constraints: {
         video: {
-            aspectRatio: {{ matrix_jitsi_web_config_aspectRatio }},
+            aspectRatio: {{ matrix_jitsi_web_config_constraints_video_aspectRatio }},
             height: {
-                ideal: {{ matrix_jitsi_web_config_height_ideal|to_json }},
-                max: {{ matrix_jitsi_web_config_height_max|to_json }},
-                min: {{ matrix_jitsi_web_config_height_min|to_json }}
+                ideal: {{ matrix_jitsi_web_config_constraints_video_height_ideal|to_json }},
+                max: {{ matrix_jitsi_web_config_constraints_video_height_max|to_json }},
+                min: {{ matrix_jitsi_web_config_constraints_video_height_min|to_json }}
             }
         }
     },
@@ -127,7 +127,7 @@ var config = {
     // Enable / disable layer suspension.  If enabled, endpoints whose HD
     // layers are not in use will be suspended (no longer sent) until they
     // are requested again.
-    enableLayerSuspension: {{ matrix_jitsi_web_config_enable_LayerSuspension|to_json }},
+    enableLayerSuspension: {{ matrix_jitsi_web_config_enableLayerSuspension|to_json }},
 
     // Suspend sending video if bandwidth estimation is too low. This may cause
     // problems with audio playback. Disabled until these are fixed.
@@ -489,4 +489,3 @@ hiddenDomain: {{ matrix_jitsi_recorder_domain|to_json }},
 };
 
 /* eslint-enable no-unused-vars, no-var */
-


### PR DESCRIPTION
I was doing several tests with jitsi. I was able to improve CPU and bandwidth consumption by adjusting parameters as per the recommendations at https://jitsi-club.gitlab.io/jitsi-self-hosting/en/01-deployment-howto/03-tuning/
I found it useful to add some variables to better manipulate these values.