### PR TITLE
Fix etherpad binding

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -765,6 +765,8 @@ matrix_dimension_database_password: "{{ matrix_synapse_macaroon_secret_key | pas
 
 matrix_etherpad_enabled: false
 
+matrix_etherpad_container_http_host_bind_port: "{{ '' if matrix_nginx_proxy_enabled else '127.0.0.1:9001' }}"
+
 matrix_etherpad_systemd_required_services_list: |
   {{
     ['docker.service']

--- a/roles/matrix-etherpad/defaults/main.yml
+++ b/roles/matrix-etherpad/defaults/main.yml
@@ -19,7 +19,7 @@ matrix_etherpad_user_gid: '5001'
 # Controls whether the matrix-etherpad container exposes its HTTP port (tcp/9001 in the container).
 #
 # Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:9001"), or empty string to not expose.
-matrix_etherpad_container_http_host_bind_port: '9001'
+matrix_etherpad_container_http_host_bind_port: ''
 
 # A list of extra arguments to pass to the container
 matrix_etherpad_container_extra_arguments: []

--- a/roles/matrix-etherpad/defaults/main.yml
+++ b/roles/matrix-etherpad/defaults/main.yml
@@ -22,7 +22,12 @@ matrix_etherpad_user_gid: '5001'
 matrix_etherpad_container_http_host_bind_port: ''
 
 # A list of extra arguments to pass to the container
-matrix_etherpad_container_extra_arguments: []
+#
+# We assume that a reverse proxy is used and tell the container to trust it
+#   Details: https://github.com/ether/etherpad-lite/blob/develop/doc/docker.md
+matrix_etherpad_container_extra_arguments: [
+  '--env TRUST_PROXY=true'
+]
 
 matrix_etherpad_public_endpoint: '/etherpad'
 


### PR DESCRIPTION
The Etherpad container's port is exposed on all interfaces in the default configuration. That means that it's possible to access Etherpad in plaintext via http://matrix.[domain]:9001. While a user would have to stretch to actually find and deliberately use this insecure form of access, it's still a minor security flaw and should be adjusted.

This PR changes the default behaviour so that Etherpad
- does not bind to the host at all if the builtin reverse proxy is used
- only binds to a loopback port if the builtin reverse proxy is _not_ used
It's still possible for advanced users to override `matrix_etherpad_container_http_host_bind_port` and customize the behaviour to their liking.

Furthermore the PR instructs the Etherpad container to trust the reverse proxy by default, so that the logs contain correct information about origin requests