### PR TITLE
Improve the example Traefik config.

### DIFF
--- a/docs/configuring-playbook-own-webserver.md
+++ b/docs/configuring-playbook-own-webserver.md
@@ -144,8 +144,7 @@ matrix_nginx_proxy_container_extra_arguments:
   - '--label "traefik.enable=true"'
 
   # The Nginx proxy container will receive traffic from these subdomains
-  # (Replace DOMAIN with your domain, e.g. example.com)
-  - '--label "traefik.http.routers.matrix-nginx-proxy.rule=Host(`matrix.DOMAIN`,`riot.DOMAIN`,`dimension.DOMAIN`)"'
+  - '--label "traefik.http.routers.matrix-nginx-proxy.rule=Host(`{{ matrix_server_fqn_matrix }}`,`{{ matrix_server_fqn_riot }}`,`{{ matrix_server_fqn_dimension }}`)"'
 
   # (The 'web-secure' entrypoint must bind to port 443 in Traefik config)
   - '--label "traefik.http.routers.matrix-nginx-proxy.entrypoints=web-secure"'
@@ -161,8 +160,7 @@ matrix_synapse_container_extra_arguments:
   - '--label "traefik.enable=true"'
 
   # The Synapse container will receive traffic from this subdomain
-  # (Replace DOMAIN with your domain, e.g. example.com)
-  - '--label "traefik.http.routers.matrix-synapse.rule=Host(`matrix.DOMAIN`)"'
+  - '--label "traefik.http.routers.matrix-synapse.rule=Host(`{{ matrix_server_fqn_matrix }}`)"'
 
   # (The 'synapse' entrypoint must bind to port 8448 in Traefik config)
   - '--label "traefik.http.routers.matrix-synapse.entrypoints=synapse"'


### PR DESCRIPTION
Use playbook variables instead of textual place-holders for the domain names.