### PR TITLE
fix error when running with Ansible 2.7 in the hydrogen setup

### DIFF
--- a/roles/matrix-client-hydrogen/tasks/init.yml
+++ b/roles/matrix-client-hydrogen/tasks/init.yml
@@ -3,7 +3,7 @@
 - name: Fail if trying to self-build on Ansible < 2.8
   fail:
     msg: "To self-build the Hydrogen image, you should use Ansible 2.8 or higher. See docs/ansible.md"
-  when: "ansible_version.major == 2 and ansible_version.minor < 8 and matrix_client_hydrogen_container_image_self_build"
+  when: "ansible_version.major == 2 and ansible_version.minor < 8 and matrix_client_hydrogen_container_image_self_build and matrix_client_hydrogen_enabled"
 
 - set_fact:
     matrix_systemd_services_list: "{{ matrix_systemd_services_list + ['matrix-client-hydrogen.service'] }}"


### PR DESCRIPTION
Without this the hydrogen task would fail for Ansible 2.7 even when hydrogen is not enabled.