### PR TITLE
Remove 'sqlite3' from the Etherpad role

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -774,8 +774,6 @@ matrix_etherpad_systemd_required_services_list: |
     (['matrix-postgres.service'] if matrix_postgres_enabled else [])
   }}
 
-# Postgres is the default, except if not using `matrix_postgres` (internal postgres)
-matrix_etherpad_database_engine: "{{ 'postgres' if matrix_postgres_enabled else 'sqlite' }}"
 matrix_etherpad_database_password: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'etherpad.db') | to_uuid }}"
 
 ######################################################################

--- a/roles/matrix-etherpad/defaults/main.yml
+++ b/roles/matrix-etherpad/defaults/main.yml
@@ -36,15 +36,8 @@ matrix_etherpad_base_url: "https://{{ matrix_server_fqn_dimension }}{{ matrix_et
 
 # Database-related configuration fields.
 #
-# Etherpad recommends using a dedicated database, and supports Sqlite only for development
-#
-# To use Postgres:
-# - change the engine (`matrix_etherpad_database_engine: 'postgres'`)
-# - adjust your database credentials via the `matrix_etherpad_postgres_*` variables
-matrix_etherpad_database_engine: 'sqlite'
-
-matrix_etherpad_sqlite_database_path_local: "{{ matrix_etherpad_base_path }}/etherpad.db"
-matrix_etherpad_sqlite_database_path_in_container: "/data/etherpad.db"
+# Etherpad requires a dedicated database
+matrix_etherpad_database_engine: 'postgres'
 
 matrix_etherpad_database_username: 'matrix_etherpad'
 matrix_etherpad_database_password: 'some-password'

--- a/roles/matrix-etherpad/tasks/validate_config.yml
+++ b/roles/matrix-etherpad/tasks/validate_config.yml
@@ -3,3 +3,9 @@
     msg: >-
       To integrate Etherpad notes with Matrix rooms you need to set "matrix_dimension_enabled" to true
   when: "not matrix_dimension_enabled|bool"
+
+- name: Fail if no database is configured for Etherpad
+  fail:
+    msg: >-
+      Etherpad requires a dedicated Postgres database. Please enable the built in one, or configure an external DB by redefining "matrix_etherpad_database_hostname"
+  when: matrix_etherpad_database_hostname == "matrix-postgres" and not matrix_postgres_enabled

--- a/roles/matrix-etherpad/templates/settings.json.j2
+++ b/roles/matrix-etherpad/templates/settings.json.j2
@@ -8,15 +8,11 @@
   "showSettingsInAdminPage": true,
   "dbType": {{ matrix_etherpad_database_engine|to_json }},
   "dbSettings": {
-    {% if matrix_etherpad_database_engine == 'sqlite' %}
-      "filename": {{ matrix_etherpad_sqlite_database_path_in_container|to_json }}
-    {% elif matrix_etherpad_database_engine == 'postgres' %}
-      "database": {{ matrix_etherpad_database_name|to_json }},
-      "host":     {{ matrix_etherpad_database_hostname|to_json }},
-      "password": {{ matrix_etherpad_database_password|to_json }},
-      "port":     {{ matrix_etherpad_database_port|to_json }},
-      "user":     {{ matrix_etherpad_database_username|to_json }}
-    {% endif %}
+    "database": {{ matrix_etherpad_database_name|to_json }},
+    "host":     {{ matrix_etherpad_database_hostname|to_json }},
+    "password": {{ matrix_etherpad_database_password|to_json }},
+    "port":     {{ matrix_etherpad_database_port|to_json }},
+    "user":     {{ matrix_etherpad_database_username|to_json }}
   },
   "defaultPadText" : {{ matrix_etherpad_default_pad_text|to_json }},
   "suppressErrorsInPadText": false,

--- a/roles/matrix-etherpad/templates/systemd/matrix-etherpad.service.j2
+++ b/roles/matrix-etherpad/templates/systemd/matrix-etherpad.service.j2
@@ -16,11 +16,6 @@ Environment="HOME={{ matrix_systemd_unit_home_path }}"
 ExecStartPre=-{{ matrix_host_command_docker }} kill matrix-etherpad
 ExecStartPre=-{{ matrix_host_command_docker }} rm matrix-etherpad
 
-# Fixup database ownership if it got changed somehow (during a server migration, etc.)
-{% if matrix_etherpad_database_engine == 'sqlite' %}
-ExecStartPre=-{{ matrix_host_command_chown }} {{ matrix_etherpad_user_uid }} {{ matrix_etherpad_sqlite_database_path_local }}
-{% endif %}
-
 ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-etherpad \
 			--log-driver=none \
 			--user={{ matrix_etherpad_user_uid }}:{{ matrix_etherpad_user_gid }} \


### PR DESCRIPTION
PR #804 incorrectly assumed that `sqlite3` databases were supported by the official Etherpad Docker image, #874 reported this error.
To avoid any further confusion, I am removing all mention of sqlite3 in the matrix-etherpad role.
Even though it is possible to add sqlite3 support to the container, it is way more difficult to do than just connecting to the postgres database. I think the latter solution should be recommended.