### PR TITLE
Undo ill-advised change

### DIFF
--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-synapse.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-synapse.conf.j2
@@ -64,7 +64,6 @@
 
 		proxy_set_header Host $host;
 		proxy_set_header X-Forwarded-For $remote_addr;
-		add_header Access-Control-Allow-Origin *;
 	}
 	{% endif %}
 


### PR DESCRIPTION
In #628 I proposed a CORS change that turns out not to be the root of the issue. Caffeine-addled diagnosis leads to sloppy thinking, and this change should be reverted. In fact, if left it will cause problems for new installations.