### PR TITLE
Ma1sd v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 2020-06-28
+
+## (Post Mortem / fixed Security Issue) Re-enabling User Directory search powered by the ma1sd Identity Server
+
+User Directory search requests used to go to the ma1sd identity server by default, which queried its own stores and the Synapse database.
+
+ma1sd's [security issue](https://github.com/ma1uta/ma1sd/issues/44) has been fixed in version `2.4.0`, with [this commit](ma1uta/ma1sd@2bb5a734d11662b06471113cf3d6b4cee5e33a85). `ma1sd 2.4.0` is now the default version for this playbook. For more information on what happened, please check the mentioned issue.
+
+We are re-enabling user directory search with this update. Those who would like to keep it disabled can use this configuration: `matrix_nginx_proxy_proxy_matrix_user_directory_search_enabled: false`
+
+As always, re-running the playbook is enough to get the updated bits.
+
 # 2020-06-11
 
 ## SMS bridging requires db reset

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -646,10 +646,7 @@ matrix_nginx_proxy_proxy_synapse_metrics: "{{ matrix_synapse_metrics_enabled }}"
 matrix_nginx_proxy_proxy_synapse_metrics_addr_with_container: "matrix-synapse:{{ matrix_synapse_metrics_port }}"
 matrix_nginx_proxy_proxy_synapse_metrics_addr_sans_container: "127.0.0.1:{{ matrix_synapse_metrics_port }}"
 
-# Not proxying the user directory search to the identity server by default anymore,
-# because it currently leaks data.
-# See: https://github.com/ma1uta/ma1sd/issues/44
-matrix_nginx_proxy_proxy_matrix_user_directory_search_enabled: false
+matrix_nginx_proxy_proxy_matrix_user_directory_search_enabled: "{{ matrix_ma1sd_enabled }}"
 matrix_nginx_proxy_proxy_matrix_user_directory_search_addr_with_container: "{{ matrix_nginx_proxy_proxy_matrix_identity_api_addr_with_container }}"
 matrix_nginx_proxy_proxy_matrix_user_directory_search_addr_sans_container: "{{ matrix_nginx_proxy_proxy_matrix_identity_api_addr_sans_container }}"
 

--- a/roles/matrix-ma1sd/defaults/main.yml
+++ b/roles/matrix-ma1sd/defaults/main.yml
@@ -5,7 +5,7 @@ matrix_ma1sd_enabled: true
 
 matrix_ma1sd_container_image_self_build: false
 
-matrix_ma1sd_docker_image: "ma1uta/ma1sd:2.3.0"
+matrix_ma1sd_docker_image: "ma1uta/ma1sd:2.4.0"
 matrix_ma1sd_docker_image_force_pull: "{{ matrix_ma1sd_docker_image.endswith(':latest') }}"
 
 matrix_ma1sd_base_path: "{{ matrix_base_data_path }}/ma1sd"


### PR DESCRIPTION
- Update to [newest release 2.4.0 of ma1sd](https://github.com/ma1uta/ma1sd/releases/tag/2.4.0)
- Re-enable user directory search, fixed in https://github.com/ma1uta/ma1sd/pull/45