### PR TITLE
Synapse LDAP auth: add support for Active Directory

### DIFF
--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -497,6 +497,8 @@ matrix_synapse_ext_password_provider_ldap_attributes_name: "cn"
 matrix_synapse_ext_password_provider_ldap_bind_dn: ""
 matrix_synapse_ext_password_provider_ldap_bind_password: ""
 matrix_synapse_ext_password_provider_ldap_filter: ""
+matrix_synapse_ext_password_provider_ldap_is_active_directory: false
+matrix_synapse_ext_password_provider_ldap_default_domain: ""
 
 # Enable this to activate the Synapse Antispam spam-checker module.
 # See: https://github.com/t2bot/synapse-simple-antispam

--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -497,7 +497,7 @@ matrix_synapse_ext_password_provider_ldap_attributes_name: "cn"
 matrix_synapse_ext_password_provider_ldap_bind_dn: ""
 matrix_synapse_ext_password_provider_ldap_bind_password: ""
 matrix_synapse_ext_password_provider_ldap_filter: ""
-matrix_synapse_ext_password_provider_ldap_is_active_directory: false
+matrix_synapse_ext_password_provider_ldap_active_directory: false
 matrix_synapse_ext_password_provider_ldap_default_domain: ""
 
 # Enable this to activate the Synapse Antispam spam-checker module.

--- a/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -2596,6 +2596,12 @@ password_providers:
       uri: {{ matrix_synapse_ext_password_provider_ldap_uri|string|to_json }}
       start_tls: {{ matrix_synapse_ext_password_provider_ldap_start_tls|to_json }}
       base: {{ matrix_synapse_ext_password_provider_ldap_base|string|to_json }}
+  {% if matrix_synapse_ext_password_provider_ldap_is_active_directory %}
+      active_directory: true
+  {% endif %}
+  {% if matrix_synapse_ext_password_provider_ldap_default_domain != '' %}
+      default_domain: {{ matrix_synapse_ext_password_provider_ldap_default_domain|string|to_json }}
+  {% endif %}
       attributes:
         uid: {{ matrix_synapse_ext_password_provider_ldap_attributes_uid|string|to_json }}
         mail: {{ matrix_synapse_ext_password_provider_ldap_attributes_mail|string|to_json }}

--- a/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -2596,12 +2596,8 @@ password_providers:
       uri: {{ matrix_synapse_ext_password_provider_ldap_uri|string|to_json }}
       start_tls: {{ matrix_synapse_ext_password_provider_ldap_start_tls|to_json }}
       base: {{ matrix_synapse_ext_password_provider_ldap_base|string|to_json }}
-  {% if matrix_synapse_ext_password_provider_ldap_is_active_directory %}
-      active_directory: true
-  {% endif %}
-  {% if matrix_synapse_ext_password_provider_ldap_default_domain != '' %}
+      active_directory: {{ matrix_synapse_ext_password_provider_ldap_active_directory|to_json }}
       default_domain: {{ matrix_synapse_ext_password_provider_ldap_default_domain|string|to_json }}
-  {% endif %}
       attributes:
         uid: {{ matrix_synapse_ext_password_provider_ldap_attributes_uid|string|to_json }}
         mail: {{ matrix_synapse_ext_password_provider_ldap_attributes_mail|string|to_json }}


### PR DESCRIPTION
Add two fields in synapse/homeserver.yaml.j2 to support AD,  
see https://github.com/matrix-org/matrix-synapse-ldap3#active-directory-forest-support   
