### PR TITLE
feat: push ephemeral events to appservices

### DIFF
--- a/roles/matrix-bridge-mautrix-facebook/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-facebook/defaults/main.yml
@@ -110,5 +110,6 @@ matrix_mautrix_facebook_registration_yaml: |
   # See https://github.com/tulir/mautrix-signal/issues/43
   sender_localpart: _bot_{{ matrix_mautrix_facebook_appservice_bot_username }}
   rate_limited: false
+  de.sorunome.msc2409.push_ephemeral: true
 
 matrix_mautrix_facebook_registration: "{{ matrix_mautrix_facebook_registration_yaml|from_yaml }}"

--- a/roles/matrix-bridge-mautrix-hangouts/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-hangouts/defaults/main.yml
@@ -110,5 +110,6 @@ matrix_mautrix_hangouts_registration_yaml: |
   # See https://github.com/tulir/mautrix-signal/issues/43
   sender_localpart: _bot_{{ matrix_mautrix_hangouts_appservice_bot_username }}
   rate_limited: false
+  de.sorunome.msc2409.push_ephemeral: true
 
 matrix_mautrix_hangouts_registration: "{{ matrix_mautrix_hangouts_registration_yaml|from_yaml }}"

--- a/roles/matrix-bridge-mautrix-instagram/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-instagram/defaults/main.yml
@@ -100,5 +100,6 @@ matrix_mautrix_instagram_registration_yaml: |
   # See https://github.com/tulir/mautrix-signal/issues/43
   sender_localpart: _bot_{{ matrix_mautrix_instagram_appservice_bot_username }}
   rate_limited: false
+  de.sorunome.msc2409.push_ephemeral: true
 
 matrix_mautrix_instagram_registration: "{{ matrix_mautrix_instagram_registration_yaml|from_yaml }}"

--- a/roles/matrix-bridge-mautrix-signal/templates/registration.yaml.j2
+++ b/roles/matrix-bridge-mautrix-signal/templates/registration.yaml.j2
@@ -15,3 +15,4 @@ url: {{ matrix_mautrix_signal_appservice_address }}
 # See https://github.com/tulir/mautrix-signal/issues/43
 sender_localpart: _bot_{{ matrix_mautrix_signal_appservice_bot_username }}
 rate_limited: false
+de.sorunome.msc2409.push_ephemeral: true

--- a/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
@@ -121,5 +121,6 @@ matrix_mautrix_telegram_registration_yaml: |
   sender_localpart: _bot_{{ matrix_mautrix_telegram_appservice_bot_username }}
   url: {{ matrix_mautrix_telegram_appservice_address }}
   rate_limited: false
+  de.sorunome.msc2409.push_ephemeral: true
 
 matrix_mautrix_telegram_registration: "{{ matrix_mautrix_telegram_registration_yaml|from_yaml }}"

--- a/roles/matrix-bridge-mautrix-whatsapp/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-whatsapp/defaults/main.yml
@@ -105,5 +105,6 @@ matrix_mautrix_whatsapp_registration_yaml: |
         exclusive: true
       - exclusive: true
         regex: '^@{{ matrix_mautrix_whatsapp_appservice_bot_username|regex_escape }}:{{ matrix_mautrix_whatsapp_homeserver_domain|regex_escape }}$'
+  de.sorunome.msc2409.push_ephemeral: true
 
 matrix_mautrix_whatsapp_registration: "{{ matrix_mautrix_whatsapp_registration_yaml|from_yaml }}"

--- a/roles/matrix-bridge-mx-puppet-discord/defaults/main.yml
+++ b/roles/matrix-bridge-mx-puppet-discord/defaults/main.yml
@@ -108,5 +108,6 @@ matrix_mx_puppet_discord_registration_yaml: |
   rate_limited: false
   sender_localpart: _discordpuppet_bot
   url: {{ matrix_mx_puppet_discord_appservice_address }}
+  de.sorunome.msc2409.push_ephemeral: true
 
 matrix_mx_puppet_discord_registration: "{{ matrix_mx_puppet_discord_registration_yaml|from_yaml }}"

--- a/roles/matrix-bridge-mx-puppet-groupme/defaults/main.yml
+++ b/roles/matrix-bridge-mx-puppet-groupme/defaults/main.yml
@@ -107,5 +107,6 @@ matrix_mx_puppet_groupme_registration_yaml: |
   rate_limited: false
   sender_localpart: _groupmepuppet_bot
   url: {{ matrix_mx_puppet_groupme_appservice_address }}
+  de.sorunome.msc2409.push_ephemeral: true
 
 matrix_mx_puppet_groupme_registration: "{{ matrix_mx_puppet_groupme_registration_yaml|from_yaml }}"

--- a/roles/matrix-bridge-mx-puppet-instagram/defaults/main.yml
+++ b/roles/matrix-bridge-mx-puppet-instagram/defaults/main.yml
@@ -98,5 +98,6 @@ matrix_mx_puppet_instagram_registration_yaml: |
   rate_limited: false
   sender_localpart: _instagrampuppet_bot
   url: {{ matrix_mx_puppet_instagram_appservice_address }}
+  de.sorunome.msc2409.push_ephemeral: true
 
 matrix_mx_puppet_instagram_registration: "{{ matrix_mx_puppet_instagram_registration_yaml|from_yaml }}"

--- a/roles/matrix-bridge-mx-puppet-skype/defaults/main.yml
+++ b/roles/matrix-bridge-mx-puppet-skype/defaults/main.yml
@@ -106,5 +106,6 @@ matrix_mx_puppet_skype_registration_yaml: |
   rate_limited: false
   sender_localpart: _skypepuppet_bot
   url: {{ matrix_mx_puppet_skype_appservice_address }}
+  de.sorunome.msc2409.push_ephemeral: true
 
 matrix_mx_puppet_skype_registration: "{{ matrix_mx_puppet_skype_registration_yaml|from_yaml }}"

--- a/roles/matrix-bridge-mx-puppet-slack/defaults/main.yml
+++ b/roles/matrix-bridge-mx-puppet-slack/defaults/main.yml
@@ -110,5 +110,6 @@ matrix_mx_puppet_slack_registration_yaml: |
   rate_limited: false
   sender_localpart: _slackpuppet_bot
   url: {{ matrix_mx_puppet_slack_appservice_address }}
+  de.sorunome.msc2409.push_ephemeral: true
 
 matrix_mx_puppet_slack_registration: "{{ matrix_mx_puppet_slack_registration_yaml|from_yaml }}"

--- a/roles/matrix-bridge-mx-puppet-steam/defaults/main.yml
+++ b/roles/matrix-bridge-mx-puppet-steam/defaults/main.yml
@@ -107,5 +107,6 @@ matrix_mx_puppet_steam_registration_yaml: |
   rate_limited: false
   sender_localpart: _steampuppet_bot
   url: {{ matrix_mx_puppet_steam_appservice_address }}
+  de.sorunome.msc2409.push_ephemeral: true
 
 matrix_mx_puppet_steam_registration: "{{ matrix_mx_puppet_steam_registration_yaml|from_yaml }}"

--- a/roles/matrix-bridge-mx-puppet-twitter/defaults/main.yml
+++ b/roles/matrix-bridge-mx-puppet-twitter/defaults/main.yml
@@ -117,5 +117,6 @@ matrix_mx_puppet_twitter_registration_yaml: |
   rate_limited: false
   sender_localpart: "{{ matrix_mx_puppet_twitter_bot_localpart }}"
   url: {{ matrix_mx_puppet_twitter_appservice_address }}
+  de.sorunome.msc2409.push_ephemeral: true
 
 matrix_mx_puppet_twitter_registration: "{{ matrix_mx_puppet_twitter_registration_yaml|from_yaml }}"


### PR DESCRIPTION
This adds https://github.com/matrix-org/matrix-doc/pull/2409 to the
appservice registrations, enabling synapse to push EDUs to appservices.