### PR TITLE
matrix-nginx-proxy: add custom nginx options to nginx.conf.j2

### DIFF
--- a/roles/matrix-nginx-proxy/defaults/main.yml
+++ b/roles/matrix-nginx-proxy/defaults/main.yml
@@ -227,8 +227,17 @@ matrix_nginx_proxy_proxy_matrix_federation_api_ssl_certificate_key: "{{ matrix_s
 # The tmpfs at /tmp needs to be large enough to handle multiple concurrent file uploads.
 matrix_nginx_proxy_tmp_directory_size_mb: "{{ (matrix_nginx_proxy_proxy_matrix_federation_api_client_max_body_size_mb | int) * 50 }}"
 
+# A list of strings containing additional configuration blocks to add to the nginx server configuration (nginx.conf).
+# for big matrixservers to enlarge the number of open files to prevent timeouts
+# matrix_nginx_proxy_proxy_additional_server_configuration_blocks:
+#  - 'worker_rlimit_nofile 30000;'
+matrix_nginx_proxy_proxy_additional_server_configuration_blocks: []
+
 # A list of strings containing additional configuration blocks to add to the nginx http's server configuration (nginx-http.conf).
 matrix_nginx_proxy_proxy_http_additional_server_configuration_blocks: []
+
+# A list of strings containing additional configuration blocks to add to the nginx event server configuration (nginx.conf).
+matrix_nginx_proxy_proxy_event_additional_server_configuration_blocks: []
 
 # A list of strings containing additional configuration blocks to add to the base matrix server configuration (matrix-domain.conf).
 matrix_nginx_proxy_proxy_matrix_additional_server_configuration_blocks: []

--- a/roles/matrix-nginx-proxy/templates/nginx/nginx.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/nginx.conf.j2
@@ -11,10 +11,15 @@
 worker_processes {{ matrix_nginx_proxy_worker_processes }};
 error_log /var/log/nginx/error.log warn;
 pid /tmp/nginx.pid;
-
+{% for configuration_block in matrix_nginx_proxy_proxy_additional_server_configuration_blocks %}
+	{{- configuration_block }}
+{% endfor %}
 
 events {
 	worker_connections {{ matrix_nginx_proxy_worker_connections }};
+{% for configuration_block in matrix_nginx_proxy_proxy_event_additional_server_configuration_blocks %}
+	{{- configuration_block }}
+{% endfor %}
 }
 
 


### PR DESCRIPTION
To have the possibility to add some custom nginx configuration options to prevent timeouts.