### PR TITLE
Allow configuration of Element's bug_report_endpoint_url and showLabsSettings

### DIFF
--- a/roles/matrix-client-element/defaults/main.yml
+++ b/roles/matrix-client-element/defaults/main.yml
@@ -30,9 +30,11 @@ matrix_client_element_integrations_rest_url: "https://scalar.vector.im/api"
 matrix_client_element_integrations_widgets_urls: ["https://scalar.vector.im/api"]
 matrix_client_element_integrations_jitsi_widget_url: "https://scalar.vector.im/api/widgets/jitsi.html"
 matrix_client_element_permalinkPrefix: "https://matrix.to"
+matrix_client_element_bug_report_endpoint_url: "https://element.io/bugreports/submit"
+matrix_client_element_showLabsSettings: true
 # Element public room directory server(s)
 matrix_client_element_roomdir_servers: ['matrix.org']
-matrix_client_element_welcome_user_id: "@riot-bot:matrix.org"
+matrix_client_element_welcome_user_id: ~
 # Branding of Element
 matrix_client_element_brand: "Element"
 

--- a/roles/matrix-client-element/templates/config.json.j2
+++ b/roles/matrix-client-element/templates/config.json.j2
@@ -20,8 +20,8 @@
 	"integrations_rest_url": {{ matrix_client_element_integrations_rest_url|string|to_json }},
 	"integrations_widgets_urls": {{ matrix_client_element_integrations_widgets_urls|to_json }},
 	"integrations_jitsi_widget_url": {{ matrix_client_element_integrations_jitsi_widget_url|string|to_json }},
-	"bug_report_endpoint_url": "https://riot.im/bugreports/submit",
-	"enableLabs": true,
+	"bug_report_endpoint_url": {{ matrix_client_element_bug_report_endpoint_url|to_json }},
+	"showLabsSettings": {{ matrix_client_element_showLabsSettings|to_json }},
 	"roomDirectory": {
 		"servers": {{ matrix_client_element_roomdir_servers|to_json }}
 	},


### PR DESCRIPTION
showLabsSettings is the new enableLabs I guess. enableLabs doesn't seem to do anything anymore. It had been deprecated for a while. I've left it enabled by default since it was previously but maybe it shouldn't be.

This PR also removes @riot-bot:matrix.org as the default welcome_user_id since it doesn't exist anymore.