### PR TITLE
Nginx proxy headers

### DIFF
--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-client-element.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-client-element.conf.j2
@@ -3,6 +3,9 @@
 {% macro render_vhost_directives() %}
 	gzip on;
 	gzip_types text/plain application/json application/javascript text/css image/x-icon font/ttf image/gif;
+	add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+	add_header X-Content-Type-Options nosniff;
+	add_header X-Frame-Options SAMEORIGIN;	
 	{% for configuration_block in matrix_nginx_proxy_proxy_element_additional_server_configuration_blocks %}
 		{{- configuration_block }}
 	{% endfor %}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-dimension.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-dimension.conf.j2
@@ -3,6 +3,9 @@
 {% macro render_vhost_directives() %}
 	gzip on;
 	gzip_types text/plain application/json application/javascript text/css image/x-icon font/ttf image/gif;
+	add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+	add_header X-Content-Type-Options nosniff;
+	add_header X-Frame-Options SAMEORIGIN;
 {% for configuration_block in matrix_nginx_proxy_proxy_dimension_additional_server_configuration_blocks %}
 	{{- configuration_block }}
 {% endfor %}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-jitsi.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-jitsi.conf.j2
@@ -3,6 +3,9 @@
 {% macro render_vhost_directives() %}
 	gzip on;
 	gzip_types text/plain application/json application/javascript text/css image/x-icon font/ttf image/gif;
+	add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+	add_header X-Content-Type-Options nosniff;
+	add_header X-Frame-Options SAMEORIGIN;
 {% for configuration_block in matrix_nginx_proxy_proxy_jitsi_additional_server_configuration_blocks %}
 	{{- configuration_block }}
 {% endfor %}


### PR DESCRIPTION
These headers add some security and I believe they are used by app.element.io and chat.mozilla.com.

I have tested them roughly and they do not seem to break our internal matrix/element/jitsi/dimension services. 

