### PR TITLE
Make ansible check mode runs silent, for non idempotent tasks

### DIFF
--- a/roles/matrix-common-after/tasks/start.yml
+++ b/roles/matrix-common-after/tasks/start.yml
@@ -1,21 +1,23 @@
 ---
 
-- name: Ensure systemd reloaded
+- name: Ensure systemd is reloaded
   service:
     daemon_reload: yes
 
-- name: Ensure Matrix services stopped
+- name: Ensure Matrix services are stopped
   service:
     name: "{{ item }}"
     state: stopped
   with_items: "{{ matrix_systemd_services_list }}"
+  when: not ansible_check_mode
 
-- name: Ensure Matrix services started
+- name: Ensure Matrix services are started
   service:
     name: "{{ item }}"
     enabled: yes
     state: started
   with_items: "{{ matrix_systemd_services_list }}"
+  when: not ansible_check_mode
 
 # If we check service state immediately, we may succeed,
 # because it takes some time for the service to attempt to start and actually fail.

--- a/roles/matrix-common-after/tasks/stop.yml
+++ b/roles/matrix-common-after/tasks/stop.yml
@@ -5,3 +5,4 @@
     name: "{{ item }}"
     state: stopped
   with_items: "{{ matrix_systemd_services_list }}"
+  when: not ansible_check_mode

--- a/roles/matrix-dimension/tasks/setup_dimension.yml
+++ b/roles/matrix-dimension/tasks/setup_dimension.yml
@@ -22,12 +22,15 @@
     group: "{{ matrix_dimension_user_gid }}"
   when: matrix_dimension_enabled|bool
 
+# This task will be always change due to default image :latest
+# to ensure idempotence, this changed_when is set to false
 - name: Ensure Dimension image is pulled
   docker_image:
     name: "{{ matrix_dimension_docker_image }}"
     source: "{{ 'pull' if ansible_version.major > 2 or ansible_version.minor > 7 else omit }}"
     force_source: "{{ matrix_dimension_docker_image_force_pull if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
     force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_dimension_docker_image_force_pull }}"
+  changed_when: False
   when: matrix_dimension_enabled|bool
 
 - name: Ensure matrix-dimension.service installed

--- a/roles/matrix-nginx-proxy/tasks/ssl/main.yml
+++ b/roles/matrix-nginx-proxy/tasks/ssl/main.yml
@@ -8,6 +8,7 @@
 
 # Common tasks, required by almost any method below.
 
+# The recurse option of this task will always return a change, which should be ignored
 - name: Ensure SSL certificate paths exists
   file:
     path: "{{ item }}"
@@ -16,6 +17,7 @@
     owner: "{{ matrix_user_username }}"
     group: "{{ matrix_user_groupname }}"
     recurse: true
+  changed_when: False
   with_items:
     - "{{ matrix_ssl_log_dir_path }}"
     - "{{ matrix_ssl_config_dir_path }}"


### PR DESCRIPTION
Make ansible check mode runs silent, for non idempotent tasks: 

* do not enforce service starts and stops in check_mode
* do not show the pull of docker_image:latest as changed
* do not show the recurse handling of nginx ssl as changed 