### PR TITLE
Update configuring-playbook-synapse.md

### DIFF
--- a/docs/configuring-playbook-synapse.md
+++ b/docs/configuring-playbook-synapse.md
@@ -55,3 +55,22 @@ Certain Synapse administration tasks (managing users and rooms, etc.) can be per
 ## Synapse + OpenID Connect for Single-Sign-On
 
 If you'd like to use OpenID Connect authentication with Synapse, you'll need some additional reverse-proxy configuration (see [our nginx reverse-proxy doc page](configuring-playbook-nginx.md#synapse-openid-connect-for-single-sign-on)).
+
+In case you encounter errors regarding the parsing of the variables, you can try to add `{%raw}` and `{% endraw %}` blocks around them. For example ;
+
+```
+ - idp_id: keycloak
+        idp_name: "Keycloak"
+        issuer: "https://url.ix/auth/realms/x"
+        client_id: "matrix"
+        client_secret: "{{ vault_synapse_keycloak }}"
+        scopes: ["openid", "profile"]
+        authorization_endpoint: "https://url.ix/auth/realms/x/protocol/openid-connect/auth"
+        token_endpoint: "https://url.ix/auth/realms/x/protocol/openid-connect/token"
+        userinfo_endpoint: "https://url.ix/auth/realms/x/protocol/openid-connect/userinfo"
+        user_mapping_provider:
+          config:
+            display_name_template: "{%raw}{{ user.given_name }}{% endraw %} {%raw}{{ user.family_name }}{% endraw %}"
+            email_template: "{%raw}{{ user.email }}{% endraw %}"
+```
+


### PR DESCRIPTION
Added an example for configuring the variables for the OpenID, that might fails because the variables are not defined for the playbook parsing, but Synapse's own config file parsing.

Based on advice given by @spantaleev on Matrix : https://matrix.to/#/!cNSQwPqhHKkIZdBnvt:devture.com/$Ob97GK84soL9TudCg7JujbWSjjEZT_P70OrtkbVgK88?via=devture.com&via=matrix.org&via=maunium.net