### PR TITLE
Check for buggy version of Ansible that Ubuntu 20.04 provides

### DIFF
--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -11,7 +11,7 @@ If your local computer cannot run Ansible, you can also run Ansible on some serv
 
 Ansible 2.7.0 or newer is required.
 
-Ubuntu (at least 20.04) ships with a buggy version (see this [bug](https://bugs.launchpad.net/ubuntu/+source/ansible/+bug/1880359)), which can't be used in combination with a host running new systemd (more detaisl in [#517](https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/517), [#669]([669](https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/669))). If this problem affects you, you can: avoid running Ubuntu 20.04 on your host; run Ansible from another machine targeting your host; or try to upgrade to a newer Ansible version (see below).
+Note: Ubuntu 20.04 ships with Ansible 2.9.6 which is a buggy version (see this [bug](https://bugs.launchpad.net/ubuntu/+source/ansible/+bug/1880359)), which can't be used in combination with a host running new systemd (more details in [#517](https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/517), [#669](https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/669)). If this problem affects you, you can: avoid running Ubuntu 20.04 on your host; run Ansible from another machine targeting your host; or try to upgrade to a newer Ansible version (see below).
 
 
 ## Checking your Ansible version

--- a/roles/matrix-base/tasks/sanity_check.yml
+++ b/roles/matrix-base/tasks/sanity_check.yml
@@ -12,7 +12,7 @@
     msg: "You are running on Ansible {{ ansible_version.string }}, which is not supported. See our guide about Ansible: https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/docs/ansible.md"
   when:
     - ansible_distribution == 'Ubuntu'
-    - "ansible_version.major = 2 and ansible_version.major == 9 and ansible_version.minor = 6"
+    - "ansible_version.major == 2 and ansible_version.major == 9 and ansible_version.minor == 6"
 
 - name: (Deprecation) Catch and report renamed settings
   fail:

--- a/roles/matrix-base/tasks/sanity_check.yml
+++ b/roles/matrix-base/tasks/sanity_check.yml
@@ -6,6 +6,14 @@
     msg: "You are running on Ansible {{ ansible_version.string }}, which is not supported. See our guide about Ansible: https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/docs/ansible.md"
   when: "(ansible_version.major < 2) or (ansible_version.major <= 2 and ansible_version.minor < 7)"
 
+# Though we do not support Ansible 2.9.6 which is buggy
+- name: Fail if running on Ansible 2.9.6 on Ubuntu
+  fail:
+    msg: "You are running on Ansible {{ ansible_version.string }}, which is not supported. See our guide about Ansible: https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/docs/ansible.md"
+  when:
+    - ansible_distribution == 'Ubuntu'
+    - "ansible_version.major = 2 and ansible_version.major == 9 and ansible_version.minor = 6"
+
 - name: (Deprecation) Catch and report renamed settings
   fail:
     msg: >-


### PR DESCRIPTION
I have no idea if this works, I haven't tested it but it should theoretically check for the buggy version of Ansible that Ubuntu 20.04 comes with and provide a nicer warning message.