### PR TITLE
Use the yaml callback plugin when running ansible-playbook

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 retry_files_enabled = False
+stdout_callback = yaml
 
 [connection]
 pipelining = True


### PR DESCRIPTION
The default default Ansible screen output encodes and prints error outputs as a hard to read dense line of JSON.
This patch changes the ansible-playbook command behavior for this project to output yaml instead.

Before:
```
TASK [matrix-synapse : Check Matrix Client API] **********************************************************************************************************************************
fatal: [matrix.domain.tld -> 127.0.0.1]: FAILED! => {"changed": false, "connection": "close", "content": "\n<html>\n  <head><title>404 - No Such Resource</title></head>\n  <body>\n    <h1>No Such Resource</h1>\n    <p>Sorry. No luck finding that resource.</p>\n  </body>\n</html>\n", "content_length": "167", "content_type": "text/html; charset=utf-8", "date": "Thu, 18 Feb 2021 14:52:15 GMT", "elapsed": 0, "msg": "Status code was 404 and not [200]: HTTP Error 404: Not Found", "redirected": false, "server": "nginx", "status": 404, "url": "https://matrix.domain.tld/_matrix/client/versionsb"}                                                                                                                      
```

After:
```yaml
TASK [matrix-synapse : Check Matrix Client API] ***************************
fatal: [matrix.domain.tld -> 127.0.0.1]: FAILED! => changed=false
  connection: close
  content: |2-

    <html>
      <head><title>404 - No Such Resource</title></head>
      <body>
        <h1>No Such Resource</h1>
        <p>Sorry. No luck finding that resource.</p>
      </body>
    </html>
  content_length: '167'
  content_type: text/html; charset=utf-8
  date: Thu, 18 Feb 2021 14:58:45 GMT
  elapsed: 0
  msg: 'Status code was 404 and not [200]: HTTP Error 404: Not Found'
  redirected: false
  server: nginx
  status: 404
  url: https://matrix.domain.tld/_matrix/client/versionsb
```