### PR TITLE
[WIP] appservice-slack: use arm64/amd64 images; selfbuild for others

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -110,7 +110,7 @@ matrix_appservice_webhooks_systemd_required_services_list: |
 # We don't enable bridges by default.
 matrix_appservice_slack_enabled: false
 
-matrix_appservice_slack_container_self_build: "{{ matrix_architecture != 'amd64' }}"
+matrix_appservice_slack_container_self_build: "{{ matrix_architecture not in ['amd64', 'arm64'] }}"
 
 # Normally, matrix-nginx-proxy is enabled and nginx can reach matrix-appservice-slack over the container network.
 # If matrix-nginx-proxy is not enabled, or you otherwise have a need for it, you can expose
@@ -444,7 +444,7 @@ matrix_mx_puppet_skype_database_password: "{{ matrix_synapse_macaroon_secret_key
 # We don't enable bridges by default.
 matrix_mx_puppet_slack_enabled: false
 
-matrix_mx_puppet_slack_container_image_self_build: "{{ matrix_architecture not in ['amd64', 'arm64'] }}"
+matrix_mx_puppet_slack_container_image_self_build: "{{ matrix_architecture != 'amd64'}}"
 
 matrix_mx_puppet_slack_systemd_required_services_list: |
   {{

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -110,6 +110,8 @@ matrix_appservice_webhooks_systemd_required_services_list: |
 # We don't enable bridges by default.
 matrix_appservice_slack_enabled: false
 
+matrix_appservice_slack_container_self_build: "{{ matrix_architecture != 'amd64' }}"
+
 # Normally, matrix-nginx-proxy is enabled and nginx can reach matrix-appservice-slack over the container network.
 # If matrix-nginx-proxy is not enabled, or you otherwise have a need for it, you can expose
 # matrix-appservice-slack's client-server port to the local host.
@@ -442,7 +444,7 @@ matrix_mx_puppet_skype_database_password: "{{ matrix_synapse_macaroon_secret_key
 # We don't enable bridges by default.
 matrix_mx_puppet_slack_enabled: false
 
-matrix_mx_puppet_slack_container_image_self_build: "{{ matrix_architecture != 'amd64'}}"
+matrix_mx_puppet_slack_container_image_self_build: "{{ matrix_architecture not in ['amd64', 'arm64'] }}"
 
 matrix_mx_puppet_slack_systemd_required_services_list: |
   {{

--- a/roles/matrix-bridge-appservice-slack/defaults/main.yml
+++ b/roles/matrix-bridge-appservice-slack/defaults/main.yml
@@ -3,6 +3,10 @@
 
 matrix_appservice_slack_enabled: true
 
+matrix_appservice_slack_container_self_build: false
+matrix_appservice_slack_docker_repo: "https://mau.dev/tulir/mautrix-telegram.git"
+matrix_appservice_slack_docker_src_files_path: "{{ matrix_base_data_path }}/appservice-slack/docker-src"
+
 matrix_appservice_slack_docker_image: "docker.io/matrixdotorg/matrix-appservice-slack:release-1.5.0"
 matrix_appservice_slack_docker_image_force_pull: "{{ matrix_appservice_slack_docker_image.endswith(':latest') }}"
 

--- a/roles/matrix-bridge-appservice-slack/tasks/setup_install.yml
+++ b/roles/matrix-bridge-appservice-slack/tasks/setup_install.yml
@@ -8,9 +8,38 @@
     owner: "{{ matrix_user_username }}"
     group: "{{ matrix_user_groupname }}"
   with_items:
-    - "{{ matrix_appservice_slack_base_path }}"
-    - "{{ matrix_appservice_slack_config_path }}"
-    - "{{ matrix_appservice_slack_data_path }}"
+    - { path: "{{ matrix_appservice_slack_base_path }}", when: true }
+    - { path: "{{ matrix_appservice_slack_config_path }}", when: true }
+    - { path: "{{ matrix_appservice_slack_data_path }}", when: true }
+    - { path: "{{ matrix_appservice_slack_docker_src_files_path }}", when: "{{ matrix_appservice_slack_container_self_build }}" }
+  when: item.when|bool
+
+- name: Ensure Mautrix Telegram image is pulled
+  docker_image:
+    name: "{{ matrix_appservice_slack_docker_image }}"
+    source: "{{ 'pull' if ansible_version.major > 2 or ansible_version.minor > 7 else omit }}"
+    force_source: "{{ matrix_appservice_slack_docker_image_force_pull if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
+    force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_appservice_slack_docker_image_force_pull }}"
+  when: "not matrix_appservice_slack_container_self_build|bool"
+
+- name: Ensure matrix-appservice-slack repository is present when self-building
+  git:
+    repo: "{{ matrix_appservice_slack_docker_repo }}"
+    dest: "{{ matrix_appservice_slack_docker_src_files_path }}"
+    force: "yes"
+  register: matrix_appservice_slack_git_pull_results
+  when: "matrix_appservice_slack_container_self_build|bool"
+
+- name: Ensure matrix-appservice-slack Docker image is build
+  docker_image:
+    name: "{{ matrix_appservice_slack_docker_image }}"
+    source: build
+    force_source: yes
+    build:
+      dockerfile: Dockerfile
+      path: "{{ matrix_appservice_slack_docker_src_files_path }}"
+      pull: yes
+  when: "matrix_appservice_slack_container_self_build|bool and matrix_appservice_slack_git_pull_results.changed"
 
 - set_fact:
     matrix_appservice_slack_requires_restart: false
@@ -28,13 +57,6 @@
             matrix_appservice_slack_requires_restart: true
       when: "matrix_appservice_slack_nedb_database_path_local_stat_result.stat.exists|bool"
   when: "matrix_appservice_slack_database_engine == 'postgres'"
-
-- name: Ensure Appservice Slack image is pulled
-  docker_image:
-    name: "{{ matrix_appservice_slack_docker_image }}"
-    source: "{{ 'pull' if ansible_version.major > 2 or ansible_version.minor > 7 else omit }}"
-    force_source: "{{ matrix_appservice_slack_docker_image_force_pull if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
-    force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_appservice_slack_docker_image_force_pull }}"
 
 - name: Ensure Matrix Appservice Slack config installed
   copy:


### PR DESCRIPTION
Currently this bridge uses only the 64-bit image. However there is already an available image for arm64 provided from the same maintainer (see [here](https://mau.dev/tulir/mautrix-telegram/container_registry/1)).

My intention with this PR is to pull the correct image (for both amd64 and arm64) based on `matrix_architecture`. For all the others, trigger a rebuild.

Sadly, this currently fails with:

```
TASK [matrix-bridge-appservice-slack : Ensure Matrix Appservice Slack config installed] **********************************************************************************************************************************************************************
fatal: [matrix.xxxxx.net]: FAILED! => {"changed": false, "checksum": "07486873673decfc8c694af1cf076ac788010922", "msg": "Destination directory /matrix/appservice-slack/config does not exist"}
```

Any help or pointers to what might be wrong would be greatly appreciated :)