### PR TITLE
Add support for CentOS (Stream) 8

### DIFF
--- a/roles/matrix-base/defaults/main.yml
+++ b/roles/matrix-base/defaults/main.yml
@@ -80,8 +80,8 @@ matrix_host_command_openssl: "/usr/bin/env openssl"
 matrix_host_command_systemctl: "/usr/bin/env systemctl"
 matrix_host_command_sh: "/usr/bin/env sh"
 
-matrix_ntpd_package: "ntp"
-matrix_ntpd_service: "{{ 'ntpd' if ansible_os_family == 'RedHat' or ansible_distribution == 'Archlinux' else 'ntp' }}"
+matrix_ntpd_package: "{{ 'systemd-timesyncd' if ansible_distribution == 'CentOS' and ansible_distribution_major_version > '7' else 'ntp' }}"
+matrix_ntpd_service: "{{ 'systemd-timesyncd' if ansible_distribution == 'CentOS' and ansible_distribution_major_version > '7' else ('ntpd' if ansible_os_family == 'RedHat' or ansible_distribution == 'Archlinux' else 'ntp') }}"
 
 matrix_homeserver_url: "https://{{ matrix_server_fqn_matrix }}"
 

--- a/roles/matrix-base/tasks/server_base/setup.yml
+++ b/roles/matrix-base/tasks/server_base/setup.yml
@@ -1,7 +1,10 @@
 ---
 
 - include_tasks: "{{ role_path }}/tasks/server_base/setup_centos.yml"
-  when: ansible_distribution == 'CentOS'
+  when: ansible_distribution == 'CentOS' and ansible_distribution_major_version < '8'
+
+- include_tasks: "{{ role_path }}/tasks/server_base/setup_centos8.yml"
+  when: ansible_distribution == 'CentOS' and ansible_distribution_major_version > '7'
 
 - block:
   # ansible_lsb is only available if lsb-release is installed.

--- a/roles/matrix-base/tasks/server_base/setup_centos8.yml
+++ b/roles/matrix-base/tasks/server_base/setup_centos8.yml
@@ -1,0 +1,47 @@
+---
+
+- name: Ensure Docker repository is enabled
+  template:
+    src: "{{ role_path }}/files/yum.repos.d/{{ item }}"
+    dest: "/etc/yum.repos.d/{{ item }}"
+    owner: "root"
+    group: "root"
+    mode: 0644
+  with_items:
+    - docker-ce.repo
+  when: matrix_docker_installation_enabled|bool and matrix_docker_package_name == 'docker-ce'
+
+- name: Ensure Docker's RPM key is trusted
+  rpm_key:
+    state: present
+    key: https://download.docker.com/linux/centos/gpg
+  when: matrix_docker_installation_enabled|bool and matrix_docker_package_name == 'docker-ce'
+
+- name: Ensure EPEL is installed
+  yum:
+    name:
+      - epel-release
+    state: latest
+    update_cache: yes
+
+- name: Ensure yum packages are installed
+  yum:
+    name:
+      - "{{ matrix_ntpd_package }}"
+      - fuse
+    state: latest
+    update_cache: yes
+
+- name: Ensure Docker is installed
+  yum:
+    name:
+      - "{{ matrix_docker_package_name }}"
+      - python3-pip
+    state: latest
+  when: matrix_docker_installation_enabled|bool
+
+- name: Ensure Docker-Py is installed
+  pip:
+    name: docker-py
+    state: latest
+  when: matrix_docker_installation_enabled|bool


### PR DESCRIPTION
With these changes I've successfully installed and have been using the server (with a few bridges) on the CentOS Stream 8. AFAIK, everything seems to be working as it should.

This PR is basically more of a request for comments. I don't know enough Ansible to replace `ntp`/`ntpd` with `chrony`/`chronyd` only for CentOS 8+.

Also, `docker-py` is installed through `pip` since I couldn't find it in any repos (checked CentOS and EPEL). Is that a good enough solution?