### PR TITLE
Update lower power config example

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -289,7 +289,7 @@ matrix_mailer_enabled: false
 
 # You can also disable this to save more RAM,
 # at the expense of audio/video calls being unreliable.
-matrix_coturn_enabled: true
+matrix_coturn_enabled: false
 
 # This makes Synapse not keep track of who is online/offline.
 #


### PR DESCRIPTION
All examples in that section show the config to lower the memory usage on the server. However the `matrix_coturn_enabled` config is set to `true` when my understanding of it is that to lower the memory usage you have to set it to `false`