### PR TITLE
Grafana csp template backward compatible with older browsers

### DIFF
--- a/roles/matrix-grafana/defaults/main.yml
+++ b/roles/matrix-grafana/defaults/main.yml
@@ -40,6 +40,8 @@ matrix_grafana_content_security_policy: true
 # specify content security policy template to customized template
 # added 'unsafe-inline' (ignored by browsers supporting nonces/hashes) to be backward compatible with older browsers.
 # added https: and http: url schemes (ignored by browsers supporting 'strict-dynamic') to be backward compatible with older browsers.
+# [Content Security Policy Browser Test] (https://content-security-policy.com/browser-test/)
+# [Content Security Policy Reference](https://content-security-policy.com/script-src/)
 matrix_grafana_content_security_policy_customized: true
 
 # A list of extra arguments to pass to the container

--- a/roles/matrix-grafana/defaults/main.yml
+++ b/roles/matrix-grafana/defaults/main.yml
@@ -37,6 +37,11 @@ matrix_grafana_default_admin_password: admin
 # [Content Security Policy](https://grafana.com/docs/grafana/latest/administration/configuration/#content_security_policy)
 matrix_grafana_content_security_policy: true
 
+# specify content security policy template to customized template
+# added 'unsafe-inline' (ignored by browsers supporting nonces/hashes) to be backward compatible with older browsers.
+# added https: and http: url schemes (ignored by browsers supporting 'strict-dynamic') to be backward compatible with older browsers.
+matrix_grafana_content_security_policy_customized: true
+
 # A list of extra arguments to pass to the container
 matrix_grafana_container_extra_arguments: []
 

--- a/roles/matrix-grafana/templates/grafana.ini.j2
+++ b/roles/matrix-grafana/templates/grafana.ini.j2
@@ -9,7 +9,7 @@ admin_password = """{{ matrix_grafana_default_admin_password }}"""
 content_security_policy = "{{ matrix_grafana_content_security_policy }}"
 
 # specify content security policy template to customized template
-{% if matrix_synapse_metrics_enabled %}
+{% if matrix_grafana_content_security_policy_customized %}
 content_security_policy_template = """script-src http: https: 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data:;base-uri 'self';connect-src 'self' grafana.com;manifest-src 'self';media-src 'none';form-action 'self';"""
 {% else %}
 {% endif %}

--- a/roles/matrix-grafana/templates/grafana.ini.j2
+++ b/roles/matrix-grafana/templates/grafana.ini.j2
@@ -8,6 +8,12 @@ admin_password = """{{ matrix_grafana_default_admin_password }}"""
 # specify content_security_policy to add the Content-Security-Policy header to your requests
 content_security_policy = "{{ matrix_grafana_content_security_policy }}"
 
+# specify content security policy template to customized template
+{% if matrix_synapse_metrics_enabled %}
+content_security_policy_template = """script-src http: https: 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data:;base-uri 'self';connect-src 'self' grafana.com;manifest-src 'self';media-src 'none';form-action 'self';"""
+{% else %}
+{% endif %}
+
 [auth.anonymous]
 # enable anonymous access
 enabled = {{ matrix_grafana_anonymous_access }}

--- a/roles/matrix-grafana/templates/grafana.ini.j2
+++ b/roles/matrix-grafana/templates/grafana.ini.j2
@@ -11,7 +11,6 @@ content_security_policy = "{{ matrix_grafana_content_security_policy }}"
 # specify content security policy template to customized template
 {% if matrix_grafana_content_security_policy_customized %}
 content_security_policy_template = """script-src http: https: 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data:;base-uri 'self';connect-src 'self' grafana.com;manifest-src 'self';media-src 'none';form-action 'self';"""
-{% else %}
 {% endif %}
 
 [auth.anonymous]


### PR DESCRIPTION
`matrix_grafana_content_security_policy_customized` to customized content security policy template.
- added 'unsafe-inline' (ignored by browsers supporting nonces/hashes) to be backward compatible with older browsers.
- added https: and http: url schemes (ignored by browsers supporting 'strict-dynamic') to be backward compatible with older browsers.