### PR TITLE
Added nginx proxy worker configuration to template and defaults

### DIFF
--- a/roles/matrix-nginx-proxy/defaults/main.yml
+++ b/roles/matrix-nginx-proxy/defaults/main.yml
@@ -364,3 +364,9 @@ matrix_nginx_proxy_synapse_generic_worker_federation_locations: []
 matrix_nginx_proxy_synapse_media_repository_locations: []
 matrix_nginx_proxy_synapse_user_dir_locations: []
 matrix_nginx_proxy_synapse_frontend_proxy_locations: []
+
+# The amount of worker processes and connections
+# Consider increasing these when you are expecting high amounts of traffic
+# http://nginx.org/en/docs/ngx_core_module.html#worker_connections
+matrix_nginx_proxy_worker_processes: 1
+matrix_nginx_proxy_worker_connections: 1024

--- a/roles/matrix-nginx-proxy/templates/nginx/nginx.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/nginx.conf.j2
@@ -8,14 +8,13 @@
 # - various temp paths are changed to `/tmp`, so that a non-root user can write to them
 # - the `user` directive was removed, as we don't want nginx to switch users
 
-worker_processes 1;
-
+worker_processes {{ matrix_nginx_proxy_worker_processes }};
 error_log /var/log/nginx/error.log warn;
 pid /tmp/nginx.pid;
 
 
 events {
-	worker_connections 1024;
+	worker_connections {{ matrix_nginx_proxy_worker_connections }};
 }
 
 


### PR DESCRIPTION
On my deployment's nginx server I get a lot of errors stating that the default amount (1024) of worker connections is not enough. This PR allows users to configure the amount of worker connections and worker processes. 
A PR (#544) was made implementing this before, but was not completed. I have implemented the comments made on that PR in this PR.