### PR TITLE
Let nginx listen op ipv6

### DIFF
--- a/roles/matrix-base/defaults/main.yml
+++ b/roles/matrix-base/defaults/main.yml
@@ -101,6 +101,9 @@ matrix_client_element_e2ee_secure_backup_setup_methods: []
 # The Docker network that all services would be put into
 matrix_docker_network: "matrix"
 
+# Controls whether we'll enable IPv6 in docker
+matrix_docker_ipv6_enabled: true
+
 # Controls whether we'll preserve the vars.yml file on the Matrix server.
 # If you have a differently organized inventory, you may wish to disable this feature,
 # or to repoint `matrix_vars_yml_snapshotting_src` to the file you'd like to preserve.

--- a/roles/matrix-base/tasks/server_base/docker_ipv6.yml
+++ b/roles/matrix-base/tasks/server_base/docker_ipv6.yml
@@ -1,0 +1,52 @@
+---
+
+- block:
+  - name: Ensure matrix-ip6tables.service exists
+    template:
+      src: "{{ role_path }}/templates/{{ item }}.j2"
+      dest: "{{ matrix_systemd_path }}/{{ item }}"
+      owner: "root"
+      group: "root"
+      mode: 0644
+    with_items:
+      - matrix-ip6tables.service
+    register: matrix_ip6tables_systemd_service_result
+
+  - name: Ensure systemd reloaded after matrix-ip6tables.service installation
+    service:
+      daemon_reload: yes
+    when: "matrix_ip6tables_systemd_service_result.changed"
+  
+  - name: Ensure matrix-ip6tables.service is started and autoruns
+    service:
+      name: matrix-ip6tables
+      state: started
+      enabled: yes
+
+  when: "matrix_docker_ipv6_enabled|bool"
+
+
+- block:
+  - name: Check existence of matrix-ip6tables service
+    stat:
+      path: "{{ matrix_systemd_path }}/matrix-ip6tables.service"
+    register: matrix_ip6tables_service_stat
+  
+  - name: Ensure matrix-ip6tables.service doesn't exist
+    file:
+      path: "{{ matrix_systemd_path }}/matrix-ip6tables.service"
+      state: absent
+    when: "matrix_ip6tables_service_stat.stat.exists"
+  
+  - name: Ensure systemd reloaded after matrix-ip6tables.service removal
+    service:
+      daemon_reload: yes
+    when: "matrix_ip6tables_service_stat.stat.exists"
+    
+  - name: Ensure /etc/docker/daemon.json doesn't exist
+    file:
+      path: "/etc/docker/daemon.json"
+      state: absent
+
+  when: "not matrix_docker_ipv6_enabled|bool"
+

--- a/roles/matrix-base/tasks/server_base/setup.yml
+++ b/roles/matrix-base/tasks/server_base/setup.yml
@@ -27,6 +27,8 @@
 - include_tasks: "{{ role_path }}/tasks/server_base/setup_archlinux.yml"
   when: ansible_distribution == 'Archlinux'
 
+- include_tasks: "{{ role_path }}/tasks/server_base/docker_ipv6.yml"
+
 - name: Ensure Docker is started and autoruns
   service:
     name: docker

--- a/roles/matrix-base/tasks/setup_matrix_base.yml
+++ b/roles/matrix-base/tasks/setup_matrix_base.yml
@@ -23,6 +23,9 @@
   docker_network:
     name: "{{ matrix_docker_network }}"
     driver: bridge
+    enable_ipv6: " {{ matrix_docker_ipv6_enabled|bool }}"
+    ipam_config:
+      - subnet: "fd00::/80"
 
 - name: Ensure matrix-remove-all script created
   template:

--- a/roles/matrix-base/templates/matrix-ip6tables.service.j2
+++ b/roles/matrix-base/templates/matrix-ip6tables.service.j2
@@ -1,0 +1,15 @@
+#jinja2: lstrip_blocks: "True"
+[Unit]
+Description=Matrix ip6tables rule to enable IPv6 internet access from containers
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+Environment="HOME={{ matrix_systemd_unit_home_path }}"
+
+ExecStart=ip6tables -t nat -A POSTROUTING -s fd00::/80 ! -o docker0 -j MASQUERADE
+
+SyslogIdentifier=matrix-ip6tables
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/matrix-nginx-proxy/tasks/ssl/setup_ssl_lets_encrypt_obtain_for_domain.yml
+++ b/roles/matrix-nginx-proxy/tasks/ssl/setup_ssl_lets_encrypt_obtain_for_domain.yml
@@ -35,6 +35,7 @@
     --user={{ matrix_user_uid }}:{{ matrix_user_gid }}
     --cap-drop=ALL
     -p {{ matrix_ssl_lets_encrypt_container_standalone_http_host_bind_port }}:8080
+    --network={{ matrix_docker_network }}
     --mount type=bind,src={{ matrix_ssl_config_dir_path }},dst=/etc/letsencrypt
     --mount type=bind,src={{ matrix_ssl_log_dir_path }},dst=/var/log/letsencrypt
     {{ matrix_ssl_lets_encrypt_certbot_docker_image }}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-client-element.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-client-element.conf.j2
@@ -28,6 +28,7 @@
 
 server {
 	listen {{ 8080 if matrix_nginx_proxy_enabled else 80 }};
+	listen [::]:{{ 8080 if matrix_nginx_proxy_enabled else 80 }};
 
 	server_name {{ matrix_nginx_proxy_proxy_element_hostname }};
 

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-dimension.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-dimension.conf.j2
@@ -27,6 +27,7 @@
 
 server {
 	listen {{ 8080 if matrix_nginx_proxy_enabled else 80 }};
+	listen [::]:{{ 8080 if matrix_nginx_proxy_enabled else 80 }};
 	server_name {{ matrix_nginx_proxy_proxy_dimension_hostname }};
 
 	server_tokens off;

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
@@ -23,6 +23,7 @@
 
 server {
 	listen {{ 8080 if matrix_nginx_proxy_enabled else 80 }};
+	listen [::]:{{ 8080 if matrix_nginx_proxy_enabled else 80 }};
 
 	server_name {{ matrix_nginx_proxy_base_domain_hostname }};
 	server_tokens off;

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-jitsi.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-jitsi.conf.j2
@@ -48,6 +48,8 @@
 
 server {
 	listen {{ 8080 if matrix_nginx_proxy_enabled else 80 }};
+	listen [::]:{{ 8080 if matrix_nginx_proxy_enabled else 80 }};
+
 	server_name {{ matrix_nginx_proxy_proxy_jitsi_hostname }};
 
 	server_tokens off;

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-riot-web.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-riot-web.conf.j2
@@ -12,6 +12,7 @@
 
 server {
 	listen {{ 8080 if matrix_nginx_proxy_enabled else 80 }};
+	listen [::]:{{ 8080 if matrix_nginx_proxy_enabled else 80 }};
 
 	server_name {{ matrix_nginx_proxy_proxy_riot_compat_redirect_hostname }};
 

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-synapse.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-synapse.conf.j2
@@ -161,6 +161,8 @@
 
 server {
 	listen {{ 8080 if matrix_nginx_proxy_enabled else 80 }};
+	listen [::]:{{ 8080 if matrix_nginx_proxy_enabled else 80 }};
+
 	server_name {{ matrix_nginx_proxy_proxy_matrix_hostname }};
 
 	server_tokens off;


### PR DESCRIPTION
This is only the nginx part

It still needs work on the docker end to actually use IPv6

I am not a docker expert but I used parts of https://medium.com/@skleeschulte/how-to-enable-ipv6-for-docker-containers-on-ubuntu-18-04-c68394a219a2 to make it work