### PR TITLE
Add sanity check for server architecture

### DIFF
--- a/roles/matrix-base/tasks/sanity_check.yml
+++ b/roles/matrix-base/tasks/sanity_check.yml
@@ -52,3 +52,10 @@
   when:
     - ansible_distribution == 'Archlinux'
     - ansible_python.version.major != 3
+
+- name: Fail if architecture is set incorrectly
+  fail:
+    msg: "Detected that variable matrix_architecture {{ matrix_architecture }} appears to be set incorrectly. See docs/alternative-architectures.md. Server appears to be {{ ansible_architecture }}."
+  when: (ansible_architecture == "x86_64" and matrix_architecture != "amd64") or
+        (ansible_architecture == "aarch64" and matrix_architecture != "arm64") or
+        (ansible_architecture.startswith("armv") and matrix_architecture != "arm32")


### PR DESCRIPTION
May fix #943

This has only been tested on an amd64 server and an arm64 server. It has not been tested on an arm32 server.

If this works properly then we might be able to automatically set `matrix_architecture` instead of making the user set it.