### PR TITLE
Run Let's Encrypt renewal checks daily instead of weekly.

### DIFF
--- a/roles/matrix-coturn/templates/systemd/matrix-coturn-reload.timer.j2
+++ b/roles/matrix-coturn/templates/systemd/matrix-coturn-reload.timer.j2
@@ -3,8 +3,8 @@ Description=Reloads matrix-coturn periodically so that new SSL certificates can 
 
 [Timer]
 Unit=matrix-coturn-reload.service
-OnCalendar=Sunday *-*-* 13:00:00
-RandomizedDelaySec=3h
+OnCalendar=*-*-* 06:30:00
+RandomizedDelaySec=1h
 
 [Install]
 WantedBy=timers.target

--- a/roles/matrix-nginx-proxy/templates/systemd/matrix-ssl-lets-encrypt-certificates-renew.timer.j2
+++ b/roles/matrix-nginx-proxy/templates/systemd/matrix-ssl-lets-encrypt-certificates-renew.timer.j2
@@ -3,8 +3,8 @@ Description=Renews Let's Encrypt SSL certificates periodically
 
 [Timer]
 Unit=matrix-ssl-lets-encrypt-certificates-renew.service
-OnCalendar=Sunday *-*-* 05:00:00
-RandomizedDelaySec=3h
+OnCalendar=*-*-* 04:00:00
+RandomizedDelaySec=2h
 
 [Install]
 WantedBy=timers.target

--- a/roles/matrix-nginx-proxy/templates/systemd/matrix-ssl-nginx-proxy-reload.timer.j2
+++ b/roles/matrix-nginx-proxy/templates/systemd/matrix-ssl-nginx-proxy-reload.timer.j2
@@ -3,8 +3,8 @@ Description=Reloads matrix-nginx-proxy periodically so that new SSL certificates
 
 [Timer]
 Unit=matrix-ssl-nginx-proxy-reload.service
-OnCalendar=Sunday *-*-* 13:00:00
-RandomizedDelaySec=3h
+OnCalendar=*-*-* 06:30:00
+RandomizedDelaySec=1h
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
Currently we check for new certificates once a week. While this works well, this pull request ensures more timely updates of certifcates.

To be honest, I'm not sure this update is really needed, but following our recent discussion I promised to submit a pull request. I won't be offended if it doesn't get merged as one could easily argue that it's not a good idea to change something that already works well.

Also, we're needlessly restarting nginx every day around 6:30 a.m. with this update (and Coturn as well if enabled), although I doubt there is much going on at this time of day in most deployments ... :smile: 