### PR TITLE
Adjust wait timeout

### DIFF
--- a/roles/matrix-common-after/tasks/start.yml
+++ b/roles/matrix-common-after/tasks/start.yml
@@ -30,7 +30,7 @@
 # as we may run into systemd's automatic restart logic retrying the service.
 - name: Wait a bit, so that services can start (or fail)
   wait_for:
-    timeout: 5
+    timeout: 15
   delegate_to: 127.0.0.1
   become: false
 


### PR DESCRIPTION
During first setup postgres takes its time to get up and running, resulting in "postgres in startup" exceptions from synapse if you run without additional services that come in between. Hence suggesting increasing the time a bit to avoid having an error which heals itself and thus is hard to spot for newcomers.