### PR TITLE
Make federation domain customizable

### DIFF
--- a/roles/matrix-base/defaults/main.yml
+++ b/roles/matrix-base/defaults/main.yml
@@ -11,6 +11,9 @@ matrix_domain: ~
 # This and the Element FQN (see below) are expected to be on the same server.
 matrix_server_fqn_matrix: "matrix.{{ matrix_domain }}"
 
+# This is where you access federation API.
+matrix_server_fqn_matrix_federation: '{{ matrix_server_fqn_matrix }}'
+
 # This is where you access the Element web UI from (if enabled via matrix_client_element_enabled; enabled by default).
 # This and the Matrix FQN (see above) are expected to be on the same server.
 matrix_server_fqn_element: "element.{{ matrix_domain }}"

--- a/roles/matrix-base/templates/static-files/well-known/matrix-server.j2
+++ b/roles/matrix-base/templates/static-files/well-known/matrix-server.j2
@@ -1,4 +1,4 @@
 #jinja2: lstrip_blocks: "True"
 {
-	"m.server": "{{ matrix_server_fqn_matrix }}:{{ matrix_federation_public_port }}"
+	"m.server": "{{ matrix_server_fqn_matrix_federation }}:{{ matrix_federation_public_port }}"
 }

--- a/roles/matrix-nginx-proxy/defaults/main.yml
+++ b/roles/matrix-nginx-proxy/defaults/main.yml
@@ -120,6 +120,7 @@ matrix_nginx_proxy_proxy_hydrogen_hostname: "{{ matrix_server_fqn_hydrogen }}"
 # Controls whether proxying the matrix domain should be done.
 matrix_nginx_proxy_proxy_matrix_enabled: false
 matrix_nginx_proxy_proxy_matrix_hostname: "{{ matrix_server_fqn_matrix }}"
+matrix_nginx_proxy_proxy_matrix_federation_hostname: "{{ matrix_nginx_proxy_proxy_matrix_hostname }}"
 # The port name used for federation in the nginx configuration.
 # This is not necessarily the port that it's actually on,
 # as port-mapping happens (`-p ..`) for the `matrix-nginx-proxy` container.

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
@@ -239,7 +239,7 @@ server {
 		listen {{ matrix_nginx_proxy_proxy_matrix_federation_port }};
 	{% endif %}
 
-	server_name {{ matrix_nginx_proxy_proxy_matrix_hostname }};
+	server_name {{ matrix_nginx_proxy_proxy_matrix_federation_hostname }};
 	server_tokens off;
 
 	root /dev/null;


### PR DESCRIPTION
**tl;dr:** Setup option to allow matrix federation fqn to be different to matrix client fqn

### Description
In some cases it might be useful to have a different domain for your matrix federation API than for your client communications.
e.g.:
- you are running the matrix-docker-ansible-deploy ecosystem behind a webproxy, which only allows `:80` and `:443` to be configured. By making the federation fqn different to client communications, you can handle the federation requests within _matrix-nginx-proxy_ separately with the nginx `server_name` key.

**Attention:** I did not checked every role and most roles does not uses federation API anyway. Therefore I am happy about advises, where these code changes to the federation domain could cause problems. 