### PR TITLE
Improve security for grafana

### DIFF
--- a/roles/matrix-grafana/defaults/main.yml
+++ b/roles/matrix-grafana/defaults/main.yml
@@ -31,6 +31,12 @@ matrix_grafana_anonymous_access_org_name: 'Main Org.'
 matrix_grafana_default_admin_user: admin
 matrix_grafana_default_admin_password: admin
 
+# Set to true to add the Content-Security-Policy header to your requests.
+# CSP allows to control resources that the user agent can load and helps 
+# prevent XSS attacks.
+# [Content Security Policy](https://grafana.com/docs/grafana/latest/administration/configuration/#content_security_policy)
+matrix_grafana_content_security_policy: true
+
 # A list of extra arguments to pass to the container
 matrix_grafana_container_extra_arguments: []
 

--- a/roles/matrix-grafana/templates/grafana.ini.j2
+++ b/roles/matrix-grafana/templates/grafana.ini.j2
@@ -5,6 +5,9 @@ admin_user = "{{ matrix_grafana_default_admin_user }}"
 # default admin password, can be changed before first start of grafana, or in profile settings
 admin_password = """{{ matrix_grafana_default_admin_password }}"""
 
+# specify content_security_policy to add the Content-Security-Policy header to your requests
+content_security_policy = "{{ matrix_grafana_content_security_policy }}"
+
 [auth.anonymous]
 # enable anonymous access
 enabled = {{ matrix_grafana_anonymous_access }}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-client-element.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-client-element.conf.j2
@@ -6,8 +6,6 @@
 	add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 	add_header X-Content-Type-Options nosniff;
 	add_header X-Frame-Options SAMEORIGIN;
-	add_header X-XSS-Protection "1; mode=block";
-	add_header Content-Security-Policy "frame-ancestors 'none'";
 	{% for configuration_block in matrix_nginx_proxy_proxy_element_additional_server_configuration_blocks %}
 		{{- configuration_block }}
 	{% endfor %}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-grafana.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-grafana.conf.j2
@@ -3,9 +3,13 @@
 {% macro render_vhost_directives() %}
 	gzip on;
 	gzip_types text/plain application/json application/javascript text/css image/x-icon font/ttf image/gif;
-	add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-	add_header X-Content-Type-Options nosniff;
-	add_header X-Frame-Options SAMEORIGIN;
+	add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+	# duplicate X-Content-Type-Options & X-Frame-Options header
+	# Enabled by grafana by default
+	# add_header X-Content-Type-Options nosniff;
+	# add_header X-Frame-Options SAMEORIGIN;
+	add_header Referrer-Policy "strict-origin-when-cross-origin";
+	proxy_cookie_path / "/; HTTPOnly; Secure";
 	{% for configuration_block in matrix_nginx_proxy_proxy_grafana_additional_server_configuration_blocks %}
 		{{- configuration_block }}
 	{% endfor %}


### PR DESCRIPTION
- removed duplicate X-Content-Type-Options
- removed duplicate X-Frame-Options header
- Referrer-Policy [Might consider adding variable]
- Secure flag with cookies
- matrix_grafana_content_security_policy variable for [Content Security Policy](https://grafana.com/docs/grafana/latest/administration/configuration/#content_security_policy)