### PR TITLE
GoMatrixHosting 0.5.2

### DIFF
--- a/roles/matrix-awx/tasks/set_variables_synapse.yml
+++ b/roles/matrix-awx/tasks/set_variables_synapse.yml
@@ -66,7 +66,7 @@
   delegate_to: 127.0.0.1
   lineinfile:
     path: '{{ awx_cached_matrix_vars }}'
-    regexp: "{{ item }}:"
+    regexp: "{{ item }}"
     line: "{{ item }}"
     insertbefore: '# Synapse Extension End'
   with_items:
@@ -78,7 +78,7 @@
   delegate_to: 127.0.0.1
   lineinfile:
     path: '{{ awx_cached_matrix_vars }}'
-    regexp: "{{ item }}:"
+    regexp: "{{ item }}"
     line: "{{ item }}"
     insertbefore: '# Synapse Extension End'
     state: absent


### PR DESCRIPTION
- Replaced poorly designed method for assigning hosts to groups in AWX with a URI module call.
- Make '00 - Ansible Delete Membership' more reliable, ensure client-list entry is deleted
- Update notes on setting up Google ReCaptcha for registration.
- Fix matrix-awx bug where the registrations_require_3pid variable aren't removed if disabled.

Follow us on [GitLab](https://gitlab.com/GoMatrixHosting), or come say hello on [Matrix](https://gitlab.com/GoMatrixHosting).