### PR TITLE
Fix prometheus network for ansible < 2.8

### DIFF
--- a/roles/matrix-prometheus/tasks/setup_install.yml
+++ b/roles/matrix-prometheus/tasks/setup_install.yml
@@ -30,8 +30,10 @@
         driver: bridge
       register: matrix_docker_network_info
 
+    # The `matrix_docker_network_info.ansible_facts.docker_network` workaround is for Ansible < 2.8.
+    # See: https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/907
     - set_fact:
-        matrix_prometheus_scraper_node_targets: ["{{ matrix_docker_network_info.network.IPAM.Config[0].Gateway }}:9100"]
+        matrix_prometheus_scraper_node_targets: ["{{ (matrix_docker_network_info.network|default(matrix_docker_network_info.ansible_facts.docker_network)).IPAM.Config[0].Gateway }}:9100"]
   when: "matrix_prometheus_scraper_node_enabled|bool and matrix_prometheus_scraper_node_targets|length == 0"
 
 


### PR DESCRIPTION
Reverts the revert badd81e0ec95811ba98688ac185f4fb406c9c8e0 with the addition of parens. Tested on ansible 2.7.7 and 2.10.8.