### PR TITLE
Disable TLS 1.0 and TLS 1.1 for coturn

### DIFF
--- a/roles/matrix-coturn/templates/turnserver.conf.j2
+++ b/roles/matrix-coturn/templates/turnserver.conf.j2
@@ -16,6 +16,8 @@ no-cli
 {% if matrix_coturn_tls_enabled %}
 cert={{ matrix_coturn_tls_cert_path }}
 pkey={{ matrix_coturn_tls_key_path }}
+no-tlsv1
+no-tlsv1_1
 {% else %}
 no-tls
 no-dtls


### PR DESCRIPTION
These old versions of TLS rely on MD5 and SHA-1, both now broken, and contain other flaws. TLS 1.0 is no longer PCI-DSS compliant and the TLS working group has adopted a document to deprecate TLS 1.0 and TLS 1.1.