### PR TITLE
Enable message retention configuration policy.

### DIFF
--- a/docs/configuring-playbook-synapse.md
+++ b/docs/configuring-playbook-synapse.md
@@ -26,3 +26,13 @@ Certain Synapse administration tasks (managing users and rooms, etc.) can be per
 ## Synapse + OpenID Connect for Single-Sign-On
 
 If you'd like to use OpenID Connect authentication with Synapse, you'll need some additional reverse-proxy configuration (see [our nginx reverse-proxy doc page](configuring-playbook-nginx.md#synapse-openid-connect-for-single-sign-on)).
+
+## Message Retention Policy
+
+Synapse can be configured to automatically delete old messages, which improves privacy and keeps resource usage under control over longer periods. To enable the default message retention policy (which sets a minimum of 1d and maximum of 1y retention), set the following in your configuration file (`inventory/host_vars/matrix.<your-domain>/vars.yml`):
+
+```yaml
+matrix_synapse_retention_enabled: true
+```
+
+For details, refer to the [Synapse documentation](https://github.com/matrix-org/synapse/blob/develop/docs/message_retention_policies.md) and check [`homeserver.yaml.j2`](../roles/matrix-synapse/templates/synapse/homeserver.yaml.j2) for all available options.

--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -426,3 +426,17 @@ matrix_synapse_configuration_extension: "{{ matrix_synapse_configuration_extensi
 # Holds the final Synapse configuration (a combination of the default and its extension).
 # You most likely don't need to touch this variable. Instead, see `matrix_synapse_configuration_yaml`.
 matrix_synapse_configuration: "{{ matrix_synapse_configuration_yaml|from_yaml|combine(matrix_synapse_configuration_extension, recursive=True) }}"
+
+# Synapse message retention policy. See homeserver.yaml.j2 for details. The
+# default values are copied from the default config parameters. See
+# https://github.com/matrix-org/synapse/blob/develop/docs/message_retention_policies.md
+# for additional details.
+matrix_synapse_retention_enabled: false
+matrix_synapse_retention_default_policy_min_lifetime: 1d
+matrix_synapse_retention_default_policy_max_lifetime: 1y
+matrix_synapse_retention_allowed_lifetime_min: 1d
+matrix_synapse_retention_allowed_lifetime_max: 1y
+matrix_synapse_retention_purge_jobs_longest_max_lifetime: 3d
+matrix_synapse_retention_purge_jobs_longest_max_lifetime_interval: 12h
+matrix_synapse_retention_purge_jobs_shortest_max_lifetime: 3d
+matrix_synapse_retention_purge_jobs_shortest_max_lifetime_interval: 1d

--- a/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -414,23 +414,23 @@ retention:
   # The message retention policies feature is disabled by default. Uncomment the
   # following line to enable it.
   #
-  #enabled: true
+  enabled: {{ matrix_synapse_retention_enabled }}
 
   # Default retention policy. If set, Synapse will apply it to rooms that lack the
   # 'm.room.retention' state event. Currently, the value of 'min_lifetime' doesn't
   # matter much because Synapse doesn't take it into account yet.
   #
-  #default_policy:
-  #  min_lifetime: 1d
-  #  max_lifetime: 1y
+  default_policy:
+   min_lifetime: {{ matrix_synapse_retention_default_policy_min_lifetime }}
+   max_lifetime: {{ matrix_synapse_retention_default_policy_max_lifetime }}
 
   # Retention policy limits. If set, and the state of a room contains a
   # 'm.room.retention' event in its state which contains a 'min_lifetime' or a
   # 'max_lifetime' that's out of these bounds, Synapse will cap the room's policy
   # to these limits when running purge jobs.
   #
-  #allowed_lifetime_min: 1d
-  #allowed_lifetime_max: 1y
+  allowed_lifetime_min: {{ matrix_synapse_retention_allowed_lifetime_min }}
+  allowed_lifetime_max: {{ matrix_synapse_retention_allowed_lifetime_max }}
 
   # Server admins can define the settings of the background jobs purging the
   # events which lifetime has expired under the 'purge_jobs' section.
@@ -462,11 +462,11 @@ retention:
   # Synapse's database (which is done using the range specified in a purge job's
   # configuration).
   #
-  #purge_jobs:
-  #  - longest_max_lifetime: 3d
-  #    interval: 12h
-  #  - shortest_max_lifetime: 3d
-  #    interval: 1d
+  purge_jobs:
+   - longest_max_lifetime: {{ matrix_synapse_retention_purge_jobs_longest_max_lifetime }}
+     interval: {{ matrix_synapse_retention_purge_jobs_longest_max_lifetime_interval }}
+   - shortest_max_lifetime: {{ matrix_synapse_retention_purge_jobs_shortest_max_lifetime }}
+     interval: {{ matrix_synapse_retention_purge_jobs_shortest_max_lifetime_interval }}
 
 # Inhibits the /requestToken endpoints from returning an error that might leak
 # information about whether an e-mail address is in use or not on this


### PR DESCRIPTION
This allows people to enable message retention policies on their homeserver.

One note: there are a few extra features that are available, but I decided to err on the side of simplicity in the implementation. For example, `purge_jobs` takes an array with a bunch of possible parameters, but I just simplified it and stuck with the defaults. If preferred, I can change the settings so that `purge_jobs` uses an array for the config values instead of extracting the parameters.