### PR TITLE
Added gpg as base dependency for Debian 10

### DIFF
--- a/roles/matrix-base/tasks/server_base/setup_debian.yml
+++ b/roles/matrix-base/tasks/server_base/setup_debian.yml
@@ -5,6 +5,7 @@
     name:
       - apt-transport-https
       - ca-certificates
+      - gpg
     state: present
     update_cache: yes
 


### PR DESCRIPTION
AWS Debian marketplace image does not have gpg preinstalled

https://aws.amazon.com/marketplace/pp/B0859NK4HC?ref=cns_srchrow

TASK [matrix-base : Ensure Docker's APT key is trusted] *******************************************************************************************************************************************************
fatal: [matrix.domain.com]: FAILED! => {"changed": false, "msg": "Failed to find required executable gpg in paths: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}

Closes #590