### PR TITLE
Recommend a better way of backing up postgres

### DIFF
--- a/docs/maintenance-postgres.md
+++ b/docs/maintenance-postgres.md
@@ -51,15 +51,12 @@ ansible-playbook -i inventory/hosts setup.yml --tags=run-postgres-vacuum,start
 To make a back up of the current PostgreSQL database, make sure it's running and then execute a command like this on the server:
 
 ```bash
-docker run \
---rm \
---log-driver=none \
---network=matrix \
+/usr/bin/docker exec \
 --env-file=/matrix/postgres/env-postgres-psql \
-docker.io/postgres:13.1-alpine \
-pg_dumpall -h matrix-postgres \
+matrix-postgres \
+/usr/local/bin/pg_dumpall -h matrix-postgres \
 | gzip -c \
-> /postgres.sql.gz
+> /matrix/postgres.sql.gz
 ```
 
 If you are using an [external Postgres server](configuring-playbook-external-postgres.md), the above command will not work, because the credentials file (`/matrix/postgres/env-postgres-psql`) is not available.

--- a/docs/maintenance-postgres.md
+++ b/docs/maintenance-postgres.md
@@ -59,9 +59,7 @@ matrix-postgres \
 > /matrix/postgres.sql.gz
 ```
 
-If you are using an [external Postgres server](configuring-playbook-external-postgres.md), the above command will not work, because the credentials file (`/matrix/postgres/env-postgres-psql`) is not available.
-
-If your server is on the ARM32 [architecture](alternative-architectures.md), you may need to remove the `-alpine` suffix from the image name in the command above.
+If you are using an [external Postgres server](configuring-playbook-external-postgres.md), the above command will not work, because neither the credentials file (`/matrix/postgres/env-postgres-psql`), nor the `matrix-postgres` container is available.
 
 Restoring a backup made this way can be done by [importing it](importing-postgres.md).
 


### PR DESCRIPTION
The recommended way of backing up postgres has a couple of drawbacks:
- It uses a hardcoded Postgres version that's not guaranteed to be the same as the running one
- It spawns an extra container just to perform the dump

This PR proposes a slightly more elegant solution:
- Calls pg_dumpall inside the matrix-postgres container, ensuring that the version is always compatible. This also removes the need to download potentially another image
- Stores the backup file under /matrix so a backup of the whole folder (as recommended) will also contain a consistent DB dump
- Uses absolute paths for good measure, just in case something in the ENV is messed up