### PR TITLE
Fix local/bin scripts autocompletion by adding rx perms to everyone

### DIFF
--- a/roles/matrix-nginx-proxy/tasks/ssl/setup_ssl_lets_encrypt.yml
+++ b/roles/matrix-nginx-proxy/tasks/ssl/setup_ssl_lets_encrypt.yml
@@ -34,7 +34,7 @@
       template:
         src: "{{ role_path }}/templates/usr-local-bin/matrix-ssl-lets-encrypt-certificates-renew.j2"
         dest: "{{ matrix_local_bin_path }}/matrix-ssl-lets-encrypt-certificates-renew"
-        mode: 0750
+        mode: 0755
 
     - name: Ensure SSL renewal systemd units installed
       template:

--- a/roles/matrix-postgres/tasks/setup_postgres.yml
+++ b/roles/matrix-postgres/tasks/setup_postgres.yml
@@ -77,14 +77,14 @@
   template:
     src: "{{ role_path }}/templates/usr-local-bin/matrix-postgres-cli.j2"
     dest: "{{ matrix_local_bin_path }}/matrix-postgres-cli"
-    mode: 0750
+    mode: 0755
   when: matrix_postgres_enabled|bool
 
 - name: Ensure matrix-change-user-admin-status script created
   template:
     src: "{{ role_path }}/templates/usr-local-bin/matrix-change-user-admin-status.j2"
     dest: "{{ matrix_local_bin_path }}/matrix-change-user-admin-status"
-    mode: 0750
+    mode: 0755
   when: matrix_postgres_enabled|bool
 
 - name: (Migration) Ensure old matrix-make-user-admin script deleted
@@ -97,7 +97,7 @@
   template:
     src: "{{ role_path }}/templates/usr-local-bin/matrix-postgres-update-user-password-hash.j2"
     dest: "{{ matrix_local_bin_path }}/matrix-postgres-update-user-password-hash"
-    mode: 0750
+    mode: 0755
   when: matrix_postgres_enabled|bool
 
 - name: Ensure matrix-postgres.service installed

--- a/roles/matrix-synapse/tasks/synapse/setup_install.yml
+++ b/roles/matrix-synapse/tasks/synapse/setup_install.yml
@@ -106,4 +106,4 @@
   template:
     src: "{{ role_path }}/templates/synapse/usr-local-bin/matrix-synapse-register-user.j2"
     dest: "{{ matrix_local_bin_path }}/matrix-synapse-register-user"
-    mode: 0750
+    mode: 0755


### PR DESCRIPTION
It's mildly annoying when trying to execute these scripts while logged in as a regular user, as the missing execute permissions will hinder autocompletion even when trying to use with sudo.

These shell scripts don't contain secrets, but may fail when ran by a regular user. The failure is due to the lack of access to the /matrix directory, and does not result in any damage.