### PR TITLE
New docker image appservice-slack

### DIFF
--- a/roles/matrix-bridge-appservice-slack/defaults/main.yml
+++ b/roles/matrix-bridge-appservice-slack/defaults/main.yml
@@ -3,7 +3,7 @@
 
 matrix_appservice_slack_enabled: true
 
-matrix_appservice_slack_docker_image: "cadair/matrix-appservice-slack:cadair"
+matrix_appservice_slack_docker_image: "matrixdotorg/matrix-appservice-slack"
 matrix_appservice_slack_docker_image_force_pull: "{{ matrix_appservice_slack_docker_image.endswith(':latest') }}"
 
 matrix_appservice_slack_base_path: "{{ matrix_base_data_path }}/appservice-slack"

--- a/roles/matrix-bridge-appservice-slack/defaults/main.yml
+++ b/roles/matrix-bridge-appservice-slack/defaults/main.yml
@@ -3,7 +3,7 @@
 
 matrix_appservice_slack_enabled: true
 
-matrix_appservice_slack_docker_image: "matrixdotorg/matrix-appservice-slack"
+matrix_appservice_slack_docker_image: "matrixdotorg/matrix-appservice-slack:release-1.5.0"
 matrix_appservice_slack_docker_image_force_pull: "{{ matrix_appservice_slack_docker_image.endswith(':latest') }}"
 
 matrix_appservice_slack_base_path: "{{ matrix_base_data_path }}/appservice-slack"


### PR DESCRIPTION
The used Docker image is no longer maintained and is outdated so it does not work anymore. 

Before upgrading existing installations, the data in the appservice-slack folder on the host server must be deleted, as the files are not compatible with the new version.