### PR TITLE
Upgrade Synapse (1.33.1 -> 1.33.2)

### DIFF
--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -15,8 +15,8 @@ matrix_synapse_docker_image_name_prefix: "{{ 'localhost/' if matrix_synapse_cont
 # amd64 gets released first.
 # arm32 relies on self-building, so the same version can be built immediately.
 # arm64 users need to wait for a prebuilt image to become available.
-matrix_synapse_version: v1.33.1
-matrix_synapse_version_arm64: v1.33.1
+matrix_synapse_version: v1.33.2
+matrix_synapse_version_arm64: v1.33.2
 matrix_synapse_docker_image_tag: "{{ matrix_synapse_version if matrix_architecture in ['arm32', 'amd64'] else matrix_synapse_version_arm64 }}"
 matrix_synapse_docker_image_force_pull: "{{ matrix_synapse_docker_image.endswith(':latest') }}"
 


### PR DESCRIPTION
This release fixes a denial of service attack (CVE-2021-29471) against Synapse's push rules implementation. Server admins are encouraged to upgrade.

Ref: https://github.com/matrix-org/synapse/releases/tag/v1.33.2