### PR TITLE
Run all API self checks in check_mode

### DIFF
--- a/roles/matrix-corporal/tasks/self_check_corporal.yml
+++ b/roles/matrix-corporal/tasks/self_check_corporal.yml
@@ -8,6 +8,7 @@
     url: "{{ corporal_client_api_url_endpoint_public }}"
     follow_redirects: none
     return_content: true
+  check_mode: no
   register: result_corporal_client_api
   ignore_errors: true
 

--- a/roles/matrix-ma1sd/tasks/self_check_ma1sd.yml
+++ b/roles/matrix-ma1sd/tasks/self_check_ma1sd.yml
@@ -8,6 +8,7 @@
     url: "{{ ma1sd_url_endpoint_public }}"
     follow_redirects: none
     validate_certs: "{{ matrix_ma1sd_self_check_validate_certificates }}"
+  check_mode: no
   register: result_ma1sd
   ignore_errors: true
 

--- a/roles/matrix-nginx-proxy/tasks/self_check_well_known_file.yml
+++ b/roles/matrix-nginx-proxy/tasks/self_check_well_known_file.yml
@@ -12,6 +12,7 @@
     follow_redirects: none
     return_content: true
     validate_certs: "{{ well_known_file_check.validate_certs }}"
+  check_mode: no
   register: result_well_known_matrix
   ignore_errors: true
 
@@ -39,6 +40,7 @@
     follow_redirects: "{{ well_known_file_check.follow_redirects }}"
     return_content: true
     validate_certs: "{{ well_known_file_check.validate_certs }}"
+  check_mode: no
   register: result_well_known_identity
   ignore_errors: true
 

--- a/roles/matrix-riot-web/tasks/self_check_riot_web.yml
+++ b/roles/matrix-riot-web/tasks/self_check_riot_web.yml
@@ -9,6 +9,7 @@
     follow_redirects: none
     validate_certs: "{{ matrix_riot_web_self_check_validate_certificates }}"
   register: result_riot_web
+  check_mode: no
   ignore_errors: true
 
 - name: Fail if riot-web not working

--- a/roles/matrix-synapse/tasks/self_check_client_api.yml
+++ b/roles/matrix-synapse/tasks/self_check_client_api.yml
@@ -7,6 +7,7 @@
     validate_certs: "{{ matrix_synapse_self_check_validate_certificates }}"
   register: result_matrix_synapse_client_api
   ignore_errors: true
+  check_mode: no
   when: matrix_synapse_enabled|bool
 
 - name: Fail if Matrix Client API not working

--- a/roles/matrix-synapse/tasks/self_check_federation_api.yml
+++ b/roles/matrix-synapse/tasks/self_check_federation_api.yml
@@ -7,6 +7,7 @@
     validate_certs: "{{ matrix_synapse_self_check_validate_certificates }}"
   register: result_matrix_synapse_federation_api
   ignore_errors: true
+  check_mode: no
   when: matrix_synapse_enabled|bool
 
 - name: Fail if Matrix Federation API not working


### PR DESCRIPTION
This PR allows running the matrix playbooks also in check_mode without failure due to undefined variables. 

It will enforce the execution of the uri module in check_mode, so all necessary variables are gathered.