### PR TITLE
Add mx-puppet-groupme support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Using this playbook, you can get the following services configured on your serve
 
 - (optional) the [mx-puppet-discord](https://github.com/matrix-discord/mx-puppet-discord) bridge for [Discord](https://discordapp.com/) - see [docs/configuring-playbook-bridge-mx-puppet-discord.md](docs/configuring-playbook-bridge-mx-puppet-discord.md) for setup documentation
 
+- (optional) the [mx-puppet-groupme](https://gitlab.com/robintown/mx-puppet-groupme) bridge for [GroupMe](https://groupme.com/) - see [docs/configuring-playbook-bridge-mx-puppet-groupme.md](docs/configuring-playbook-bridge-mx-puppet-groupme.md) for setup documentation
+
 - (optional) the [mx-puppet-steam](https://github.com/icewind1991/mx-puppet-steam) bridge for [Steam](https://steamapp.com/) - see [docs/configuring-playbook-bridge-mx-puppet-steam.md](docs/configuring-playbook-bridge-mx-puppet-steam.md) for setup documentation
 
 - (optional) [Email2Matrix](https://github.com/devture/email2matrix) for relaying email messages to Matrix rooms - see [docs/configuring-playbook-email2matrix.md](docs/configuring-playbook-email2matrix.md) for setup documentation

--- a/docs/configuring-playbook-bridge-mx-puppet-groupme.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-groupme.md
@@ -30,7 +30,7 @@ To link your GroupMe account, go to [dev.groupme.com](https://dev.groupme.com/),
 link <access token>
 ```
 
-Once logged in, send `list` to the bot user to list the available rooms.
+Once logged in, send `listrooms` to the bot user to list the available rooms.
 
 Clicking rooms in the list will result in you receiving an invitation to the
 bridged room.

--- a/docs/configuring-playbook-bridge-mx-puppet-groupme.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-groupme.md
@@ -1,0 +1,38 @@
+# Setting up MX Puppet GroupMe (optional)
+
+The playbook can install and configure
+[mx-puppet-groupme](https://gitlab.com/robintown/mx-puppet-groupme) for you.
+
+See the project page to learn what it does and why it might be useful to you.
+
+To enable the [GroupMe](https://groupme.com/) bridge just use the following
+playbook configuration:
+
+
+```yaml
+matrix_mx_puppet_groupme_enabled: true
+matrix_mx_puppet_groupme_client_id: ""
+matrix_mx_puppet_groupme_client_secret: ""
+```
+
+
+## Usage
+
+Once the bot is enabled you need to start a chat with `GroupMe Puppet Bridge` with
+the handle `@_groupmepuppet_bot:YOUR_DOMAIN` (where `YOUR_DOMAIN` is your base
+domain, not the `matrix.` domain).
+
+One authentication method is available.
+
+To link your GroupMe account, go to [dev.groupme.com](https://dev.groupme.com/), sign in, and select "Access Token" from the top menu. Copy the token and message the bridge with:
+
+```
+link <access token>
+```
+
+Once logged in, send `list` to the bot user to list the available rooms.
+
+Clicking rooms in the list will result in you receiving an invitation to the
+bridged room.
+
+Also send `help` to the bot to see the commands available.

--- a/docs/configuring-playbook.md
+++ b/docs/configuring-playbook.md
@@ -116,6 +116,8 @@ When you're done with all the configuration you'd like to do, continue with [Ins
 
 - [Setting up MX Puppet Discord bridging](configuring-playbook-bridge-mx-puppet-discord.md) (optional)
 
+- [Setting up MX Puppet GroupMe bridging](configuring-playbook-bridge-mx-puppet-groupme.md) (optional)
+
 - [Setting up MX Puppet Steam bridging](configuring-playbook-bridge-mx-puppet-steam.md) (optional)
 
 - [Setting up Email2Matrix](configuring-playbook-email2matrix.md) (optional)

--- a/docs/container-images.md
+++ b/docs/container-images.md
@@ -70,6 +70,8 @@ These services are not part of our default installation, but can be enabled by [
 
 - [sorunome/mx-puppet-discord](https://hub.docker.com/r/sorunome/mx-puppet-discord) - the [mx-puppet-discord](https://github.com/matrix-discord/mx-puppet-discord) bridge to [Discord](https://discordapp.com) (optional)
 
+- [xangelix/mx-puppet-groupme](https://hub.docker.com/r/xangelix/mx-puppet-groupme) - the [mx-puppet-groupme](https://gitlab.com/robintown/mx-puppet-groupme) bridge to [GroupMe](https://groupme.com/) (optional)
+
 - [icewind1991/mx-puppet-steam](https://hub.docker.com/r/icewind1991/mx-puppet-steam) - the [mx-puppet-steam](https://github.com/icewind1991/mx-puppet-steam) bridge to [Steam](https://steampowered.com) (optional)
 
 - [turt2live/matrix-dimension](https://hub.docker.com/r/turt2live/matrix-dimension) - the [Dimension](https://dimension.t2bot.io/) integrations manager (optional)

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -622,6 +622,41 @@ matrix_mx_puppet_steam_database_password: "{{ matrix_synapse_macaroon_secret_key
 #
 ######################################################################
 
+######################################################################
+#
+# matrix-bridge-mx-puppet-groupme
+#
+######################################################################
+
+# We don't enable bridges by default.
+matrix_mx_puppet_groupme_enabled: false
+
+matrix_mx_puppet_groupme_container_image_self_build: "{{ matrix_architecture != 'amd64'}}"
+
+matrix_mx_puppet_groupme_systemd_required_services_list: |
+  {{
+    ['docker.service']
+    +
+    (['matrix-synapse.service'] if matrix_synapse_enabled else [])
+    +
+    (['matrix-postgres.service'] if matrix_postgres_enabled else [])
+  }}
+
+matrix_mx_puppet_groupme_appservice_token: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'mxste.as.tok') | to_uuid }}"
+
+matrix_mx_puppet_groupme_homeserver_token: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'mxste.hs.tok') | to_uuid }}"
+
+matrix_mx_puppet_groupme_login_shared_secret: "{{ matrix_synapse_ext_password_provider_shared_secret_auth_shared_secret if matrix_synapse_ext_password_provider_shared_secret_auth_enabled else '' }}"
+
+# Postgres is the default, except if not using `matrix_postgres` (internal postgres)
+matrix_mx_puppet_groupme_database_engine: "{{ 'postgres' if matrix_postgres_enabled else 'sqlite' }}"
+matrix_mx_puppet_groupme_database_password: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'mxpup.groupme.db') | to_uuid }}"
+
+######################################################################
+#
+# /matrix-bridge-mx-puppet-groupme
+#
+######################################################################
 
 ######################################################################
 #

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -1213,6 +1213,12 @@ matrix_postgres_additional_databases: |
     }] if (matrix_mx_puppet_steam_enabled and matrix_mx_puppet_steam_database_engine == 'postgres' and matrix_mx_puppet_steam_database_hostname == 'matrix-postgres') else [])
     +
     ([{
+      'name': matrix_mx_puppet_groupme_database_name,
+      'username': matrix_mx_puppet_groupme_database_username,
+      'password': matrix_mx_puppet_groupme_database_password,
+    }] if (matrix_mx_puppet_groupme_enabled and matrix_mx_puppet_groupme_database_engine == 'postgres' and matrix_mx_puppet_groupme_database_hostname == 'matrix-postgres') else [])
+    +
+    ([{
       'name': matrix_dimension_database_name,
       'username': matrix_dimension_database_username,
       'password': matrix_dimension_database_password,

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -642,9 +642,9 @@ matrix_mx_puppet_groupme_systemd_required_services_list: |
     (['matrix-postgres.service'] if matrix_postgres_enabled else [])
   }}
 
-matrix_mx_puppet_groupme_appservice_token: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'mxste.as.tok') | to_uuid }}"
+matrix_mx_puppet_groupme_appservice_token: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'mxgro.as.tok') | to_uuid }}"
 
-matrix_mx_puppet_groupme_homeserver_token: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'mxste.hs.tok') | to_uuid }}"
+matrix_mx_puppet_groupme_homeserver_token: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'mxgro.hs.tok') | to_uuid }}"
 
 matrix_mx_puppet_groupme_login_shared_secret: "{{ matrix_synapse_ext_password_provider_shared_secret_auth_shared_secret if matrix_synapse_ext_password_provider_shared_secret_auth_enabled else '' }}"
 

--- a/roles/matrix-bridge-mx-puppet-groupme/defaults/main.yml
+++ b/roles/matrix-bridge-mx-puppet-groupme/defaults/main.yml
@@ -1,0 +1,110 @@
+# Mx Puppet GroupMe is a Matrix <-> GroupMe bridge
+# See: https://gitlab.com/robintown/mx-puppet-groupme
+
+matrix_mx_puppet_groupme_enabled: true
+
+matrix_mx_puppet_groupme_container_image_self_build: false
+matrix_mx_puppet_groupme_container_image_self_build_repo: "https://gitlab.com/robintown/mx-puppet-groupme"
+
+# Controls whether the mx-puppet-groupme container exposes its HTTP port (tcp/8432 in the container).
+#
+# Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:8437"), or empty string to not expose.
+matrix_mx_puppet_groupme_container_http_host_bind_port: ''
+
+matrix_mx_puppet_groupme_docker_image: "{{ matrix_mx_puppet_groupme_docker_image_name_prefix }}jeffcasavant/mx-puppet-groupme:latest"
+matrix_mx_puppet_groupme_docker_image_name_prefix: "{{ 'localhost/' if matrix_mx_puppet_groupme_container_image_self_build else 'docker.io/' }}"
+matrix_mx_puppet_groupme_docker_image_force_pull: "{{ matrix_mx_puppet_groupme_docker_image.endswith(':latest') }}"
+
+matrix_mx_puppet_groupme_base_path: "{{ matrix_base_data_path }}/mx-puppet-groupme"
+matrix_mx_puppet_groupme_config_path: "{{ matrix_mx_puppet_groupme_base_path }}/config"
+matrix_mx_puppet_groupme_data_path: "{{ matrix_mx_puppet_groupme_base_path }}/data"
+matrix_mx_puppet_groupme_docker_src_files_path: "{{ matrix_mx_puppet_groupme_base_path }}/docker-src"
+
+matrix_mx_puppet_groupme_appservice_port: "8437"
+
+matrix_mx_puppet_groupme_homeserver_address: 'http://matrix-synapse:8008'
+matrix_mx_puppet_groupme_homeserver_domain: '{{ matrix_domain }}'
+matrix_mx_puppet_groupme_appservice_address: 'http://matrix-mx-puppet-groupme:{{ matrix_mx_puppet_groupme_appservice_port }}'
+
+matrix_mx_puppet_groupme_client_id: ''
+matrix_mx_puppet_groupme_client_secret: ''
+
+# "@user:server.com" to allow specific user
+# "@.*:yourserver.com" to allow users on a specific homeserver
+# "@.*" to allow anyone
+matrix_mx_puppet_groupme_provisioning_whitelist:
+  - "@.*:{{ matrix_domain|regex_escape }}"
+
+# Leave empty to disable blacklist
+# "@user:server.com" disallow a specific user
+# "@.*:yourserver.com" disallow users on a specific homeserver
+matrix_mx_puppet_groupme_provisioning_blacklist: []
+
+# A list of extra arguments to pass to the container
+matrix_mx_puppet_groupme_container_extra_arguments: []
+
+# List of systemd services that matrix-puppet-groupme.service depends on.
+matrix_mx_puppet_groupme_systemd_required_services_list: ['docker.service']
+
+# List of systemd services that matrix-puppet-groupme.service wants
+matrix_mx_puppet_groupme_systemd_wanted_services_list: []
+
+matrix_mx_puppet_groupme_appservice_token: ''
+matrix_mx_puppet_groupme_homeserver_token: ''
+
+# Can be set to enable automatic double-puppeting via Shared Secret Auth (https://github.com/devture/matrix-synapse-shared-secret-auth).
+matrix_mx_puppet_groupme_login_shared_secret: ''
+
+matrix_mx_puppet_groupme_database_engine: sqlite
+
+matrix_mx_puppet_groupme_sqlite_database_path_local: "{{ matrix_mx_puppet_groupme_data_path }}/database.db"
+matrix_mx_puppet_groupme_sqlite_database_path_in_container: "/data/database.db"
+
+matrix_mx_puppet_groupme_database_username: matrix_mx_puppet_groupme
+matrix_mx_puppet_groupme_database_password: ~
+matrix_mx_puppet_groupme_database_hostname: 'matrix-postgres'
+matrix_mx_puppet_groupme_database_port: 5432
+matrix_mx_puppet_groupme_database_name: matrix_mx_puppet_groupme
+
+matrix_mx_puppet_groupme_database_connection_string: 'postgresql://{{ matrix_mx_puppet_groupme_database_username }}:{{ matrix_mx_puppet_groupme_database_password }}@{{ matrix_mx_puppet_groupme_database_hostname }}:{{ matrix_mx_puppet_groupme_database_port }}/{{ matrix_mx_puppet_groupme_database_name }}?sslmode=disable'
+
+# Default configuration template which covers the generic use case.
+# You can customize it by controlling the various variables inside it.
+#
+# For a more advanced customization, you can extend the default (see `matrix_mx_puppet_groupme_configuration_extension_yaml`)
+# or completely replace this variable with your own template.
+matrix_mx_puppet_groupme_configuration_yaml: "{{ lookup('template', 'templates/config.yaml.j2') }}"
+
+matrix_mx_puppet_groupme_configuration_extension_yaml: |
+  # Your custom YAML configuration goes here.
+  # This configuration extends the default starting configuration (`matrix_mx_puppet_groupme_configuration_yaml`).
+  #
+  # You can override individual variables from the default configuration, or introduce new ones.
+  #
+  # If you need something more special, you can take full control by
+  # completely redefining `matrix_mx_puppet_groupme_configuration_yaml`.
+
+matrix_mx_puppet_groupme_configuration_extension: "{{ matrix_mx_puppet_groupme_configuration_extension_yaml|from_yaml if matrix_mx_puppet_groupme_configuration_extension_yaml|from_yaml is mapping else {} }}"
+
+# Holds the final configuration (a combination of the default and its extension).
+# You most likely don't need to touch this variable. Instead, see `matrix_mx_puppet_groupme_configuration_yaml`.
+matrix_mx_puppet_groupme_configuration: "{{ matrix_mx_puppet_groupme_configuration_yaml|from_yaml|combine(matrix_mx_puppet_groupme_configuration_extension, recursive=True) }}"
+
+matrix_mx_puppet_groupme_registration_yaml: |
+  as_token: "{{ matrix_mx_puppet_groupme_appservice_token }}"
+  hs_token: "{{ matrix_mx_puppet_groupme_homeserver_token }}"
+  id: groupme-puppet
+  namespaces:
+    users:
+      - exclusive: true
+        regex: '@_groupmepuppet_.*:{{ matrix_mx_puppet_groupme_homeserver_domain|regex_escape }}'
+    rooms: []
+    aliases:
+      - exclusive: true
+        regex: '#_groupmepuppet_.*:{{ matrix_mx_puppet_groupme_homeserver_domain|regex_escape }}'
+  protocols: []
+  rate_limited: false
+  sender_localpart: _groupmepuppet_bot
+  url: {{ matrix_mx_puppet_groupme_appservice_address }}
+
+matrix_mx_puppet_groupme_registration: "{{ matrix_mx_puppet_groupme_registration_yaml|from_yaml }}"

--- a/roles/matrix-bridge-mx-puppet-groupme/defaults/main.yml
+++ b/roles/matrix-bridge-mx-puppet-groupme/defaults/main.yml
@@ -6,7 +6,7 @@ matrix_mx_puppet_groupme_enabled: true
 matrix_mx_puppet_groupme_container_image_self_build: false
 matrix_mx_puppet_groupme_container_image_self_build_repo: "https://gitlab.com/robintown/mx-puppet-groupme"
 
-# Controls whether the mx-puppet-groupme container exposes its HTTP port (tcp/8432 in the container).
+# Controls whether the mx-puppet-groupme container exposes its HTTP port (tcp/8437 in the container).
 #
 # Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:8437"), or empty string to not expose.
 matrix_mx_puppet_groupme_container_http_host_bind_port: ''

--- a/roles/matrix-bridge-mx-puppet-groupme/defaults/main.yml
+++ b/roles/matrix-bridge-mx-puppet-groupme/defaults/main.yml
@@ -11,7 +11,7 @@ matrix_mx_puppet_groupme_container_image_self_build_repo: "https://gitlab.com/ro
 # Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:8437"), or empty string to not expose.
 matrix_mx_puppet_groupme_container_http_host_bind_port: ''
 
-matrix_mx_puppet_groupme_docker_image: "{{ matrix_mx_puppet_groupme_docker_image_name_prefix }}jeffcasavant/mx-puppet-groupme:latest"
+matrix_mx_puppet_groupme_docker_image: "{{ matrix_mx_puppet_groupme_docker_image_name_prefix }}xangelix/mx-puppet-groupme:latest"
 matrix_mx_puppet_groupme_docker_image_name_prefix: "{{ 'localhost/' if matrix_mx_puppet_groupme_container_image_self_build else 'docker.io/' }}"
 matrix_mx_puppet_groupme_docker_image_force_pull: "{{ matrix_mx_puppet_groupme_docker_image.endswith(':latest') }}"
 

--- a/roles/matrix-bridge-mx-puppet-groupme/tasks/init.yml
+++ b/roles/matrix-bridge-mx-puppet-groupme/tasks/init.yml
@@ -1,0 +1,23 @@
+- set_fact:
+    matrix_systemd_services_list: "{{ matrix_systemd_services_list + ['matrix-mx-puppet-groupme.service'] }}"
+  when: matrix_mx_puppet_groupme_enabled|bool
+
+# If the matrix-synapse role is not used, these variables may not exist.
+- set_fact:
+    matrix_synapse_container_extra_arguments: >
+      {{ matrix_synapse_container_extra_arguments|default([]) }}
+      +
+      ["--mount type=bind,src={{ matrix_mx_puppet_groupme_config_path }}/registration.yaml,dst=/matrix-mx-puppet-groupme-registration.yaml,ro"]
+
+    matrix_synapse_app_service_config_files: >
+      {{ matrix_synapse_app_service_config_files|default([]) }}
+      +
+      {{ ["/matrix-mx-puppet-groupme-registration.yaml"] }}
+  when: matrix_mx_puppet_groupme_enabled|bool
+
+# ansible lower than 2.8, does not support docker_image build parameters
+# for self buildig it is explicitly needed, so we rather fail here
+- name: Fail if running on Ansible lower than 2.8 and trying self building
+  fail:
+    msg: "To self build Puppet Slack image, you should usa ansible 2.8 or higher. E.g. pip contains such packages."
+  when: "ansible_version.major == 2 and ansible_version.minor < 8 and matrix_mx_puppet_groupme_container_image_self_build"

--- a/roles/matrix-bridge-mx-puppet-groupme/tasks/main.yml
+++ b/roles/matrix-bridge-mx-puppet-groupme/tasks/main.yml
@@ -1,0 +1,21 @@
+- import_tasks: "{{ role_path }}/tasks/init.yml"
+  tags:
+    - always
+
+- import_tasks: "{{ role_path }}/tasks/validate_config.yml"
+  when: "run_setup|bool and matrix_mx_puppet_groupme_enabled|bool"
+  tags:
+    - setup-all
+    - setup-mx-puppet-groupme
+
+- import_tasks: "{{ role_path }}/tasks/setup_install.yml"
+  when: "run_setup|bool and matrix_mx_puppet_groupme_enabled|bool"
+  tags:
+    - setup-all
+    - setup-mx-puppet-groupme
+
+- import_tasks: "{{ role_path }}/tasks/setup_uninstall.yml"
+  when: "run_setup|bool and not matrix_mx_puppet_groupme_enabled|bool"
+  tags:
+    - setup-all
+    - setup-mx-puppet-groupme

--- a/roles/matrix-bridge-mx-puppet-groupme/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mx-puppet-groupme/tasks/setup_install.yml
@@ -1,0 +1,127 @@
+---
+
+# If the matrix-synapse role is not used, `matrix_synapse_role_executed` won't exist.
+# We don't want to fail in such cases.
+- name: Fail if matrix-synapse role already executed
+  fail:
+    msg: >-
+      The matrix-bridge-mx-puppet-groupme role needs to execute before the matrix-synapse role.
+  when: "matrix_synapse_role_executed|default(False)"
+
+- name: Ensure MX Puppet Groupme paths exist
+  file:
+    path: "{{ item.path }}"
+    state: directory
+    mode: 0750
+    owner: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
+  with_items:
+    - { path: "{{ matrix_mx_puppet_groupme_base_path }}", when: true }
+    - { path: "{{ matrix_mx_puppet_groupme_config_path }}", when: true }
+    - { path: "{{ matrix_mx_puppet_groupme_data_path }}", when: true }
+    - { path: "{{ matrix_mx_puppet_groupme_docker_src_files_path }}", when: "{{ matrix_mx_puppet_groupme_container_image_self_build }}" }
+  when: matrix_mx_puppet_groupme_enabled|bool and item.when|bool
+
+- name: Check if an old database file already exists
+  stat:
+    path: "{{ matrix_mx_puppet_groupme_base_path }}/database.db"
+  register: matrix_mx_puppet_groupme_stat_database
+
+- name: (Data relocation) Ensure matrix-mx-puppet-groupme.service is stopped
+  service:
+    name: matrix-mx-puppet-groupme
+    state: stopped
+    daemon_reload: yes
+  failed_when: false
+  when: "matrix_mx_puppet_groupme_stat_database.stat.exists"
+
+- name: (Data relocation) Move mx-puppet-groupme database file to ./data directory
+  command: "mv {{ matrix_mx_puppet_groupme_base_path }}/database.db {{ matrix_mx_puppet_groupme_data_path }}/database.db"
+  when: "matrix_mx_puppet_groupme_stat_database.stat.exists"
+
+- set_fact:
+    matrix_mx_puppet_groupme_requires_restart: false
+
+- block:
+    - name: Check if an SQLite database already exists
+      stat:
+        path: "{{ matrix_mx_puppet_groupme_sqlite_database_path_local }}"
+      register: matrix_mx_puppet_groupme_sqlite_database_path_local_stat_result
+
+    - block:
+        - set_fact:
+            matrix_postgres_db_migration_request:
+              src: "{{ matrix_mx_puppet_groupme_sqlite_database_path_local }}"
+              dst: "{{ matrix_mx_puppet_groupme_database_connection_string }}"
+              caller: "{{ role_path|basename }}"
+              engine_variable_name: 'matrix_mx_puppet_groupme_database_engine'
+              engine_old: 'sqlite'
+              systemd_services_to_stop: ['matrix-mx-puppet-groupme.service']
+
+        - import_tasks: "{{ role_path }}/../matrix-postgres/tasks/util/migrate_db_to_postgres.yml"
+
+        - set_fact:
+            matrix_mx_puppet_groupme_requires_restart: true
+      when: "matrix_mx_puppet_groupme_sqlite_database_path_local_stat_result.stat.exists|bool"
+  when: "matrix_mx_puppet_groupme_database_engine == 'postgres'"
+
+- name: Ensure MX Puppet Groupme image is pulled
+  docker_image:
+    name: "{{ matrix_mx_puppet_groupme_docker_image }}"
+    source: "{{ 'pull' if ansible_version.major > 2 or ansible_version.minor > 7 else omit }}"
+    force_source: "{{ matrix_mx_puppet_groupme_docker_image_force_pull if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
+    force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_mx_puppet_groupme_docker_image_force_pull }}"
+  when: matrix_mx_puppet_groupme_enabled|bool and not matrix_mx_puppet_groupme_container_image_self_build
+
+- name: Ensure MX Puppet Groupme repository is present on self build
+  git:
+    repo: "{{ matrix_mx_puppet_groupme_container_image_self_build_repo }}"
+    dest: "{{ matrix_mx_puppet_groupme_docker_src_files_path }}"
+    force: "yes"
+  register: matrix_mx_puppet_groupme_git_pull_results
+  when: "matrix_mx_puppet_groupme_enabled|bool and matrix_mx_puppet_groupme_container_image_self_build"
+
+- name: Ensure MX Puppet Groupme Docker image is built
+  docker_image:
+    name: "{{ matrix_mx_puppet_groupme_docker_image }}"
+    source: build
+    force_source: "{{ matrix_mx_puppet_groupme_git_pull_results.changed }}"
+    build:
+      dockerfile: Dockerfile
+      path: "{{ matrix_mx_puppet_groupme_docker_src_files_path }}"
+      pull: yes
+  when: "matrix_mx_puppet_groupme_enabled|bool and matrix_mx_puppet_groupme_container_image_self_build"
+
+- name: Ensure mx-puppet-groupme config.yaml installed
+  copy:
+    content: "{{ matrix_mx_puppet_groupme_configuration|to_nice_yaml }}"
+    dest: "{{ matrix_mx_puppet_groupme_config_path }}/config.yaml"
+    mode: 0644
+    owner: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
+
+- name: Ensure mx-puppet-groupme groupme-registration.yaml installed
+  copy:
+    content: "{{ matrix_mx_puppet_groupme_registration|to_nice_yaml }}"
+    dest: "{{ matrix_mx_puppet_groupme_config_path }}/registration.yaml"
+    mode: 0644
+    owner: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
+
+- name: Ensure matrix-mx-puppet-groupme.service installed
+  template:
+    src: "{{ role_path }}/templates/systemd/matrix-mx-puppet-groupme.service.j2"
+    dest: "/etc/systemd/system/matrix-mx-puppet-groupme.service"
+    mode: 0644
+  register: matrix_mx_puppet_groupme_systemd_service_result
+
+- name: Ensure systemd reloaded after matrix-mx-puppet-groupme.service installation
+  service:
+    daemon_reload: yes
+  when: "matrix_mx_puppet_groupme_systemd_service_result.changed"
+
+- name: Ensure matrix-mx-puppet-groupme.service restarted, if necessary
+  service:
+    name: "matrix-mx-puppet-groupme.service"
+    state: restarted
+  when: "matrix_mx_puppet_groupme_requires_restart|bool"

--- a/roles/matrix-bridge-mx-puppet-groupme/tasks/setup_uninstall.yml
+++ b/roles/matrix-bridge-mx-puppet-groupme/tasks/setup_uninstall.yml
@@ -1,0 +1,24 @@
+---
+
+- name: Check existence of matrix-mx-puppet-groupme service
+  stat:
+    path: "/etc/systemd/system/matrix-mx-puppet-groupme.service"
+  register: matrix_mx_puppet_groupme_service_stat
+
+- name: Ensure matrix-mx-puppet-groupme is stopped
+  service:
+    name: matrix-mx-puppet-groupme
+    state: stopped
+    daemon_reload: yes
+  when: "matrix_mx_puppet_groupme_service_stat.stat.exists"
+
+- name: Ensure matrix-mx-puppet-groupme.service doesn't exist
+  file:
+    path: "/etc/systemd/system/matrix-mx-puppet-groupme.service"
+    state: absent
+  when: "matrix_mx_puppet_groupme_service_stat.stat.exists"
+
+- name: Ensure systemd reloaded after matrix-mx-puppet-groupme.service removal
+  service:
+    daemon_reload: yes
+  when: "matrix_mx_puppet_groupme_service_stat.stat.exists"

--- a/roles/matrix-bridge-mx-puppet-groupme/tasks/validate_config.yml
+++ b/roles/matrix-bridge-mx-puppet-groupme/tasks/validate_config.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Fail if required settings not defined
+  fail:
+    msg: >-
+      You need to define a required configuration setting (`{{ item }}`).
+  when: "vars[item] == ''"
+  with_items:
+    - "matrix_mx_puppet_groupme_appservice_token"
+    - "matrix_mx_puppet_groupme_homeserver_token"

--- a/roles/matrix-bridge-mx-puppet-groupme/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mx-puppet-groupme/templates/config.yaml.j2
@@ -1,0 +1,86 @@
+#jinja2: lstrip_blocks: "True"
+bridge:
+  # Port to host the bridge on
+  # Used for communication between the homeserver and the bridge
+  port: {{ matrix_mx_puppet_groupme_appservice_port }}
+  # The host connections to the bridge's webserver are allowed from
+  bindAddress: 0.0.0.0
+  # Public domain of the homeserver
+  domain: {{ matrix_mx_puppet_groupme_homeserver_domain }}
+  # Reachable URL of the Matrix homeserver
+  homeserverUrl: {{ matrix_mx_puppet_groupme_homeserver_address }}
+  {% if matrix_mx_puppet_groupme_login_shared_secret != '' %}
+  loginSharedSecretMap:
+    {{ matrix_domain }}: {{ matrix_mx_puppet_groupme_login_shared_secret }}
+  {% endif %}
+  # Display name of the bridge bot
+  displayname: GroupMe Puppet Bridge
+  # Optionally specify a different media URL used for the media store
+  #
+  # This is where GroupMe will download user profile pictures and media
+  # from
+  #mediaUrl: https://external-url.org
+
+presence:
+  # Bridge GroupMe online/offline status
+  enabled: true
+  # How often to send status to the homeserver in milliseconds
+  interval: 5000
+
+provisioning:
+  # Regex of Matrix IDs allowed to use the puppet bridge
+  whitelist: {{ matrix_mx_puppet_groupme_provisioning_whitelist|to_json }}
+    # Allow a specific user
+    #- "@user:server\\.com"
+    # Allow users on a specific homeserver
+    #- "@.*:yourserver\\.com"
+    # Allow anyone
+    #- ".*"
+  # Regex of Matrix IDs forbidden from using the puppet bridge
+  #blacklist:
+    # Disallow a specific user
+    #- "@user:server\\.com"
+    # Disallow users on a specific homeserver
+    #- "@.*:yourserver\\.com"
+  blacklist: {{ matrix_mx_puppet_groupme_provisioning_blacklist|to_json }}
+
+relay:
+  # Regex of Matrix IDs who are allowed to use the bridge in relay mode.
+  # Relay mode is when a single GroupMe bot account relays messages of
+  # multiple Matrix users
+  #
+  # Same format as in provisioning
+  whitelist: {{ matrix_mx_puppet_groupme_provisioning_whitelist|to_json }}
+  blacklist: {{ matrix_mx_puppet_groupme_provisioning_blacklist|to_json }}
+
+selfService:
+  # Regex of Matrix IDs who are allowed to use bridge self-servicing (plumbed rooms)
+  #
+  # Same format as in provisioning
+  whitelist: {{ matrix_mx_puppet_groupme_provisioning_whitelist|to_json }}
+  blacklist: {{ matrix_mx_puppet_groupme_provisioning_blacklist|to_json }}
+
+database:
+{% if matrix_mx_puppet_groupme_database_engine == 'postgres' %}
+  # Use Postgres as a database backend
+  # If set, will be used instead of SQLite3
+  # Connection string to connect to the Postgres instance
+  # with username "user", password "pass", host "localhost" and database name "dbname".
+  # Modify each value as necessary
+  connString: {{ matrix_mx_puppet_groupme_database_connection_string|to_json }}
+{% else %}
+  # Use SQLite3 as a database backend
+  # The name of the database file
+  filename: {{ matrix_mx_puppet_groupme_sqlite_database_path_in_container|to_json }}
+{% endif %}
+
+logging:
+  # Log level of console output
+  # Allowed values starting with most verbose:
+  # silly, debug, verbose, info, warn, error
+  console: info
+  # Date and time formatting
+  lineDateFormat: MMM-D HH:mm:ss.SSS
+  # Logging files
+  # Log files are rotated daily by default
+  files: []

--- a/roles/matrix-bridge-mx-puppet-groupme/templates/systemd/matrix-mx-puppet-groupme.service.j2
+++ b/roles/matrix-bridge-mx-puppet-groupme/templates/systemd/matrix-mx-puppet-groupme.service.j2
@@ -1,0 +1,43 @@
+#jinja2: lstrip_blocks: "True"
+[Unit]
+Description=Matrix Mx Puppet Groupme bridge
+{% for service in matrix_mx_puppet_groupme_systemd_required_services_list %}
+Requires={{ service }}
+After={{ service }}
+{% endfor %}
+{% for service in matrix_mx_puppet_groupme_systemd_wanted_services_list %}
+Wants={{ service }}
+{% endfor %}
+DefaultDependencies=no
+
+[Service]
+Type=simple
+Environment="HOME={{ matrix_systemd_unit_home_path }}"
+ExecStartPre=-{{ matrix_host_command_sh }} -c '{{ matrix_host_command_docker }} kill matrix-mx-puppet-groupme 2>/dev/null'
+ExecStartPre=-{{ matrix_host_command_sh }} -c '{{ matrix_host_command_docker }} rm matrix-mx-puppet-groupme 2>/dev/null'
+
+# Intentional delay, so that the homeserver (we likely depend on) can manage to start.
+ExecStartPre={{ matrix_host_command_sleep }} 5
+
+ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-mx-puppet-groupme \
+			--log-driver=none \
+			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
+			--cap-drop=ALL \
+			--network={{ matrix_docker_network }} \
+			-e CONFIG_PATH=/config/config.yaml \
+			-e REGISTRATION_PATH=/config/registration.yaml \
+			-v {{ matrix_mx_puppet_groupme_config_path }}:/config:z \
+			-v {{ matrix_mx_puppet_groupme_data_path }}:/data:z \
+			{% for arg in matrix_mx_puppet_groupme_container_extra_arguments %}
+			{{ arg }} \
+			{% endfor %}
+			{{ matrix_mx_puppet_groupme_docker_image }}
+
+ExecStop=-{{ matrix_host_command_sh }} -c '{{ matrix_host_command_docker }} kill matrix-mx-puppet-groupme 2>/dev/null'
+ExecStop=-{{ matrix_host_command_sh }} -c '{{ matrix_host_command_docker }} rm matrix-mx-puppet-groupme 2>/dev/null'
+Restart=always
+RestartSec=30
+SyslogIdentifier=matrix-mx-puppet-groupme
+
+[Install]
+WantedBy=multi-user.target

--- a/setup.yml
+++ b/setup.yml
@@ -19,6 +19,7 @@
     - matrix-bridge-mautrix-telegram
     - matrix-bridge-mautrix-whatsapp
     - matrix-bridge-mx-puppet-discord
+    - matrix-bridge-mx-puppet-groupme
     - matrix-bridge-mx-puppet-steam
     - matrix-bridge-mx-puppet-skype
     - matrix-bridge-mx-puppet-slack


### PR DESCRIPTION
Adds support for: https://gitlab.com/robintown/mx-puppet-groupme

Modeled after the other mx-puppet bridges.

WIP as additional testing needs to be done--however, there are no currently known issues.