### PR TITLE
Use up-to-date PostgreSQL container version for backups.

### DIFF
--- a/docs/maintenance-postgres.md
+++ b/docs/maintenance-postgres.md
@@ -45,7 +45,7 @@ docker run \
 --log-driver=none \
 --network=matrix \
 --env-file=/matrix/postgres/env-postgres-psql \
-postgres:12.4-alpine \
+postgres:13.0-alpine \
 pg_dumpall -h matrix-postgres \
 | gzip -c \
 > /postgres.sql.gz


### PR DESCRIPTION
This follows up on the recent upgrade of the PostgreSQL container to v13.0.