### PR TITLE
Fix adminme.js usage for matrix-appservice-discord

### DIFF
--- a/docs/configuring-playbook-bridge-appservice-discord.md
+++ b/docs/configuring-playbook-bridge-appservice-discord.md
@@ -38,8 +38,9 @@ To [adjust room access privileges](#adjusting-room-access-privileges) or do vari
 
 There's the Discord bridge's guide for [setting privileges on bridge managed rooms](https://github.com/Half-Shot/matrix-appservice-discord/blob/master/docs/howto.md#set-privileges-on-bridge-managed-rooms). To do the same with our container setup, run the following command on the server:
 
-```
-docker exec -it matrix-appservice-discord /bin/sh -c 'cp /build/tools/adminme.js /tmp/adminme.js && cp /cfg/registration.yaml /tmp/discord-registration.yaml && cd /tmp && node /tmp/adminme.js -c /cfg/config.yaml -r "!ROOM_ID:SERVER" -u "@USER:SERVER" -p 100'
+```sh
+docker exec -it matrix-appservice-discord \
+node /build/tools/adminme.js -c /cfg/config.yaml -r /cfg/registration.yaml -m '!ROOM_ID:SERVER' -u '@USER:SERVER' -p 100
 ```
 
 


### PR DESCRIPTION
Related to:
- https://github.com/Half-Shot/matrix-appservice-discord/pull/666
- https://github.com/Half-Shot/matrix-appservice-discord/pull/667

Will fix:
- https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/795
- https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/822

.. but only after a new version of matrix-appservice-discord is released
and we upgrade to it.