### PR TITLE
Make the proxy_pass address in Grafana's nginx config use a variable

### DIFF
--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-grafana.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-grafana.conf.j2
@@ -18,7 +18,11 @@
 			proxy_pass http://$backend;
 		{% else %}
 			{# Generic configuration for use outside of our container setup #}
-			proxy_pass http://127.0.0.1:3000;
+			{% if matrix_grafana_container_http_host_bind_port|length > 5 %}
+				proxy_pass http://{{matrix_grafana_container_http_host_bind_port}};
+			{% else %}
+				proxy_pass http://127.0.0.1:{{matrix_grafana_container_http_host_bind_port}};
+			{% endif %}
 		{% endif %}
 
 		proxy_set_header Host $host;


### PR DESCRIPTION
This adjusts the proxy_pass port/IP so that it follows the `matrix_grafana_container_http_host_bind_port` variable from `/roles/matrix-grafana/defaults/main.yml` when using an external webserver. The code checks how long the variable is (if the user has set just a port, \<port\>, or the full address, \<ip\>:\<port\>), and sets the proxy_pass value accordingly. 

Has been tested with both a full address and just a port, and seems to work. 