### PR TITLE
Use the same naming convention as the other mx-puppet suite.

### DIFF
--- a/roles/matrix-bridge-mx-puppet-instagram/templates/systemd/matrix-mx-puppet-instagram.service.j2
+++ b/roles/matrix-bridge-mx-puppet-instagram/templates/systemd/matrix-mx-puppet-instagram.service.j2
@@ -1,6 +1,6 @@
 #jinja2: lstrip_blocks: "True"
 [Unit]
-Description=Matrix mx-puppet-instagram bridge
+Description=Matrix Mx Puppet Instagram server
 {% for service in matrix_mx_puppet_instagram_systemd_required_services_list %}
 Requires={{ service }}
 After={{ service }}


### PR DESCRIPTION
For consistency