### PR TITLE
Make realms and sessions optional for go-neb config

### DIFF
--- a/roles/matrix-bot-go-neb/defaults/main.yml
+++ b/roles/matrix-bot-go-neb/defaults/main.yml
@@ -68,7 +68,7 @@ matrix_bot_go_neb_clients: {}
 # Delete or modify this list as appropriate.
 # See the docs for /configureAuthRealm for the full list of options:
 # https://matrix-org.github.io/go-neb/pkg/github.com/matrix-org/go-neb/api/index.html#ConfigureAuthRealmRequest
-matrix_bot_go_neb_realms: {}
+#matrix_bot_go_neb_realms:
 #  - ID: "github_realm"
 #    Type: "github"
 #    Config: {} # No need for client ID or Secret as Go-NEB isn't generating OAuth URLs
@@ -78,7 +78,7 @@ matrix_bot_go_neb_realms: {}
 # The full list of options are shown below: there is no single HTTP endpoint
 # which maps to this section.
 # https://matrix-org.github.io/go-neb/pkg/github.com/matrix-org/go-neb/api/index.html#Session
-matrix_bot_go_neb_sessions: {}
+#matrix_bot_go_neb_sessions:
 #  - SessionID: "your_github_session"
 #    RealmID: "github_realm"
 #    UserID: "@YOUR_USER_ID:{{ matrix_domain }}" # This needs to be the username of the person that's allowed to use the !github commands

--- a/roles/matrix-bot-go-neb/templates/config.yaml.j2
+++ b/roles/matrix-bot-go-neb/templates/config.yaml.j2
@@ -25,16 +25,20 @@ clients:
 # Delete or modify this list as appropriate.
 # See the docs for /configureAuthRealm for the full list of options:
 # https://matrix-org.github.io/go-neb/pkg/github.com/matrix-org/go-neb/api/index.html#ConfigureAuthRealmRequest
+{% if matrix_bot_go_neb_realms is defined %}
 realms:
   {{ matrix_bot_go_neb_realms|to_json }}
+{% endif %}
 
 # The list of *authenticated* sessions which Go-NEB is aware of.
 # Delete or modify this list as appropriate.
 # The full list of options are shown below: there is no single HTTP endpoint
 # which maps to this section.
 # https://matrix-org.github.io/go-neb/pkg/github.com/matrix-org/go-neb/api/index.html#Session
+{% if matrix_bot_go_neb_sessions is defined %}
 sessions:
   {{ matrix_bot_go_neb_sessions|to_json }}
+{% endif %}
 
 # The list of services which Go-NEB is aware of.
 # Delete or modify this list as appropriate.


### PR DESCRIPTION
Go-NEB fails to start if the var is defined, but contains nothing:
```
matrix-bot-go-neb[16190]: time="2021-03-27T10:39:59Z" level=panic msg="Failed to load config file" config_file=/config/config.yaml error="Failed to convert to config file: json: cannot unmarshal object into Go struct field ConfigFile.Realms of type []api.ConfigureAuthRealmRequest"
```