### PR TITLE
matrix-nginx-proxy: specify Origin header, comply with CORS

### DIFF
--- a/roles/matrix-nginx-proxy/tasks/self_check_well_known_file.yml
+++ b/roles/matrix-nginx-proxy/tasks/self_check_well_known_file.yml
@@ -12,6 +12,8 @@
     follow_redirects: none
     return_content: true
     validate_certs: "{{ well_known_file_check.validate_certs }}"
+    headers:
+      Origin: example.com
   check_mode: no
   register: result_well_known_matrix
   ignore_errors: true
@@ -40,6 +42,8 @@
     follow_redirects: "{{ well_known_file_check.follow_redirects }}"
     return_content: true
     validate_certs: "{{ well_known_file_check.validate_certs }}"
+    headers:
+      Origin: example.com
   check_mode: no
   register: result_well_known_identity
   ignore_errors: true


### PR DESCRIPTION
Self-checks against the .well-known URIs look for the HTTP header
"Access-Control-Allow-Origin" indicating that the remode endpoint
supports CORS. But the remote server is not required to include
said header in the response if the HTTP request does not include
the "Origin" header. This is in accordance with the specification
[1] stating: 'A CORS request is an HTTP request that includes an
"Origin" header.'

This is in fact true for Gitlab pages hosting and that's why the
issue was identified.

Let's specify "Origin" header in the respective uri tasks performing
the HTTP request and ensure a CORS request.

[1] https://fetch.spec.whatwg.org/#http-requests