### PR TITLE
Switch to official coturn image

### DIFF
--- a/docs/container-images.md
+++ b/docs/container-images.md
@@ -11,7 +11,7 @@ These services are enabled and used by default, but you can turn them off, if yo
 
 - [matrixdotorg/synapse](https://hub.docker.com/r/matrixdotorg/synapse/) - the official [Synapse](https://github.com/matrix-org/synapse) Matrix homeserver (optional)
 
-- [instrumentisto/coturn](https://hub.docker.com/r/instrumentisto/coturn/) - the [Coturn](https://github.com/coturn/coturn) STUN/TURN server (optional)
+- [coturn/coturn](https://hub.docker.com/r/coturn/coturn/) - the [Coturn](https://github.com/coturn/coturn) STUN/TURN server (optional)
 
 - [vectorim/element-web](https://hub.docker.com/r/vectorim/element-web/) - the [Element](https://element.io/) web client (optional)
 

--- a/roles/matrix-coturn/defaults/main.yml
+++ b/roles/matrix-coturn/defaults/main.yml
@@ -1,10 +1,10 @@
 matrix_coturn_enabled: true
 
 matrix_coturn_container_image_self_build: false
-matrix_coturn_container_image_self_build_repo: "https://github.com/instrumentisto/coturn-docker-image.git"
+matrix_coturn_container_image_self_build_repo: "https://github.com/coturn/coturn/tree/master/docker/coturn/alpine.git"
 
 matrix_coturn_version: 4.5.2
-matrix_coturn_docker_image: "{{ matrix_coturn_docker_image_name_prefix }}instrumentisto/coturn:{{ matrix_coturn_version }}"
+matrix_coturn_docker_image: "{{ matrix_coturn_docker_image_name_prefix }}coturn/coturn:{{ matrix_coturn_version }}"
 matrix_coturn_docker_image_name_prefix: "{{ 'localhost/' if matrix_coturn_container_image_self_build else matrix_container_global_registry_prefix }}"
 matrix_coturn_docker_image_force_pull: "{{ matrix_coturn_docker_image.endswith(':latest') }}"
 

--- a/roles/matrix-coturn/templates/systemd/matrix-coturn.service.j2
+++ b/roles/matrix-coturn/templates/systemd/matrix-coturn.service.j2
@@ -17,6 +17,7 @@ ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-coturn \
 			--log-driver=none \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
+			--cap-add=NET_BIND_SERVICE \
 			--entrypoint=turnserver \
 			--read-only \
 			--tmpfs=/var/tmp:rw,noexec,nosuid,size=100m \


### PR DESCRIPTION
Coturn got an official image recently (https://github.com/coturn/coturn/pull/746) from the maintainer of `instrumentisto/coturn`. As far as I can tell the original image isn't deprecated yet but probably will be soon, e.g. https://github.com/instrumentisto/coturn-docker-image/issues/37#issuecomment-767876958.