### PR TITLE
Upgrade Element (1.7.24 -> 1.7.24.1)

### DIFF
--- a/roles/matrix-client-element/defaults/main.yml
+++ b/roles/matrix-client-element/defaults/main.yml
@@ -3,7 +3,7 @@ matrix_client_element_enabled: true
 matrix_client_element_container_image_self_build: false
 matrix_client_element_container_image_self_build_repo: "https://github.com/vector-im/riot-web.git"
 
-matrix_client_element_version: v1.7.24
+matrix_client_element_version: v1.7.24.1
 matrix_client_element_docker_image: "{{ matrix_client_element_docker_image_name_prefix }}vectorim/element-web:{{ matrix_client_element_version }}"
 matrix_client_element_docker_image_name_prefix: "{{ 'localhost/' if matrix_client_element_container_image_self_build else 'docker.io/' }}"
 matrix_client_element_docker_image_force_pull: "{{ matrix_client_element_docker_image.endswith(':latest') }}"


### PR DESCRIPTION
Not totally sure what this fixes but apparently it is a Docker only release

> Element Web 1.7.24.1 has been tagged to fix a compressed resources issue which only affects the official Docker build. If you don't use the official Docker build, feel free to ignore this version.
