### PR TITLE
Update Jitsi to stable-4627-1

### DIFF
--- a/roles/matrix-jitsi/defaults/main.yml
+++ b/roles/matrix-jitsi/defaults/main.yml
@@ -50,7 +50,7 @@ matrix_jitsi_jibri_recorder_user: recorder
 matrix_jitsi_jibri_recorder_password: ''
 
 
-matrix_jitsi_web_docker_image: "jitsi/web:stable-4548-1"
+matrix_jitsi_web_docker_image: "jitsi/web:stable-4627-1"
 matrix_jitsi_web_docker_image_force_pull: "{{ matrix_jitsi_web_docker_image.endswith(':latest') }}"
 
 matrix_jitsi_web_base_path: "{{ matrix_base_data_path }}/jitsi/web"
@@ -111,7 +111,7 @@ matrix_jitsi_web_config_constraints_video_height_ideal: 720
 matrix_jitsi_web_config_constraints_video_height_max: 720
 matrix_jitsi_web_config_constraints_video_height_min: 240
 
-matrix_jitsi_prosody_docker_image: "jitsi/prosody:stable-4548-1"
+matrix_jitsi_prosody_docker_image: "jitsi/prosody:stable-4627-1"
 matrix_jitsi_prosody_docker_image_force_pull: "{{ matrix_jitsi_prosody_docker_image.endswith(':latest') }}"
 
 matrix_jitsi_prosody_base_path: "{{ matrix_base_data_path }}/jitsi/prosody"
@@ -125,7 +125,7 @@ matrix_jitsi_prosody_container_extra_arguments: []
 matrix_jitsi_prosody_systemd_required_services_list: ['docker.service']
 
 
-matrix_jitsi_jicofo_docker_image: "jitsi/jicofo:stable-4548-1"
+matrix_jitsi_jicofo_docker_image: "jitsi/jicofo:stable-4627-1"
 matrix_jitsi_jicofo_docker_image_force_pull: "{{ matrix_jitsi_jicofo_docker_image.endswith(':latest') }}"
 
 matrix_jitsi_jicofo_base_path: "{{ matrix_base_data_path }}/jitsi/jicofo"
@@ -142,7 +142,7 @@ matrix_jitsi_jicofo_auth_user: focus
 matrix_jitsi_jicofo_auth_password: ''
 
 
-matrix_jitsi_jvb_docker_image: "jitsi/jvb:stable-4548-1"
+matrix_jitsi_jvb_docker_image: "jitsi/jvb:stable-4627-1"
 matrix_jitsi_jvb_docker_image_force_pull: "{{ matrix_jitsi_jvb_docker_image.endswith(':latest') }}"
 
 matrix_jitsi_jvb_base_path: "{{ matrix_base_data_path }}/jitsi/jvb"


### PR DESCRIPTION
- Update jitsi containers to latest release [stable 4627-1](https://github.com/jitsi/docker-jitsi-meet/releases)
- Notable changes: https://github.com/jitsi/docker-jitsi-meet/compare/stable-4548-1...stable-4627-1

The update should not contain any breaking changes.