### PR TITLE
Fix appservice-slack default db: nedb

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -129,7 +129,7 @@ matrix_appservice_slack_systemd_required_services_list: |
   }}
 
 # Postgres is the default, except if not using `matrix_postgres` (internal postgres)
-matrix_appservice_slack_database_engine: "{{ 'postgres' if matrix_postgres_enabled else 'sqlite' }}"
+matrix_appservice_slack_database_engine: "{{ 'postgres' if matrix_postgres_enabled else 'nedb' }}"
 matrix_appservice_slack_database_password: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'as.slack.db') | to_uuid }}"
 
 ######################################################################


### PR DESCRIPTION
- fix for error when updating in a homeserver environment with external Postgres DB:
```
TASK [matrix-bridge-appservice-slack : Ensure Matrix Appservice Slack config installed] ***************************************************************
fatal: [matrix.pub.solar]: FAILED! => {"msg": "The task includes an option with an undefined variable. 
The error was: {{ matrix_appservice_slack_configuration_yaml|from_yaml|combine(matrix_appservice_slack_configuration_extension, recursive=True) }}: {{ lookup('template', 'templates/config.yaml.j2') }}: {{ { 'nedb': 'nedb:///data', 'postgres': matrix_appservice_slack_database_connection_string, }[matrix_appservice_slack_database_engine] }}: 'dict object' has no attribute 'sqlite'

The error appears to be in '/home/teutates/CodeRoom/github.com/matrix-docker-ansible-deploy/roles/matrix-bridge-appservice-slack/tasks/setup_install.yml': line 39, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:


- name: Ensure Matrix Appservice Slack config installed\n  ^ here\n"}
```