### PR TITLE
Remove the recording button from the Jitsi UI if recording is disabled.

### DIFF
--- a/roles/matrix-jitsi/templates/web/interface_config.js.j2
+++ b/roles/matrix-jitsi/templates/web/interface_config.js.j2
@@ -205,9 +205,11 @@ var interfaceConfig = {
 		{% if matrix_jitsi_enable_transcriptions %}
             'closedcaptions',
 		{% endif %}
-
+		{% if matrix_jitsi_enable_recording %}
+            'recording',
+		{% endif %}
         'microphone', 'camera', 'desktop', 'embedmeeting', 'fullscreen',
-        'fodeviceselection', 'hangup', 'profile', 'chat', 'recording',
+        'fodeviceselection', 'hangup', 'profile', 'chat',
         'livestreaming', 'etherpad', 'sharedvideo', 'settings', 'raisehand',
         'videoquality', 'filmstrip', 'invite', 'feedback', 'stats', 'shortcuts',
         'tileview', 'videobackgroundblur', 'download', 'help', 'mute-everyone', 'security'


### PR DESCRIPTION
Recording in Jitsi was disabled by default in commit e0d7d5f0, but the button is still visible in the UI. This PR removes the button from the Jitsi Web toolbar if recording is disabled.