### PR TITLE
Check IRC appservice service is present before stopping it

### DIFF
--- a/roles/matrix-bridge-appservice-irc/tasks/migrate_nedb_to_postgres.yml
+++ b/roles/matrix-bridge-appservice-irc/tasks/migrate_nedb_to_postgres.yml
@@ -26,10 +26,16 @@
   become: false
   when: "matrix_postgres_service_start_result.changed|bool"
 
+- name: Check existence of matrix-appservice-irc service
+  stat:
+    path: "{{ matrix_systemd_path }}/matrix-appservice-irc.service"
+  register: matrix_appservice_irc_service_stat
+
 - name: Ensure matrix-appservice-irc is stopped
   service:
     name: matrix-appservice-irc
     state: stopped
+  when: "matrix_appservice_irc_service_stat.stat.exists"
 
 - name: Import appservice-irc NeDB database into Postgres
   command:


### PR DESCRIPTION
In the edge case where the appservice IRC bridge was set up and subsequently disabled again before the migration to Postgres, trying to enable it again will trigger that migration. That tries unconditionally to stop the matrix-appservice-irc systemd service, which will fail because the service file isn't present (because the bridge had been disabled).

This PR adds a check for the presence of that service file, copied from here:

https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/36e583cc215f1419eb6b32821ab9ac74cd6aa4b2/roles/matrix-bridge-appservice-irc/tasks/setup_uninstall.yml#L3-L13

I've tested this on my own homeserver and it seems to solve the problem.