### PR TITLE
Fixes: a66a604e ("Selfbuild appservice-slack bridge")

### DIFF
--- a/roles/matrix-bridge-appservice-slack/tasks/setup_install.yml
+++ b/roles/matrix-bridge-appservice-slack/tasks/setup_install.yml
@@ -2,7 +2,7 @@
 
 - name: Ensure AppService Slack paths exist
   file:
-    path: "{{ item }}"
+    path: "{{ item.path }}"
     state: directory
     mode: 0750
     owner: "{{ matrix_user_username }}"


### PR DESCRIPTION
It was missing the right variable name.