### PR TITLE
rust-compress-state debug: indent the chonky json

### DIFF
--- a/roles/matrix-synapse/tasks/rust-synapse-compress-state/main.yml
+++ b/roles/matrix-synapse/tasks/rust-synapse-compress-state/main.yml
@@ -100,7 +100,7 @@
           The following rooms contain more than {{ matrix_synapse_rust_synapse_compress_state_min_state_groups_required }} state group rows
           (configurable via `matrix_synapse_rust_synapse_compress_state_min_state_groups_required`)
           and will be compressed:
-          {{ matrix_synapse_rust_synapse_compress_state_eligible_rooms }}
+          {{ matrix_synapse_rust_synapse_compress_state_eligible_rooms | to_nice_json(indent=2) }}
 
     - name: Compress room state
       include_tasks: "{{ role_path }}/tasks/rust-synapse-compress-state/compress_room.yml"


### PR DESCRIPTION
If the room list gets posted in the debug step, at least make it readable.

However something doesn't seem right to me.
Internally, `{{ matrix_synapse_rust_synapse_compress_state_eligible_rooms }}` is an array of objects, not a JSON string.
The **debug** step should have a sane default to pretty print the output, and not rely on us manually applying the filter.
If there is a way to configure what filter is used when Ansible is printing data to a terminal, let me know please.