### PR TITLE
Adding an initialization script

### DIFF
--- a/docs/configuring-playbook.md
+++ b/docs/configuring-playbook.md
@@ -6,7 +6,7 @@ To configure the playbook, you need to have done the following things:
 - [configured your DNS records](configuring-dns.md)
 - [retrieved the playbook's source code](getting-the-playbook.md) to your computer
 
-You can then initialize the the configuration files `vars.yml` and `hosts` by running `./initialize.sh`. If you need to change the variables, you can opt to run the script again.
+You can then initialize the configuration files `vars.yml` and `hosts` by running `./initialize.sh`. If you need to change the variables, you can opt to run the script again.
 
 For a basic Matrix installation, that's all you need.
 For a more custom setup, see the [Other configuration options](#other-configuration-options) below.

--- a/docs/configuring-playbook.md
+++ b/docs/configuring-playbook.md
@@ -6,18 +6,7 @@ To configure the playbook, you need to have done the following things:
 - [configured your DNS records](configuring-dns.md)
 - [retrieved the playbook's source code](getting-the-playbook.md) to your computer
 
-You can then follow these steps inside the playbook directory:
-
-- create a directory to hold your configuration (`mkdir inventory/host_vars/matrix.<your-domain>`)
-
-- copy the sample configuration file (`cp examples/vars.yml inventory/host_vars/matrix.<your-domain>/vars.yml`)
-
-- edit the configuration file (`inventory/host_vars/matrix.<your-domain>/vars.yml`) to your liking. You may also take a look at the various `roles/ROLE_NAME_HERE/defaults/main.yml` files and see if there's something you'd like to copy over and override in your `vars.yml` configuration file.
-
-- copy the sample inventory hosts file (`cp examples/hosts inventory/hosts`)
-
-- edit the inventory hosts file (`inventory/hosts`) to your liking
-
+You can then initialize the the configuration files `vars.yml` and `hosts` by running `./initialize.sh`. If you need to change the variables, you can opt to run the script again.
 
 For a basic Matrix installation, that's all you need.
 For a more custom setup, see the [Other configuration options](#other-configuration-options) below.

--- a/initialize.sh
+++ b/initialize.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# clear out old variables if they exist
+if test -f ./vars.yml*; then
+  rm ./vars.yml*
+fi
+if test -f ./hosts*; then
+  rm ./hosts*
+fi
+rm -rf inventory/host_vars/*
+if test -f inventory/hosts*; then
+  rm inventory/hosts*
+fi
+
+# prompt the user for basic info
+read -p "Enter the base domain (e.g. example.com): " domain
+read -p "Enter the external IP address: " address
+
+# initialize vars.yml
+mkdir inventory/host_vars/matrix.$domain
+cp examples/vars.yml inventory/host_vars/matrix.$domain/vars.yml
+sed -i "s/matrix_domain: YOUR_BARE_DOMAIN_NAME_HERE/matrix_domain: $domain/" inventory/host_vars/matrix.$domain/vars.yml
+
+read -p "Enable automatic SSL certificate management? (y/n): " cert
+
+if [[ $cert == "n" || $cert == "N" ]]
+then
+  sed -i "s/matrix_ssl_lets_encrypt_support_email: ''/matrix_ssl_retrieval_method: /" inventory/host_vars/matrix.$domain/vars.yml
+else
+  read -p "Provide an email for contact from Let's Encrypt: " email
+  sed -i "s/matrix_ssl_lets_encrypt_support_email: '/matrix_ssl_lets_encrypt_support_email: \'$email/" inventory/host_vars/matrix.$domain/vars.yml
+fi
+
+pw=$(openssl rand -hex 64)
+sed -i "s/matrix_coturn_turn_static_auth_secret: '/matrix_coturn_turn_static_auth_secret: \'$pw/" inventory/host_vars/matrix.$domain/vars.yml
+pw=$(openssl rand -hex 64)
+sed -i "s/matrix_synapse_macaroon_secret_key: '/matrix_synapse_macaroon_secret_key: \'$pw/" inventory/host_vars/matrix.$domain/vars.yml
+pw=$(openssl rand -hex 64)
+sed -i "s/matrix_postgres_connection_password: '/matrix_postgres_connection_password: \'$pw/" inventory/host_vars/matrix.$domain/vars.yml
+
+# initialize hosts
+cp examples/hosts inventory/hosts
+sed -i "s/matrix.<your-domain> ansible_host=<your-server's external IP address>/matrix.$domain ansible_host=$address/" inventory/hosts
+
+read -p "Are you running this Ansible playbook on the same server as the one you're installing to? (y/n): " same
+
+if [[ $same == "y" || $same == "Y" ]]
+then
+  sed -i "s/ansible_ssh_user=root/ansible_ssh_user=root ansible_connection=local/" inventory/hosts
+fi
+
+# create symbolic links to make the config files more accessible
+ln -s inventory/host_vars/matrix.$domain/vars.yml .
+ln -s inventory/hosts .
+
+echo "The files 'vars.yml' and 'hosts' are ready to be configured."


### PR DESCRIPTION
I created a basic bash script to streamline the initial process for creating the `vars.yml` and `hosts` files. Users can simply run the script and enter the prompted information. If the user desires to change the previously entered information, they can simply run the script again.