### PR TITLE
Add Jibri work in progress

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -676,6 +676,7 @@ matrix_jitsi_jvb_container_colibri_ws_host_bind_port: "{{ '' if matrix_nginx_pro
 matrix_jitsi_jibri_xmpp_password: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'jibri') | to_uuid }}"
 matrix_jitsi_jicofo_auth_password: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'jicofo') | to_uuid }}"
 matrix_jitsi_jvb_auth_password: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'jvb') | to_uuid }}"
+matrix_jitsi_jibri_recorder_password: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'recorder') | to_uuid }}"
 
 matrix_jitsi_web_stun_servers: |
   {{

--- a/roles/matrix-jitsi/defaults/main.yml
+++ b/roles/matrix-jitsi/defaults/main.yml
@@ -264,7 +264,7 @@ matrix_jitsi_jibri_config_path: "{{ matrix_jitsi_jibri_base_path }}/config"
 matrix_jitsi_jibri_logs_path: "{{ matrix_jitsi_jibri_base_path }}/logs"
 matrix_jitsi_jibri_recording_path: "{{ matrix_jitsi_jibri_base_path }}/recordings"
 matrix_jitsi_jibri_finalize_recording_script_path: "{{ matrix_jitsi_jibri_config_path }}/finalize.sh"
-matrix_jitsi_jibri_strip_domain_jid: muc
+matrix_jitsi_jibri_strip_domain_jid: ''
 # A list of extra arguments to pass to the container
 matrix_jitsi_jibri_container_extra_arguments: []
 

--- a/roles/matrix-jitsi/defaults/main.yml
+++ b/roles/matrix-jitsi/defaults/main.yml
@@ -252,3 +252,20 @@ matrix_jitsi_jvb_container_rtp_tcp_host_bind_port: "{{ matrix_jitsi_jvb_rtp_tcp_
 #
 # Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:12090"), or empty string to not expose.
 matrix_jitsi_jvb_container_colibri_ws_host_bind_port: ''
+
+#Jibri
+matrix_jitsi_jibri_enabled: false
+matrix_jitsi_jibri_docker_image: "docker.io/jitsi/jibri:{{ matrix_jitsi_container_image_tag }}"
+matrix_jitsi_jibri_docker_image_force_pull: "{{ matrix_jitsi_jibri_docker_image.endswith(':latest') }}"
+
+matrix_jitsi_jibri_base_path: "{{ matrix_base_data_path }}/jitsi/jibri"
+matrix_jitsi_jibri_config_path: "{{ matrix_jitsi_jibri_base_path }}/config"
+matrix_jitsi_jibri_logs_path: "{{ matrix_jitsi_jibri_base_path }}/logs"
+matrix_jitsi_jibri_recording_path: "{{ matrix_jitsi_jibri_base_path }}/recordings"
+matrix_jitsi_jibri_finalize_recording_script_path: "{{ matrix_jitsi_jibri_config_path }}/finalize.sh"
+matrix_jitsi_jibri_strip_domain_jid: muc
+# A list of extra arguments to pass to the container
+matrix_jitsi_jibri_container_extra_arguments: []
+
+# List of systemd services that matrix-jitsi-jibri.service depends on
+matrix_jitsi_jibri_systemd_required_services_list: ['docker.service', 'matrix-jitsi-jicofo.service', 'matrix-jitsi-prosody.service']

--- a/roles/matrix-jitsi/defaults/main.yml
+++ b/roles/matrix-jitsi/defaults/main.yml
@@ -165,6 +165,7 @@ matrix_jitsi_prosody_docker_image_force_pull: "{{ matrix_jitsi_prosody_docker_im
 matrix_jitsi_prosody_base_path: "{{ matrix_base_data_path }}/jitsi/prosody"
 matrix_jitsi_prosody_config_path: "{{ matrix_jitsi_prosody_base_path }}/config"
 matrix_jitsi_prosody_plugins_path: "{{ matrix_jitsi_prosody_base_path }}/prosody-plugins-custom"
+matrix_jitsi_prosody_confd_path: "{{ matrix_jitsi_prosody_config_path }}/conf.d"
 
 # A list of extra arguments to pass to the container
 matrix_jitsi_prosody_container_extra_arguments: []

--- a/roles/matrix-jitsi/tasks/init_jibri.yml
+++ b/roles/matrix-jitsi/tasks/init_jibri.yml
@@ -1,0 +1,3 @@
+- set_fact:
+    matrix_systemd_services_list: "{{ matrix_systemd_services_list + ['matrix-jitsi-jibri'] }}"
+  when: matrix_jitsi_jibri_enabled|bool

--- a/roles/matrix-jitsi/tasks/main.yml
+++ b/roles/matrix-jitsi/tasks/main.yml
@@ -2,6 +2,10 @@
   tags:
     - always
 
+- import_tasks: "{{ role_path }}/tasks/init_jibri.yml"
+  tags:
+    - always
+
 - import_tasks: "{{ role_path }}/tasks/validate_config.yml"
   when: "run_setup|bool and matrix_jitsi_enabled|bool"
   tags:
@@ -33,6 +37,12 @@
     - setup-jitsi
 
 - import_tasks: "{{ role_path }}/tasks/setup_jitsi_jvb.yml"
+  when: run_setup|bool
+  tags:
+    - setup-all
+    - setup-jitsi
+
+- import_tasks: "{{ role_path }}/tasks/setup_jitsi_jibri.yml"
   when: run_setup|bool
   tags:
     - setup-all

--- a/roles/matrix-jitsi/tasks/setup_jitsi_jibri.yml
+++ b/roles/matrix-jitsi/tasks/setup_jitsi_jibri.yml
@@ -1,0 +1,65 @@
+---
+
+#
+# Tasks related to setting up jitsi-jibri
+#
+
+- name: Ensure Matrix jitsi-jibri path exists
+  file:
+    path: "{{ item.path }}"
+    state: directory
+    mode: 0777
+    owner: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
+  with_items:
+    - { path: "{{ matrix_jitsi_jibri_base_path }}", when: true }
+    - { path: "{{ matrix_jitsi_jibri_config_path }}", when: true }
+    - { path: "{{ matrix_jitsi_jibri_logs_path }}" , when: true}
+    - { path: "{{ matrix_jitsi_jibri_recording_path }}" , when: true}
+  when: matrix_jitsi_enabled|bool and matrix_jitsi_jibri_enabled|bool and item.when
+
+- name: Ensure jitsi-jibri Docker image is pulled
+  docker_image:
+    name: "{{ matrix_jitsi_jibri_docker_image }}"
+    source: "{{ 'pull' if ansible_version.major > 2 or ansible_version.minor > 7 else omit }}"
+    force_source: "{{ matrix_jitsi_jibri_docker_image_force_pull if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
+    force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_jitsi_jibri_docker_image_force_pull }}"
+  when: matrix_jitsi_enabled|bool and matrix_jitsi_jibri_enabled|bool
+
+- name: Ensure jitsi-jibri environment variables file created
+  template:
+    src: "{{ role_path }}/templates/jibri/env.j2"
+    dest: "{{ matrix_jitsi_jibri_base_path }}/env"
+    mode: 0640
+  when: matrix_jitsi_enabled|bool and matrix_jitsi_jibri_enabled|bool
+
+- name: Ensure jitsi-jibri finalize.sh file created
+  template:
+    src: "{{ role_path }}/templates/jibri/finalize.sh.j2"
+    dest: "{{ matrix_jitsi_jibri_config_path }}/finalize.sh"
+    mode: 0740
+  when: matrix_jitsi_enabled|bool and matrix_jitsi_jibri_enabled|bool
+
+
+- name: Ensure jitsi-jibri configuration files created
+  template:
+    src: "{{ role_path }}/templates/jibri/{{ item }}.j2"
+    dest: "{{ matrix_jitsi_jibri_config_path }}/{{ item }}"
+    mode: 0644
+  with_items:
+    - config.json
+    - logging.properties
+  when: matrix_jitsi_enabled|bool and matrix_jitsi_jibri_enabled|bool
+
+- name: Ensure matrix-jitsi-jibri.service installed
+  template:
+    src: "{{ role_path }}/templates/jibri/matrix-jitsi-jibri.service.j2"
+    dest: "{{ matrix_systemd_path }}/matrix-jitsi-jibri.service"
+    mode: 0644
+  register: matrix_jitsi_jibri_systemd_service_result
+  when: matrix_jitsi_enabled|bool and matrix_jitsi_jibri_enabled|bool
+
+- name: Ensure systemd reloaded after matrix-jitsi-jibri.service installation
+  service:
+    daemon_reload: yes
+  when: "matrix_jitsi_enabled and matrix_jitsi_jibri_systemd_service_result.changed"

--- a/roles/matrix-jitsi/tasks/setup_jitsi_prosody.yml
+++ b/roles/matrix-jitsi/tasks/setup_jitsi_prosody.yml
@@ -15,6 +15,7 @@
     - { path: "{{ matrix_jitsi_prosody_base_path }}", when: true }
     - { path: "{{ matrix_jitsi_prosody_config_path }}", when: true }
     - { path: "{{ matrix_jitsi_prosody_plugins_path }}", when: true }
+    - { path: "{{ matrix_jitsi_prosody_confd_path }}", when: true }
   when: matrix_jitsi_enabled|bool and item.when
 
 - name: Ensure jitsi-prosody Docker image is pulled
@@ -31,6 +32,13 @@
     dest: "{{ matrix_jitsi_prosody_base_path }}/env"
     mode: 0640
   when: matrix_jitsi_enabled|bool
+
+- name: Ensure jitsi- jibri.cfg.lua file created
+  template:
+    src: "{{ role_path }}/templates/jibri/jibri.cfg.lua.j2"
+    dest: "{{ matrix_jitsi_prosody_confd_path }}/jibri.cfg.lua"
+    mode: 0644
+  when: matrix_jitsi_enabled|bool and matrix_jitsi_jibri_enabled|bool
 
 - name: Ensure matrix-jitsi-prosody.service installed
   template:

--- a/roles/matrix-jitsi/templates/jibri/config.json.j2
+++ b/roles/matrix-jitsi/templates/jibri/config.json.j2
@@ -13,15 +13,15 @@
                 {{ matrix_jitsi_xmpp_server|string|to_json }}
             ],
             "xmpp_domain": {{ matrix_jitsi_xmpp_domain|string|to_json }},
-            // Jibri will login to the xmpp server as a privileged user 
+            // Jibri will login to the xmpp server as a privileged user
             "control_login": {
                 "domain": {{ matrix_jitsi_xmpp_auth_domain|string|to_json }},
                 // The credentials for logging in
                 "username": {{ matrix_jitsi_jibri_xmpp_user|string|to_json }},
                 "password": {{ matrix_jitsi_jibri_xmpp_password|string|to_json }}
             },
-            // Using the control_login information above, Jibri will join 
-            //  a control muc as a means of announcing its availability 
+            // Using the control_login information above, Jibri will join
+            //  a control muc as a means of announcing its availability
             //  to provide services for a given environment
             "control_muc": {
                 "domain": {{ matrix_jitsi_xmpp_internal_muc_domain|string|to_json }},
@@ -47,12 +47,12 @@
             //  has its participants join a muc at conference.xmpp_domain) then
             //  list that prefix here so it can be stripped out to generate
             //  the call url correctly
-            "room_jid_domain_string_to_strip_from_start": {{ matrix_jitsi_jibri_logs_path|string|to_json }},
+            "room_jid_domain_string_to_strip_from_start": {{ matrix_jitsi_jibri_strip_domain_jid|string|to_json }},
             // The amount of time, in minutes, a service is allowed to continue.
             //  Once a service has been running for this long, it will be
             //  stopped (cleanly).  A value of 0 means an indefinite amount
             //  of time is allowed
-            "usage_timeout": "0"
+            "usage_timeout": "0",
             // Whether or not we'll automatically trust any cert on
             // this XMPP domain
             trust-all-xmpp-certs = true

--- a/roles/matrix-jitsi/templates/jibri/config.json.j2
+++ b/roles/matrix-jitsi/templates/jibri/config.json.j2
@@ -1,0 +1,61 @@
+{
+    "recording_directory":{{ matrix_jitsi_jibri_recording_path|string|to_json }},
+    // The path to the script which will be run on completed recordings
+    "finalize_recording_script_path": {{ matrix_jitsi_jibri_finalize_recording_script_path|string|to_json }},
+    "xmpp_environments": [
+        {
+            // A friendly name for this environment which can be used
+            //  for logging, stats, etc.
+            "name": "prod environment",
+            // The hosts of the XMPP servers to connect to as part of
+            //  this environment
+            "xmpp_server_hosts": [
+                {{ matrix_jitsi_xmpp_server|string|to_json }}
+            ],
+            "xmpp_domain": {{ matrix_jitsi_xmpp_domain|string|to_json }},
+            // Jibri will login to the xmpp server as a privileged user 
+            "control_login": {
+                "domain": {{ matrix_jitsi_xmpp_auth_domain|string|to_json }},
+                // The credentials for logging in
+                "username": {{ matrix_jitsi_jibri_xmpp_user|string|to_json }},
+                "password": {{ matrix_jitsi_jibri_xmpp_password|string|to_json }}
+            },
+            // Using the control_login information above, Jibri will join 
+            //  a control muc as a means of announcing its availability 
+            //  to provide services for a given environment
+            "control_muc": {
+                "domain": {{ matrix_jitsi_xmpp_internal_muc_domain|string|to_json }},
+                "room_name": {{ matrix_jitsi_jibri_brewery_muc|string|to_json }},
+		// MUST be unic for every instanse
+                "nickname": "jibri-instanse-1"
+            },
+            // All participants in a call join a muc so they can exchange
+            //  information.  Jibri can be instructed to join a special muc
+            //  with credentials to give it special abilities (e.g. not being
+            //  displayed to other users like a normal participant)
+            "call_login": {
+                "domain": {{ matrix_jitsi_recorder_domain|string|to_json }},
+                "username": {{ matrix_jitsi_jibri_recorder_user|string|to_json }},
+                "password": {{ matrix_jitsi_jibri_recorder_password|string|to_json }}
+            },
+            // When jibri gets a request to start a service for a room, the room
+            //  jid will look like:
+            //  roomName@optional.prefixes.subdomain.xmpp_domain
+            // We'll build the url for the call by transforming that into:
+            //  https://xmpp_domain/subdomain/roomName
+            // So if there are any prefixes in the jid (like jitsi meet, which
+            //  has its participants join a muc at conference.xmpp_domain) then
+            //  list that prefix here so it can be stripped out to generate
+            //  the call url correctly
+            "room_jid_domain_string_to_strip_from_start": {{ matrix_jitsi_jibri_logs_path|string|to_json }},
+            // The amount of time, in minutes, a service is allowed to continue.
+            //  Once a service has been running for this long, it will be
+            //  stopped (cleanly).  A value of 0 means an indefinite amount
+            //  of time is allowed
+            "usage_timeout": "0"
+            // Whether or not we'll automatically trust any cert on
+            // this XMPP domain
+            trust-all-xmpp-certs = true
+        }
+    ]
+}

--- a/roles/matrix-jitsi/templates/jibri/env.j2
+++ b/roles/matrix-jitsi/templates/jibri/env.j2
@@ -1,0 +1,16 @@
+XMPP_AUTH_DOMAIN={{ matrix_jitsi_xmpp_auth_domain }}
+XMPP_INTERNAL_MUC_DOMAIN={{ matrix_jitsi_xmpp_internal_muc_domain }}
+XMPP_RECORDER_DOMAIN={{ matrix_jitsi_recorder_domain }}
+XMPP_SERVER={{ matrix_jitsi_xmpp_server }}
+XMPP_DOMAIN={{ matrix_jitsi_xmpp_domain }}
+JIBRI_XMPP_USER={{ matrix_jitsi_jibri_xmpp_user }}
+JIBRI_XMPP_PASSWORD={{ matrix_jitsi_jibri_xmpp_password }}
+JIBRI_BREWERY_MUC={{ matrix_jitsi_jvb_brewery_muc }}
+JIBRI_RECORDER_USER={{ matrix_jitsi_jibri_recorder_user }}
+JIBRI_RECORDER_PASSWORD={{ matrix_jitsi_jibri_recorder_password }}
+JIBRI_RECORDING_DIR={{ matrix_jitsi_jibri_recording_path }}
+JIBRI_FINALIZE_RECORDING_SCRIPT_PATH={{ matrix_jitsi_jibri_finalize_recording_script_path }}
+JIBRI_STRIP_DOMAIN_JID={{ matrix_jitsi_jibri_strip_domain_jid }}
+JIBRI_LOGS_DIR={{ matrix_jitsi_jibri_logs_path }}
+DISPLAY=:0
+TZ={{ matrix_jitsi_timezone }}

--- a/roles/matrix-jitsi/templates/jibri/jibri.cfg.lua.j2
+++ b/roles/matrix-jitsi/templates/jibri/jibri.cfg.lua.j2
@@ -1,0 +1,12 @@
+Component {{ matrix_jitsi_xmpp_internal_muc_domain|string|to_json }} "muc"
+    modules_enabled = {
+      "ping";
+    }
+    storage = "memory"
+    muc_room_cache_size = 1000
+
+VirtualHost {{ matrix_jitsi_recorder_domain|string|to_json }}
+    modules_enabled = {
+      "ping";
+    }
+    authentication = "internal_plain"

--- a/roles/matrix-jitsi/templates/jibri/logging.properties.j2
+++ b/roles/matrix-jitsi/templates/jibri/logging.properties.j2
@@ -1,0 +1,34 @@
+handlers = java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+java.util.logging.FileHandler.level = FINE
+java.util.logging.FileHandler.pattern   = {{ matrix_jitsi_jibri_logs_path }}/log.%g.txt
+java.util.logging.FileHandler.formatter = net.java.sip.communicator.util.ScLogFormatter
+java.util.logging.FileHandler.count = 10
+java.util.logging.FileHandler.limit = 10000000
+
+org.jitsi.jibri.capture.ffmpeg.util.FfmpegFileHandler.level = FINE
+org.jitsi.jibri.capture.ffmpeg.util.FfmpegFileHandler.pattern   = {{ matrix_jitsi_jibri_logs_path }}/ffmpeg.%g.txt
+org.jitsi.jibri.capture.ffmpeg.util.FfmpegFileHandler.formatter = net.java.sip.communicator.util.ScLogFormatter
+org.jitsi.jibri.capture.ffmpeg.util.FfmpegFileHandler.count = 10
+org.jitsi.jibri.capture.ffmpeg.util.FfmpegFileHandler.limit = 10000000
+
+org.jitsi.jibri.sipgateway.pjsua.util.PjsuaFileHandler.level = FINE
+org.jitsi.jibri.sipgateway.pjsua.util.PjsuaFileHandler.pattern   = {{ matrix_jitsi_jibri_logs_path }}/pjsua.%g.txt
+org.jitsi.jibri.sipgateway.pjsua.util.PjsuaFileHandler.formatter = net.java.sip.communicator.util.ScLogFormatter
+org.jitsi.jibri.sipgateway.pjsua.util.PjsuaFileHandler.count = 10
+org.jitsi.jibri.sipgateway.pjsua.util.PjsuaFileHandler.limit = 10000000
+
+org.jitsi.jibri.selenium.util.BrowserFileHandler.level = FINE
+org.jitsi.jibri.selenium.util.BrowserFileHandler.pattern   = {{ matrix_jitsi_jibri_logs_path }}/browser.%g.txt
+org.jitsi.jibri.selenium.util.BrowserFileHandler.formatter = net.java.sip.communicator.util.ScLogFormatter
+org.jitsi.jibri.selenium.util.BrowserFileHandler.count = 10
+org.jitsi.jibri.selenium.util.BrowserFileHandler.limit = 10000000
+
+java.util.logging.ConsoleHandler.level = FINE
+java.util.logging.ConsoleHandler.formatter = net.java.sip.communicator.util.ScLogFormatter
+
+org.jitsi.level = FINE
+
+org.glassfish.level = INFO
+org.osgi.level = INFO
+

--- a/roles/matrix-jitsi/templates/jibri/matrix-jitsi-jibri.service.j2
+++ b/roles/matrix-jitsi/templates/jibri/matrix-jitsi-jibri.service.j2
@@ -1,0 +1,32 @@
+#jinja2: lstrip_blocks: "True"
+[Unit]
+Description=Matrix jitsi-jibri server
+{% for service in matrix_jitsi_jibri_systemd_required_services_list %}
+Requires={{ service }}
+After={{ service }}
+{% endfor %}
+
+[Service]
+Type=simple
+ExecStartPre=-{{ matrix_host_command_docker }} kill matrix-jitsi-jibri
+ExecStartPre=-{{ matrix_host_command_docker }} rm matrix-jitsi-jibri
+
+ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-jitsi-jibri \
+			--log-driver=none \
+			--network={{ matrix_docker_network }} \
+			--env-file={{ matrix_jitsi_jibri_base_path }}/env \
+            --device=/dev/snd:/dev/snd \
+			--mount type=bind,src={{ matrix_jitsi_jibri_config_path }},dst=/config \
+			{% for arg in matrix_jitsi_jibri_container_extra_arguments %}
+			{{ arg }} \
+			{% endfor %}
+			{{ matrix_jitsi_jibri_docker_image }}
+
+ExecStop=-{{ matrix_host_command_docker }} kill matrix-jitsi-jibri
+ExecStop=-{{ matrix_host_command_docker }} rm matrix-jitsi-jibri
+Restart=always
+RestartSec=30
+SyslogIdentifier=matrix-jitsi-jibri
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
[WIP] I'm working on adding jibri to the jitsi role.
I did not add host preparation tasks for Jibri to the playbook at the moment. (I did them manually on my host).
-ansible-playbook -i inventory / hosts setup.yml --tags = setup-jitsi, start -
ends without errors, but I must be missing some configuration because the recordings are not working.
The only weird thing I see in the logs is:
org.jitsi.xmpp.extensions.DefaultPacketExtensionProvider.parse () Could not add a provider for element busy-status from namespace http://jitsi.org/protocol/jibri
I leave it here to see if someone finds the error. (I already have my eyes crossed ... ha)