### PR TITLE
Client well known compatibility

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -18,8 +18,6 @@
 
 matrix_identity_server_url: "{{ ('https://' + matrix_server_fqn_matrix) if matrix_ma1sd_enabled else None }}"
 
-matrix_riot_jitsi_preferredDomain: "{{ matrix_server_fqn_jitsi if matrix_jitsi_enabled else '' }}"
-
 ######################################################################
 #
 # /matrix-base

--- a/roles/matrix-base/defaults/main.yml
+++ b/roles/matrix-base/defaults/main.yml
@@ -59,13 +59,13 @@ matrix_integration_manager_ui_url: ~
 
 # The domain name where a Jitsi server is self-hosted.
 # If set, `/.well-known/matrix/client` will suggest Element clients to use that Jitsi server.
-# See: https://github.com/vector-im/riot-web/blob/develop/docs/jitsi.md#configuring-riot-to-use-your-self-hosted-jitsi-server
-matrix_riot_jitsi_preferredDomain: ''
+# See: https://github.com/vector-im/element-web/blob/develop/docs/jitsi.md#configuring-element-to-use-your-self-hosted-jitsi-server
+matrix_client_element_jitsi_preferredDomain: ''
 
 # Controls whether Element should use End-to-End Encryption by default.
 # Setting this to false will update `/.well-known/matrix/client` and tell Element clients to avoid E2EE.
-# See: https://github.com/vector-im/riot-web/blob/develop/docs/e2ee.md
-matrix_riot_e2ee_default: true
+# See: https://github.com/vector-im/element-web/blob/develop/docs/e2ee.md
+matrix_client_element_e2ee_default: true
 
 # The Docker network that all services would be put into
 matrix_docker_network: "matrix"

--- a/roles/matrix-base/templates/static-files/well-known/matrix-client.j2
+++ b/roles/matrix-base/templates/static-files/well-known/matrix-client.j2
@@ -18,12 +18,12 @@
 		]
 	}
 	{% endif %}
-	{% if matrix_riot_jitsi_preferredDomain %},
+	{% if matrix_client_element_jitsi_preferredDomain %},
 	"im.vector.riot.jitsi": {
-		"preferredDomain": {{ matrix_riot_jitsi_preferredDomain|to_json }}
+		"preferredDomain": {{ matrix_client_element_jitsi_preferredDomain|to_json }}
 	}
 	{% endif %}
-	{% if not matrix_riot_e2ee_default %},
+	{% if not matrix_client_element_e2ee_default %},
 	"im.vector.riot.e2ee": {
 		"default": false
 	}

--- a/roles/matrix-base/templates/static-files/well-known/matrix-client.j2
+++ b/roles/matrix-base/templates/static-files/well-known/matrix-client.j2
@@ -19,11 +19,17 @@
 	}
 	{% endif %}
 	{% if matrix_client_element_jitsi_preferredDomain %},
+	"io.element.jitsi": {
+		"preferredDomain": {{ matrix_client_element_jitsi_preferredDomain|to_json }}
+	},
 	"im.vector.riot.jitsi": {
 		"preferredDomain": {{ matrix_client_element_jitsi_preferredDomain|to_json }}
 	}
 	{% endif %}
 	{% if not matrix_client_element_e2ee_default %},
+	"io.element.e2ee": {
+		"default": false
+	},
 	"im.vector.riot.e2ee": {
 		"default": false
 	}


### PR DESCRIPTION
Support both the `im.vector.riot` and `io.element` variants in `.well-known/matrix/client`.

According to the docs, `e2ee` [is already under](https://github.com/vector-im/element-web/blob/develop/docs/e2ee.md#disabling-encryption-by-default) `io.element` however `jitsi` [is still under](https://github.com/vector-im/element-web/blob/develop/docs/jitsi.md#configuring-element-to-use-your-self-hosted-jitsi-server) `im.vector.riot`.

For now let's just maintain backward and forward compatibility for both settings since the client version is out of the control of this playbook. If somebody has a better proposal I am happy to hear it.

Also, I fixed a few remaining `*_riot_*` variables. Note that this is again a breaking change (similar to 2020-07-17), due to the variable name change.

