### PR TITLE
Non root user and Matrix group

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -12,6 +12,11 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all
 
 **Note**: if you **do** use SSH keys for authentication, **and** use a non-root user to *become* root (sudo), you may need to add `-K` (`--ask-become-pass`) to the above (and all other) Ansible commands.
 
+**Note**: if you use a non-root user you must make sure this user is a member of the matrix group.
+```
+usermod -aG matrix $USER
+```
+
 The above command **doesn't start any services just yet** (another step does this later - below).
 
 Feel free to **re-run this setup command any time** you think something is off with the server configuration.


### PR DESCRIPTION
This might be obvious to more experienced users but it took me a while to realize non-root users needed to be a member of the matrix group. 