### PR TITLE
Added paragraph about updating DNS to get stats

### DIFF
--- a/docs/configuring-playbook-prometheus-grafana.md
+++ b/docs/configuring-playbook-prometheus-grafana.md
@@ -4,6 +4,8 @@ It can be useful to have some (visual) insight into the performance of your home
 
 You can enable this with the following settings in your configuration file (`inventory/host_vars/matrix.<your-domain>/vars.yml`):
 
+Remember to add `stats.<your-domain>` to DNS as described in [Configuring DNS](configuring-dns.md) before running the playbook.
+
 ```yaml
 matrix_prometheus_enabled: true
 


### PR DESCRIPTION
This document didn't describe that it is necessary to have a DNS-entry for stats sub-domain.