### PR TITLE
Added config sample for synapse admin with traefik 2

### DIFF
--- a/docs/configuring-playbook-synapse-admin.md
+++ b/docs/configuring-playbook-synapse-admin.md
@@ -57,6 +57,6 @@ matrix_synapse_admin_container_extra_arguments:
     # (The 'default' certificate resolver must be defined in Traefik config)
     - '--label "traefik.http.routers.matrix-synapse-admin.tls.certResolver=default"'
 
-    # The Synapse Admin container uses port 8766 internally
-    - '--label "traefik.http.services.matrix-synapse-admin.loadbalancer.server.port=8766"'
+    # The Synapse Admin container uses port 80 by default
+    - '--label "traefik.http.services.matrix-synapse-admin.loadbalancer.server.port=80"'
 ```

--- a/docs/configuring-playbook-synapse-admin.md
+++ b/docs/configuring-playbook-synapse-admin.md
@@ -6,6 +6,7 @@ It's a web UI tool you can use to **administrate users and rooms on your Matrix 
 
 See the project's [documentation](https://github.com/Awesome-Technologies/synapse-admin) to learn what it does and why it might be useful to you.
 
+
 ## Adjusting the playbook configuration
 
 Add the following configuration to your `inventory/host_vars/matrix.DOMAIN/vars.yml` file:
@@ -14,6 +15,7 @@ Add the following configuration to your `inventory/host_vars/matrix.DOMAIN/vars.
 matrix_synapse_admin_enabled: true
 ```
 
+
 ## Installing
 
 After configuring the playbook, run the [installation](installing.md) command again:
@@ -21,6 +23,7 @@ After configuring the playbook, run the [installation](installing.md) command ag
 ```
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
+
 
 ## Usage
 
@@ -46,7 +49,7 @@ matrix_synapse_admin_container_extra_arguments:
     - '--label "traefik.enable=true"'
 
     # The Synapse Admin container will only receive traffic from this subdomain and path
-    - '--label "traefik.http.routers.matrix-synapse-admin.rule=(Host(`{{ matrix_server_fqn_matrix }}`) && Path(`{matrix_synapse_admin_public_endpoint}`))"'
+    - '--label "traefik.http.routers.matrix-synapse-admin.rule=(Host(`{{ matrix_server_fqn_matrix }}`) && Path(`{{matrix_synapse_admin_public_endpoint}}`))"'
 
     # (Define your entrypoint)
     - '--label "traefik.http.routers.matrix-synapse-admin.entrypoints=web-secure"'

--- a/docs/configuring-playbook-synapse-admin.md
+++ b/docs/configuring-playbook-synapse-admin.md
@@ -6,7 +6,6 @@ It's a web UI tool you can use to **administrate users and rooms on your Matrix 
 
 See the project's [documentation](https://github.com/Awesome-Technologies/synapse-admin) to learn what it does and why it might be useful to you.
 
-
 ## Adjusting the playbook configuration
 
 Add the following configuration to your `inventory/host_vars/matrix.DOMAIN/vars.yml` file:
@@ -14,7 +13,6 @@ Add the following configuration to your `inventory/host_vars/matrix.DOMAIN/vars.
 ```yaml
 matrix_synapse_admin_enabled: true
 ```
-
 
 ## Installing
 
@@ -24,7 +22,6 @@ After configuring the playbook, run the [installation](installing.md) command ag
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-
 ## Usage
 
 After installation, Synapse Admin will be accessible at: `https://matrix.DOMAIN/synapse-admin/`
@@ -32,3 +29,31 @@ After installation, Synapse Admin will be accessible at: `https://matrix.DOMAIN/
 To use Synapse Admin, you need to have [registered at least one administrator account](registering-users.md) on your server.
 
 The Homeserver URL to use on Synapse Admin's login page is: `https://matrix.DOMAIN`
+
+### Sample configuration for running behind Traefik 2.0
+
+Below is a sample configuration for using this playbook with a [Traefik](https://traefik.io/) 2.0 reverse proxy.
+
+This an extension to Traefik config sample in [own-webserver-documentation](./configuring-playbook-own-webserver.md).
+
+```yaml
+# Don't bind any HTTP or federation port to the host
+# (Traefik will proxy directly into the containers)
+matrix_synapse_admin_container_http_host_bind_port: ""
+
+matrix_synapse_admin_container_extra_arguments:
+    # May be unnecessary depending on Traefik config, but can't hurt
+    - '--label "traefik.enable=true"'
+
+    # The Synapse Admin container will only receive traffic from this subdomain and path
+    - '--label "traefik.http.routers.matrix-synapse-admin.rule=(Host(`{{ matrix_server_fqn_matrix }}`) && Path(`{matrix_synapse_admin_public_endpoint}`))"'
+
+    # (Define your entrypoint)
+    - '--label "traefik.http.routers.matrix-synapse-admin.entrypoints=web-secure"'
+
+    # (The 'default' certificate resolver must be defined in Traefik config)
+    - '--label "traefik.http.routers.matrix-synapse-admin.tls.certResolver=default"'
+
+    # The Synapse Admin container uses port 8766 internally
+    - '--label "traefik.http.services.matrix-synapse-admin.loadbalancer.server.port=8766"'
+```


### PR DESCRIPTION
I used the config sample at https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/docs/configuring-playbook-own-webserver.md and extended it for the new synapse admin container, so that it would be available at https://matrix.DOMAIN/synapse-admin.
Please review and edit this PR.