### PR TITLE
GoMatrixHosting v0.4.4 update

### DIFF
--- a/roles/matrix-awx/surveys/access_export.json.j2
+++ b/roles/matrix-awx/surveys/access_export.json.j2
@@ -1,0 +1,42 @@
+{
+  "name": "Access Export",
+  "description": "Access the services export.",
+  "spec": [
+    {
+      "question_name": "SFTP Authorisation Method",
+      "question_description": "Set whether you want to disable SFTP, use a password to connect to SFTP or connect with a more secure SSH key.",
+      "required": true,
+      "min": null,
+      "max": null,
+      "default": "{{ sftp_auth_method | string }}",
+      "choices": "Disabled\nPassword\nSSH Key",
+      "new_question": true,
+      "variable": "sftp_auth_method",
+      "type": "multiplechoice"
+    },
+    {
+      "question_name": "SFTP Password",
+      "question_description": "Sets the password of the 'sftp' account, which allows you to upload a multi-file static website by SFTP, as well as export the latest copy of your Matrix service. Must be defined if 'Password' method is selected. WARNING: You must set a strong and unique password here.",
+      "required": false,
+      "min": 0,
+      "max": 64,
+      "default": "{{ sftp_password }}",
+      "choices": "",
+      "new_question": true,
+      "variable": "sftp_password",
+      "type": "password"
+    },
+    {
+      "question_name": "SFTP Public SSH Key (More Secure)",
+      "question_description": "Sets the public SSH key used to access the 'sftp' account, which allows you to upload a multi-file static website by SFTP, as well as export the latest copy of your Matrix service. Must be defined if 'SSH Key' method is selected.",
+      "required": false,
+      "min": 0,
+      "max": 16384,
+      "default": "{{ sftp_public_key }}",
+      "choices": "",
+      "new_question": true,
+      "variable": "sftp_public_key",
+      "type": "text"
+    }
+  ]
+}

--- a/roles/matrix-awx/surveys/backup_server.json.j2
+++ b/roles/matrix-awx/surveys/backup_server.json.j2
@@ -1,6 +1,6 @@
 {
   "name": "Backup Server",
-  "description": "",
+  "description": "Performs a backup of the entire service to a remote location.",
   "spec": [
     {
       "question_name": "Enable Backup",

--- a/roles/matrix-awx/surveys/configure_corporal.json.j2
+++ b/roles/matrix-awx/surveys/configure_corporal.json.j2
@@ -1,6 +1,6 @@
 {
   "name": "Configure Matrix Corporal",
-  "description": "",
+  "description": "Configure Matrix Corporal, a tool that manages your Matrix server according to a configuration policy.",
   "spec": [
     {
       "question_name": "Enable Corporal",

--- a/roles/matrix-awx/surveys/configure_dimension.json.j2
+++ b/roles/matrix-awx/surveys/configure_dimension.json.j2
@@ -1,6 +1,6 @@
 {
   "name": "Configure Dimension",
-  "description": "",
+  "description": "Configure Dimension, the self-hosted integrations server.",
   "spec": [
     {
       "question_name": "Enable Dimension",

--- a/roles/matrix-awx/surveys/configure_element.json.j2
+++ b/roles/matrix-awx/surveys/configure_element.json.j2
@@ -1,6 +1,6 @@
 {
-  "name": "",
-  "description": "",
+  "name": "Configure Element",
+  "description": "Configure Element web client, Element is the most developed Matrix client software.",
   "spec": [
     {
       "question_name": "Enable Element-Web",

--- a/roles/matrix-awx/surveys/configure_jitsi.json.j2
+++ b/roles/matrix-awx/surveys/configure_jitsi.json.j2
@@ -1,6 +1,6 @@
 {
-  "name": "",
-  "description": "",
+  "name": "Configure Jitsi",
+  "description": "Configure Jitsi conferencing settings.",
   "spec": [
     {
       "question_name": "Enable Jitsi",

--- a/roles/matrix-awx/surveys/configure_ma1sd.json.j2
+++ b/roles/matrix-awx/surveys/configure_ma1sd.json.j2
@@ -1,6 +1,6 @@
 {
-  "name": "",
-  "description": "",
+  "name": "Configure ma1sd",
+  "description": "Configure ma1sd settings, ma1sd is a self-hosted identity server for Matrix.",
   "spec": [
     {
       "question_name": "Enable ma1sd",

--- a/roles/matrix-awx/surveys/configure_synapse.json.j2
+++ b/roles/matrix-awx/surveys/configure_synapse.json.j2
@@ -1,6 +1,6 @@
 {
   "name": "Configure Synapse",
-  "description": "",
+  "description": "Configure Synapse settings. Synapse is the homeserver software that powers your Matrix instance.",
   "spec": [
     {
       "question_name": "Enable Public Registration",

--- a/roles/matrix-awx/tasks/customise_website_access_export.yml
+++ b/roles/matrix-awx/tasks/customise_website_access_export.yml
@@ -8,7 +8,7 @@
     insertafter: '# Base Domain Settings Start'
   with_dict:
     'matrix_nginx_proxy_base_domain_homepage_enabled': 'true'
-  when: customise_base_domain_website|bool == false
+  when: (customise_base_domain_website is defined) and not customise_base_domain_website|bool
 
 - name: Disable index.html creation to allow multi-file site if user does wish to customise base domain
   delegate_to: 127.0.0.1
@@ -19,7 +19,19 @@
     insertafter: '# Base Domain Settings Start'
   with_dict:
     'matrix_nginx_proxy_base_domain_homepage_enabled': 'false'
-  when: customise_base_domain_website|bool == true
+  when: (customise_base_domain_website is defined) and customise_base_domain_website|bool
+
+- name: Record custom 'Customise Website + Access Export' variables locally on AWX
+  delegate_to: 127.0.0.1
+  lineinfile:
+    path: '{{ awx_cached_matrix_vars }}'
+    regexp: "^#? *{{ item.key | regex_escape() }}:"
+    line: "{{ item.key }}: {{ item.value }}"
+    insertafter: '# Custom Settings Start'
+  with_dict:
+    'sftp_auth_method': '"{{ sftp_auth_method }}"'
+    'sftp_password': '"{{ sftp_password }}"'
+    'sftp_public_key': '"{{ sftp_public_key }}"'
 
 - name: Record custom 'Customise Website + Access Export' variables locally on AWX
   delegate_to: 127.0.0.1
@@ -30,28 +42,40 @@
     insertafter: '# Custom Settings Start'
   with_dict:
     'customise_base_domain_website': '{{ customise_base_domain_website }}'
-    'sftp_auth_method': '"{{ sftp_auth_method }}"'
-    'sftp_password': '"{{ sftp_password }}"'
-    'sftp_public_key': '"{{ sftp_public_key }}"'
+  when: customise_base_domain_website is defined
 
 - name: Reload vars in matrix_vars.yml
   include_vars:
     file: '{{ awx_cached_matrix_vars }}'
   no_log: True
 
-# ^ Is this even needed?
-
 - name: Save new 'Customise Website + Access Export' survey.json to the AWX tower, template
   delegate_to: 127.0.0.1
   template:
     src: './roles/matrix-awx/surveys/configure_website_access_export.json.j2'
     dest: '/var/lib/awx/projects/clients/{{ member_id }}/{{ subscription_id }}/configure_website_access_export.json'
+  when: customise_base_domain_website is defined
 
 - name: Copy new 'Customise Website + Access Export' survey.json to target machine
   copy:
     src: '/var/lib/awx/projects/clients/{{ member_id }}/{{ subscription_id }}/configure_website_access_export.json'
     dest:  '/matrix/awx/configure_website_access_export.json'
     mode: '0660'
+  when: customise_base_domain_website is defined
+
+- name: Save new 'Customise Website + Access Export' survey.json to the AWX tower, template
+  delegate_to: 127.0.0.1
+  template:
+    src: './roles/matrix-awx/surveys/access_export.json.j2'
+    dest: '/var/lib/awx/projects/clients/{{ member_id }}/{{ subscription_id }}/access_export.json'
+  when: customise_base_domain_website is undefined
+
+- name: Copy new 'Customise Website + Access Export' survey.json to target machine
+  copy:
+    src: '/var/lib/awx/projects/clients/{{ member_id }}/{{ subscription_id }}/access_export.json'
+    dest:  '/matrix/awx/access_export.json'
+    mode: '0660'
+  when: customise_base_domain_website is undefined
 
 - name: Collect AWX admin token the hard way!
   delegate_to: 127.0.0.1
@@ -60,7 +84,7 @@
   register: tower_token
   no_log: True
 
-- name: Recreate 'Customise Base Domain Export' job template
+- name: Recreate 'Configure Website + Access Export' job template
   delegate_to: 127.0.0.1
   awx.awx.tower_job_template:
     name: "{{ matrix_domain }} - 1 - Configure Website + Access Export"
@@ -80,6 +104,29 @@
     tower_host: "https://{{ tower_host }}"
     tower_oauthtoken: "{{ tower_token.stdout }}"
     validate_certs: yes
+  when: customise_base_domain_website is defined
+
+- name: Recreate 'Access Export' job template
+  delegate_to: 127.0.0.1
+  awx.awx.tower_job_template:
+    name: "{{ matrix_domain }} - 1 - Access Export"
+    description: "Access the services export."
+    extra_vars: "{{ lookup('file', '/var/lib/awx/projects/clients/{{ member_id }}/{{ subscription_id }}/extra_vars.json') }}"
+    job_type: run
+    job_tags: "start,setup-nginx-proxy"
+    inventory: "{{ member_id }}"
+    project: "{{ member_id }} - Matrix Docker Ansible Deploy"
+    playbook: setup.yml
+    credential: "{{ member_id }} - AWX SSH Key"
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', '/var/lib/awx/projects/clients/{{ member_id }}/{{ subscription_id }}/access_export.json') }}"
+    become_enabled: yes
+    state: present
+    verbosity: 1
+    tower_host: "https://{{ tower_host }}"
+    tower_oauthtoken: "{{ tower_token.stdout }}"
+    validate_certs: yes
+  when: customise_base_domain_website is undefined
 
 - name: Ensure group "sftp" exists
   group:
@@ -113,6 +160,7 @@
     name: sftp
     groups: matrix
     append: yes
+  when: customise_base_domain_website is defined
 
 - name: Create the ro /chroot directory with sticky bit if it doesn't exist. (/chroot/website has matrix:matrix permissions and is mounted to nginx container)
   file:
@@ -129,6 +177,7 @@
     owner: matrix
     group: matrix
     mode: '0574'
+  when: customise_base_domain_website is defined
 
 - name: Ensure /chroot/export location exists
   file:

--- a/roles/matrix-awx/tasks/import_awx.yml
+++ b/roles/matrix-awx/tasks/import_awx.yml
@@ -16,8 +16,3 @@
 - name: Ensure correct ownership of /matrix/synapse
   shell: chown -R matrix:matrix /matrix/synapse
 
-- name: Fetch matrix_vars.yml file to AWX
-  fetch:
-    src: /matrix/awx/matrix_vars.yml
-    dest: /var/lib/awx/projects/clients/{{ member_id }}/{{ subscription_id }}/
-    flat: yes

--- a/roles/matrix-awx/tasks/set_variables_dimension.yml
+++ b/roles/matrix-awx/tasks/set_variables_dimension.yml
@@ -4,9 +4,11 @@
     file: '{{ awx_cached_matrix_vars }}'
   no_log: True
 
-- name: Install jq on remote machine
+- name: Install jq and curl on remote machine
   apt:
-    name: jq
+    name: 
+      - jq
+      - curl
     state: present
 
 - name: Collect access token of Dimension user

--- a/roles/matrix-common-after/tasks/awx_post.yml
+++ b/roles/matrix-common-after/tasks/awx_post.yml
@@ -35,3 +35,18 @@
   with_dict:
     'matrix_awx_dimension_user_created': 'true'
   when: not matrix_awx_dimension_user_created|bool
+  
+- name: Ensure /chroot/website location has correct permissions
+  file:
+    path: /chroot/website
+    state: directory
+    owner: matrix
+    group: matrix
+    mode: '0574'
+  when: customise_base_domain_website is defined
+
+- name: Ensure erroneous /chroot/website/matrix-domain location doesn't exist
+  file:
+    path: /chroot/website/matrix-domain
+    state: absent
+  when: customise_base_domain_website is defined


### PR DESCRIPTION
# GoMatrixHosting v0.4.4

Create new 'Access Export' playbook for subscriptions that aren't hosting the base domain through AWX.
Allow metrics ports in firewall.
Update postgresql tuning and change default cache factor.
Added swappiness settings.
User manual updates.
Added a changelog with upgrade notes for AWX.

# Upgrade notes for v0.4.4

- Delete '{{ matrix_domain }} - 1 - Configure Website + Access Export from on-premises servers, re-provision.
- Delete 'customise_base_domain_website' variable in every on-premises subscribers matrix_vars.yml in AWX
- Set 'matrix_synapse_caches_global_factor' to '4.0' in every subscribers matrix_vars.yml in AWX