### PR TITLE
Fix issues building ma1sd Docker image

### DIFF
--- a/roles/matrix-ma1sd/defaults/main.yml
+++ b/roles/matrix-ma1sd/defaults/main.yml
@@ -11,7 +11,7 @@ matrix_ma1sd_docker_image: "ma1uta/ma1sd:2.4.0-{{ matrix_ma1sd_architecture }}"
 matrix_ma1sd_docker_image_force_pull: "{{ matrix_ma1sd_docker_image.endswith(':latest') }}"
 
 matrix_ma1sd_base_path: "{{ matrix_base_data_path }}/ma1sd"
-matrix_ma1sd_docker_src_files_path: "{{ matrix_ma1sd_base_path }}/docker-src"
+matrix_ma1sd_docker_src_files_path: "{{ matrix_ma1sd_base_path }}/docker-src/ma1sd"
 matrix_ma1sd_config_path: "{{ matrix_ma1sd_base_path }}/config"
 matrix_ma1sd_data_path: "{{ matrix_ma1sd_base_path }}/data"
 

--- a/roles/matrix-ma1sd/defaults/main.yml
+++ b/roles/matrix-ma1sd/defaults/main.yml
@@ -11,6 +11,7 @@ matrix_ma1sd_docker_image: "ma1uta/ma1sd:2.4.0-{{ matrix_ma1sd_architecture }}"
 matrix_ma1sd_docker_image_force_pull: "{{ matrix_ma1sd_docker_image.endswith(':latest') }}"
 
 matrix_ma1sd_base_path: "{{ matrix_base_data_path }}/ma1sd"
+# We need the docker src directory to be named ma1sd. See: https://github.com/spantaleev/matrix-docker-ansible-deploy/pull/588
 matrix_ma1sd_docker_src_files_path: "{{ matrix_ma1sd_base_path }}/docker-src/ma1sd"
 matrix_ma1sd_config_path: "{{ matrix_ma1sd_base_path }}/config"
 matrix_ma1sd_data_path: "{{ matrix_ma1sd_base_path }}/data"

--- a/roles/matrix-ma1sd/tasks/setup_ma1sd.yml
+++ b/roles/matrix-ma1sd/tasks/setup_ma1sd.yml
@@ -61,7 +61,6 @@
     shell: "./gradlew dockerBuild"
     args:
       chdir: "{{ matrix_ma1sd_docker_src_files_path }}"
-    when: "matrix_ma1sd_enabled|bool and matrix_ma1sd_container_image_self_build"
 
   - name: Ensure ma1sd Docker image is tagged correctly
     docker_image:
@@ -69,7 +68,7 @@
       repository: "{{ matrix_ma1sd_docker_image }}"
       force_tag: yes
       source: local
-    when: "matrix_ma1sd_enabled|bool and matrix_ma1sd_container_image_self_build"
+  when: "matrix_ma1sd_enabled|bool and matrix_ma1sd_container_image_self_build"
 
 - name: Ensure ma1sd config installed
   copy:

--- a/roles/matrix-ma1sd/tasks/setup_ma1sd.yml
+++ b/roles/matrix-ma1sd/tasks/setup_ma1sd.yml
@@ -61,7 +61,15 @@
     shell: "./gradlew dockerBuild"
     args:
       chdir: "{{ matrix_ma1sd_docker_src_files_path }}"
-  when: "matrix_ma1sd_enabled|bool and matrix_ma1sd_container_image_self_build"
+    when: "matrix_ma1sd_enabled|bool and matrix_ma1sd_container_image_self_build"
+
+  - name: Ensure ma1sd Docker image is tagged correctly
+    docker_image:
+      name: "{{ matrix_ma1sd_docker_image.split('-')[0] }}"
+      repository: "{{ matrix_ma1sd_docker_image }}"
+      force_tag: yes
+      source: local
+    when: "matrix_ma1sd_enabled|bool and matrix_ma1sd_container_image_self_build"
 
 - name: Ensure ma1sd config installed
   copy:

--- a/roles/matrix-ma1sd/tasks/setup_ma1sd.yml
+++ b/roles/matrix-ma1sd/tasks/setup_ma1sd.yml
@@ -54,7 +54,7 @@
     git:
       repo: https://github.com/ma1uta/ma1sd.git
       dest: "{{ matrix_ma1sd_docker_src_files_path }}"
-      version: "v{{ matrix_ma1sd_docker_image.split(':')[1] }}"
+      version: "{{ matrix_ma1sd_docker_image.split(':')[1].split('-')[0] }}"
       force: "yes"
 
   - name: Ensure ma1sd Docker image is built


### PR DESCRIPTION
The tag format used in the `ma1sd` repo have change. Versions no longer
start with 'v', and when building for non-amd64, we also need to strip
off the '-$arch' bit from the Docker image name.

Further, when building the .jar file, `ma1sd` currently names the .jar
based on the project's directory, which we call 'docker-src'. This means
other parts of the `ma1sd` build can't find the .jar file. Remedy this
by ensuring that the dir is called `docker-src/ma1sd`.
(I've proposed a patch to `ma1sd` on PR https://github.com/ma1uta/ma1sd/pull/55 to fix this: https://github.com/ma1uta/ma1sd/pull/55/commits/7b992c1060c58e2a46c814ce76a8fcc9435d89c2)