### PR TITLE
keycloak SSO

### DIFF
--- a/docs/configuring-playbook-nginx.md
+++ b/docs/configuring-playbook-nginx.md
@@ -26,7 +26,7 @@ matrix_nginx_proxy_proxy_matrix_nginx_status_allowed_addresses:
 
 ## Using Keycloak OIDC SSO
 
-If you want to use Keycloak OpenId Connect as SSO provider - see [synapse doc](https://github.com/matrix-org/synapse/blob/develop/docs/openid.md) - , you need to enable following variable to instruc nginx to proceed location /_synapse/oidc/callback  
+If you want to use Keycloak OpenId Connect as SSO provider - see [synapse doc](https://github.com/matrix-org/synapse/blob/develop/docs/openid.md) - , you need to enable following variable to instruct nginx to proceed location /_synapse/oidc/callback  
 
 ```yaml
 matrix_nginx_proxy_proxy_matrix_synapse_oidc_provider_keycloak: true

--- a/docs/configuring-playbook-nginx.md
+++ b/docs/configuring-playbook-nginx.md
@@ -23,3 +23,12 @@ matrix_nginx_proxy_proxy_matrix_nginx_status_allowed_addresses:
 - 8.8.8.8
 - 1.1.1.1
 ```
+
+## Using Keycloak OIDC SSO
+
+If you want to use Keycloak OpenId Connect as SSO provider - see [synapse doc](https://github.com/matrix-org/synapse/blob/develop/docs/openid.md) - , you need to enable following variable to instruc nginx to proceed location /_synapse/oidc/callback  
+
+```yaml
+matrix_nginx_proxy_proxy_matrix_synapse_oidc_provider_keycloak: true
+```
+

--- a/roles/matrix-nginx-proxy/defaults/main.yml
+++ b/roles/matrix-nginx-proxy/defaults/main.yml
@@ -273,3 +273,6 @@ matrix_ssl_log_dir_path: "{{ matrix_ssl_base_path }}/log"
 # nginx status page configurations.
 matrix_nginx_proxy_proxy_matrix_nginx_status_enabled: false
 matrix_nginx_proxy_proxy_matrix_nginx_status_allowed_addresses: ['{{ ansible_default_ipv4.address }}']
+
+# nginx configuration for synapse auth via openidconnect with keycloak
+matrix_nginx_proxy_proxy_matrix_synapse_oidc_provider_keycloak: false

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-synapse.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-synapse.conf.j2
@@ -67,6 +67,28 @@
 	}
 	{% endif %}
 
+        {% if matrix_nginx_proxy_proxy_matrix_synapse_oidc_provider_keycloak %}
+        location /_synapse/oidc/callback {
+                {% if matrix_nginx_proxy_enabled %}
+                        {# Use the embedded DNS resolver in Docker containers to discover the service #}
+                        resolver 127.0.0.11 valid=5s;
+                        set $backend "{{ matrix_nginx_proxy_proxy_matrix_client_api_addr_with_container }}";
+                        proxy_pass http://$backend;
+                {% else %}
+                        {# Generic configuration for use outside of our container setup #}
+                        proxy_pass http://{{ matrix_nginx_proxy_proxy_matrix_client_api_addr_sans_container }};
+                {% endif %}
+
+                proxy_set_header Host $host;
+                proxy_set_header X-Forwarded-For $remote_addr;
+
+                client_body_buffer_size 25M;
+                client_max_body_size {{ matrix_nginx_proxy_proxy_matrix_client_api_client_max_body_size_mb }}M;
+                proxy_max_temp_file_size 0;
+        }
+        {% endif %}
+
+
 	{% if matrix_nginx_proxy_proxy_matrix_user_directory_search_enabled %}
 	location ^~ /_matrix/client/r0/user_directory/search {
 		{% if matrix_nginx_proxy_enabled %}


### PR DESCRIPTION
add nginx conf for /_synapse/oidc/callback, used for keycloak SSO.   

It had been broken by commit 63a49bb2dc7780e023b2801a7230cda529b2b3c1