### PR TITLE
Add worker metrics to prometheus exporter

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -1768,6 +1768,7 @@ matrix_prometheus_container_http_host_bind_port: "{{ '' if matrix_nginx_proxy_en
 
 matrix_prometheus_scraper_synapse_enabled: "{{ matrix_synapse_enabled and matrix_synapse_metrics_enabled }}"
 matrix_prometheus_scraper_synapse_targets: ['matrix-synapse:{{ matrix_synapse_metrics_port }}']
+matrix_prometheus_scraper_synapse_workers_enabled_list: "{{ matrix_synapse_workers_enabled_list }}"
 matrix_prometheus_scraper_synapse_rules_synapse_tag: "{{ matrix_synapse_docker_image_tag }}"
 
 matrix_prometheus_scraper_node_enabled: "{{ matrix_prometheus_node_exporter_enabled }}"

--- a/roles/matrix-prometheus/defaults/main.yml
+++ b/roles/matrix-prometheus/defaults/main.yml
@@ -34,6 +34,7 @@ matrix_prometheus_scraper_synapse_rules_synapse_tag: "master"
 matrix_prometheus_scraper_synapse_rules_download_url: "https://raw.githubusercontent.com/matrix-org/synapse/{{ matrix_prometheus_scraper_synapse_rules_synapse_tag }}/contrib/prometheus/synapse-v2.rules"
 
 matrix_prometheus_scraper_synapse_targets: []
+matrix_prometheus_scraper_synapse_workers_enabled_list: []
 
 # Tells whether the "node" scraper configuration is enabled.
 # This configuration aims to scrape the current node (this server).

--- a/roles/matrix-prometheus/templates/prometheus.yml.j2
+++ b/roles/matrix-prometheus/templates/prometheus.yml.j2
@@ -30,15 +30,20 @@ scrape_configs:
   - job_name: 'synapse'
     metrics_path: '/_synapse/metrics'
     static_configs:
-    - targets:
-    {% for target in matrix_prometheus_scraper_synapse_targets %}
-      - {{ target }}
-    {% endfor %}
-    {% for worker in matrix_synapse_workers_enabled_list|d([]) %}
-    {% if worker.metrics_port != 0 %}
-      - 'matrix-synapse-worker-{{ worker.type }}-{{ worker.instanceId }}:{{ worker.metrics_port }}'
-    {% endif %}
-    {% endfor %}
+    - targets: {{ matrix_prometheus_scraper_synapse_targets|to_json }}
+      labels:
+        instance: {{ matrix_domain }}
+        job: master
+        index: 1
+  {% for worker in matrix_synapse_workers_enabled_list|d([]) %}
+  {% if worker.metrics_port != 0 %}
+    - targets: ['matrix-synapse-worker-{{ worker.type }}-{{ worker.instanceId }}:{{ worker.metrics_port }}']
+      labels:
+        instance: {{ matrix_domain }}
+        job: {{ worker.type }}
+        index: {{ worker.instanceId }}
+  {% endif %}
+  {% endfor %}
   {% endif %}
 
   {% if matrix_prometheus_scraper_node_enabled %}

--- a/roles/matrix-prometheus/templates/prometheus.yml.j2
+++ b/roles/matrix-prometheus/templates/prometheus.yml.j2
@@ -30,7 +30,15 @@ scrape_configs:
   - job_name: 'synapse'
     metrics_path: '/_synapse/metrics'
     static_configs:
-    - targets: {{ matrix_prometheus_scraper_synapse_targets|to_json }}
+    - targets:
+    {% for target in matrix_prometheus_scraper_synapse_targets %}
+      - {{ target }}
+    {% endfor %}
+    {% for worker in matrix_synapse_workers_enabled_list|d([]) %}
+    {% if worker.metrics_port != 0 %}
+      - 'matrix-synapse-worker-{{ worker.type }}-{{ worker.instanceId }}:{{ worker.metrics_port }}'
+    {% endif %}
+    {% endfor %}
   {% endif %}
 
   {% if matrix_prometheus_scraper_node_enabled %}

--- a/roles/matrix-prometheus/templates/prometheus.yml.j2
+++ b/roles/matrix-prometheus/templates/prometheus.yml.j2
@@ -34,7 +34,7 @@ scrape_configs:
       labels:
         instance: {{ matrix_domain }}
         job: master
-        index: 1
+        index: 0
   {% for worker in matrix_synapse_workers_enabled_list|d([]) %}
   {% if worker.metrics_port != 0 %}
     - targets: ['matrix-synapse-worker-{{ worker.type }}-{{ worker.instanceId }}:{{ worker.metrics_port }}']

--- a/roles/matrix-prometheus/templates/prometheus.yml.j2
+++ b/roles/matrix-prometheus/templates/prometheus.yml.j2
@@ -35,7 +35,7 @@ scrape_configs:
         instance: {{ matrix_domain }}
         job: master
         index: 0
-  {% for worker in matrix_synapse_workers_enabled_list|d([]) %}
+  {% for worker in matrix_prometheus_scraper_synapse_workers_enabled_list %}
   {% if worker.metrics_port != 0 %}
     - targets: ['matrix-synapse-worker-{{ worker.type }}-{{ worker.instanceId }}:{{ worker.metrics_port }}']
       labels:


### PR DESCRIPTION
I tried a few ways of doing this in various levels of insanity. This was the only way I could come up with that actually worked, but I appreciate it's using a synapse variable in the prometheus role.