### PR TITLE
Adding vars to synapse for private servers

### DIFF
--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -181,6 +181,26 @@ matrix_synapse_allow_public_rooms_without_auth: false
 # For private servers, you most likely wish to forbid it.
 matrix_synapse_allow_public_rooms_over_federation: false
 
+# Whether to require authentication to retrieve profile data (avatars,
+# display names) of other users through the client API. Defaults to
+# 'false'. Note that profile data is also available via the federation
+# API, so this setting is of limited value if federation is enabled on
+# the server.
+matrix_synapse_require_auth_for_profile_requests: false
+
+# Set to true to require a user to share a room with another user in order
+# to retrieve their profile information. Only checked on Client-Server
+# requests. Profile requests from other servers should be checked by the
+# requesting server. Defaults to 'false'.
+matrix_synapse_limit_profile_requests_to_users_who_share_rooms: false
+
+# Set to false to prevent a user's profile data from being retrieved and
+# displayed in a room until they have joined it. By default, a user's
+# profile data is included in an invite event, regardless of the values
+# of the above two settings, and whether or not the users share a server.
+# Defaults to 'true'.
+matrix_synapse_include_profile_data_on_invite: true
+
 # Controls whether people with access to the homeserver can register by themselves.
 matrix_synapse_enable_registration: false
 

--- a/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -68,14 +68,14 @@ use_presence: {{ matrix_synapse_use_presence|to_json }}
 # API, so this setting is of limited value if federation is enabled on
 # the server.
 #
-#require_auth_for_profile_requests: true
+require_auth_for_profile_requests: {{ matrix_synapse_require_auth_for_profile_requests|to_json }}
 
 # Uncomment to require a user to share a room with another user in order
 # to retrieve their profile information. Only checked on Client-Server
 # requests. Profile requests from other servers should be checked by the
 # requesting server. Defaults to 'false'.
 #
-#limit_profile_requests_to_users_who_share_rooms: true
+limit_profile_requests_to_users_who_share_rooms: {{ matrix_synapse_limit_profile_requests_to_users_who_share_rooms|to_json }}
 
 # Uncomment to prevent a user's profile data from being retrieved and
 # displayed in a room until they have joined it. By default, a user's
@@ -83,7 +83,7 @@ use_presence: {{ matrix_synapse_use_presence|to_json }}
 # of the above two settings, and whether or not the users share a server.
 # Defaults to 'true'.
 #
-#include_profile_data_on_invite: false
+include_profile_data_on_invite: {{ matrix_synapse_include_profile_data_on_invite|to_json }}
 
 # If set to 'true', removes the need for authentication to access the server's
 # public rooms directory through the client API, meaning that anyone can


### PR DESCRIPTION
Added Ansible vars to be able to configure the following synapse settings:

- include_profile_data_on_invite
- require_auth_for_profile_requests
- limit_profile_requests_to_users_who_share_rooms