### PR TITLE
Correct inabillity for appservice-discord to connect

### DIFF
--- a/roles/matrix-bridge-appservice-discord/defaults/main.yml
+++ b/roles/matrix-bridge-appservice-discord/defaults/main.yml
@@ -37,7 +37,7 @@ matrix_appservice_discord_appservice_url: 'http://matrix-appservice-discord:9005
 
 matrix_appservice_discord_bridge_domain: "{{ matrix_domain }}"
 # As of right now, the homeserver URL must be a public URL. See below.
-matrix_appservice_discord_bridge_homeserverUrl: "{{ matrix_homeserver_url }}"
+matrix_appservice_discord_bridge_homeserverUrl: "http://matrix-synapse:8008"
 matrix_appservice_discord_bridge_disablePresence: false
 matrix_appservice_discord_bridge_enableSelfServiceBridging: false
 


### PR DESCRIPTION
After recently updating my matrix-docker-ansible-deploy installation, matrix-appservice-discord would refuse to start, logging ECONNREFUSED to https://matrix.[mydomain]:443, which was resolving to 172.18.0.2 due to the `--hostname` in mailer grabbing that hostname.

Curious why the IRC bridge didn't have this issue, I looked into it, and it was connecting to `http://matrix-synapse:8008`.  Correcting this one to that URL resolved the issue.