### PR TITLE
Use the correct variable name in Postgres password length check.

### DIFF
--- a/roles/matrix-postgres/tasks/validate_config.yml
+++ b/roles/matrix-postgres/tasks/validate_config.yml
@@ -36,4 +36,4 @@
 - name: Fail if Postgres password length exceeded
   fail:
     msg: "The maximum `matrix_postgres_connection_password` length is 99 characters"
-  when: "matrix_postgres_connection_hostname|length > 99"
+  when: "matrix_postgres_connection_password|length > 99"


### PR DESCRIPTION
This PR fixes a small error when verifying the maximum PostgreSQL password length. The check mistakenly looked at the variable `matrix_postgres_connection_hostname` instead of `matrix_postgres_connection_password`.