### PR TITLE
prometheus security update 2.27.1

### DIFF
--- a/roles/matrix-prometheus/defaults/main.yml
+++ b/roles/matrix-prometheus/defaults/main.yml
@@ -3,7 +3,7 @@
 
 matrix_prometheus_enabled: false
 
-matrix_prometheus_version: v2.27.0
+matrix_prometheus_version: v2.27.1
 matrix_prometheus_docker_image: "{{ matrix_container_global_registry_prefix }}prom/prometheus:{{ matrix_prometheus_version }}"
 matrix_prometheus_docker_image_force_pull: "{{ matrix_prometheus_docker_image.endswith(':latest') }}"
 


### PR DESCRIPTION
[CVE-2021-29622](https://github.com/prometheus/prometheus/security/advisories/GHSA-vx57-7f4q-fpc7)