### PR TITLE
Expose reCAPTCHA variables and document

### DIFF
--- a/docs/configuring-captcha.md
+++ b/docs/configuring-captcha.md
@@ -1,0 +1,24 @@
+(Adapted from the [upstream project](https://github.com/matrix-org/synapse/blob/develop/docs/CAPTCHA_SETUP.md))
+
+# Overview
+Captcha can be enabled for this home server. This file explains how to do that.
+The captcha mechanism used is Google's ReCaptcha. This requires API keys from Google.
+
+## Getting keys
+
+Requires a site/secret key pair from:
+
+<https://developers.google.com/recaptcha/>
+
+Must be a reCAPTCHA v2 key using the "I'm not a robot" Checkbox option
+
+## Setting ReCaptcha Keys
+
+Once registered as above, set the following values:
+
+    matrix_synapse_recaptcha_public_key: 'YOUR_SITE_KEY'
+    matrix_synapse_recaptcha_private_key: 'YOUR_SECRET_KEY'
+
+In addition, you MUST enable captchas via:
+
+    matrix_synapse_enable_registration_captcha: true

--- a/docs/configuring-captcha.md
+++ b/docs/configuring-captcha.md
@@ -2,7 +2,7 @@
 
 # Overview
 Captcha can be enabled for this home server. This file explains how to do that.
-The captcha mechanism used is Google's ReCaptcha. This requires API keys from Google.
+The captcha mechanism used is Google's [ReCaptcha](https://www.google.com/recaptcha/). This requires API keys from Google.
 
 ## Getting keys
 
@@ -10,15 +10,14 @@ Requires a site/secret key pair from:
 
 <http://www.google.com/recaptcha/admin>
 
-Must be a reCAPTCHA v2 key using the "I'm not a robot" Checkbox option
+Must be a reCAPTCHA **v2** key using the "I'm not a robot" Checkbox option
 
 ## Setting ReCaptcha Keys
 
 Once registered as above, set the following values:
 
-    matrix_synapse_recaptcha_public_key: 'YOUR_SITE_KEY'
-    matrix_synapse_recaptcha_private_key: 'YOUR_SECRET_KEY'
-
-In addition, you MUST enable captchas via:
-
-    matrix_synapse_enable_registration_captcha: true
+```yaml
+matrix_synapse_enable_registration_captcha: true
+matrix_synapse_recaptcha_public_key: 'YOUR_SITE_KEY'
+matrix_synapse_recaptcha_private_key: 'YOUR_SECRET_KEY'
+```

--- a/docs/configuring-captcha.md
+++ b/docs/configuring-captcha.md
@@ -8,7 +8,7 @@ The captcha mechanism used is Google's ReCaptcha. This requires API keys from Go
 
 Requires a site/secret key pair from:
 
-<https://developers.google.com/recaptcha/>
+<http://www.google.com/recaptcha/admin>
 
 Must be a reCAPTCHA v2 key using the "I'm not a robot" Checkbox option
 

--- a/docs/configuring-playbook-ma1sd.md
+++ b/docs/configuring-playbook-ma1sd.md
@@ -31,6 +31,8 @@ To use the [Registration](https://github.com/ma1uta/ma1sd/blob/master/docs/featu
 
 - `matrix_synapse_enable_registration` - to enable user-initiated registration in Synapse
 
+- `matrix_synapse_enable_registration_captcha` - to validate registering users using reCAPTCHA, as described in the [enabling reCAPTCHA](configuring_captcha.md) documentation.
+
 - `matrix_synapse_registrations_require_3pid` - to control the types of 3pid (`'email'`, `'msisdn'`) required by the Synapse server for registering
 
 - variables prefixed with `matrix_nginx_proxy_proxy_matrix_3pid_registration_` (e.g. `matrix_nginx_proxy_proxy_matrix_3pid_registration_enabled`) - to configure the integrated nginx webserver to send registration requests to ma1sd (instead of Synapse), so it can apply its additional functionality

--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -162,6 +162,11 @@ matrix_synapse_allow_public_rooms_over_federation: false
 # Controls whether people with access to the homeserver can register by themselves.
 matrix_synapse_enable_registration: false
 
+# reCAPTCHA API for validating registration attempts
+matrix_synapse_enable_registration_captcha: false
+matrix_synapse_recaptcha_public_key: ''
+matrix_synapse_recaptcha_private_key: ''
+
 # Allows non-server-admin users to create groups on this server
 matrix_synapse_enable_group_creation: false
 

--- a/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -934,18 +934,18 @@ url_preview_accept_language:
 # This homeserver's ReCAPTCHA public key. Must be specified if
 # enable_registration_captcha is enabled.
 #
-#recaptcha_public_key: "YOUR_PUBLIC_KEY"
+#recaptcha_public_key: {{ matrix_synapse_recaptcha_public_key }}
 
 # This homeserver's ReCAPTCHA private key. Must be specified if
 # enable_registration_captcha is enabled.
 #
-#recaptcha_private_key: "YOUR_PRIVATE_KEY"
+#recaptcha_private_key: {{ matrix_synapse_recaptcha_private_key }}
 
 # Uncomment to enable ReCaptcha checks when registering, preventing signup
 # unless a captcha is answered. Requires a valid ReCaptcha
 # public/private key. Defaults to 'false'.
 #
-#enable_registration_captcha: true
+enable_registration_captcha: {{ matrix_synapse_enable_registration_captcha }}
 
 # The API endpoint to use for verifying m.login.recaptcha responses.
 # Defaults to "https://www.recaptcha.net/recaptcha/api/siteverify".

--- a/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -934,18 +934,18 @@ url_preview_accept_language:
 # This homeserver's ReCAPTCHA public key. Must be specified if
 # enable_registration_captcha is enabled.
 #
-recaptcha_public_key: {{ matrix_synapse_recaptcha_public_key }}
+recaptcha_public_key: {{ matrix_synapse_recaptcha_public_key|to_json }}
 
 # This homeserver's ReCAPTCHA private key. Must be specified if
 # enable_registration_captcha is enabled.
 #
-recaptcha_private_key: {{ matrix_synapse_recaptcha_private_key }}
+recaptcha_private_key: {{ matrix_synapse_recaptcha_private_key|to_json }}
 
 # Uncomment to enable ReCaptcha checks when registering, preventing signup
 # unless a captcha is answered. Requires a valid ReCaptcha
 # public/private key. Defaults to 'false'.
 #
-enable_registration_captcha: {{ matrix_synapse_enable_registration_captcha }}
+enable_registration_captcha: {{ matrix_synapse_enable_registration_captcha|to_json }}
 
 # The API endpoint to use for verifying m.login.recaptcha responses.
 # Defaults to "https://www.recaptcha.net/recaptcha/api/siteverify".

--- a/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -934,12 +934,12 @@ url_preview_accept_language:
 # This homeserver's ReCAPTCHA public key. Must be specified if
 # enable_registration_captcha is enabled.
 #
-#recaptcha_public_key: {{ matrix_synapse_recaptcha_public_key }}
+recaptcha_public_key: {{ matrix_synapse_recaptcha_public_key }}
 
 # This homeserver's ReCAPTCHA private key. Must be specified if
 # enable_registration_captcha is enabled.
 #
-#recaptcha_private_key: {{ matrix_synapse_recaptcha_private_key }}
+recaptcha_private_key: {{ matrix_synapse_recaptcha_private_key }}
 
 # Uncomment to enable ReCaptcha checks when registering, preventing signup
 # unless a captcha is answered. Requires a valid ReCaptcha


### PR DESCRIPTION
Running a public site pretty much demands Human-ness validation, and Synapse supports reCAPTCHA integration directly. It was simple enough to expose the necessary variables, so I've done it here. I've also added a quick bit of documentation to help new users figure it out.