### PR TITLE
Fix concatenation of additional databases

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -1098,14 +1098,14 @@ matrix_postgres_import_roles_to_ignore: |
   {{
     [matrix_postgres_connection_username]
     +
-    matrix_postgres_additional_databases|map(attribute='username')
+    matrix_postgres_additional_databases|map(attribute='username')|list
   }}
 
 matrix_postgres_import_databases_to_ignore: |
   {{
     [matrix_postgres_db_name]
     +
-    matrix_postgres_additional_databases|map(attribute='name')
+    matrix_postgres_additional_databases|map(attribute='name')|list
   }}
 
 ######################################################################


### PR DESCRIPTION
Otherwise the postgres upgrade fails with the following error:

```
Unexpected templating type error occurred on ({{
  [matrix_postgres_connection_username]
  +
  matrix_postgres_additional_databases|map(attribute='username')
}}
): can only concatenate list (not "generator") to list
```