### PR TITLE
matrix.{{ matrix_domain }} -> {{ matrix_server_fqn_matrix }}

### DIFF
--- a/roles/matrix-awx/surveys/configure_synapse_admin.json.j2
+++ b/roles/matrix-awx/surveys/configure_synapse_admin.json.j2
@@ -4,7 +4,7 @@
   "spec": [
     {
       "question_name": "Enable Synapse Admin",
-      "question_description": "Set if Synapse Admin is enabled or not. If enabled you can access it at https://matrix.{{ matrix_domain }}/synapse-admin.",
+      "question_description": "Set if Synapse Admin is enabled or not. If enabled you can access it at https://{{ matrix_server_fqn_matrix }}/synapse-admin.",
       "required": false,
       "min": null,
       "max": null,

--- a/roles/matrix-bridge-appservice-slack/defaults/main.yml
+++ b/roles/matrix-bridge-appservice-slack/defaults/main.yml
@@ -32,7 +32,7 @@ matrix_appservice_slack_slack_port: 9003
 # Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:9999"), or empty string to not expose.
 matrix_appservice_slack_container_http_host_bind_port: ''
 
-matrix_appservice_slack_homeserver_media_url: "matrix.{{ matrix_domain }}"
+matrix_appservice_slack_homeserver_media_url: "{{ matrix_server_fqn_matrix }}"
 matrix_appservice_slack_homeserver_url: "http://matrix-synapse:8008"
 matrix_appservice_slack_homeserver_domain: "{{ matrix_domain }}"
 matrix_appservice_slack_appservice_url: 'http://matrix-appservice-slack'

--- a/roles/matrix-bridge-appservice-webhooks/defaults/main.yml
+++ b/roles/matrix-bridge-appservice-webhooks/defaults/main.yml
@@ -28,7 +28,7 @@ matrix_appservice_webhooks_matrix_port: 6789
 # Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:9999"), or empty string to not expose.
 matrix_appservice_webhooks_container_http_host_bind_port: ''
 
-matrix_appservice_webhooks_homeserver_media_url: "matrix.{{ matrix_domain }}"
+matrix_appservice_webhooks_homeserver_media_url: "{{ matrix_server_fqn_matrix }}"
 matrix_appservice_webhooks_homeserver_url: "http://matrix-synapse:8008"
 matrix_appservice_webhooks_homeserver_domain: "{{ matrix_domain }}"
 matrix_appservice_webhooks_appservice_url: 'http://matrix-appservice-webhooks'


### PR DESCRIPTION
In case anyone wanted to use a domain name other than matrix.DOMAIN