### PR TITLE
fix wrong json parameter in webhook documentation

### DIFF
--- a/docs/configuring-playbook-bridge-appservice-webhooks.md
+++ b/docs/configuring-playbook-bridge-appservice-webhooks.md
@@ -45,7 +45,7 @@ matrix_appservice_webhooks_log_level: '<log_level>'
     "text": "Hello world!",
     "format": "plain",
     "displayName": "My Cool Webhook",
-    "avatarUrl": "http://i.imgur.com/IDOBtEJ.png"
+    "avatar_url": "http://i.imgur.com/IDOBtEJ.png"
 }
 ```
 
@@ -57,7 +57,7 @@ curl --header "Content-Type: application/json" \
 "text": "Hello world!",
 "format": "plain",
 "displayName": "My Cool Webhook",
-"avatarUrl": "http://i.imgur.com/IDOBtEJ.png"
+"avatar_url": "http://i.imgur.com/IDOBtEJ.png"
 }' \
 <the link you've gotten in 5.>
 ```


### PR DESCRIPTION
fixes HTTP 400 Error: "{\"errcode\":\"M_MISSING_PARAM\",\"error\":\"Missing key 'avatar_url'\"}"