### PR TITLE
Allow Jitsi XMPP websocket support for users using own webserver.

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -1053,6 +1053,8 @@ matrix_jitsi_web_container_http_host_bind_port: "{{ '' if matrix_nginx_proxy_ena
 
 matrix_jitsi_jvb_container_colibri_ws_host_bind_port: "{{ '' if matrix_nginx_proxy_enabled else '127.0.0.1:13090' }}"
 
+matrix_jitsi_prosody_container_http_host_bind_port: "{{ '' if matrix_nginx_proxy_enabled else '127.0.0.1:5280' }}"
+
 matrix_jitsi_jibri_xmpp_password: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'jibri') | to_uuid }}"
 matrix_jitsi_jicofo_auth_password: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'jicofo') | to_uuid }}"
 matrix_jitsi_jvb_auth_password: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'jvb') | to_uuid }}"

--- a/roles/matrix-jitsi/defaults/main.yml
+++ b/roles/matrix-jitsi/defaults/main.yml
@@ -175,7 +175,9 @@ matrix_jitsi_prosody_container_extra_arguments: []
 
 # List of systemd services that matrix-jitsi-prosody.service depends on
 matrix_jitsi_prosody_systemd_required_services_list: ['docker.service']
-matrix_jitsi_prosody_container_http_host_bind_port: ''
+
+# Neccessary Port binding for those disabling the integrated nginx proxy
+matrix_jitsi_prosody_container_http_host_bind_port: 5280
 
 matrix_jitsi_jicofo_docker_image: "{{ matrix_container_global_registry_prefix }}jitsi/jicofo:{{ matrix_jitsi_container_image_tag }}"
 matrix_jitsi_jicofo_docker_image_force_pull: "{{ matrix_jitsi_jicofo_docker_image.endswith(':latest') }}"

--- a/roles/matrix-jitsi/defaults/main.yml
+++ b/roles/matrix-jitsi/defaults/main.yml
@@ -175,7 +175,7 @@ matrix_jitsi_prosody_container_extra_arguments: []
 
 # List of systemd services that matrix-jitsi-prosody.service depends on
 matrix_jitsi_prosody_systemd_required_services_list: ['docker.service']
-
+matrix_jitsi_prosody_container_http_host_bind_port: ''
 
 matrix_jitsi_jicofo_docker_image: "{{ matrix_container_global_registry_prefix }}jitsi/jicofo:{{ matrix_jitsi_container_image_tag }}"
 matrix_jitsi_jicofo_docker_image_force_pull: "{{ matrix_jitsi_jicofo_docker_image.endswith(':latest') }}"

--- a/roles/matrix-jitsi/defaults/main.yml
+++ b/roles/matrix-jitsi/defaults/main.yml
@@ -177,7 +177,7 @@ matrix_jitsi_prosody_container_extra_arguments: []
 matrix_jitsi_prosody_systemd_required_services_list: ['docker.service']
 
 # Neccessary Port binding for those disabling the integrated nginx proxy
-matrix_jitsi_prosody_container_http_host_bind_port: 5280
+matrix_jitsi_prosody_container_http_host_bind_port: ''
 
 matrix_jitsi_jicofo_docker_image: "{{ matrix_container_global_registry_prefix }}jitsi/jicofo:{{ matrix_jitsi_container_image_tag }}"
 matrix_jitsi_jicofo_docker_image_force_pull: "{{ matrix_jitsi_jicofo_docker_image.endswith(':latest') }}"

--- a/roles/matrix-jitsi/templates/prosody/matrix-jitsi-prosody.service.j2
+++ b/roles/matrix-jitsi/templates/prosody/matrix-jitsi-prosody.service.j2
@@ -16,7 +16,7 @@ ExecStartPre=-{{ matrix_host_command_sh }} -c '{{ matrix_host_command_docker }} 
 ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-jitsi-prosody \
 			--log-driver=none \
 			--network={{ matrix_docker_network }} \
-			{% if matrix_nginx_proxy_enabled == false %}
+			{% if matrix_jitsi_prosody_container_http_host_bind_port %}
 			-p {{ matrix_jitsi_prosody_container_http_host_bind_port }}:5280 \
 			{% endif %}
 			--env-file={{ matrix_jitsi_prosody_base_path }}/env \

--- a/roles/matrix-jitsi/templates/prosody/matrix-jitsi-prosody.service.j2
+++ b/roles/matrix-jitsi/templates/prosody/matrix-jitsi-prosody.service.j2
@@ -16,8 +16,8 @@ ExecStartPre=-{{ matrix_host_command_sh }} -c '{{ matrix_host_command_docker }} 
 ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-jitsi-prosody \
 			--log-driver=none \
 			--network={{ matrix_docker_network }} \
-			{% if matrix_jitsi_prosody_container_http_host_bind_port %}
-			-p {{ matrix_jitsi_prosody_container_http_host_bind_port }}:{{ matrix_jitsi_prosody_container_http_host_bind_port }}
+			{% if matrix_nginx_proxy_enabled == false %}
+			-p {{ matrix_jitsi_prosody_container_http_host_bind_port }}:5280 \
 			{% endif %}
 			--env-file={{ matrix_jitsi_prosody_base_path }}/env \
 			--mount type=bind,src={{ matrix_jitsi_prosody_config_path }},dst=/config \

--- a/roles/matrix-jitsi/templates/prosody/matrix-jitsi-prosody.service.j2
+++ b/roles/matrix-jitsi/templates/prosody/matrix-jitsi-prosody.service.j2
@@ -16,6 +16,9 @@ ExecStartPre=-{{ matrix_host_command_sh }} -c '{{ matrix_host_command_docker }} 
 ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-jitsi-prosody \
 			--log-driver=none \
 			--network={{ matrix_docker_network }} \
+			{% if matrix_jitsi_prosody_container_http_host_bind_port %}
+			-p {{ matrix_jitsi_prosody_container_http_host_bind_port }}:{{ matrix_jitsi_prosody_container_http_host_bind_port }}
+			{% endif %}
 			--env-file={{ matrix_jitsi_prosody_base_path }}/env \
 			--mount type=bind,src={{ matrix_jitsi_prosody_config_path }},dst=/config \
 			--mount type=bind,src={{ matrix_jitsi_prosody_plugins_path }},dst=/prosody-plugins-custom \


### PR DESCRIPTION
Since the update to Jitsi from 5142 to 5765 (#1037) and the corresponding changes to the nginx template to allow for the XMPP websocket client support (#1037), people using their webservers might not have been able to create calls using the web client. This manifested in the "You have been disconnected" error when starting a call.

The above commit added and {{else}} for people that disabled the internal nginx-proxy that redirected ```/xmpp-websocket``` to ```http://127.0.0.1:5280;```.
The prosody containers that ```/xmpp-websocket``` needed to redirect to lacked the necessary port binding to allow this for people running their own webserver.

To fix this I have added:
 - Conditional localhost Port bindings for Jitsi Prosody systemd template
- Added variable to main.yml to allow overriding from vars.yml

Manually editing the systemd file for prodsody for my server seems to fix this and remove the "You have been disconnected" error.

I am sure there is a way to more intelligently set this when people set ```matrix_nginx_proxy_enabled: false``` but my knowledge of the playbook (and ansible) is not yet such to do that. I will keep thinking and make another PR when I work it out!

(This being my first PR, I may have done things wrong, apologies in advance if so!)