### PR TITLE
Deprecate nginx oidc location forwarding setting

### DIFF
--- a/docs/configuring-playbook-nginx.md
+++ b/docs/configuring-playbook-nginx.md
@@ -46,7 +46,7 @@ For more information about these variables, check the `roles/matrix-nginx-proxy/
 
 ## Synapse + OpenID Connect for Single-Sign-On
 
-If you want to use OpenID Connect as an SSO provider (as per the [Synapse OpenID docs](https://github.com/matrix-org/synapse/blob/develop/docs/openid.md)), you need to use the following configuration (in your `vars.yml` file) to instruct nginx to forward `/_synapse/oidc` to Synapse:
+If you want to use OpenID Connect as an SSO provider (as per the [Synapse OpenID docs](https://github.com/matrix-org/synapse/blob/develop/docs/openid.md)), you need to use the following configuration (in your `vars.yml` file) to instruct nginx to forward `/_synapse/client/oidc` to Synapse:
 
 ```yaml
 matrix_nginx_proxy_proxy_matrix_client_api_forwarded_location_synapse_oidc_api_enabled: true

--- a/docs/configuring-playbook-nginx.md
+++ b/docs/configuring-playbook-nginx.md
@@ -46,10 +46,10 @@ For more information about these variables, check the `roles/matrix-nginx-proxy/
 
 ## Synapse + OpenID Connect for Single-Sign-On
 
-If you want to use OpenID Connect as an SSO provider (as per the [Synapse OpenID docs](https://github.com/matrix-org/synapse/blob/develop/docs/openid.md)), you need to use the following configuration (in your `vars.yml` file) to instruct nginx to forward `/_synapse/client/oidc` to Synapse:
+If you want to use OpenID Connect as an SSO provider (as per the [Synapse OpenID docs](https://github.com/matrix-org/synapse/blob/develop/docs/openid.md)), you need to use the following configuration (in your `vars.yml` file) to instruct nginx to forward `/_synapse/client`, including `/_synapse/client/oidc` to Synapse:
 
 ```yaml
-matrix_nginx_proxy_proxy_matrix_client_api_forwarded_location_synapse_oidc_api_enabled: true
+matrix_nginx_proxy_proxy_matrix_client_api_forwarded_location_synapse_client_api_enabled: true
 ```
 
 ## Disable Nginx access logs

--- a/roles/matrix-nginx-proxy/defaults/main.yml
+++ b/roles/matrix-nginx-proxy/defaults/main.yml
@@ -190,10 +190,6 @@ matrix_nginx_proxy_proxy_matrix_client_api_client_max_body_size_mb: 50
 # Tells whether `/_synapse/client` is forwarded to the Matrix Client API server.
 matrix_nginx_proxy_proxy_matrix_client_api_forwarded_location_synapse_client_api_enabled: true
 
-# Tells whether `/_synapse/oidc` is forwarded to the Matrix Client API server.
-# Enable this if you need OpenID Connect authentication support.
-matrix_nginx_proxy_proxy_matrix_client_api_forwarded_location_synapse_oidc_api_enabled: false
-
 # Tells whether `/_synapse/admin` is forwarded to the Matrix Client API server.
 # Following these recommendations (https://github.com/matrix-org/synapse/blob/master/docs/reverse_proxy.md), by default, we don't.
 matrix_nginx_proxy_proxy_matrix_client_api_forwarded_location_synapse_admin_api_enabled: false
@@ -206,8 +202,6 @@ matrix_nginx_proxy_proxy_matrix_client_api_forwarded_location_prefix_regexes: |
     (['/_matrix'])
     +
     (['/_synapse/client'] if matrix_nginx_proxy_proxy_matrix_client_api_forwarded_location_synapse_client_api_enabled else [])
-    +
-    (['/_synapse/oidc'] if matrix_nginx_proxy_proxy_matrix_client_api_forwarded_location_synapse_oidc_api_enabled else [])
     +
     (['/_synapse/admin'] if matrix_nginx_proxy_proxy_matrix_client_api_forwarded_location_synapse_admin_api_enabled else [])
     +

--- a/roles/matrix-nginx-proxy/tasks/validate_config.yml
+++ b/roles/matrix-nginx-proxy/tasks/validate_config.yml
@@ -14,6 +14,7 @@
     - {'old': 'matrix_nginx_proxy_proxy_riot_enabled', 'new': 'matrix_nginx_proxy_proxy_element_enabled'}
     - {'old': 'matrix_ssl_lets_encrypt_renew_cron_time_definition', 'new': '<not configurable anymore>'}
     - {'old': 'matrix_nginx_proxy_reload_cron_time_definition', 'new': '<not configurable anymore>'}
+    - {'old': 'matrix_nginx_proxy_proxy_matrix_client_api_forwarded_location_synapse_oidc_api_enabled', 'new': '<not configurable anymore>'}
 
 - name: Fail on unknown matrix_ssl_retrieval_method
   fail:


### PR DESCRIPTION
Since synapse 1.27.0rc1 open id connect callback URI changed to `/_synapse/client/oidc` from `/_synapse/oidc`. 

Please comment if deprecation is not suitable and if some other way is preferred. If someone uses older version of synapse then old prefix will work and if such case is supported by playbook this pr should be changed/rejected.

resolves https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/1163