### PR TITLE
Enable OCSP Stapling

### DIFF
--- a/roles/matrix-nginx-proxy/defaults/main.yml
+++ b/roles/matrix-nginx-proxy/defaults/main.yml
@@ -279,18 +279,6 @@ matrix_nginx_proxy_proxy_domain_additional_server_configuration_blocks: []
 # Of course, a better solution is to just stop using browsers (like Chrome), which participate in such tracking practices.
 matrix_nginx_proxy_floc_optout_enabled: true
 
-# OCSP Stapling eliminating the need for clients to contact the CA, with the aim of improving both security and performance.
-# OCSP stapling can provide a performance boost of up to 30%
-# nginx web server supports OCSP stapling since version 1.3.7.
-#
-# *warning* Nginx is lazy loading OCSP responses, which means that for the first few web requests it is unable to add the OCSP response.
-#  
-# Learn more about what it is here:
-# - https://en.wikipedia.org/wiki/OCSP_stapling
-# - https://blog.cloudflare.com/high-reliability-ocsp-stapling/
-# - https://blog.mozilla.org/security/2013/07/29/ocsp-stapling-in-firefox/
-matrix_nginx_proxy_ocsp_stapling_enabled: true
-
 # Specifies the SSL configuration that should be used for the SSL protocols and ciphers
 # This is based on the Mozilla Server Side TLS Recommended configurations.
 #
@@ -396,6 +384,18 @@ matrix_ssl_log_dir_path: "{{ matrix_ssl_base_path }}/log"
 # This could be something like `matrix-dynamic-dns`, etc.
 matrix_ssl_pre_obtaining_required_service_name: ~
 matrix_ssl_pre_obtaining_required_service_start_wait_time_seconds: 60
+
+# OCSP Stapling eliminating the need for clients to contact the CA, with the aim of improving both security and performance.
+# OCSP stapling can provide a performance boost of up to 30%
+# nginx web server supports OCSP stapling since version 1.3.7.
+#
+# *warning* Nginx is lazy loading OCSP responses, which means that for the first few web requests it is unable to add the OCSP response.
+#  
+# Learn more about what it is here:
+# - https://en.wikipedia.org/wiki/OCSP_stapling
+# - https://blog.cloudflare.com/high-reliability-ocsp-stapling/
+# - https://blog.mozilla.org/security/2013/07/29/ocsp-stapling-in-firefox/
+matrix_nginx_proxy_ocsp_stapling_enabled: true
 
 # nginx status page configurations.
 matrix_nginx_proxy_proxy_matrix_nginx_status_enabled: false

--- a/roles/matrix-nginx-proxy/defaults/main.yml
+++ b/roles/matrix-nginx-proxy/defaults/main.yml
@@ -390,6 +390,7 @@ matrix_ssl_pre_obtaining_required_service_start_wait_time_seconds: 60
 # nginx web server supports OCSP stapling since version 1.3.7.
 #
 # *warning* Nginx is lazy loading OCSP responses, which means that for the first few web requests it is unable to add the OCSP response.
+# set matrix_nginx_proxy_ocsp_stapling_enabled false to disable OCSP Stapling
 #  
 # Learn more about what it is here:
 # - https://en.wikipedia.org/wiki/OCSP_stapling

--- a/roles/matrix-nginx-proxy/defaults/main.yml
+++ b/roles/matrix-nginx-proxy/defaults/main.yml
@@ -279,6 +279,18 @@ matrix_nginx_proxy_proxy_domain_additional_server_configuration_blocks: []
 # Of course, a better solution is to just stop using browsers (like Chrome), which participate in such tracking practices.
 matrix_nginx_proxy_floc_optout_enabled: true
 
+# OCSP Stapling eliminating the need for clients to contact the CA, with the aim of improving both security and performance.
+# OCSP stapling can provide a performance boost of up to 30%
+# nginx web server supports OCSP stapling since version 1.3.7.
+#
+# *warning* Nginx is lazy loading OCSP responses, which means that for the first few web requests it is unable to add the OCSP response.
+#  
+# Learn more about what it is here:
+# - https://en.wikipedia.org/wiki/OCSP_stapling
+# - https://blog.cloudflare.com/high-reliability-ocsp-stapling/
+# - https://blog.mozilla.org/security/2013/07/29/ocsp-stapling-in-firefox/
+matrix_nginx_proxy_ocsp_stapling_enabled: true
+
 # Specifies the SSL configuration that should be used for the SSL protocols and ciphers
 # This is based on the Mozilla Server Side TLS Recommended configurations.
 #

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-base-domain.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-base-domain.conf.j2
@@ -9,6 +9,12 @@
 	{% if matrix_nginx_proxy_floc_optout_enabled %}
 		add_header Permissions-Policy interest-cohort=() always;
 	{% endif %}
+	
+	{% if matrix_nginx_proxy_ocsp_stapling_enabled and matrix_ssl_retrieval_method in ["lets-encrypt", "manually-managed"] %}
+		ssl_stapling on;
+		ssl_stapling_verify on;
+		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_base_domain_hostname }}/chain.pem;
+	{% endif %}
 
 	{% for configuration_block in matrix_nginx_proxy_proxy_domain_additional_server_configuration_blocks %}
 		{{- configuration_block }}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-base-domain.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-base-domain.conf.j2
@@ -9,12 +9,6 @@
 	{% if matrix_nginx_proxy_floc_optout_enabled %}
 		add_header Permissions-Policy interest-cohort=() always;
 	{% endif %}
-	
-	{% if matrix_nginx_proxy_ocsp_stapling_enabled and matrix_ssl_retrieval_method in ["lets-encrypt", "manually-managed"] %}
-		ssl_stapling on;
-		ssl_stapling_verify on;
-		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_base_domain_hostname }}/chain.pem;
-	{% endif %}
 
 	{% for configuration_block in matrix_nginx_proxy_proxy_domain_additional_server_configuration_blocks %}
 		{{- configuration_block }}
@@ -75,6 +69,12 @@ server {
 	ssl_ciphers {{ matrix_nginx_proxy_ssl_ciphers }};
 	{% endif %}
 	ssl_prefer_server_ciphers {{ matrix_nginx_proxy_ssl_prefer_server_ciphers }};
+	
+	{% if matrix_nginx_proxy_ocsp_stapling_enabled %}
+		ssl_stapling on;
+		ssl_stapling_verify on;
+		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_base_domain_hostname }}/chain.pem;
+	{% endif %}	
 
 	{{ render_vhost_directives() }}
 }

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-bot-go-neb.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-bot-go-neb.conf.j2
@@ -7,6 +7,12 @@
 	add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 	add_header X-Content-Type-Options nosniff;
 
+	{% if matrix_nginx_proxy_ocsp_stapling_enabled and matrix_ssl_retrieval_method in ["lets-encrypt", "manually-managed"] %}
+		ssl_stapling on;
+		ssl_stapling_verify on;
+		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_base_domain_hostname }}/chain.pem;
+	{% endif %}
+
 {% for configuration_block in matrix_nginx_proxy_proxy_bot_go_neb_additional_server_configuration_blocks %}
 	{{- configuration_block }}
 {% endfor %}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-bot-go-neb.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-bot-go-neb.conf.j2
@@ -7,12 +7,6 @@
 	add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 	add_header X-Content-Type-Options nosniff;
 
-	{% if matrix_nginx_proxy_ocsp_stapling_enabled and matrix_ssl_retrieval_method in ["lets-encrypt", "manually-managed"] %}
-		ssl_stapling on;
-		ssl_stapling_verify on;
-		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_base_domain_hostname }}/chain.pem;
-	{% endif %}
-
 {% for configuration_block in matrix_nginx_proxy_proxy_bot_go_neb_additional_server_configuration_blocks %}
 	{{- configuration_block }}
 {% endfor %}
@@ -79,6 +73,12 @@ server {
 	ssl_ciphers {{ matrix_nginx_proxy_ssl_ciphers }};
 	{% endif %}
 	ssl_prefer_server_ciphers {{ matrix_nginx_proxy_ssl_prefer_server_ciphers }};
+
+	{% if matrix_nginx_proxy_ocsp_stapling_enabled %}
+		ssl_stapling on;
+		ssl_stapling_verify on;
+		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_base_domain_hostname }}/chain.pem;
+	{% endif %}
 
 	{{ render_vhost_directives() }}
 }

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-client-element.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-client-element.conf.j2
@@ -10,12 +10,6 @@
 	{% if matrix_nginx_proxy_floc_optout_enabled %}
 		add_header Permissions-Policy interest-cohort=() always;
 	{% endif %}
-	
-	{% if matrix_nginx_proxy_ocsp_stapling_enabled and matrix_ssl_retrieval_method in ["lets-encrypt", "manually-managed"] %}
-		ssl_stapling on;
-		ssl_stapling_verify on;
-		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_base_domain_hostname }}/chain.pem;
-	{% endif %}
 
 	{% for configuration_block in matrix_nginx_proxy_proxy_element_additional_server_configuration_blocks %}
 		{{- configuration_block }}
@@ -85,6 +79,12 @@ server {
 	{% endif %}
 	ssl_prefer_server_ciphers {{ matrix_nginx_proxy_ssl_prefer_server_ciphers }};
 
+	{% if matrix_nginx_proxy_ocsp_stapling_enabled %}
+		ssl_stapling on;
+		ssl_stapling_verify on;
+		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_base_domain_hostname }}/chain.pem;
+	{% endif %}	
+	
 	{{ render_vhost_directives() }}
 }
 {% endif %}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-client-element.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-client-element.conf.j2
@@ -10,6 +10,12 @@
 	{% if matrix_nginx_proxy_floc_optout_enabled %}
 		add_header Permissions-Policy interest-cohort=() always;
 	{% endif %}
+	
+	{% if matrix_nginx_proxy_ocsp_stapling_enabled and matrix_ssl_retrieval_method in ["lets-encrypt", "manually-managed"] %}
+		ssl_stapling on;
+		ssl_stapling_verify on;
+		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_base_domain_hostname }}/chain.pem;
+	{% endif %}
 
 	{% for configuration_block in matrix_nginx_proxy_proxy_element_additional_server_configuration_blocks %}
 		{{- configuration_block }}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-dimension.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-dimension.conf.j2
@@ -9,6 +9,12 @@
 	{% if matrix_nginx_proxy_floc_optout_enabled %}
 		add_header Permissions-Policy interest-cohort=() always;
 	{% endif %}
+	
+	{% if matrix_nginx_proxy_ocsp_stapling_enabled and matrix_ssl_retrieval_method in ["lets-encrypt", "manually-managed"] %}
+		ssl_stapling on;
+		ssl_stapling_verify on;
+		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_base_domain_hostname }}/chain.pem;
+	{% endif %}
 
 {% for configuration_block in matrix_nginx_proxy_proxy_dimension_additional_server_configuration_blocks %}
 	{{- configuration_block }}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-dimension.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-dimension.conf.j2
@@ -9,12 +9,6 @@
 	{% if matrix_nginx_proxy_floc_optout_enabled %}
 		add_header Permissions-Policy interest-cohort=() always;
 	{% endif %}
-	
-	{% if matrix_nginx_proxy_ocsp_stapling_enabled and matrix_ssl_retrieval_method in ["lets-encrypt", "manually-managed"] %}
-		ssl_stapling on;
-		ssl_stapling_verify on;
-		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_base_domain_hostname }}/chain.pem;
-	{% endif %}
 
 {% for configuration_block in matrix_nginx_proxy_proxy_dimension_additional_server_configuration_blocks %}
 	{{- configuration_block }}
@@ -82,6 +76,12 @@ server {
 	ssl_ciphers {{ matrix_nginx_proxy_ssl_ciphers }};
 	{% endif %}
 	ssl_prefer_server_ciphers {{ matrix_nginx_proxy_ssl_prefer_server_ciphers }};
+
+	{% if matrix_nginx_proxy_ocsp_stapling_enabled %}
+		ssl_stapling on;
+		ssl_stapling_verify on;
+		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_base_domain_hostname }}/chain.pem;
+	{% endif %}	
 
 	{{ render_vhost_directives() }}
 }

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
@@ -20,6 +20,12 @@
 	{% if matrix_nginx_proxy_floc_optout_enabled %}
 		add_header Permissions-Policy interest-cohort=() always;
 	{% endif %}
+	
+	{% if matrix_nginx_proxy_ocsp_stapling_enabled and matrix_ssl_retrieval_method in ["lets-encrypt", "manually-managed"] %}
+		ssl_stapling on;
+		ssl_stapling_verify on;
+		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_base_domain_hostname }}/chain.pem;
+	{% endif %}
 
 	location /.well-known/matrix {
 		root {{ matrix_static_files_base_path }};

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
@@ -20,12 +20,6 @@
 	{% if matrix_nginx_proxy_floc_optout_enabled %}
 		add_header Permissions-Policy interest-cohort=() always;
 	{% endif %}
-	
-	{% if matrix_nginx_proxy_ocsp_stapling_enabled and matrix_ssl_retrieval_method in ["lets-encrypt", "manually-managed"] %}
-		ssl_stapling on;
-		ssl_stapling_verify on;
-		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_base_domain_hostname }}/chain.pem;
-	{% endif %}
 
 	location /.well-known/matrix {
 		root {{ matrix_static_files_base_path }};
@@ -201,6 +195,12 @@ server {
 	ssl_ciphers {{ matrix_nginx_proxy_ssl_ciphers }};
 	{% endif %}
 	ssl_prefer_server_ciphers {{ matrix_nginx_proxy_ssl_prefer_server_ciphers }};
+	
+	{% if matrix_nginx_proxy_ocsp_stapling_enabled %}
+		ssl_stapling on;
+		ssl_stapling_verify on;
+		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_base_domain_hostname }}/chain.pem;
+	{% endif %}
 
 	{{ render_vhost_directives() }}
 }

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-grafana.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-grafana.conf.j2
@@ -10,6 +10,13 @@
 	# add_header X-Content-Type-Options nosniff;
 	# add_header X-Frame-Options SAMEORIGIN;
 	add_header Referrer-Policy "strict-origin-when-cross-origin";
+	
+	{% if matrix_nginx_proxy_ocsp_stapling_enabled and matrix_ssl_retrieval_method in ["lets-encrypt", "manually-managed"] %}
+		ssl_stapling on;
+		ssl_stapling_verify on;
+		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_base_domain_hostname }}/chain.pem;
+	{% endif %}
+	
 	{% if matrix_nginx_proxy_floc_optout_enabled %}
 		add_header Permissions-Policy interest-cohort=() always;
 	{% endif %}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-grafana.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-grafana.conf.j2
@@ -11,12 +11,6 @@
 	# add_header X-Frame-Options SAMEORIGIN;
 	add_header Referrer-Policy "strict-origin-when-cross-origin";
 	
-	{% if matrix_nginx_proxy_ocsp_stapling_enabled and matrix_ssl_retrieval_method in ["lets-encrypt", "manually-managed"] %}
-		ssl_stapling on;
-		ssl_stapling_verify on;
-		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_base_domain_hostname }}/chain.pem;
-	{% endif %}
-	
 	{% if matrix_nginx_proxy_floc_optout_enabled %}
 		add_header Permissions-Policy interest-cohort=() always;
 	{% endif %}
@@ -90,6 +84,12 @@ server {
 	ssl_ciphers {{ matrix_nginx_proxy_ssl_ciphers }};
 	{% endif %}
 	ssl_prefer_server_ciphers {{ matrix_nginx_proxy_ssl_prefer_server_ciphers }};
+
+	{% if matrix_nginx_proxy_ocsp_stapling_enabled %}
+		ssl_stapling on;
+		ssl_stapling_verify on;
+		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_base_domain_hostname }}/chain.pem;
+	{% endif %}	
 
 	{{ render_vhost_directives() }}
 }

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-jitsi.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-jitsi.conf.j2
@@ -9,6 +9,12 @@
 	{% if matrix_nginx_proxy_floc_optout_enabled %}
 		add_header Permissions-Policy interest-cohort=() always;
 	{% endif %}
+	
+	{% if matrix_nginx_proxy_ocsp_stapling_enabled and matrix_ssl_retrieval_method in ["lets-encrypt", "manually-managed"] %}
+		ssl_stapling on;
+		ssl_stapling_verify on;
+		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_base_domain_hostname }}/chain.pem;
+	{% endif %}
 
 {% for configuration_block in matrix_nginx_proxy_proxy_jitsi_additional_server_configuration_blocks %}
 	{{- configuration_block }}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-jitsi.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-jitsi.conf.j2
@@ -9,12 +9,6 @@
 	{% if matrix_nginx_proxy_floc_optout_enabled %}
 		add_header Permissions-Policy interest-cohort=() always;
 	{% endif %}
-	
-	{% if matrix_nginx_proxy_ocsp_stapling_enabled and matrix_ssl_retrieval_method in ["lets-encrypt", "manually-managed"] %}
-		ssl_stapling on;
-		ssl_stapling_verify on;
-		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_base_domain_hostname }}/chain.pem;
-	{% endif %}
 
 {% for configuration_block in matrix_nginx_proxy_proxy_jitsi_additional_server_configuration_blocks %}
 	{{- configuration_block }}
@@ -124,6 +118,12 @@ server {
 	ssl_ciphers {{ matrix_nginx_proxy_ssl_ciphers }};
 	{% endif %}
 	ssl_prefer_server_ciphers {{ matrix_nginx_proxy_ssl_prefer_server_ciphers }};
+
+	{% if matrix_nginx_proxy_ocsp_stapling_enabled %}
+		ssl_stapling on;
+		ssl_stapling_verify on;
+		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_base_domain_hostname }}/chain.pem;
+	{% endif %}	
 
 	{{ render_vhost_directives() }}
 }

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-riot-web.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-riot-web.conf.j2
@@ -4,12 +4,6 @@
 	{% if matrix_nginx_proxy_floc_optout_enabled %}
 		add_header Permissions-Policy interest-cohort=() always;
 	{% endif %}
-	
-	{% if matrix_nginx_proxy_ocsp_stapling_enabled and matrix_ssl_retrieval_method in ["lets-encrypt", "manually-managed"] %}
-		ssl_stapling on;
-		ssl_stapling_verify on;
-		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_base_domain_hostname }}/chain.pem;
-	{% endif %}
 
 	{% for configuration_block in matrix_nginx_proxy_proxy_riot_additional_server_configuration_blocks %}
 		{{- configuration_block }}
@@ -67,6 +61,12 @@ server {
 	ssl_ciphers {{ matrix_nginx_proxy_ssl_ciphers }};
 	{% endif %}
 	ssl_prefer_server_ciphers {{ matrix_nginx_proxy_ssl_prefer_server_ciphers }};
+
+	{% if matrix_nginx_proxy_ocsp_stapling_enabled %}
+		ssl_stapling on;
+		ssl_stapling_verify on;
+		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_base_domain_hostname }}/chain.pem;
+	{% endif %}	
 
 	{{ render_vhost_directives() }}
 }

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-riot-web.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-riot-web.conf.j2
@@ -4,6 +4,12 @@
 	{% if matrix_nginx_proxy_floc_optout_enabled %}
 		add_header Permissions-Policy interest-cohort=() always;
 	{% endif %}
+	
+	{% if matrix_nginx_proxy_ocsp_stapling_enabled and matrix_ssl_retrieval_method in ["lets-encrypt", "manually-managed"] %}
+		ssl_stapling on;
+		ssl_stapling_verify on;
+		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_base_domain_hostname }}/chain.pem;
+	{% endif %}
 
 	{% for configuration_block in matrix_nginx_proxy_proxy_riot_additional_server_configuration_blocks %}
 		{{- configuration_block }}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-sygnal.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-sygnal.conf.j2
@@ -76,6 +76,12 @@ server {
 	{% endif %}
 	ssl_prefer_server_ciphers {{ matrix_nginx_proxy_ssl_prefer_server_ciphers }};
 
+	{% if matrix_nginx_proxy_ocsp_stapling_enabled %}
+		ssl_stapling on;
+		ssl_stapling_verify on;
+		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_base_domain_hostname }}/chain.pem;
+	{% endif %}	
+
 	{{ render_vhost_directives() }}
 }
 {% endif %}


### PR DESCRIPTION
`matrix_nginx_proxy_ocsp_stapling_enabled` Added. Default value:

```
# set false to disable OCSP Stapling
matrix_nginx_proxy_ocsp_stapling_enabled: true
```

- OCSP Stapling eliminating the need for clients to contact the CA, with the aim of improving both security and performance.
- OCSP stapling can provide a performance boost of up to 30%
- nginx web server supports OCSP stapling since version 1.3.7.

> **warning** Nginx is lazy loading OCSP responses, which means that for the first few web requests might unable to add the OCSP response.
  
Learn more about what it is here:
 - https://en.wikipedia.org/wiki/OCSP_stapling
 - https://blog.cloudflare.com/high-reliability-ocsp-stapling/
 - https://blog.mozilla.org/security/2013/07/29/ocsp-stapling-in-firefox/