### PR TITLE
Update jitsi web to stable-5142

### DIFF
--- a/roles/matrix-jitsi/defaults/main.yml
+++ b/roles/matrix-jitsi/defaults/main.yml
@@ -51,7 +51,7 @@ matrix_jitsi_jibri_recorder_password: ''
 
 matrix_jitsi_enable_lobby: false
 
-matrix_jitsi_container_image_tag: "stable-4857"
+matrix_jitsi_container_image_tag: "stable-5142"
 
 matrix_jitsi_web_docker_image: "jitsi/web:{{ matrix_jitsi_container_image_tag }}"
 matrix_jitsi_web_docker_image_force_pull: "{{ matrix_jitsi_web_docker_image.endswith(':latest') }}"


### PR DESCRIPTION
Latest stable jitsi version is `stable-5142`.

[Changelog](https://github.com/jitsi/jitsi-meet-release-notes/blob/master/CHANGELOG-WEB.md) doesn't seem to indicate any breaking change.

**Also worth seeing:**
Changelog for this specific version: https://github.com/jitsi/jitsi-meet/releases/tag/stable%2Fjitsi-meet_5142
Full commit changelog comparing to current version (if needed): https://github.com/jitsi/jitsi-meet/compare/stable/jitsi-meet_4857...stable/jitsi-meet_5142

