### PR TITLE
Skip importing validate_config task when Synapse is disabled

### DIFF
--- a/roles/matrix-synapse/tasks/main.yml
+++ b/roles/matrix-synapse/tasks/main.yml
@@ -3,7 +3,7 @@
     - always
 
 - import_tasks: "{{ role_path }}/tasks/validate_config.yml"
-  when: run_setup|bool
+  when: run_setup|bool and matrix_synapse_enabled|bool
   tags:
     - setup-all
     - setup-synapse


### PR DESCRIPTION
When running the playbook for a host with `matrix_synapse_enabled: false`, it would fail on task `Fail if required Synapse settings not defined`.

The easiest fix I see is checking for this condition when importing the task itself.