### PR TITLE
updated matrix_grafana_docker_image to v7.5.4

### DIFF
--- a/roles/matrix-grafana/defaults/main.yml
+++ b/roles/matrix-grafana/defaults/main.yml
@@ -3,7 +3,7 @@
 
 matrix_grafana_enabled: false
 
-matrix_grafana_version: 7.5.2
+matrix_grafana_version: 7.5.4
 matrix_grafana_docker_image: "{{ matrix_container_global_registry_prefix }}grafana/grafana:{{ matrix_grafana_version }}"
 matrix_grafana_docker_image_force_pull: "{{ matrix_grafana_docker_image.endswith(':latest') }}"
 


### PR DESCRIPTION
Latest stable grafana version is [7.5.4 (2021-04-14)](https://github.com/grafana/grafana/releases/tag/v7.5.4)