### PR TITLE
Add double quotes 'matrix-postgres-init-additional-db-user-and-role.sql.j2' template

### DIFF
--- a/roles/matrix-postgres/templates/sql/init-additional-db-user-and-role.sql.j2
+++ b/roles/matrix-postgres/templates/sql/init-additional-db-user-and-role.sql.j2
@@ -2,18 +2,18 @@
 -- Seen here: https://stackoverflow.com/a/49858797
 DO $$
 BEGIN
-  CREATE USER {{ additional_db.username }};
+  CREATE USER "{{ additional_db.username }}";
   EXCEPTION WHEN DUPLICATE_OBJECT THEN
-  RAISE NOTICE 'not creating user {{ additional_db.username }}, since it already exists';
+  RAISE NOTICE 'not creating user "{{ additional_db.username }}", since it already exists';
 END
 $$;
 
 -- This is useful for initial user creation (since we don't assign a password above) and for handling subsequent password changes
 -- TODO - we should escape quotes in the password.
-ALTER ROLE {{ additional_db.username }} PASSWORD '{{ additional_db.password }}';
+ALTER ROLE "{{ additional_db.username }}" PASSWORD '{{ additional_db.password }}';
 
 -- This will generate an error on subsequent execution
-CREATE DATABASE {{ additional_db.name }} WITH LC_CTYPE 'C' LC_COLLATE 'C' OWNER {{ additional_db.username }};
+CREATE DATABASE "{{ additional_db.name }}" WITH LC_CTYPE 'C' LC_COLLATE 'C' OWNER "{{ additional_db.username }}";
 
 -- This is useful for changing the database owner subsequently
-ALTER DATABASE {{ additional_db.name }} OWNER TO {{ additional_db.username }};
+ALTER DATABASE "{{ additional_db.name }}" OWNER TO "{{ additional_db.username }}";


### PR DESCRIPTION
### Description

If `additional_db.username` or `additional_db.name` contains some special characters like `'-'` the _SQL commands_ will not be accepted AND ansible will not notice it. The playbook will continue, but the _db user_ will not be created.

### Error message
```sh
homeserver# docker run --rm --user=996:1005 --cap-drop=ALL --env-file=/srv/matrix/_postgres/env-postgres-server --network postgres --mount type=bind,src=/tmp/matrix-postgres-init-additional-db-user-and-role.sql,dst=/matrix-postgres-init-additional-db-user-and-role.sql,ro -ti --entrypoint=/bin/sh docker.io/postgres:13.1-alpine
```
```sh
\ $ psql -h matrix-postgres --file=/matrix-postgres-init-additional-db-user-and-role.sql
psql:/matrix-postgres-init-additional-db-user-and-role.sql:9: ERROR:  syntax error at or near "-"
LINE 3:   CREATE USER matrix-registration;
                            ^
psql:/matrix-postgres-init-additional-db-user-and-role.sql:13: ERROR:  syntax error at or near "-"
LINE 1: ALTER ROLE matrix-registration PASSWORD 'xyz...
                         ^
psql:/matrix-postgres-init-additional-db-user-and-role.sql:16: ERROR:  syntax error at or near "-"
LINE 1: CREATE DATABASE matrix-registration WITH LC_CTYPE 'C' LC...
                              ^
psql:/matrix-postgres-init-additional-db-user-and-role.sql:19: ERROR:  syntax error at or near "-"
LINE 1: ALTER DATABASE matrix-registration OWNER TO matrix-regis...
                             ^
```

### Correct results after changes:
```sh
/ $ psql -h matrix-postgres --file=/matrix-postgres-init-additional-db-user-and-role.sql
DO
ALTER ROLE
CREATE DATABASE
ALTER DATABASE
/ $
```

### Notes
I am using a patched version of [matrix-docker-ansible-deploy](https://github.com/spantaleev/matrix-docker-ansible-deploy). That is why there are some minor difference between the default identifiers.
