### PR TITLE
security** node-exporter data & port publicly exposed

### DIFF
--- a/roles/matrix-prometheus-node-exporter/defaults/main.yml
+++ b/roles/matrix-prometheus-node-exporter/defaults/main.yml
@@ -18,5 +18,5 @@ matrix_prometheus_node_exporter_systemd_wanted_services_list: []
 
 # Controls whether the matrix-prometheus container exposes its HTTP port (tcp/9100 in the container).
 #
-# Takes an "<ip>:<port>" value (e.g. "127.0.0.1:9100"), or empty string to not expose.
+# Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:9100"), or empty string to not expose.
 matrix_prometheus_node_exporter_container_http_host_bind_port: ''

--- a/roles/matrix-prometheus-node-exporter/defaults/main.yml
+++ b/roles/matrix-prometheus-node-exporter/defaults/main.yml
@@ -18,5 +18,5 @@ matrix_prometheus_node_exporter_systemd_wanted_services_list: []
 
 # Controls whether the matrix-prometheus container exposes its HTTP port (tcp/9100 in the container).
 #
-# Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:9100"), or empty string to not expose.
+# Takes an "<ip>:<port>" value (e.g. "127.0.0.1:9100"), or empty string to not expose.
 matrix_prometheus_node_exporter_container_http_host_bind_port: ''

--- a/roles/matrix-prometheus-node-exporter/templates/systemd/matrix-prometheus-node-exporter.service.j2
+++ b/roles/matrix-prometheus-node-exporter/templates/systemd/matrix-prometheus-node-exporter.service.j2
@@ -22,6 +22,9 @@ ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-prometheus-nod
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
 			--read-only \
+			{% if matrix_prometheus_node_exporter_container_http_host_bind_port %}
+			-p {{ matrix_prometheus_node_exporter_container_http_host_bind_port }}:9100 \
+			{% endif %}
 			{% for arg in matrix_prometheus_node_exporter_container_extra_arguments %}
 			{{ arg }} \
 			{% endfor %}
@@ -29,12 +32,6 @@ ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-prometheus-nod
 			--pid=host \
 			--mount type=bind,src=/,dst=/host,ro,bind-propagation=rslave \
 			{{ matrix_prometheus_node_exporter_docker_image }} \
-                        {{ matrix_prometheus_node_exporter_docker_image }} \
-                        {% if matrix_prometheus_node_exporter_container_http_host_bind_port %}
-                        --web.listen-address={{ matrix_prometheus_node_exporter_container_http_host_bind_port }} \
-                        {% else %}
-                        --web.listen-address=localhost:9100 \
-                        {% endif %}
 			--path.rootfs=/host
 
 ExecStop=-{{ matrix_host_command_sh }} -c '{{ matrix_host_command_docker }} kill matrix-prometheus-node-exporter 2>/dev/null'

--- a/roles/matrix-prometheus-node-exporter/templates/systemd/matrix-prometheus-node-exporter.service.j2
+++ b/roles/matrix-prometheus-node-exporter/templates/systemd/matrix-prometheus-node-exporter.service.j2
@@ -22,9 +22,6 @@ ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-prometheus-nod
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
 			--read-only \
-			{% if matrix_prometheus_node_exporter_container_http_host_bind_port %}
-			-p {{ matrix_prometheus_node_exporter_container_http_host_bind_port }}:9100 \
-			{% endif %}
 			{% for arg in matrix_prometheus_node_exporter_container_extra_arguments %}
 			{{ arg }} \
 			{% endfor %}
@@ -32,6 +29,12 @@ ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-prometheus-nod
 			--pid=host \
 			--mount type=bind,src=/,dst=/host,ro,bind-propagation=rslave \
 			{{ matrix_prometheus_node_exporter_docker_image }} \
+                        {{ matrix_prometheus_node_exporter_docker_image }} \
+                        {% if matrix_prometheus_node_exporter_container_http_host_bind_port %}
+                        --web.listen-address={{ matrix_prometheus_node_exporter_container_http_host_bind_port }} \
+                        {% else %}
+                        --web.listen-address=localhost:9100 \
+                        {% endif %}
 			--path.rootfs=/host
 
 ExecStop=-{{ matrix_host_command_sh }} -c '{{ matrix_host_command_docker }} kill matrix-prometheus-node-exporter 2>/dev/null'

--- a/roles/matrix-prometheus-node-exporter/templates/systemd/matrix-prometheus-node-exporter.service.j2
+++ b/roles/matrix-prometheus-node-exporter/templates/systemd/matrix-prometheus-node-exporter.service.j2
@@ -22,9 +22,6 @@ ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-prometheus-nod
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
 			--read-only \
-			{% if matrix_prometheus_node_exporter_container_http_host_bind_port %}
-			-p {{ matrix_prometheus_node_exporter_container_http_host_bind_port }}:9100 \
-			{% endif %}
 			{% for arg in matrix_prometheus_node_exporter_container_extra_arguments %}
 			{{ arg }} \
 			{% endfor %}
@@ -32,6 +29,11 @@ ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-prometheus-nod
 			--pid=host \
 			--mount type=bind,src=/,dst=/host,ro,bind-propagation=rslave \
 			{{ matrix_prometheus_node_exporter_docker_image }} \
+			{% if matrix_prometheus_node_exporter_container_http_host_bind_port %}
+			--web.listen-address={{ matrix_prometheus_node_exporter_container_http_host_bind_port }} \
+			{% else %}
+			--web.listen-address=localhost:9100 \
+			{% endif %}
 			--path.rootfs=/host
 
 ExecStop=-{{ matrix_host_command_sh }} -c '{{ matrix_host_command_docker }} kill matrix-prometheus-node-exporter 2>/dev/null'


### PR DESCRIPTION
By default node-exporter docker container expose port 9100

```
**netstat -ntlp**
tcp6       0      0 :::9100                 :::*                    LISTEN      7577/node_exporter
```