### PR TITLE
added "matrix_%SERVICE%_version" variable to all roles

### DIFF
--- a/roles/matrix-bot-matrix-reminder-bot/defaults/main.yml
+++ b/roles/matrix-bot-matrix-reminder-bot/defaults/main.yml
@@ -2,8 +2,8 @@
 # See: https://github.com/anoadragon453/matrix-reminder-bot
 
 matrix_bot_matrix_reminder_bot_enabled: true
-
-matrix_bot_matrix_reminder_bot_docker_image: "docker.io/anoa/matrix-reminder-bot:release-v0.2.0"
+matrix_bot_matrix_reminder_bot_version: release-v0.2.0
+matrix_bot_matrix_reminder_bot_docker_image: "docker.io/anoa/matrix-reminder-bot:{{ matrix_bot_matrix_reminder_bot_version }}"
 matrix_bot_matrix_reminder_bot_docker_image_force_pull: "{{ matrix_bot_matrix_reminder_bot_docker_image.endswith(':latest') }}"
 
 matrix_bot_matrix_reminder_bot_base_path: "{{ matrix_base_data_path }}/matrix-reminder-bot"

--- a/roles/matrix-bridge-appservice-discord/defaults/main.yml
+++ b/roles/matrix-bridge-appservice-discord/defaults/main.yml
@@ -3,7 +3,8 @@
 
 matrix_appservice_discord_enabled: true
 
-matrix_appservice_discord_docker_image: "docker.io/halfshot/matrix-appservice-discord:v1.0.0"
+matrix_appservice_discord_version: v1.0.0
+matrix_appservice_discord_docker_image: "docker.io/halfshot/matrix-appservice-discord:{{ matrix_appservice_discord_version }}"
 matrix_appservice_discord_docker_image_force_pull: "{{ matrix_appservice_discord_docker_image.endswith(':latest') }}"
 
 matrix_appservice_discord_base_path: "{{ matrix_base_data_path }}/appservice-discord"

--- a/roles/matrix-bridge-appservice-irc/defaults/main.yml
+++ b/roles/matrix-bridge-appservice-irc/defaults/main.yml
@@ -7,7 +7,8 @@ matrix_appservice_irc_container_self_build: false
 matrix_appservice_irc_docker_repo: "https://github.com/matrix-org/matrix-appservice-irc.git"
 matrix_appservice_irc_docker_src_files_path: "{{ matrix_base_data_path }}/appservice-irc/docker-src"
 
-matrix_appservice_irc_docker_image: "docker.io/matrixdotorg/matrix-appservice-irc:release-0.23.0"
+matrix_appservice_irc_version: release-0.23.0
+matrix_appservice_irc_docker_image: "docker.io/matrixdotorg/matrix-appservice-irc:{{ matrix_appservice_irc_version }}"
 matrix_appservice_irc_docker_image_force_pull: "{{ matrix_appservice_irc_docker_image.endswith(':latest') }}"
 
 matrix_appservice_irc_base_path: "{{ matrix_base_data_path }}/appservice-irc"

--- a/roles/matrix-bridge-appservice-slack/defaults/main.yml
+++ b/roles/matrix-bridge-appservice-slack/defaults/main.yml
@@ -7,7 +7,8 @@ matrix_appservice_slack_container_self_build: false
 matrix_appservice_slack_docker_repo: "https://github.com/matrix-org/matrix-appservice-slack.git"
 matrix_appservice_slack_docker_src_files_path: "{{ matrix_base_data_path }}/appservice-slack/docker-src"
 
-matrix_appservice_slack_docker_image: "docker.io/matrixdotorg/matrix-appservice-slack:release-1.5.0"
+matrix_appservice_slack_version: release-1.5.0
+matrix_appservice_slack_docker_image: "docker.io/matrixdotorg/matrix-appservice-slack:{{ matrix_appservice_slack_version }}"
 matrix_appservice_slack_docker_image_force_pull: "{{ matrix_appservice_slack_docker_image.endswith(':latest') }}"
 
 matrix_appservice_slack_base_path: "{{ matrix_base_data_path }}/appservice-slack"

--- a/roles/matrix-bridge-appservice-webhooks/defaults/main.yml
+++ b/roles/matrix-bridge-appservice-webhooks/defaults/main.yml
@@ -3,7 +3,8 @@
 
 matrix_appservice_webhooks_enabled: true
 
-matrix_appservice_webhooks_docker_image: "docker.io/turt2live/matrix-appservice-webhooks:latest"
+matrix_appservice_webhooks_version: latest
+matrix_appservice_webhooks_docker_image: "docker.io/turt2live/matrix-appservice-webhooks:{{ matrix_appservice_webhooks_version }}"
 matrix_appservice_webhooks_docker_image_force_pull: "{{ matrix_appservice_webhooks_docker_image.endswith(':latest') }}"
 
 matrix_appservice_webhooks_base_path: "{{ matrix_base_data_path }}/appservice-webhooks"

--- a/roles/matrix-bridge-mautrix-facebook/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-facebook/defaults/main.yml
@@ -6,8 +6,9 @@ matrix_mautrix_facebook_enabled: true
 matrix_mautrix_facebook_container_image_self_build: false
 matrix_mautrix_facebook_container_image_self_build_repo: "https://github.com/tulir/mautrix-facebook.git"
 
+matrix_mautrix_facebook_version: latest
 # See: https://mau.dev/tulir/mautrix-facebook/container_registry
-matrix_mautrix_facebook_docker_image: "{{ matrix_mautrix_facebook_docker_image_name_prefix }}tulir/mautrix-facebook:latest"
+matrix_mautrix_facebook_docker_image: "{{ matrix_mautrix_facebook_docker_image_name_prefix }}tulir/mautrix-facebook:{{ matrix_mautrix_facebook_version }}"
 matrix_mautrix_facebook_docker_image_name_prefix: "{{ 'localhost/' if matrix_mautrix_facebook_container_image_self_build else 'dock.mau.dev/' }}"
 matrix_mautrix_facebook_docker_image_force_pull: "{{ matrix_mautrix_facebook_docker_image.endswith(':latest') }}"
 

--- a/roles/matrix-bridge-mautrix-hangouts/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-hangouts/defaults/main.yml
@@ -6,8 +6,9 @@ matrix_mautrix_hangouts_enabled: true
 matrix_mautrix_hangouts_container_image_self_build: false
 matrix_mautrix_hangouts_container_image_self_build_repo: "https://github.com/tulir/mautrix-hangouts.git"
 
+matrix_mautrix_hangouts_version: latest
 # See: https://mau.dev/tulir/mautrix-hangouts/container_registry
-matrix_mautrix_hangouts_docker_image: "{{ matrix_mautrix_hangouts_docker_image_name_prefix }}tulir/mautrix-hangouts:latest"
+matrix_mautrix_hangouts_docker_image: "{{ matrix_mautrix_hangouts_docker_image_name_prefix }}tulir/mautrix-hangouts:{{ matrix_mautrix_hangouts_version }}"
 matrix_mautrix_hangouts_docker_image_name_prefix: "{{ 'localhost/' if matrix_mautrix_hangouts_container_image_self_build else 'dock.mau.dev/' }}"
 matrix_mautrix_hangouts_docker_image_force_pull: "{{ matrix_mautrix_hangouts_docker_image.endswith(':latest') }}"
 

--- a/roles/matrix-bridge-mautrix-instagram/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-instagram/defaults/main.yml
@@ -6,8 +6,9 @@ matrix_mautrix_instagram_enabled: true
 matrix_mautrix_instagram_container_image_self_build: false
 matrix_mautrix_instagram_container_image_self_build_repo: "https://github.com/tulir/mautrix-instagram.git"
 
+matrix_mautrix_instagram_version: latest
 # See: https://mau.dev/tulir/mautrix-instagram/container_registry
-matrix_mautrix_instagram_docker_image: "{{ matrix_mautrix_instagram_docker_image_name_prefix }}tulir/mautrix-instagram:latest"
+matrix_mautrix_instagram_docker_image: "{{ matrix_mautrix_instagram_docker_image_name_prefix }}tulir/mautrix-instagram:{{ matrix_mautrix_instagram_version }}"
 matrix_mautrix_instagram_docker_image_name_prefix: "{{ 'localhost/' if matrix_mautrix_instagram_container_image_self_build else 'dock.mau.dev/' }}"
 matrix_mautrix_instagram_docker_image_force_pull: "{{ matrix_mautrix_instagram_docker_image.endswith(':latest') }}"
 
@@ -34,7 +35,7 @@ matrix_mautrix_instagram_homeserver_token: ''
 
 
 # Database-related configuration fields.
-# 
+#
 # To use Postgres:
 # - adjust your database credentials via the `matrix_mautrix_instagram_postgres_*` variables
 matrix_mautrix_instagram_database_engine: 'postgres'

--- a/roles/matrix-bridge-mautrix-signal/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-signal/defaults/main.yml
@@ -3,11 +3,13 @@
 
 matrix_mautrix_signal_enabled: true
 
+matrix_mautrix_signal_version: latest
+matrix_mautrix_signal_daemon_version: latest
 # See: https://mau.dev/tulir/mautrix-signal/container_registry
-matrix_mautrix_signal_docker_image: "dock.mau.dev/tulir/mautrix-signal:latest"
+matrix_mautrix_signal_docker_image: "dock.mau.dev/tulir/mautrix-signal:{{ matrix_mautrix_signal_version }}"
 matrix_mautrix_signal_docker_image_force_pull: "{{ matrix_mautrix_signal_docker_image.endswith(':latest') }}"
 
-matrix_mautrix_signal_daemon_docker_image: "dock.mau.dev/maunium/signald:latest"
+matrix_mautrix_signal_daemon_docker_image: "dock.mau.dev/maunium/signald:{{ matrix_mautrix_signal_daemon_version }}"
 matrix_mautrix_signal_daemon_docker_image_force_pull: "{{ matrix_mautrix_signal_daemon_docker_image.endswith(':latest') }}"
 
 matrix_mautrix_signal_base_path: "{{ matrix_base_data_path }}/mautrix-signal"

--- a/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
@@ -7,8 +7,9 @@ matrix_mautrix_telegram_container_self_build: false
 matrix_mautrix_telegram_docker_repo: "https://mau.dev/tulir/mautrix-telegram.git"
 matrix_mautrix_telegram_docker_src_files_path: "{{ matrix_base_data_path }}/mautrix-telegram/docker-src"
 
+matrix_mautrix_telegram_version: v0.9.0
 # See: https://mau.dev/tulir/mautrix-telegram/container_registry
-matrix_mautrix_telegram_docker_image: "dock.mau.dev/tulir/mautrix-telegram:v0.9.0"
+matrix_mautrix_telegram_docker_image: "dock.mau.dev/tulir/mautrix-telegram:{{ matrix_mautrix_telegram_version }}"
 matrix_mautrix_telegram_docker_image_force_pull: "{{ matrix_mautrix_telegram_docker_image.endswith(':latest') }}"
 
 matrix_mautrix_telegram_base_path: "{{ matrix_base_data_path }}/mautrix-telegram"

--- a/roles/matrix-bridge-mautrix-whatsapp/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-whatsapp/defaults/main.yml
@@ -3,8 +3,9 @@
 
 matrix_mautrix_whatsapp_enabled: true
 
+matrix_mautrix_whatsapp_version: latest
 # See: https://mau.dev/tulir/mautrix-whatsapp/container_registry
-matrix_mautrix_whatsapp_docker_image: "dock.mau.dev/tulir/mautrix-whatsapp:latest"
+matrix_mautrix_whatsapp_docker_image: "dock.mau.dev/tulir/mautrix-whatsapp:{{ matrix_mautrix_whatsapp_version }}"
 matrix_mautrix_whatsapp_docker_image_force_pull: "{{ matrix_mautrix_whatsapp_docker_image.endswith(':latest') }}"
 
 matrix_mautrix_whatsapp_base_path: "{{ matrix_base_data_path }}/mautrix-whatsapp"

--- a/roles/matrix-bridge-mx-puppet-discord/defaults/main.yml
+++ b/roles/matrix-bridge-mx-puppet-discord/defaults/main.yml
@@ -11,7 +11,8 @@ matrix_mx_puppet_discord_container_image_self_build_repo: "https://github.com/ma
 # Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:8432"), or empty string to not expose.
 matrix_mx_puppet_discord_container_http_host_bind_port: ''
 
-matrix_mx_puppet_discord_docker_image: "{{ matrix_mx_puppet_discord_docker_image_name_prefix }}sorunome/mx-puppet-discord:latest"
+matrix_mx_puppet_discord_version: latest
+matrix_mx_puppet_discord_docker_image: "{{ matrix_mx_puppet_discord_docker_image_name_prefix }}sorunome/mx-puppet-discord:{{ matrix_mx_puppet_discord_version }}"
 matrix_mx_puppet_discord_docker_image_name_prefix: "{{ 'localhost/' if matrix_mx_puppet_discord_container_image_self_build else 'docker.io/' }}"
 matrix_mx_puppet_discord_docker_image_force_pull: "{{ matrix_mx_puppet_discord_docker_image.endswith(':latest') }}"
 

--- a/roles/matrix-bridge-mx-puppet-groupme/defaults/main.yml
+++ b/roles/matrix-bridge-mx-puppet-groupme/defaults/main.yml
@@ -11,7 +11,8 @@ matrix_mx_puppet_groupme_container_image_self_build_repo: "https://gitlab.com/ro
 # Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:8437"), or empty string to not expose.
 matrix_mx_puppet_groupme_container_http_host_bind_port: ''
 
-matrix_mx_puppet_groupme_docker_image: "{{ matrix_mx_puppet_groupme_docker_image_name_prefix }}xangelix/mx-puppet-groupme:latest"
+matrix_mx_puppet_groupme_version: latest
+matrix_mx_puppet_groupme_docker_image: "{{ matrix_mx_puppet_groupme_docker_image_name_prefix }}xangelix/mx-puppet-groupme:{{ matrix_mx_puppet_groupme_version }}"
 matrix_mx_puppet_groupme_docker_image_name_prefix: "{{ 'localhost/' if matrix_mx_puppet_groupme_container_image_self_build else 'docker.io/' }}"
 matrix_mx_puppet_groupme_docker_image_force_pull: "{{ matrix_mx_puppet_groupme_docker_image.endswith(':latest') }}"
 

--- a/roles/matrix-bridge-mx-puppet-instagram/defaults/main.yml
+++ b/roles/matrix-bridge-mx-puppet-instagram/defaults/main.yml
@@ -6,7 +6,8 @@ matrix_mx_puppet_instagram_enabled: true
 matrix_mx_puppet_instagram_container_image_self_build: false
 matrix_mx_puppet_instagram_container_image_self_build_repo: "https://github.com/Sorunome/mx-puppet-instagram.git"
 
-matrix_mx_puppet_instagram_docker_image: "{{ matrix_mx_puppet_instagram_docker_image_name_prefix }}sorunome/mx-puppet-instagram:latest"
+matrix_mx_puppet_instagram_version: latest
+matrix_mx_puppet_instagram_docker_image: "{{ matrix_mx_puppet_instagram_docker_image_name_prefix }}sorunome/mx-puppet-instagram:{{ matrix_mx_puppet_instagram_version }}"
 matrix_mx_puppet_instagram_docker_image_name_prefix: "{{ 'localhost/' if matrix_mx_puppet_instagram_container_image_self_build else 'docker.io/' }}"
 matrix_mx_puppet_instagram_docker_image_force_pull: "{{ matrix_mx_puppet_instagram_docker_image.endswith(':latest') }}"
 

--- a/roles/matrix-bridge-mx-puppet-skype/defaults/main.yml
+++ b/roles/matrix-bridge-mx-puppet-skype/defaults/main.yml
@@ -6,7 +6,8 @@ matrix_mx_puppet_skype_enabled: true
 matrix_mx_puppet_skype_container_image_self_build: false
 matrix_mx_puppet_skype_container_image_self_build_repo: "https://github.com/Sorunome/mx-puppet-skype.git"
 
-matrix_mx_puppet_skype_docker_image: "{{ matrix_mx_puppet_skype_docker_image_name_prefix }}sorunome/mx-puppet-skype:latest"
+matrix_mx_puppet_skype_version: latest
+matrix_mx_puppet_skype_docker_image: "{{ matrix_mx_puppet_skype_docker_image_name_prefix }}sorunome/mx-puppet-skype:{{ matrix_mx_puppet_skype_version }}"
 matrix_mx_puppet_skype_docker_image_name_prefix: "{{ 'localhost/' if matrix_mx_puppet_skype_container_image_self_build else 'docker.io/' }}"
 matrix_mx_puppet_skype_docker_image_force_pull: "{{ matrix_mx_puppet_skype_docker_image.endswith(':latest') }}"
 

--- a/roles/matrix-bridge-mx-puppet-slack/defaults/main.yml
+++ b/roles/matrix-bridge-mx-puppet-slack/defaults/main.yml
@@ -11,7 +11,8 @@ matrix_mx_puppet_slack_container_image_self_build_repo: "https://github.com/Soru
 # Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:8432"), or empty string to not expose.
 matrix_mx_puppet_slack_container_http_host_bind_port: ''
 
-matrix_mx_puppet_slack_docker_image: "{{ matrix_mx_puppet_slack_docker_image_name_prefix }}sorunome/mx-puppet-slack:latest"
+matrix_mx_puppet_slack_version: latest
+matrix_mx_puppet_slack_docker_image: "{{ matrix_mx_puppet_slack_docker_image_name_prefix }}sorunome/mx-puppet-slack:{{ matrix_mx_puppet_slack_version }}"
 matrix_mx_puppet_slack_docker_image_name_prefix: "{{ 'localhost/' if matrix_mx_puppet_slack_container_image_self_build else 'docker.io/' }}"
 matrix_mx_puppet_slack_docker_image_force_pull: "{{ matrix_mx_puppet_slack_docker_image.endswith(':latest') }}"
 

--- a/roles/matrix-bridge-mx-puppet-steam/defaults/main.yml
+++ b/roles/matrix-bridge-mx-puppet-steam/defaults/main.yml
@@ -11,7 +11,8 @@ matrix_mx_puppet_steam_container_image_self_build_repo: "https://github.com/icew
 # Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:8432"), or empty string to not expose.
 matrix_mx_puppet_steam_container_http_host_bind_port: ''
 
-matrix_mx_puppet_steam_docker_image: "{{ matrix_mx_puppet_steam_docker_image_name_prefix }}icewind1991/mx-puppet-steam:latest"
+matrix_mx_puppet_steam_version: latest
+matrix_mx_puppet_steam_docker_image: "{{ matrix_mx_puppet_steam_docker_image_name_prefix }}icewind1991/mx-puppet-steam:{{ matrix_mx_puppet_steam_version }}"
 matrix_mx_puppet_steam_docker_image_name_prefix: "{{ 'localhost/' if matrix_mx_puppet_steam_container_image_self_build else 'docker.io/' }}"
 matrix_mx_puppet_steam_docker_image_force_pull: "{{ matrix_mx_puppet_steam_docker_image.endswith(':latest') }}"
 

--- a/roles/matrix-bridge-mx-puppet-twitter/defaults/main.yml
+++ b/roles/matrix-bridge-mx-puppet-twitter/defaults/main.yml
@@ -11,7 +11,8 @@ matrix_mx_puppet_twitter_container_image_self_build_repo: "https://github.com/So
 # Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:8432"), or empty string to not expose.
 matrix_mx_puppet_twitter_container_http_host_bind_port: ''
 
-matrix_mx_puppet_twitter_docker_image: "{{ matrix_mx_puppet_twitter_docker_image_name_prefix }}sorunome/mx-puppet-twitter:latest"
+matrix_mx_puppet_twitter_version: latest
+matrix_mx_puppet_twitter_docker_image: "{{ matrix_mx_puppet_twitter_docker_image_name_prefix }}sorunome/mx-puppet-twitter:{{ matrix_mx_puppet_twitter_version }}"
 matrix_mx_puppet_twitter_docker_image_name_prefix: "{{ 'localhost/' if matrix_mx_puppet_twitter_container_image_self_build else 'docker.io/' }}"
 matrix_mx_puppet_twitter_docker_image_force_pull: "{{ matrix_mx_puppet_twitter_docker_image.endswith(':latest') }}"
 

--- a/roles/matrix-bridge-sms/defaults/main.yml
+++ b/roles/matrix-bridge-sms/defaults/main.yml
@@ -3,7 +3,8 @@
 
 matrix_sms_bridge_enabled: true
 
-matrix_sms_bridge_docker_image: "docker.io/folivonet/matrix-sms-bridge:0.5.5"
+matrix_sms_bridge_version: 0.5.5
+matrix_sms_bridge_docker_image: "docker.io/folivonet/matrix-sms-bridge:{{ matrix_sms_bridge_version }}"
 
 matrix_sms_bridge_base_path: "{{ matrix_base_data_path }}/matrix-sms-bridge"
 matrix_sms_bridge_config_path: "{{ matrix_base_data_path }}/matrix-sms-bridge/config"

--- a/roles/matrix-client-element/defaults/main.yml
+++ b/roles/matrix-client-element/defaults/main.yml
@@ -3,7 +3,8 @@ matrix_client_element_enabled: true
 matrix_client_element_container_image_self_build: false
 matrix_client_element_container_image_self_build_repo: "https://github.com/vector-im/riot-web.git"
 
-matrix_client_element_docker_image: "{{ matrix_client_element_docker_image_name_prefix }}vectorim/element-web:v1.7.21"
+matrix_client_element_version: v1.7.21
+matrix_client_element_docker_image: "{{ matrix_client_element_docker_image_name_prefix }}vectorim/element-web:{{ matrix_client_element_version }}"
 matrix_client_element_docker_image_name_prefix: "{{ 'localhost/' if matrix_client_element_container_image_self_build else 'docker.io/' }}"
 matrix_client_element_docker_image_force_pull: "{{ matrix_client_element_docker_image.endswith(':latest') }}"
 

--- a/roles/matrix-corporal/defaults/main.yml
+++ b/roles/matrix-corporal/defaults/main.yml
@@ -22,9 +22,10 @@ matrix_corporal_container_extra_arguments: []
 # List of systemd services that matrix-corporal.service depends on
 matrix_corporal_systemd_required_services_list: ['docker.service']
 
+matrix_corporal_version: 2.1.0
 matrix_corporal_docker_image: "{{ matrix_corporal_docker_image_name_prefix }}devture/matrix-corporal:{{ matrix_corporal_docker_image_tag }}"
 matrix_corporal_docker_image_name_prefix: "{{ 'localhost/' if matrix_corporal_container_image_self_build else 'docker.io/' }}"
-matrix_corporal_docker_image_tag: "2.1.0"
+matrix_corporal_docker_image_tag: "{{ matrix_corporal_version }}" # for backward-compatibility
 matrix_corporal_docker_image_force_pull: "{{ matrix_corporal_docker_image.endswith(':latest') }}"
 
 matrix_corporal_base_path: "{{ matrix_base_data_path }}/corporal"

--- a/roles/matrix-coturn/defaults/main.yml
+++ b/roles/matrix-coturn/defaults/main.yml
@@ -3,7 +3,8 @@ matrix_coturn_enabled: true
 matrix_coturn_container_image_self_build: false
 matrix_coturn_container_image_self_build_repo: "https://github.com/instrumentisto/coturn-docker-image.git"
 
-matrix_coturn_docker_image: "{{ matrix_coturn_docker_image_name_prefix }}instrumentisto/coturn:4.5.2"
+matrix_coturn_version: 4.5.2
+matrix_coturn_docker_image: "{{ matrix_coturn_docker_image_name_prefix }}instrumentisto/coturn:{{ matrix_coturn_version }}"
 matrix_coturn_docker_image_name_prefix: "{{ 'localhost/' if matrix_coturn_container_image_self_build else 'docker.io/' }}"
 matrix_coturn_docker_image_force_pull: "{{ matrix_coturn_docker_image.endswith(':latest') }}"
 

--- a/roles/matrix-dimension/defaults/main.yml
+++ b/roles/matrix-dimension/defaults/main.yml
@@ -12,7 +12,8 @@ matrix_dimension_widgets_allow_self_signed_ssl_certificates: false
 
 matrix_dimension_base_path: "{{ matrix_base_data_path }}/dimension"
 
-matrix_dimension_docker_image: "docker.io/turt2live/matrix-dimension:latest"
+matrix_dimension_version: latest
+matrix_dimension_docker_image: "docker.io/turt2live/matrix-dimension:{{ matrix_dimension_version }}"
 matrix_dimension_docker_image_force_pull: "{{ matrix_dimension_docker_image.endswith(':latest') }}"
 
 # List of systemd services that matrix-dimension.service depends on.

--- a/roles/matrix-dynamic-dns/defaults/main.yml
+++ b/roles/matrix-dynamic-dns/defaults/main.yml
@@ -4,8 +4,10 @@ matrix_dynamic_dns_enabled: true
 # The dynamic dns daemon interval
 matrix_dynamic_dns_daemon_interval: '300'
 
+matrix_dynamic_dns_version: v3.9.1-ls45
+
 # The docker container to use when in mode
-matrix_dynamic_dns_docker_image: '{{ matrix_dynamic_dns_docker_image_name_prefix }}linuxserver/ddclient:v3.9.1-ls45'
+matrix_dynamic_dns_docker_image: "{{ matrix_dynamic_dns_docker_image_name_prefix }}linuxserver/ddclient:{{ matrix_dynamic_dns_version }}"
 
 matrix_dynamic_dns_docker_image_name_prefix: "{{ 'localhost/' if matrix_dynamic_dns_container_image_self_build else 'docker.io/' }}"
 

--- a/roles/matrix-email2matrix/defaults/main.yml
+++ b/roles/matrix-email2matrix/defaults/main.yml
@@ -3,7 +3,8 @@ matrix_email2matrix_enabled: true
 matrix_email2matrix_base_path: "{{ matrix_base_data_path }}/email2matrix"
 matrix_email2matrix_config_dir_path: "{{ matrix_email2matrix_base_path }}/config"
 
-matrix_email2matrix_docker_image: "docker.io/devture/email2matrix:1.0.1"
+matrix_email2matrix_version: 1.0.1
+matrix_email2matrix_docker_image: "docker.io/devture/email2matrix:{{ matrix_email2matrix_version }}"
 matrix_email2matrix_docker_image_force_pull: "{{ matrix_email2matrix_docker_image.endswith(':latest') }}"
 
 # A list of extra arguments to pass to the container

--- a/roles/matrix-etherpad/defaults/main.yml
+++ b/roles/matrix-etherpad/defaults/main.yml
@@ -2,7 +2,8 @@ matrix_etherpad_enabled: false
 
 matrix_etherpad_base_path: "{{ matrix_base_data_path }}/etherpad"
 
-matrix_etherpad_docker_image: "docker.io/etherpad/etherpad:1.8.7"
+matrix_etherpad_version: 1.8.7
+matrix_etherpad_docker_image: "docker.io/etherpad/etherpad:{{ matrix_etherpad_version }}"
 matrix_etherpad_docker_image_force_pull: "{{ matrix_etherpad_docker_image.endswith(':latest') }}"
 
 # List of systemd services that matrix-etherpad.service depends on.

--- a/roles/matrix-grafana/defaults/main.yml
+++ b/roles/matrix-grafana/defaults/main.yml
@@ -3,7 +3,8 @@
 
 matrix_grafana_enabled: false
 
-matrix_grafana_docker_image: "docker.io/grafana/grafana:7.4.0"
+matrix_grafana_version: 7.4.0
+matrix_grafana_docker_image: "docker.io/grafana/grafana:{{ matrix_grafana_version }}"
 matrix_grafana_docker_image_force_pull: "{{ matrix_grafana_docker_image.endswith(':latest') }}"
 
 # Not conditional, because when someone disables metrics

--- a/roles/matrix-jitsi/defaults/main.yml
+++ b/roles/matrix-jitsi/defaults/main.yml
@@ -52,7 +52,8 @@ matrix_jitsi_jibri_recorder_password: ''
 
 matrix_jitsi_enable_lobby: false
 
-matrix_jitsi_container_image_tag: "stable-5142"
+matrix_jitsi_version: stable-5142
+matrix_jitsi_container_image_tag: "{{ matrix_jitsi_version }}" # for backward-compatibility
 
 matrix_jitsi_web_docker_image: "docker.io/jitsi/web:{{ matrix_jitsi_container_image_tag }}"
 matrix_jitsi_web_docker_image_force_pull: "{{ matrix_jitsi_web_docker_image.endswith(':latest') }}"

--- a/roles/matrix-mailer/defaults/main.yml
+++ b/roles/matrix-mailer/defaults/main.yml
@@ -7,7 +7,8 @@ matrix_mailer_container_image_self_build_repository_url: "https://github.com/dev
 matrix_mailer_container_image_self_build_src_files_path: "{{ matrix_mailer_base_path }}/docker-src"
 matrix_mailer_container_image_self_build_version: "{{ matrix_mailer_docker_image.split(':')[1] }}"
 
-matrix_mailer_docker_image: "{{ matrix_mailer_docker_image_name_prefix }}devture/exim-relay:4.93-r1"
+matrix_mailer_version: 4.93-r1
+matrix_mailer_docker_image: "{{ matrix_mailer_docker_image_name_prefix }}devture/exim-relay:{{ matrix_mailer_version }}"
 matrix_mailer_docker_image_name_prefix: "{{ 'localhost/' if matrix_mailer_container_image_self_build else 'docker.io/' }}"
 matrix_mailer_docker_image_force_pull: "{{ matrix_mailer_docker_image.endswith(':latest') }}"
 

--- a/roles/matrix-nginx-proxy/defaults/main.yml
+++ b/roles/matrix-nginx-proxy/defaults/main.yml
@@ -1,9 +1,10 @@
 matrix_nginx_proxy_enabled: true
+matrix_nginx_proxy_version: 1.19.6-alpine
 
 # We use an official nginx image, which we fix-up to run unprivileged.
 # An alternative would be an `nginxinc/nginx-unprivileged` image, but
 # that is frequently out of date.
-matrix_nginx_proxy_docker_image: "docker.io/nginx:1.19.6-alpine"
+matrix_nginx_proxy_docker_image: "docker.io/nginx:{{ matrix_nginx_proxy_version }}"
 matrix_nginx_proxy_docker_image_force_pull: "{{ matrix_nginx_proxy_docker_image.endswith(':latest') }}"
 
 matrix_nginx_proxy_base_path: "{{ matrix_base_data_path }}/nginx-proxy"

--- a/roles/matrix-prometheus-node-exporter/defaults/main.yml
+++ b/roles/matrix-prometheus-node-exporter/defaults/main.yml
@@ -3,7 +3,8 @@
 
 matrix_prometheus_node_exporter_enabled: false
 
-matrix_prometheus_node_exporter_docker_image: "docker.io/prom/node-exporter:v1.1.0"
+matrix_prometheus_node_exporter_version: v1.1.0
+matrix_prometheus_node_exporter_docker_image: "docker.io/prom/node-exporter:{{ matrix_prometheus_node_exporter_version }}"
 matrix_prometheus_node_exporter_docker_image_force_pull: "{{ matrix_prometheus_node_exporter_docker_image.endswith(':latest') }}"
 
 # A list of extra arguments to pass to the container

--- a/roles/matrix-prometheus/defaults/main.yml
+++ b/roles/matrix-prometheus/defaults/main.yml
@@ -3,7 +3,8 @@
 
 matrix_prometheus_enabled: false
 
-matrix_prometheus_docker_image: "docker.io/prom/prometheus:v2.24.1"
+matrix_prometheus_version: v2.24.1
+matrix_prometheus_docker_image: "docker.io/prom/prometheus:{{ matrix_prometheus_version }}"
 matrix_prometheus_docker_image_force_pull: "{{ matrix_prometheus_docker_image.endswith(':latest') }}"
 
 matrix_prometheus_base_path: "{{ matrix_base_data_path }}/prometheus"

--- a/roles/matrix-redis/defaults/main.yml
+++ b/roles/matrix-redis/defaults/main.yml
@@ -5,7 +5,8 @@ matrix_redis_connection_password: ""
 matrix_redis_base_path: "{{ matrix_base_data_path }}/redis"
 matrix_redis_data_path: "{{ matrix_redis_base_path }}/data"
 
-matrix_redis_docker_image_v6: "docker.io/redis:6.0.10-alpine"
+matrix_redis_version: 6.0.10-alpine
+matrix_redis_docker_image_v6: "docker.io/redis:{{ matrix_redis_version }}"
 matrix_redis_docker_image_latest: "{{ matrix_redis_docker_image_v6 }}"
 matrix_redis_docker_image_to_use: '{{ matrix_redis_docker_image_latest }}'
 

--- a/roles/matrix-synapse-admin/defaults/main.yml
+++ b/roles/matrix-synapse-admin/defaults/main.yml
@@ -8,7 +8,8 @@ matrix_synapse_admin_container_self_build_repo: "https://github.com/Awesome-Tech
 
 matrix_synapse_admin_docker_src_files_path: "{{ matrix_base_data_path }}/synapse-admin/docker-src"
 
-matrix_synapse_admin_docker_image: "{{ matrix_synapse_admin_docker_image_name_prefix }}awesometechnologies/synapse-admin:0.7.0"
+matrix_synapse_admin_version: 0.7.0
+matrix_synapse_admin_docker_image: "{{ matrix_synapse_admin_docker_image_name_prefix }}awesometechnologies/synapse-admin:{{ matrix_synapse_admin_version }}"
 matrix_synapse_admin_docker_image_name_prefix: "{{ 'localhost/' if matrix_synapse_admin_container_self_build else 'docker.io/' }}"
 matrix_synapse_admin_docker_image_force_pull: "{{ matrix_synapse_admin_docker_image.endswith(':latest') }}"
 

--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -15,7 +15,9 @@ matrix_synapse_docker_image_name_prefix: "{{ 'localhost/' if matrix_synapse_cont
 # amd64 gets released first.
 # arm32 relies on self-building, so the same version can be built immediately.
 # arm64 users need to wait for a prebuilt image to become available.
-matrix_synapse_docker_image_tag: "{{ 'v1.27.0' if matrix_architecture in ['arm32', 'amd64'] else 'v1.26.0' }}"
+matrix_synapse_version: v1.27.0
+matrix_synapse_version_arm64: v1.26.0
+matrix_synapse_docker_image_tag: "{{ matrix_synapse_version if matrix_architecture in ['arm32', 'amd64'] else matrix_synapse_version_arm64 }}"
 matrix_synapse_docker_image_force_pull: "{{ matrix_synapse_docker_image.endswith(':latest') }}"
 
 matrix_synapse_base_path: "{{ matrix_base_data_path }}/synapse"


### PR DESCRIPTION
Hello,
I want to propose `matrix_%SERVICE%_version` variable to simplify version management of dependencies.

Eventually, i want to have some kind of notification if new version of (just example) synapse-admin released and not included in the repo's role, but for now using such format allows to have standard way of defining docker images' version for all services and simplifies version check with "one-liners" (like grep/awk scripts to get list of used version).

simple example of "one-liner": 

```bash
grep -rhE "^matrix_.*_version: " ./roles/*/defaults/main.yml | sed -e "s/matrix_//;s/_version//" | sort
```

<details> 
  <summary>Result</summary>

```
appservice_discord: v1.0.0
appservice_irc: release-0.23.0
appservice_slack: release-1.5.0
appservice_webhooks: latest
bot_matrix_reminder_bot: release-v0.2.0
client_element: v1.7.21
corporal: 2.1.0
coturn: 4.5.2
dimension: latest
dynamic_dns: v3.9.1-ls45
email2matrix: 1.0.1
etherpad: 1.8.7
grafana: 7.4.0
jitsi_ldap: "3"
jitsi: stable-5142
ma1sd: "2.4.0"
mailer: 4.93-r1
mailer_container_image_self_build: "{{ matrix_mailer_docker_image.split(':')[1] }}"
mautrix_facebook: latest
mautrix_hangouts: latest
mautrix_instagram: latest
mautrix_signal_daemon: latest
mautrix_signal: latest
mautrix_telegram: v0.9.0
mautrix_whatsapp: latest
mx_puppet_discord: latest
mx_puppet_groupme: latest
mx_puppet_instagram: latest
mx_puppet_skype: latest
mx_puppet_slack: latest
mx_puppet_steam: latest
mx_puppet_twitter: latest
nginx_proxy: 1.19.6-alpine
prometheus_node_exporter: v1.1.0
prometheus: v2.24.1
redis: 6.0.10-alpine
registration: "v0.7.2"
sms_bridge: 0.5.5
synapse_admin: 0.7.0
synapse_default_room: "6"
synapse_ext_spam_checker_synapse_simple_antispam_git: "f058d9ce2c7d4195ae461dcdd02df11a2d06a36b"
synapse: v1.27.0
```

</details>

PS: that PR preserves backward-compatibility with roles/services that already used similar variables