### PR TITLE
Update synapse to v1.38.0

### DIFF
--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -15,8 +15,8 @@ matrix_synapse_docker_image_name_prefix: "{{ 'localhost/' if matrix_synapse_cont
 # amd64 gets released first.
 # arm32 relies on self-building, so the same version can be built immediately.
 # arm64 users need to wait for a prebuilt image to become available.
-matrix_synapse_version: v1.37.1
-matrix_synapse_version_arm64: v1.37.1
+matrix_synapse_version: v1.38.0
+matrix_synapse_version_arm64: v1.38.0
 matrix_synapse_docker_image_tag: "{{ matrix_synapse_version if matrix_architecture in ['arm32', 'amd64'] else matrix_synapse_version_arm64 }}"
 matrix_synapse_docker_image_force_pull: "{{ matrix_synapse_docker_image.endswith(':latest') }}"
 


### PR DESCRIPTION
There are no breaking changes, but there is a database index rebuild needed, that can consume approximately 4 times more space.

Release notes: https://github.com/matrix-org/synapse/releases/tag/v1.38.0