### PR TITLE
Update synapse version (1.31.0 -> 1.32.1)

### DIFF
--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -15,8 +15,8 @@ matrix_synapse_docker_image_name_prefix: "{{ 'localhost/' if matrix_synapse_cont
 # amd64 gets released first.
 # arm32 relies on self-building, so the same version can be built immediately.
 # arm64 users need to wait for a prebuilt image to become available.
-matrix_synapse_version: v1.31.0
-matrix_synapse_version_arm64: v1.31.0
+matrix_synapse_version: v1.32.1
+matrix_synapse_version_arm64: v1.32.1
 matrix_synapse_docker_image_tag: "{{ matrix_synapse_version if matrix_architecture in ['arm32', 'amd64'] else matrix_synapse_version_arm64 }}"
 matrix_synapse_docker_image_force_pull: "{{ matrix_synapse_docker_image.endswith(':latest') }}"
 


### PR DESCRIPTION
**NOTE**: Matrix.org now builds both amd64 and arm64 containers at the same time, may be it's time to remove separate arm64 version param?