### PR TITLE
prometheus version 2.28.0 -> 2.28.1

### DIFF
--- a/roles/matrix-prometheus/defaults/main.yml
+++ b/roles/matrix-prometheus/defaults/main.yml
@@ -3,7 +3,7 @@
 
 matrix_prometheus_enabled: false
 
-matrix_prometheus_version: v2.28.0
+matrix_prometheus_version: v2.28.1
 matrix_prometheus_docker_image: "{{ matrix_container_global_registry_prefix }}prom/prometheus:{{ matrix_prometheus_version }}"
 matrix_prometheus_docker_image_force_pull: "{{ matrix_prometheus_docker_image.endswith(':latest') }}"
 


### PR DESCRIPTION
- [2.28.1 / 2021-07-01](https://github.com/prometheus/prometheus/releases/tag/v2.28.1)