### PR TITLE
Use synapse db host var instead of hard coding matrix-postgres

### DIFF
--- a/roles/matrix-synapse/tasks/rust-synapse-compress-state/main.yml
+++ b/roles/matrix-synapse/tasks/rust-synapse-compress-state/main.yml
@@ -57,7 +57,7 @@
       --network={{ matrix_docker_network }}
       --env-file={{ matrix_postgres_base_path }}/env-postgres-psql
       {{ matrix_postgres_docker_image_latest }}
-      psql -v ON_ERROR_STOP=1 -h matrix-postgres {{ matrix_synapse_database_database }} -c
+      psql -v ON_ERROR_STOP=1 -h {{ matrix_synapse_database_host }} {{ matrix_synapse_database_database }} -c
       'SELECT array_to_json(array_agg(row_to_json (r))) FROM (SELECT room_id, count(*) AS count FROM state_groups_state GROUP BY room_id HAVING count(*) > {{ matrix_synapse_rust_synapse_compress_state_min_state_groups_required }} ORDER BY count DESC) r;'
 
 - name: Find rooms eligible for compression with rust-synapse-compress-state


### PR DESCRIPTION
I found one place where the playbook is hardcoding "matrix-postgres" instead of using the variable `matrix_synapse_database_host`
