### PR TITLE
add variables for secure_backup_required and secure_backup_setup_methods

### DIFF
--- a/roles/matrix-base/defaults/main.yml
+++ b/roles/matrix-base/defaults/main.yml
@@ -70,12 +70,12 @@ matrix_client_element_e2ee_default: true
 # Controls whether Element should require a secure backup set up before Element can be used.
 # Setting this to true will update `/.well-known/matrix/client` and tell Element require a secure backup.
 # See: https://github.com/vector-im/element-web/blob/develop/docs/e2ee.md
-matrix_client_element_e2ee_backup_required: false
+matrix_client_element_e2ee_secure_backup_required: false
 
 # Controls which backup methods from ["key", "passphrase"] should be used, both is the default.
 # Setting this to other then empty will update `/.well-known/matrix/client` and tell Element which method to use
 # See: https://github.com/vector-im/element-web/blob/develop/docs/e2ee.md
-matrix_client_element_e2ee_backup_methods: []
+matrix_client_element_e2ee_secure_backup_setup_methods: []
 
 # The Docker network that all services would be put into
 matrix_docker_network: "matrix"

--- a/roles/matrix-base/defaults/main.yml
+++ b/roles/matrix-base/defaults/main.yml
@@ -75,7 +75,7 @@ matrix_client_element_e2ee_backup_required: false
 # Controls which backup methods from ["key", "passphrase"] should be used, both is the default.
 # Setting this to other then empty will update `/.well-known/matrix/client` and tell Element which method to use
 # See: https://github.com/vector-im/element-web/blob/develop/docs/e2ee.md
-matrix_client_element_e2ee_backup_methods: []
+matrix_client_element_e2ee_backup_methods: [ "key", "passphrase" ]
 
 # The Docker network that all services would be put into
 matrix_docker_network: "matrix"

--- a/roles/matrix-base/defaults/main.yml
+++ b/roles/matrix-base/defaults/main.yml
@@ -75,7 +75,7 @@ matrix_client_element_e2ee_backup_required: false
 # Controls which backup methods from ["key", "passphrase"] should be used, both is the default.
 # Setting this to other then empty will update `/.well-known/matrix/client` and tell Element which method to use
 # See: https://github.com/vector-im/element-web/blob/develop/docs/e2ee.md
-matrix_client_element_e2ee_backup_methods: [ "key", "passphrase" ]
+matrix_client_element_e2ee_backup_methods: []
 
 # The Docker network that all services would be put into
 matrix_docker_network: "matrix"

--- a/roles/matrix-base/defaults/main.yml
+++ b/roles/matrix-base/defaults/main.yml
@@ -67,6 +67,16 @@ matrix_client_element_jitsi_preferredDomain: ''
 # See: https://github.com/vector-im/element-web/blob/develop/docs/e2ee.md
 matrix_client_element_e2ee_default: true
 
+# Controls whether Element should require a secure backup set up before Element can be used.
+# Setting this to true will update `/.well-known/matrix/client` and tell Element require a secure backup.
+# See: https://github.com/vector-im/element-web/blob/develop/docs/e2ee.md
+matrix_client_element_e2ee_backup_required: false
+
+# Controls which backup methods from ["key", "passphrase"] should be used, both is the default.
+# Setting this to other then empty will update `/.well-known/matrix/client` and tell Element which method to use
+# See: https://github.com/vector-im/element-web/blob/develop/docs/e2ee.md
+matrix_client_element_e2ee_backup_methods: []
+
 # The Docker network that all services would be put into
 matrix_docker_network: "matrix"
 

--- a/roles/matrix-base/templates/static-files/well-known/matrix-client.j2
+++ b/roles/matrix-base/templates/static-files/well-known/matrix-client.j2
@@ -27,26 +27,12 @@
 	}
 	{% endif %}
 	,
-        "io.element.e2ee": {
-        	{% if not matrix_client_element_e2ee_default %}
-		   "default": false,
-		{% else %}
-		   "default": true,
-                {% endif %}
-		{% if matrix_client_element_e2ee_backup_required %}
-	           "secure_backup_required": true
-		{% else %}
-	           "secure_backup_required": false
-         	{% endif %}
-		{% if matrix_client_element_e2ee_backup_methods %},
-		   "secure_backup_setup_methods": {{ matrix_client_element_e2ee_backup_methods|to_json }}
-                {% endif %}
+	"io.element.e2ee": {
+		"default": {{ matrix_client_element_e2ee_default|to_json }},
+		"secure_backup_required": {{ matrix_client_element_e2ee_backup_required|to_json }},
+		"secure_backup_setup_methods": {{ matrix_client_element_e2ee_backup_methods|to_json }}
 	},
 	"im.vector.riot.e2ee": {
-        	{% if not matrix_client_element_e2ee_default %}
-		   "default": false
-		{% else %}
-		   "default": true
-                {% endif %}
+		"default": {{ matrix_client_element_e2ee_default|to_json }}
 	}
 }

--- a/roles/matrix-base/templates/static-files/well-known/matrix-client.j2
+++ b/roles/matrix-base/templates/static-files/well-known/matrix-client.j2
@@ -26,12 +26,27 @@
 		"preferredDomain": {{ matrix_client_element_jitsi_preferredDomain|to_json }}
 	}
 	{% endif %}
-	{% if not matrix_client_element_e2ee_default %},
-	"io.element.e2ee": {
-		"default": false
+	,
+        "io.element.e2ee": {
+        	{% if not matrix_client_element_e2ee_default %}
+		   "default": false
+		{% else %}
+		   "default": true
+                {% endif %}
+		{% if matrix_client_element_e2ee_backup_required %},
+	           "secure_backup_required": true
+		{% else %}
+	           "secure_backup_required": false
+         	{% endif %}
+		{% if matrix_client_element_e2ee_backup_methods %},
+		   "secure_backup_setup_methods": {{ matrix_client_element_e2ee_backup_methods|to_json }}
+                {% endif %}
 	},
 	"im.vector.riot.e2ee": {
-		"default": false
+        	{% if not matrix_client_element_e2ee_default %}
+		   "default": false
+		{% else %}
+		   "default": true
+                {% endif %}
 	}
-	{% endif %}
 }

--- a/roles/matrix-base/templates/static-files/well-known/matrix-client.j2
+++ b/roles/matrix-base/templates/static-files/well-known/matrix-client.j2
@@ -29,8 +29,8 @@
 	,
 	"io.element.e2ee": {
 		"default": {{ matrix_client_element_e2ee_default|to_json }},
-		"secure_backup_required": {{ matrix_client_element_e2ee_backup_required|to_json }},
-		"secure_backup_setup_methods": {{ matrix_client_element_e2ee_backup_methods|to_json }}
+		"secure_backup_required": {{ matrix_client_element_e2ee_secure_backup_required|to_json }},
+		"secure_backup_setup_methods": {{ matrix_client_element_e2ee_secure_backup_setup_methods|to_json }}
 	},
 	"im.vector.riot.e2ee": {
 		"default": {{ matrix_client_element_e2ee_default|to_json }}

--- a/roles/matrix-base/templates/static-files/well-known/matrix-client.j2
+++ b/roles/matrix-base/templates/static-files/well-known/matrix-client.j2
@@ -29,11 +29,11 @@
 	,
         "io.element.e2ee": {
         	{% if not matrix_client_element_e2ee_default %}
-		   "default": false
+		   "default": false,
 		{% else %}
-		   "default": true
+		   "default": true,
                 {% endif %}
-		{% if matrix_client_element_e2ee_backup_required %},
+		{% if matrix_client_element_e2ee_backup_required %}
 	           "secure_backup_required": true
 		{% else %}
 	           "secure_backup_required": false


### PR DESCRIPTION
Hi.
I had to put all the options into "io.element.e2ee" dictionary to make them work.
Actually I could not find out, how "secure_backup_required" true or false did make any difference, but it was requested in the chatroom.
The "secure_backup_setup_methods" definitely work, although it needs a tough deleting of every caching possible in the browser to see the change...
Same goes for the "default" option.