### PR TITLE
add option to disable nginx access log

### DIFF
--- a/docs/configuring-playbook-nginx.md
+++ b/docs/configuring-playbook-nginx.md
@@ -24,11 +24,18 @@ matrix_nginx_proxy_proxy_matrix_nginx_status_allowed_addresses:
 - 1.1.1.1
 ```
 
-
 ## Synapse + OpenID Connect for Single-Sign-On
 
 If you want to use OpenID Connect as an SSO provider (as per the [Synapse OpenID docs](https://github.com/matrix-org/synapse/blob/develop/docs/openid.md)), you need to use the following configuration (in your `vars.yml` file) to instruct nginx to forward `/_synapse/oidc` to Synapse:
 
 ```yaml
 matrix_nginx_proxy_proxy_matrix_client_api_forwarded_location_synapse_oidc_api_enabled: true
+```
+
+## Disable Nginx access logs
+
+This will disable the access logging for nginx.
+
+```yaml
+matrix_nginx_proxy_access_log_enabled: false
 ```

--- a/roles/matrix-nginx-proxy/defaults/main.yml
+++ b/roles/matrix-nginx-proxy/defaults/main.yml
@@ -92,6 +92,8 @@ matrix_nginx_proxy_base_domain_homepage_template: |-
     </body>
   </html>
 
+# Option to disable the access log
+matrix_nginx_proxy_access_log_enabled: true
 
 # Controls whether proxying the riot domain should be done.
 matrix_nginx_proxy_proxy_riot_compat_redirect_enabled: false

--- a/roles/matrix-nginx-proxy/templates/nginx/nginx.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/nginx.conf.j2
@@ -33,7 +33,11 @@ http {
 					'$status $body_bytes_sent "$http_referer" '
 					'"$http_user_agent" "$http_x_forwarded_for"';
 
+	{% if matrix_nginx_proxy_access_log_enabled %}
 	access_log /var/log/nginx/access.log main;
+	{% else %}
+	access_log off;
+	{% endif %}
 
 	sendfile on;
 	#tcp_nopush on;


### PR DESCRIPTION
Would be nice to have an option to disable the nginx access log for the proxy. This should be optional but possible. 