### PR TITLE
Updating to ma1sd v2.5.0

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -1117,17 +1117,7 @@ matrix_mailer_container_image_self_build: "{{ matrix_architecture != 'amd64'}}"
 # If you wish to use the public identity servers (matrix.org, vector.im) instead of your own you may wish to disable this.
 matrix_ma1sd_enabled: true
 
-# There's no prebuilt ma1sd image for the `arm32` architecture.
-# We're relying on self-building there.
-matrix_ma1sd_architecture: "{{
-	{
-		'amd64': 'amd64',
-		'arm32': 'arm32',
-		'arm64': 'arm64',
-	}[matrix_architecture]
-}}"
-
-matrix_ma1sd_container_image_self_build: "{{ matrix_architecture not in ['arm64', 'amd64'] }}"
+matrix_ma1sd_container_image_self_build: "{{ matrix_architecture != 'amd64' }}"
 
 # Normally, matrix-nginx-proxy is enabled and nginx can reach ma1sd over the container network.
 # If matrix-nginx-proxy is not enabled, or you otherwise have a need for it, you can expose

--- a/roles/matrix-ma1sd/defaults/main.yml
+++ b/roles/matrix-ma1sd/defaults/main.yml
@@ -7,9 +7,9 @@ matrix_ma1sd_container_image_self_build: false
 matrix_ma1sd_container_image_self_build_repo: "https://github.com/ma1uta/ma1sd.git"
 matrix_ma1sd_container_image_self_build_branch: "{{ matrix_ma1sd_version }}"
 
-matrix_ma1sd_architecture: "amd64"
+matrix_ma1sd_architecture: ""
 
-matrix_ma1sd_version: "2.4.0"
+matrix_ma1sd_version: "2.5.0"
 
 matrix_ma1sd_docker_image: "{{ matrix_ma1sd_docker_image_name_prefix }}ma1uta/ma1sd:{{ matrix_ma1sd_version }}-{{ matrix_ma1sd_architecture }}"
 matrix_ma1sd_docker_image_name_prefix: "{{ 'localhost/' if matrix_ma1sd_container_image_self_build else matrix_container_global_registry_prefix }}"

--- a/roles/matrix-ma1sd/defaults/main.yml
+++ b/roles/matrix-ma1sd/defaults/main.yml
@@ -7,11 +7,9 @@ matrix_ma1sd_container_image_self_build: false
 matrix_ma1sd_container_image_self_build_repo: "https://github.com/ma1uta/ma1sd.git"
 matrix_ma1sd_container_image_self_build_branch: "{{ matrix_ma1sd_version }}"
 
-matrix_ma1sd_architecture: ""
-
 matrix_ma1sd_version: "2.5.0"
 
-matrix_ma1sd_docker_image: "{{ matrix_ma1sd_docker_image_name_prefix }}ma1uta/ma1sd:{{ matrix_ma1sd_version }}-{{ matrix_ma1sd_architecture }}"
+matrix_ma1sd_docker_image: "{{ matrix_ma1sd_docker_image_name_prefix }}ma1uta/ma1sd:{{ matrix_ma1sd_version }}"
 matrix_ma1sd_docker_image_name_prefix: "{{ 'localhost/' if matrix_ma1sd_container_image_self_build else matrix_container_global_registry_prefix }}"
 matrix_ma1sd_docker_image_force_pull: "{{ matrix_ma1sd_docker_image.endswith(':latest') }}"
 

--- a/roles/matrix-ma1sd/tasks/validate_config.yml
+++ b/roles/matrix-ma1sd/tasks/validate_config.yml
@@ -28,6 +28,7 @@
     - 'matrix_ma1sd_ldap_auth_filter'
     - 'matrix_ma1sd_ldap_directory_filter'
     - 'matrix_ma1sd_template_config'
+    - 'matrix_ma1sd_architecture'
 
 - name: Ensure ma1sd configuration does not contain any dot-notation keys
   fail:


### PR DESCRIPTION
Version 2.5.0 did not have an architecture tag.
https://hub.docker.com/r/ma1uta/ma1sd/tags?page=1&ordering=last_updated