### PR TITLE
Fix wrong docker image being pulled

### DIFF
--- a/roles/matrix-bridge-mautrix-signal/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mautrix-signal/tasks/setup_install.yml
@@ -21,7 +21,7 @@
     name: "{{ matrix_mautrix_signal_daemon_docker_image }}"
     source: "{{ 'pull' if ansible_version.major > 2 or ansible_version.minor > 7 else omit }}"
     force_source: "{{ matrix_mautrix_signal_daemon_docker_image_force_pull if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
-    force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_mautrix_signal_docker_image_force_pull }}"
+    force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_mautrix_signal_daemon_docker_image_force_pull }}"
   when: matrix_mautrix_signal_enabled|bool
 
 - name: Ensure Mautrix Signal paths exist


### PR DESCRIPTION
Changed `matrix_mautrix_signal_docker_image_force_pull` to `matrix_mautrix_signal_daemon_docker_image_force_pull` when force pulling the daemon