### PR TITLE
Python requires docker package and other small improvements

### DIFF
--- a/docs/configuring-playbook-client-element.md
+++ b/docs/configuring-playbook-client-element.md
@@ -6,7 +6,7 @@ If that's okay, you can skip this document.
 
 ## Disabling Element
 
-If you'd like for the playbook to not install Element (or to uninstall the previously installed Element), you can disable it in your configuration file (`inventory/host_vars/matrix.<your-domain>/vars.yml`):
+If you'd like for the playbook to not install Element (or to uninstall it if it was previously installed), you can disable it in your configuration file (`inventory/host_vars/matrix.<your-domain>/vars.yml`):
 
 ```yaml
 matrix_client_element_enabled: false

--- a/docs/configuring-playbook-client-element.md
+++ b/docs/configuring-playbook-client-element.md
@@ -6,7 +6,7 @@ If that's okay, you can skip this document.
 
 ## Disabling Element
 
-If you'd like for the playbook to not install (or to uninstall the previously installed Element), you can disable it in your configuration file (`inventory/host_vars/matrix.<your-domain>/vars.yml`):
+If you'd like for the playbook to not install Element (or to uninstall the previously installed Element), you can disable it in your configuration file (`inventory/host_vars/matrix.<your-domain>/vars.yml`):
 
 ```yaml
 matrix_client_element_enabled: false

--- a/docs/configuring-playbook-ma1sd.md
+++ b/docs/configuring-playbook-ma1sd.md
@@ -11,7 +11,7 @@ ma1sd is a fork of [mxisd](https://github.com/kamax-io/mxisd) which was pronounc
 
 ma1sd, being an Identity Server, is not strictly needed. It is only used for 3PIDs (3rd party identifiers like E-mail and phone numbers) and some [enhanced features](https://github.com/ma1uta/ma1sd/#features).
 
-If you'd like for the playbook to not install ma1sd (or to uninstall the previously installed ma1sd), you can disable it in your configuration file (`inventory/host_vars/matrix.<your-domain>/vars.yml`):
+If you'd like for the playbook to not install ma1sd (or to uninstall it if it was previously installed), you can disable it in your configuration file (`inventory/host_vars/matrix.<your-domain>/vars.yml`):
 
 ```yaml
 matrix_ma1sd_enabled: false

--- a/docs/configuring-playbook-ma1sd.md
+++ b/docs/configuring-playbook-ma1sd.md
@@ -6,6 +6,17 @@ This server is private by default, potentially at the expense of user discoverab
 
 ma1sd is a fork of [mxisd](https://github.com/kamax-io/mxisd) which was pronounced end of life 2019-06-21.
 
+
+## Disabling ma1sd
+
+ma1sd, being an Identity Server, is not strictly needed. It is only used for 3PIDs (3rd party identifiers like E-mail and phone numbers) and some [enhanced features](https://github.com/ma1uta/ma1sd/#features).
+
+If you'd like for the playbook to not install ma1sd (or to uninstall the previously installed ma1sd), you can disable it in your configuration file (`inventory/host_vars/matrix.<your-domain>/vars.yml`):
+
+```yaml
+matrix_ma1sd_enabled: false
+```
+
 ## Matrix.org lookup forwarding
 
 To ensure maximum discovery, you can make your identity server also forward lookups to the central matrix.org Identity server (at the cost of potentially leaking all your contacts information).

--- a/docs/configuring-playbook-ssl-certificates.md
+++ b/docs/configuring-playbook-ssl-certificates.md
@@ -28,6 +28,8 @@ If self-signed certificates are alright with you, you can ask the playbook to ge
 matrix_ssl_retrieval_method: self-signed
 ```
 
+If you get a `Cannot reach homeserver` error in Element, you will have to visit `https://matrix.<your-domain>` in your browser and agree to the certificate exception before you can login.
+
 
 ## Using your own SSL certificates
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -4,7 +4,7 @@
 
 - `root` access to your server (or a user capable of elevating to `root` via `sudo`).
 
-- [Python](https://www.python.org/) being installed on the server. Most distributions install Python by default, but some don't (e.g. Ubuntu 18.04) and require manual installation (something like `apt-get install python`).
+- [Python](https://www.python.org/) and the [`docker`](https://pypi.org/project/docker/) package (requires [`pip`](https://packaging.python.org/guides/installing-using-linux-tools/)) being installed on the server. Most distributions install Python by default, but some don't (e.g. Ubuntu 18.04) and require manual installation (something like `apt-get install python`).
 
 - A `cron`-like tool installed on the server such as `cron` or `anacron` to automatically schedule the Let's Encrypt SSL certificates's renewal. *This can be ignored if you use your own SSL certificates.*
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -4,7 +4,7 @@
 
 - `root` access to your server (or a user capable of elevating to `root` via `sudo`).
 
-- [Python](https://www.python.org/) and the [`docker`](https://pypi.org/project/docker/) package (requires [`pip`](https://packaging.python.org/guides/installing-using-linux-tools/)) being installed on the server. Most distributions install Python by default, but some don't (e.g. Ubuntu 18.04) and require manual installation (something like `apt-get install python`).
+- [Python](https://www.python.org/) being installed on the server. Most distributions install Python by default, but some don't (e.g. Ubuntu 18.04) and require manual installation (something like `apt-get install python`).
 
 - A `cron`-like tool installed on the server such as `cron` or `anacron` to automatically schedule the Let's Encrypt SSL certificates's renewal. *This can be ignored if you use your own SSL certificates.*
 

--- a/roles/matrix-base/defaults/main.yml
+++ b/roles/matrix-base/defaults/main.yml
@@ -85,7 +85,7 @@ matrix_vars_yml_snapshotting_src: "{{ inventory_dir }}/host_vars/{{ inventory_ho
 matrix_well_known_matrix_server_enabled: true
 
 # Controls whether Docker is automatically installed.
-# If you change this to false you must install and update Docker manually.
+# If you change this to false you must install and update Docker manually. You also need to install the [`docker`](https://pypi.org/project/docker/) Python package.
 matrix_docker_installation_enabled: true
 
 # Controls the Docker package that is installed.

--- a/roles/matrix-base/defaults/main.yml
+++ b/roles/matrix-base/defaults/main.yml
@@ -85,7 +85,7 @@ matrix_vars_yml_snapshotting_src: "{{ inventory_dir }}/host_vars/{{ inventory_ho
 matrix_well_known_matrix_server_enabled: true
 
 # Controls whether Docker is automatically installed.
-# If you change this to false you must install and update Docker manually. You also need to install the [`docker`](https://pypi.org/project/docker/) Python package.
+# If you change this to false you must install and update Docker manually. You also need to install the docker (https://pypi.org/project/docker/) Python package.
 matrix_docker_installation_enabled: true
 
 # Controls the Docker package that is installed.


### PR DESCRIPTION
Hello all.

Having never used Ansible, the guide was a great help in getting a Matrix server up and running. I installed it locally to experiment and only ran into a few issues. I want to share my experience for anyone else who might run into these issues.

- The playbook requires the docker package.

- ma1sd is the 2nd most memory hungry container, so if you don't need the features you can disable it.

- Being installed locally, i used a self-signed SSL certificate. You have to add a security exception to Matrix by visiting `matrix.<your-domain>` (as well as Element of course).

I have a few questions, which I hope someone can answer:

- I am new to Ansible, so is it safe to disable ma1sd? Are there other configuration options that are depending on it?
- I had to run the ansible commands with sudo. I was thinking about adding either "sudo" in front of the command or adding "as superuser" above it (in installing.md). What do you think?

Please review and comment. You are free to merge if there are no problems.