### PR TITLE
Run API self checks in check_mode

### DIFF
--- a/roles/matrix-synapse/tasks/self_check_client_api.yml
+++ b/roles/matrix-synapse/tasks/self_check_client_api.yml
@@ -7,14 +7,17 @@
     validate_certs: "{{ matrix_synapse_self_check_validate_certificates }}"
   register: result_matrix_synapse_client_api
   ignore_errors: true
+  check_mode: no
   when: matrix_synapse_enabled|bool
 
 - name: Fail if Matrix Client API not working
   fail:
     msg: "Failed checking Matrix Client API is up at `{{ matrix_server_fqn_matrix }}` (checked endpoint: `{{ matrix_synapse_client_api_url_endpoint_public }}`). Is Synapse running? Is port 443 open in your firewall? Full error: {{ result_matrix_synapse_client_api }}"
+  check_mode: no
   when: "matrix_synapse_enabled|bool and (result_matrix_synapse_client_api.failed or 'json' not in result_matrix_synapse_client_api)"
 
 - name: Report working Matrix Client API
   debug:
     msg: "The Matrix Client API at `{{ matrix_server_fqn_matrix }}` (checked endpoint: `{{ matrix_synapse_client_api_url_endpoint_public }}`) is working"
+  check_mode: no
   when: matrix_synapse_enabled|bool

--- a/roles/matrix-synapse/tasks/self_check_federation_api.yml
+++ b/roles/matrix-synapse/tasks/self_check_federation_api.yml
@@ -7,19 +7,23 @@
     validate_certs: "{{ matrix_synapse_self_check_validate_certificates }}"
   register: result_matrix_synapse_federation_api
   ignore_errors: true
+  check_mode: no
   when: matrix_synapse_enabled|bool
 
 - name: Fail if Matrix Federation API not working
   fail:
     msg: "Failed checking Matrix Federation API is up at `{{ matrix_server_fqn_matrix }}` (checked endpoint: `{{ matrix_synapse_federation_api_url_endpoint_public }}`). Is Synapse running? Is port {{ matrix_federation_public_port }} open in your firewall? Full error: {{ result_matrix_synapse_federation_api }}"
+  check_mode: no
   when: "matrix_synapse_enabled|bool and matrix_synapse_federation_enabled|bool and (result_matrix_synapse_federation_api.failed or 'json' not in result_matrix_synapse_federation_api)"
 
 - name: Fail if Matrix Federation API unexpectedly enabled
   fail:
       msg: "Matrix Federation API is up at `{{ matrix_server_fqn_matrix }}` (checked endpoint: `{{ matrix_synapse_federation_api_url_endpoint_public }}`) despite being disabled."
+  check_mode: no
   when: "matrix_synapse_enabled|bool and not matrix_synapse_federation_enabled|bool and not result_matrix_synapse_federation_api.failed"
 
 - name: Report working Matrix Federation API
   debug:
     msg: "The Matrix Federation API at `{{ matrix_server_fqn_matrix }}` (checked endpoint: `{{ matrix_synapse_federation_api_url_endpoint_public }}`) is working"
+  check_mode: no
   when: "matrix_synapse_enabled|bool and matrix_synapse_federation_enabled|bool"


### PR DESCRIPTION
This PR ensure, that the API self checks run also in check mode. Else the modules fail at those steps.