### PR TITLE
Another field with 'invalid input syntax for type smallint'

### DIFF
--- a/roles/matrix-dimension/tasks/setup_install.yml
+++ b/roles/matrix-dimension/tasks/setup_install.yml
@@ -40,6 +40,7 @@
             - {'table': 'dimension_sticker_packs', 'column': 'isPublic', 'default': ''}
             - {'table': 'dimension_slack_bridges', 'column': 'isEnabled', 'default': ''}
             - {'table': 'dimension_neb_integrations', 'column': 'isPublic', 'default': ''}
+            - {'table': 'dimension_neb_integrations', 'column': 'isEnabled', 'default': ''}
             - {'table': 'dimension_irc_bridges', 'column': 'isEnabled', 'default': ''}
             - {'table': 'dimension_irc_bridge_networks', 'column': 'isEnabled', 'default': ''}
             - {'table': 'dimension_gitter_bridges', 'column': 'isEnabled', 'default': ''}


### PR DESCRIPTION
Looks like this field was forgotten in https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/80c72615c7bfdcf47644d55f033e88f4e610cf25

SequelizeDatabaseError: invalid input syntax for type smallint: "false" error in the logs when adding a custom go-neb bot in dimension.