### PR TITLE
Drop the old workaround for an Ansible bug that has been fixed three years ago

### DIFF
--- a/roles/matrix-base/tasks/setup_matrix_base.yml
+++ b/roles/matrix-base/tasks/setup_matrix_base.yml
@@ -19,31 +19,10 @@
     mode: '0660'
   when: "matrix_vars_yml_snapshotting_enabled|bool"
 
-# `docker_network` doesn't work as expected when the given network
-# is a substring of a network that already exists.
-#
-# See:
-# - https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/12
-# - https://github.com/ansible/ansible/issues/32926
-#
-# Due to that, we employ a workaround below.
-#
-# - name: Ensure Matrix network is created in Docker
-#   docker_network:
-#     name: "{{ matrix_docker_network }}"
-#     driver: bridge
-
-- name: Check existence of Matrix network in Docker
-  shell:
-    cmd: "docker network ls -q --filter='name=^{{ matrix_docker_network }}$'"
-  register: result_check_docker_network
-  changed_when: false
-  check_mode: no
-
-- name: Create Matrix network in Docker
-  shell:
-    cmd: "docker network create --driver=bridge {{ matrix_docker_network }}"
-  when: "result_check_docker_network.stdout == '' and not ansible_check_mode"
+- name: Ensure Matrix network is created in Docker
+  docker_network:
+    name: "{{ matrix_docker_network }}"
+    driver: bridge
 
 - name: Ensure matrix-remove-all script created
   template:

--- a/roles/matrix-coturn/tasks/setup_coturn.yml
+++ b/roles/matrix-coturn/tasks/setup_coturn.yml
@@ -59,22 +59,11 @@
     mode: 0644
   when: matrix_coturn_enabled|bool
 
-# `docker_network` doesn't work as expected when the given network
-# is a substring of a network that already exists.
-#
-# See our other comments in `roles/matrix-base/tasks/setup_matrix_base.yml`
-- name: Check existence of Coturn network in Docker
-  shell:
-    cmd: "docker network ls -q --filter='name=^{{ matrix_coturn_docker_network }}$'"
-  register: matrix_coturn_result_docker_network
-  changed_when: false
+- name: Ensure Coturn network is created in Docker
+  docker_network:
+    name: "{{ matrix_coturn_docker_network }}"
+    driver: bridge
   when: matrix_coturn_enabled|bool
-  check_mode: no
-
-- name: Create Coturn network in Docker
-  shell:
-    cmd: "docker network create --driver=bridge {{ matrix_coturn_docker_network }}"
-  when: "matrix_coturn_enabled|bool and matrix_coturn_result_docker_network.stdout == '' and not ansible_check_mode"
 
 - name: Ensure matrix-coturn.service installed
   template:


### PR DESCRIPTION
This PR cleans up an old workaround.

No issues running like this for at least six months.

```
$ ansible --version
ansible 2.9.13
...
```