### PR TITLE
Added config hint for SMS verification

### DIFF
--- a/docs/configuring-playbook-ma1sd.md
+++ b/docs/configuring-playbook-ma1sd.md
@@ -74,7 +74,7 @@ To learn more about how to do this, refer to the information about `matrix_ma1sd
 
 ## Example: SMS verification
 
-If your use case requires mobile verification, it is quite simple to integrate ma1sd with Twilio, an online telephony services gateway. Their prices are reasonable for low-volume projects and integration can be done with the following configuration:
+If your use case requires mobile verification, it is quite simple to integrate ma1sd with [Twilio](https://www.twilio.com/), an online telephony services gateway. Their prices are reasonable for low-volume projects and integration can be done with the following configuration:
 
 ```matrix_ma1sd_configuration_extension_yaml: |
   threepid:

--- a/docs/configuring-playbook-ma1sd.md
+++ b/docs/configuring-playbook-ma1sd.md
@@ -72,6 +72,20 @@ To use a more custom configuration, you can define a `matrix_ma1sd_configuration
 and put your configuration in it.
 To learn more about how to do this, refer to the information about `matrix_ma1sd_configuration_extension_yaml` in the [default variables file](../roles/matrix-ma1sd/defaults/main.yml) of the ma1sd component.
 
+## Example: SMS verification
+
+If your use case requires mobile verification, it is quite simple to integrate ma1sd with Twilio, an online telephony services gateway. Their prices are reasonable for low-volume projects and integration can be done with the following configuration:
+
+```matrix_ma1sd_configuration_extension_yaml: |
+  threepid:
+    medium:
+      msisdn:
+        connectors:
+          twilio:
+            account_sid: '<secret-SID>'
+            auth_token: '<secret-token>'
+            number: '+<msisdn-number>'
+```
 
 ## Troubleshooting
 


### PR DESCRIPTION
After some excellent help by @aaronraimist, and his suggestion that we document this particular use-case, I thought I'd give it a go. It's trivially easy to make SMS happen but finding the resultant options to twiddle wasn't intuitive.

Since I suspect many people would very much want to enable this option, I here suggest a small addition to the documentation to point the way.