### PR TITLE
Allow federation to re-use existing port on separate domain

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -1024,6 +1024,8 @@ matrix_ssl_domains_to_obtain_certificates_for: |
     +
     ([matrix_server_fqn_jitsi] if matrix_jitsi_enabled else [])
     +
+    ([matrix_server_fqn_matrix_federation] if matrix_server_fqn_matrix_federation != matrix_server_fqn_matrix else [])
+    +
     ([matrix_domain] if matrix_nginx_proxy_base_domain_serving_enabled else [])
   }}
 

--- a/roles/matrix-base/defaults/main.yml
+++ b/roles/matrix-base/defaults/main.yml
@@ -21,6 +21,8 @@ matrix_server_fqn_dimension: "dimension.{{ matrix_domain }}"
 # This is where you access Jitsi.
 matrix_server_fqn_jitsi: "jitsi.{{ matrix_domain }}"
 
+# This is where other Matrix servers can access Synapse (if enabled via matrix_synapse_federation_enabled; enabled by default).
+matrix_server_fqn_matrix_federation: "{{ matrix_server_fqn_matrix }}"
 matrix_federation_public_port: 8448
 
 # The architecture that your server runs.

--- a/roles/matrix-base/templates/static-files/well-known/matrix-server.j2
+++ b/roles/matrix-base/templates/static-files/well-known/matrix-server.j2
@@ -1,4 +1,4 @@
 #jinja2: lstrip_blocks: "True"
 {
-	"m.server": "{{ matrix_server_fqn_matrix }}:{{ matrix_federation_public_port }}"
+	"m.server": "{{ matrix_server_fqn_matrix_federation }}:{{ matrix_federation_public_port }}"
 }

--- a/roles/matrix-nginx-proxy/defaults/main.yml
+++ b/roles/matrix-nginx-proxy/defaults/main.yml
@@ -106,6 +106,7 @@ matrix_nginx_proxy_proxy_element_hostname: "{{ matrix_server_fqn_element }}"
 # Controls whether proxying the matrix domain should be done.
 matrix_nginx_proxy_proxy_matrix_enabled: false
 matrix_nginx_proxy_proxy_matrix_hostname: "{{ matrix_server_fqn_matrix }}"
+matrix_nginx_proxy_proxy_matrix_federation_hostname: "{{ matrix_server_fqn_matrix_federation }}"
 
 # Controls whether proxying the dimension domain should be done.
 matrix_nginx_proxy_proxy_dimension_enabled: false
@@ -188,8 +189,8 @@ matrix_nginx_proxy_proxy_matrix_federation_api_enabled: false
 matrix_nginx_proxy_proxy_matrix_federation_api_addr_with_container: "matrix-synapse:8048"
 matrix_nginx_proxy_proxy_matrix_federation_api_addr_sans_container: "localhost:8048"
 matrix_nginx_proxy_proxy_matrix_federation_api_client_max_body_size_mb: "{{ (matrix_nginx_proxy_proxy_matrix_client_api_client_max_body_size_mb | int) * 3 }}"
-matrix_nginx_proxy_proxy_matrix_federation_api_ssl_certificate: "{{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_proxy_matrix_hostname }}/fullchain.pem"
-matrix_nginx_proxy_proxy_matrix_federation_api_ssl_certificate_key: "{{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_proxy_matrix_hostname }}/privkey.pem"
+matrix_nginx_proxy_proxy_matrix_federation_api_ssl_certificate: "{{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_proxy_matrix_federation_hostname }}/fullchain.pem"
+matrix_nginx_proxy_proxy_matrix_federation_api_ssl_certificate_key: "{{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_proxy_matrix_federation_hostname }}/privkey.pem"
 
 # The tmpfs at /tmp needs to be large enough to handle multiple concurrent file uploads.
 matrix_nginx_proxy_tmp_directory_size_mb: "{{ (matrix_nginx_proxy_proxy_matrix_federation_api_client_max_body_size_mb | int) * 50 }}"

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-synapse.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-synapse.conf.j2
@@ -221,13 +221,13 @@ server {
 #}
 server {
 	{% if matrix_nginx_proxy_https_enabled %}
-		listen 8448 ssl http2;
-		listen [::]:8448 ssl http2;
+		listen {% 8448 if matrix_nginx_proxy_container_https_host_bind_port != matrix_nginx_proxy_container_federation_host_bind_port else 8443 %} ssl http2;
+		listen [::]:{% 8448 if matrix_nginx_proxy_container_https_host_bind_port != matrix_nginx_proxy_container_federation_host_bind_port else 8443 %} ssl http2;
 	{% else %}
-		listen 8448;
+		listen {% 8448 if matrix_nginx_proxy_container_http_host_bind_port != matrix_nginx_proxy_container_federation_host_bind_port else 8080 %};
 	{% endif %}
 
-	server_name {{ matrix_nginx_proxy_proxy_matrix_hostname }};
+	server_name {{ matrix_nginx_proxy_proxy_matrix_federation_hostname }};
 	server_tokens off;
 
 	root /dev/null;

--- a/roles/matrix-nginx-proxy/templates/systemd/matrix-nginx-proxy.service.j2
+++ b/roles/matrix-nginx-proxy/templates/systemd/matrix-nginx-proxy.service.j2
@@ -29,7 +29,7 @@ ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-nginx-proxy \
 			{% if matrix_nginx_proxy_https_enabled and matrix_nginx_proxy_container_https_host_bind_port %}
 			-p {{ matrix_nginx_proxy_container_https_host_bind_port }}:8443 \
 			{% endif %}
-			{% if matrix_nginx_proxy_proxy_matrix_federation_api_enabled and matrix_nginx_proxy_container_federation_host_bind_port %}
+			{% if matrix_nginx_proxy_proxy_matrix_federation_api_enabled and matrix_nginx_proxy_container_federation_host_bind_port and matrix_nginx_proxy_container_federation_host_bind_port not in [matrix_nginx_proxy_container_http_host_bind_port, matrix_nginx_proxy_container_https_host_bind_port] %}
 			-p {{ matrix_nginx_proxy_container_federation_host_bind_port }}:8448 \
 			{% endif %}
 			--mount type=bind,src={{ matrix_nginx_proxy_base_path }}/nginx.conf,dst=/etc/nginx/nginx.conf,ro \

--- a/roles/matrix-synapse/tasks/self_check_federation_api.yml
+++ b/roles/matrix-synapse/tasks/self_check_federation_api.yml
@@ -12,15 +12,15 @@
 
 - name: Fail if Matrix Federation API not working
   fail:
-    msg: "Failed checking Matrix Federation API is up at `{{ matrix_server_fqn_matrix }}` (checked endpoint: `{{ matrix_synapse_federation_api_url_endpoint_public }}`). Is Synapse running? Is port {{ matrix_federation_public_port }} open in your firewall? Full error: {{ result_matrix_synapse_federation_api }}"
+    msg: "Failed checking Matrix Federation API is up at `{{ matrix_server_fqn_matrix_federation }}` (checked endpoint: `{{ matrix_synapse_federation_api_url_endpoint_public }}`). Is Synapse running? Is port {{ matrix_federation_public_port }} open in your firewall? Full error: {{ result_matrix_synapse_federation_api }}"
   when: "matrix_synapse_enabled|bool and matrix_synapse_federation_enabled|bool and (result_matrix_synapse_federation_api.failed or 'json' not in result_matrix_synapse_federation_api)"
 
 - name: Fail if Matrix Federation API unexpectedly enabled
   fail:
-      msg: "Matrix Federation API is up at `{{ matrix_server_fqn_matrix }}` (checked endpoint: `{{ matrix_synapse_federation_api_url_endpoint_public }}`) despite being disabled."
+      msg: "Matrix Federation API is up at `{{ matrix_server_fqn_matrix_federation }}` (checked endpoint: `{{ matrix_synapse_federation_api_url_endpoint_public }}`) despite being disabled."
   when: "matrix_synapse_enabled|bool and not matrix_synapse_federation_enabled|bool and not result_matrix_synapse_federation_api.failed"
 
 - name: Report working Matrix Federation API
   debug:
-    msg: "The Matrix Federation API at `{{ matrix_server_fqn_matrix }}` (checked endpoint: `{{ matrix_synapse_federation_api_url_endpoint_public }}`) is working"
+    msg: "The Matrix Federation API at `{{ matrix_server_fqn_matrix_federation }}` (checked endpoint: `{{ matrix_synapse_federation_api_url_endpoint_public }}`) is working"
   when: "matrix_synapse_enabled|bool and matrix_synapse_federation_enabled|bool"

--- a/roles/matrix-synapse/vars/main.yml
+++ b/roles/matrix-synapse/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 
 matrix_synapse_client_api_url_endpoint_public: "https://{{ matrix_server_fqn_matrix }}/_matrix/client/versions"
-matrix_synapse_federation_api_url_endpoint_public: "https://{{ matrix_server_fqn_matrix }}:{{ matrix_federation_public_port }}/_matrix/federation/v1/version"
+matrix_synapse_federation_api_url_endpoint_public: "https://{{ matrix_server_fqn_matrix_federation }}:{{ matrix_federation_public_port }}/_matrix/federation/v1/version"
 
 # Tells whether this role had executed or not. Toggled to `true` during runtime.
 matrix_synapse_role_executed: false


### PR DESCRIPTION
This pull request makes it possible to run federation over the same port that Matrix clients use (for example port 443). However, it is necessary to use another subdomain for the vhost.

Example configuration:

```yaml
matrix_server_fqn_matrix_federation: "matrix-federation.{{ matrix_domain }}"
matrix_federation_public_port: 443
```

This pull request is still work-in-progress, please do not merge yet.

During development I wondered why the matrix-nginx-proxy role uses different ports when `matrix_nginx_proxy_enabled` is `false`.
As I did not understand the purpose, I also did not copy this behavior in this pull request.
Shouldn't nginx be fully disabled, in this case?