### PR TITLE
Add additional domains for Let's Encrypt certificates to be obtained

### DIFF
--- a/docs/configuring-playbook-nginx.md
+++ b/docs/configuring-playbook-nginx.md
@@ -59,3 +59,17 @@ This will disable the access logging for nginx.
 ```yaml
 matrix_nginx_proxy_access_log_enabled: false
 ```
+
+## Additional configuration
+
+<!-- TODO: Introductory blurb -->
+
+<!-- TODO: Add section for including config files, however that's done -->
+
+Make sure that you have set the DNS configuration for the domains you want to include to point at your server.
+
+```yaml
+matrix_ssl_additional_domains_to_obtain_certificates_for:
+  - domain.one.example
+  - domain.two.example
+```

--- a/docs/configuring-playbook-nginx.md
+++ b/docs/configuring-playbook-nginx.md
@@ -64,7 +64,7 @@ matrix_nginx_proxy_access_log_enabled: false
 
 This playbook also allows for additional configuration to be applied to the nginx server.
 
-If you want this playbook to obtain and renew certificates for other domains, then you can set the `matrix_ssl_additional_domains_to_obtain_certificates_for` variable. Make sure that you have set the DNS configuration for the domains you want to include to point at your server.
+If you want this playbook to obtain and renew certificates for other domains, then you can set the `matrix_ssl_additional_domains_to_obtain_certificates_for` variable (as mentioned in the [Obtaining SSL certificates for additional domains](configuring-playbook-ssl-certificates.md#obtaining-ssl-certificates-for-additional-domains) documentation as well). Make sure that you have set the DNS configuration for the domains you want to include to point at your server.
 
 ```yaml
 matrix_ssl_additional_domains_to_obtain_certificates_for:
@@ -72,7 +72,7 @@ matrix_ssl_additional_domains_to_obtain_certificates_for:
   - domain.two.example
 ```
 
-You can include additional nginx configuration by setting the `matrix_nginx_proxy_proxy_http_additional_server_configuration_blocks` variable. 
+You can include additional nginx configuration by setting the `matrix_nginx_proxy_proxy_http_additional_server_configuration_blocks` variable.
 
 ```yaml
 matrix_nginx_proxy_proxy_http_additional_server_configuration_blocks:

--- a/docs/configuring-playbook-nginx.md
+++ b/docs/configuring-playbook-nginx.md
@@ -62,14 +62,23 @@ matrix_nginx_proxy_access_log_enabled: false
 
 ## Additional configuration
 
-<!-- TODO: Introductory blurb -->
+This playbook also allows for additional configuration to be applied to the nginx server.
 
-<!-- TODO: Add section for including config files, however that's done -->
-
-Make sure that you have set the DNS configuration for the domains you want to include to point at your server.
+If you want this playbook to obtain and renew certificates for other domains, then you can set the `matrix_ssl_additional_domains_to_obtain_certificates_for` variable. Make sure that you have set the DNS configuration for the domains you want to include to point at your server.
 
 ```yaml
 matrix_ssl_additional_domains_to_obtain_certificates_for:
   - domain.one.example
   - domain.two.example
+```
+
+You can include additional nginx configuration by setting the `matrix_nginx_proxy_proxy_http_additional_server_configuration_blocks` variable. 
+
+```yaml
+matrix_nginx_proxy_proxy_http_additional_server_configuration_blocks:
+  - |
+    # These lines will be included in the nginx configuration.
+    # This is at the top level of the file, so you will need to define all of the `server { ... }` blocks.
+  - |
+    # For advanced use, have a look at the template files in `roles/matrix-nginx-proxy/templates/nginx/conf.d`
 ```

--- a/docs/configuring-playbook-ssl-certificates.md
+++ b/docs/configuring-playbook-ssl-certificates.md
@@ -74,15 +74,12 @@ If you are hosting other domains on the Matrix machine, you can make the playboo
 To do that, simply define your own custom configuration like this:
 
 ```yaml
-# Note: we need to explicitly list the aforementioned Matrix domains that you use (Matrix, Element, Dimension).
-# In this example, we retrieve an extra certificate - one for the base domain (in the `matrix_domain` variable).
+# In this example, we retrieve 2 extra certificates,
+# one for the base domain (in the `matrix_domain` variable) and one for a hardcoded domain.
 # Adding any other additional domains (hosted on the same machine) is possible.
-matrix_ssl_domains_to_obtain_certificates_for:
-  - '{{ matrix_server_fqn_matrix }}'
-  - '{{ matrix_server_fqn_element }}'
-  - '{{ matrix_server_fqn_dimension }}'
-  - '{{ matrix_server_fqn_jitsi }}'
+matrix_ssl_additional_domains_to_obtain_certificates_for:
   - '{{ matrix_domain }}'
+  - 'another.domain.example.com'
 ```
 
 After redefining `matrix_ssl_domains_to_obtain_certificates_for`, to actually obtain certificates you should:
@@ -91,9 +88,9 @@ After redefining `matrix_ssl_domains_to_obtain_certificates_for`, to actually ob
 
 - re-run the SSL part of the playbook and restart all services: `ansible-playbook -i inventory/hosts setup.yml --tags=setup-ssl,start`
 
-The certificate files would be available in `/matrix/ssl/config/live/<your-other-domain>/...`.
+The certificate files would be made available in `/matrix/ssl/config/live/<your-other-domain>/...`.
 
 For automated certificate renewal to work, each port `80` vhost for each domain you are obtaining certificates for needs to forward requests for `/.well-known/acme-challenge` to the certbot container we use for renewal.
 
 See how this is configured for the `matrix.` subdomain in `/matrix/nginx-proxy/conf.d/matrix-synapse.conf`
-Don't be alarmed if the above configuraiton file says port `8080`, instead of port `80`. It's due to port mapping due to our use of containers.
+Don't be alarmed if the above configuration file says port `8080`, instead of port `80`. It's due to port mapping due to our use of containers.

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -1025,6 +1025,8 @@ matrix_ssl_domains_to_obtain_certificates_for: |
     ([matrix_server_fqn_jitsi] if matrix_jitsi_enabled else [])
     +
     ([matrix_domain] if matrix_nginx_proxy_base_domain_serving_enabled else [])
+    +
+    matrix_ssl_additional_domains_to_obtain_certificates_for
   }}
 
 matrix_ssl_architecture: "{{

--- a/roles/matrix-nginx-proxy/defaults/main.yml
+++ b/roles/matrix-nginx-proxy/defaults/main.yml
@@ -290,8 +290,12 @@ matrix_ssl_retrieval_method: "lets-encrypt"
 
 matrix_ssl_architecture: "amd64"
 
-# The list of domains that this role will obtain certificates for.
-matrix_ssl_domains_to_obtain_certificates_for: []
+# The full list of domains that this role will obtain certificates for.
+# This variable is likely redefined outside of the role, to include the domains that are necessary (depending on the services that are enabled).
+# To add additional domain names, consider using `matrix_ssl_additional_domains_to_obtain_certificates_for` instead.
+matrix_ssl_domains_to_obtain_certificates_for: "{{ matrix_ssl_additional_domains_to_obtain_certificates_for }}"
+
+# A list of additional domain names to obtain certificates for.
 matrix_ssl_additional_domains_to_obtain_certificates_for: []
 
 # Controls whether to obtain production or staging certificates from Let's Encrypt.

--- a/roles/matrix-nginx-proxy/defaults/main.yml
+++ b/roles/matrix-nginx-proxy/defaults/main.yml
@@ -292,6 +292,7 @@ matrix_ssl_architecture: "amd64"
 
 # The list of domains that this role will obtain certificates for.
 matrix_ssl_domains_to_obtain_certificates_for: []
+matrix_ssl_additional_domains_to_obtain_certificates_for: []
 
 # Controls whether to obtain production or staging certificates from Let's Encrypt.
 matrix_ssl_lets_encrypt_staging: false


### PR DESCRIPTION
This pull request adds a new variable (`matrix_ssl_additional_domains_to_obtain_certificates_for`) which is an array of extra domain names, specified in the user's `vars.yml`. These domains get included in the `matrix_ssl_domains_to_obtain_certificates_for` variable, which is what the playbook loops over to obtain/renew certificates.

It also adds documentation to `configuring-playbook-nginx.md` for using this new variable and the already existing `matrix_nginx_proxy_proxy_http_additional_server_configuration_blocks`. This should hopefully make it clear how the nginx proxy added in this playbook can be configured to act as a reverse proxy for other services as well, reducing the need to set up your own webserver.

---

I think future work could be done to make additional reverse proxy blocks easier to configure (I basically copied an entire template file into my vars.yml for my own configuration), but that's not really the concern of this PR, and, if wanted, should be discussed in its own issue.