### PR TITLE
Optimize SSL session

### DIFF
--- a/roles/matrix-nginx-proxy/defaults/main.yml
+++ b/roles/matrix-nginx-proxy/defaults/main.yml
@@ -386,6 +386,34 @@ matrix_ssl_log_dir_path: "{{ matrix_ssl_base_path }}/log"
 matrix_ssl_pre_obtaining_required_service_name: ~
 matrix_ssl_pre_obtaining_required_service_start_wait_time_seconds: 60
 
+# Nginx Optimize SSL Session
+#
+# ssl_session_cache:
+# - Creating a cache of TLS connection parameters reduces the number of handshakes 
+#   and thus can improve the performance of application.
+# - Default session cache is not optimal as it can be used by only one worker process
+#   and can cause memory fragmentation. It is much better to use shared cache.
+# - Learn More: https://nginx.org/en/docs/http/ngx_http_ssl_module.html
+#
+# ssl_session_timeout:
+# - Nginx by default it is set to 5 minutes which is very low.
+#   should be like 4h or 1d but will require you to increase the size of cache.
+# - Learn More: 
+#     https://github.com/certbot/certbot/issues/6903
+#     https://github.com/mozilla/server-side-tls/issues/198
+#
+# ssl_session_tickets:
+# - In case of session tickets, information about session is given to the client.
+#   Enabling this improve performance also make Perfect Forward Secrecy useless.
+# - If you would instead like to use ssl_session_tickets by yourself, you can set
+#   matrix_nginx_proxy_ssl_session_tickets_off false.
+# - Learn More: https://github.com/mozilla/server-side-tls/issues/135
+#
+# Presets are taken from Mozilla's Server Side TLS Recommended configurations
+matrix_nginx_proxy_ssl_session_cache: "shared:MozSSL:10m"
+matrix_nginx_proxy_ssl_session_timeout: "1d"
+matrix_nginx_proxy_ssl_session_tickets_off: true
+
 # OCSP Stapling eliminating the need for clients to contact the CA, with the aim of improving both security and performance.
 # OCSP stapling can provide a performance boost of up to 30%
 # nginx web server supports OCSP stapling since version 1.3.7.

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-base-domain.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-base-domain.conf.j2
@@ -74,7 +74,13 @@ server {
 		ssl_stapling on;
 		ssl_stapling_verify on;
 		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_base_domain_hostname }}/chain.pem;
-	{% endif %}	
+	{% endif %}
+	
+	{% if matrix_nginx_proxy_ssl_session_tickets_off %}
+		ssl_session_tickets off;
+	{% endif %}
+	ssl_session_cache {{ matrix_nginx_proxy_ssl_session_cache }};
+	ssl_session_timeout {{ matrix_nginx_proxy_ssl_session_timeout }};
 
 	{{ render_vhost_directives() }}
 }

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-bot-go-neb.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-bot-go-neb.conf.j2
@@ -79,6 +79,12 @@ server {
 		ssl_stapling_verify on;
 		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_proxy_bot_go_neb_hostname }}/chain.pem;
 	{% endif %}
+	
+	{% if matrix_nginx_proxy_ssl_session_tickets_off %}
+		ssl_session_tickets off;
+	{% endif %}
+	ssl_session_cache {{ matrix_nginx_proxy_ssl_session_cache }};
+	ssl_session_timeout {{ matrix_nginx_proxy_ssl_session_timeout }};
 
 	{{ render_vhost_directives() }}
 }

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-client-element.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-client-element.conf.j2
@@ -85,6 +85,12 @@ server {
 		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_proxy_element_hostname }}/chain.pem;
 	{% endif %}
 
+	{% if matrix_nginx_proxy_ssl_session_tickets_off %}
+		ssl_session_tickets off;
+	{% endif %}
+	ssl_session_cache {{ matrix_nginx_proxy_ssl_session_cache }};
+	ssl_session_timeout {{ matrix_nginx_proxy_ssl_session_timeout }};
+
 	{{ render_vhost_directives() }}
 }
 {% endif %}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-dimension.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-dimension.conf.j2
@@ -82,6 +82,12 @@ server {
 		ssl_stapling_verify on;
 		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_proxy_dimension_hostname }}/chain.pem;
 	{% endif %}
+	
+	{% if matrix_nginx_proxy_ssl_session_tickets_off %}
+		ssl_session_tickets off;
+	{% endif %}
+	ssl_session_cache {{ matrix_nginx_proxy_ssl_session_cache }};
+	ssl_session_timeout {{ matrix_nginx_proxy_ssl_session_timeout }};
 
 	{{ render_vhost_directives() }}
 }

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
@@ -207,6 +207,12 @@ server {
 		ssl_stapling_verify on;
 		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_proxy_matrix_hostname }}/chain.pem;
 	{% endif %}
+	
+	{% if matrix_nginx_proxy_ssl_session_tickets_off %}
+		ssl_session_tickets off;
+	{% endif %}
+	ssl_session_cache {{ matrix_nginx_proxy_ssl_session_cache }};
+	ssl_session_timeout {{ matrix_nginx_proxy_ssl_session_timeout }};	
 
 	{{ render_vhost_directives() }}
 }
@@ -248,6 +254,12 @@ server {
 			ssl_stapling_verify on;
 			ssl_trusted_certificate {{ matrix_nginx_proxy_proxy_matrix_federation_api_ssl_trusted_certificate }};
 		{% endif %}
+		
+		{% if matrix_nginx_proxy_ssl_session_tickets_off %}
+			ssl_session_tickets off;
+		{% endif %}
+		ssl_session_cache {{ matrix_nginx_proxy_ssl_session_cache }};
+		ssl_session_timeout {{ matrix_nginx_proxy_ssl_session_timeout }};
 	{% endif %}
 
 	location / {

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-grafana.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-grafana.conf.j2
@@ -90,6 +90,12 @@ server {
 		ssl_stapling_verify on;
 		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_proxy_grafana_hostname }}/chain.pem;
 	{% endif %}
+	
+	{% if matrix_nginx_proxy_ssl_session_tickets_off %}
+		ssl_session_tickets off;
+	{% endif %}
+	ssl_session_cache {{ matrix_nginx_proxy_ssl_session_cache }};
+	ssl_session_timeout {{ matrix_nginx_proxy_ssl_session_timeout }};	
 
 	{{ render_vhost_directives() }}
 }

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-jitsi.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-jitsi.conf.j2
@@ -124,6 +124,12 @@ server {
 		ssl_stapling_verify on;
 		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_proxy_jitsi_hostname }}/chain.pem;
 	{% endif %}
+	
+	{% if matrix_nginx_proxy_ssl_session_tickets_off %}
+		ssl_session_tickets off;
+	{% endif %}
+	ssl_session_cache {{ matrix_nginx_proxy_ssl_session_cache }};
+	ssl_session_timeout {{ matrix_nginx_proxy_ssl_session_timeout }};
 
 	{{ render_vhost_directives() }}
 }

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-riot-web.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-riot-web.conf.j2
@@ -67,6 +67,12 @@ server {
 		ssl_stapling_verify on;
 		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_proxy_riot_compat_redirect_hostname }}/chain.pem;
 	{% endif %}
+	
+	{% if matrix_nginx_proxy_ssl_session_tickets_off %}
+		ssl_session_tickets off;
+	{% endif %}
+	ssl_session_cache {{ matrix_nginx_proxy_ssl_session_cache }};
+	ssl_session_timeout {{ matrix_nginx_proxy_ssl_session_timeout }};
 
 	{{ render_vhost_directives() }}
 }

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-sygnal.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-sygnal.conf.j2
@@ -81,6 +81,12 @@ server {
 		ssl_stapling_verify on;
 		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_proxy_sygnal_hostname }}/chain.pem;
 	{% endif %}
+	
+	{% if matrix_nginx_proxy_ssl_session_tickets_off %}
+		ssl_session_tickets off;
+	{% endif %}
+	ssl_session_cache {{ matrix_nginx_proxy_ssl_session_cache }};
+	ssl_session_timeout {{ matrix_nginx_proxy_ssl_session_timeout }};
 
 	{{ render_vhost_directives() }}
 }


### PR DESCRIPTION
**ssl_session_cache:**
- Creating a cache of TLS connection parameters reduces the number of handshakes 
  and thus can improve the performance of application.
- Default session cache is not optimal as it can be used by only one worker process
  and can cause memory fragmentation. It is much better to use shared cache.
- Learn More: https://nginx.org/en/docs/http/ngx_http_ssl_module.html

**ssl_session_timeout:**
- Nginx by default it is set to 5 minutes which is very low.
  should be like 4h or 1d but will require you to increase the size of cache.
- Learn More: 
    https://github.com/certbot/certbot/issues/6903
    https://github.com/mozilla/server-side-tls/issues/198

**ssl_session_tickets:**
- In case of session tickets, information about session is given to the client.
  Enabling this improve performance also make Perfect Forward Secrecy useless.
- If you would instead like to use ssl_session_tickets by yourself, you can set
  matrix_nginx_proxy_ssl_session_tickets_off false.
- Learn More: https://github.com/mozilla/server-side-tls/issues/135

**Note: Presets are taken from Mozilla's Server Side TLS Recommended configurations**