### PR TITLE
Configure root_url in granafa.ini

### DIFF
--- a/docs/configuring-playbook-prometheus-grafana.md
+++ b/docs/configuring-playbook-prometheus-grafana.md
@@ -56,6 +56,7 @@ Name | Description
 `matrix_nginx_proxy_proxy_synapse_metrics`|Set this to `true` to make matrix-nginx-proxy expose the Synapse metrics at `https://matrix.DOMAIN/_synapse/metrics`
 `matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_enabled`|Set this to `true` to password-protect (using HTTP Basic Auth) `https://matrix.DOMAIN/_synapse/metrics` (the username is always `prometheus`, the password is defined in `matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_key`)
 `matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_key`|Set this to a password to use for HTTP Basic Auth for protecting `https://matrix.DOMAIN/_synapse/metrics` (the username is always `prometheus` - it's not configurable)
+`matrix_server_fqn_grafana`|Use this variable to override the Grafana web user-interface.
 
 
 ## More information

--- a/docs/configuring-playbook-prometheus-grafana.md
+++ b/docs/configuring-playbook-prometheus-grafana.md
@@ -56,7 +56,7 @@ Name | Description
 `matrix_nginx_proxy_proxy_synapse_metrics`|Set this to `true` to make matrix-nginx-proxy expose the Synapse metrics at `https://matrix.DOMAIN/_synapse/metrics`
 `matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_enabled`|Set this to `true` to password-protect (using HTTP Basic Auth) `https://matrix.DOMAIN/_synapse/metrics` (the username is always `prometheus`, the password is defined in `matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_key`)
 `matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_key`|Set this to a password to use for HTTP Basic Auth for protecting `https://matrix.DOMAIN/_synapse/metrics` (the username is always `prometheus` - it's not configurable)
-`matrix_server_fqn_grafana`|Use this variable to override the Grafana web user-interface.
+`matrix_server_fqn_grafana`|Use this variable to override the domain at which the Grafana web user-interface is at (defaults to `stats.DOMAIN`).
 
 
 ## More information

--- a/roles/matrix-grafana/templates/grafana.ini.j2
+++ b/roles/matrix-grafana/templates/grafana.ini.j2
@@ -1,3 +1,6 @@
+[server]
+root_url = "https://{{ matrix_server_fqn_grafana }}"
+
 [security]
 # default admin user, created on startup
 admin_user = "{{ matrix_grafana_default_admin_user }}"


### PR DESCRIPTION
Because grafana is running behind a reverse proxy, it will in some cases (e.g. in notifications) show links to localhost:3000 instead the web interface address.

This PR fixes that.