### PR TITLE
Update CORS for ma1sd

### DIFF
--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-synapse.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-synapse.conf.j2
@@ -64,6 +64,7 @@
 
 		proxy_set_header Host $host;
 		proxy_set_header X-Forwarded-For $remote_addr;
+		add_header Access-Control-Allow-Origin *;
 	}
 	{% endif %}
 


### PR DESCRIPTION
Even with the v2 updates listed in #503 and partially addressed in #614, this is still needed to enable identity services to function with Element Desktop/Web. Testing on multiple clients with a clean config has confirmed this, at least for my installation.

This could be a case of a stubborn client, however making the change seems to fix the user experience. Here's the error in latest release of Element Desktop on macOS:

<img width="530" alt="image" src="https://user-images.githubusercontent.com/2736774/89724853-c41d5080-d9cd-11ea-8085-6094927aa7d3.png">
