### PR TITLE
Fixed self-build functionality for mautrix-signal

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -374,7 +374,8 @@ matrix_mautrix_signal_login_shared_secret: "{{ matrix_synapse_ext_password_provi
 matrix_mautrix_signal_database_engine: 'postgres'
 matrix_mautrix_signal_database_password: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'mau.signal.db') | to_uuid }}"
 
-matrix_mautrix_signal_daemon_container_self_build: "{{ matrix_architecture != 'amd64' }}" # sadly not automatic detectable because no manifest
+matrix_mautrix_signal_container_self_build: "{{ matrix_architecture not in ['amd64', 'arm64'] }}"
+matrix_mautrix_signal_daemon_container_self_build: "{{ matrix_architecture != 'amd64' }}"
 
 ######################################################################
 #

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -374,13 +374,13 @@ matrix_mautrix_signal_login_shared_secret: "{{ matrix_synapse_ext_password_provi
 matrix_mautrix_signal_database_engine: 'postgres'
 matrix_mautrix_signal_database_password: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'mau.signal.db') | to_uuid }}"
 
+matrix_mautrix_signal_daemon_container_self_build: "{{ matrix_architecture != 'amd64' }}" # sadly not automatic detectable because no manifest
+
 ######################################################################
 #
 # /matrix-bridge-mautrix-signal
 #
 ######################################################################
-
-matrix_mautrix_signal_container_self_build: "{{ matrix_architecture not in ['arm64', 'amd64'] }}"
 
 ######################################################################
 #

--- a/roles/matrix-bridge-mautrix-signal/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-signal/defaults/main.yml
@@ -3,7 +3,7 @@
 
 matrix_mautrix_signal_enabled: true
 
-matrix_mautrix_signal_self_build: false
+matrix_mautrix_signal_container_self_build: false
 matrix_mautrix_signal_docker_repo: "https://mau.dev/tulir/mautrix-signal.git"
 matrix_mautrix_signal_docker_src_files_path: "{{ matrix_base_data_path }}/mautrix-signal/docker-src"
 
@@ -12,6 +12,10 @@ matrix_mautrix_signal_daemon_version: latest
 # See: https://mau.dev/tulir/mautrix-signal/container_registry
 matrix_mautrix_signal_docker_image: "dock.mau.dev/tulir/mautrix-signal:{{ matrix_mautrix_signal_version }}"
 matrix_mautrix_signal_docker_image_force_pull: "{{ matrix_mautrix_signal_docker_image.endswith(':latest') }}"
+
+matrix_mautrix_signal_daemon_container_self_build: false
+matrix_mautrix_signal_daemon_docker_repo: "https://mau.dev/maunium/signald.git"
+matrix_mautrix_signal_daemon_docker_src_files_path: "{{ matrix_base_data_path }}/mautrix-signald/docker-src"
 
 matrix_mautrix_signal_daemon_docker_image: "dock.mau.dev/maunium/signald:{{ matrix_mautrix_signal_daemon_version }}"
 matrix_mautrix_signal_daemon_docker_image_force_pull: "{{ matrix_mautrix_signal_daemon_docker_image.endswith(':latest') }}"

--- a/roles/matrix-bridge-mautrix-signal/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mautrix-signal/tasks/setup_install.yml
@@ -35,7 +35,7 @@
       dockerfile: Dockerfile
       path: "{{ matrix_mautrix_signal_docker_src_files_path }}"
       pull: yes
-  when: "matrix_mautrix_signal_enabled|bool and (matrix_mautrix_signal_container_self_build|bool or matrix_mautrix_signal_pull_results is failed)"
+  when: "matrix_mautrix_signal_enabled|bool and matrix_mautrix_signal_container_self_build|bool"
   
 
 - name: Ensure Mautrix Signal Daemon image is pulled

--- a/roles/matrix-bridge-mautrix-signal/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mautrix-signal/tasks/setup_install.yml
@@ -46,7 +46,6 @@
     force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_mautrix_signal_daemon_docker_image_force_pull }}"
   when: matrix_mautrix_signal_enabled and not matrix_mautrix_signal_daemon_container_self_build|bool
   register: matrix_mautrix_signal_daemon_pull_results
-  ignore_errors: yes
 
 - name: Ensure Mautrix Signal Daemon repository is present on self-build
   git:
@@ -54,7 +53,7 @@
     dest: "{{ matrix_mautrix_signal_daemon_docker_src_files_path }}"
     force: "yes"
   register: matrix_mautrix_signal_daemon_git_pull_results
-  when: "matrix_mautrix_signal_enabled|bool and (matrix_mautrix_signal_daemon_container_self_build|bool or matrix_mautrix_signal_daemon_pull_results is failed)"
+  when: "matrix_mautrix_signal_enabled|bool and matrix_mautrix_signal_daemon_container_self_build|bool"
 
 - name: Ensure Mautrix Signal Daemon image is built
   docker_image:
@@ -66,7 +65,7 @@
       dockerfile: Dockerfile
       path: "{{ matrix_mautrix_signal_daemon_docker_src_files_path }}"
       pull: yes
-  when: "matrix_mautrix_signal_enabled|bool and (matrix_mautrix_signal_daemon_container_self_build|bool or matrix_mautrix_signal_daemon_pull_results is failed)"
+  when: "matrix_mautrix_signal_enabled|bool and matrix_mautrix_signal_daemon_container_self_build|bool"
 
 - name: Ensure Mautrix Signal paths exist
   file:

--- a/roles/matrix-bridge-mautrix-signal/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mautrix-signal/tasks/setup_install.yml
@@ -8,13 +8,25 @@
       The matrix-bridge-mautrix-signal role needs to execute before the matrix-synapse role.
   when: "matrix_synapse_role_executed|default(False)"
 
+- name: Ensure Mautrix Signal image is pulled
+  docker_image:
+    name: "{{ matrix_mautrix_signal_docker_image }}"
+    source: "{{ 'pull' if ansible_version.major > 2 or ansible_version.minor > 7 else omit }}"
+    force_source: "{{ matrix_mautrix_signal_docker_image_force_pull if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
+    force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_mautrix_signal_docker_image_force_pull }}"
+#    pull:
+#        platform: "{{ matrix_architecture }}"
+  when: "matrix_mautrix_signal_enabled|bool and not matrix_mautrix_signal_container_self_build|bool"
+  register: matrix_mautrix_signal_pull_results
+  ignore_errors: yes
+
 - name: Ensure Mautrix Signal repository is present on self-build
   git:
     repo: "{{ matrix_mautrix_signal_docker_repo }}"
     dest: "{{ matrix_mautrix_signal_docker_src_files_path }}"
     force: "yes"
   register: matrix_mautrix_signal_git_pull_results
-  when: "matrix_mautrix_signal_enabled|bool and matrix_mautrix_signal_container_self_build|bool"
+  when: "matrix_mautrix_signal_enabled|bool and (matrix_mautrix_signal_container_self_build|bool or matrix_mautrix_signal_pull_results is failed)"
 
 - name: Ensure Mautrix Signal image is built
   docker_image:
@@ -26,16 +38,8 @@
       dockerfile: Dockerfile
       path: "{{ matrix_mautrix_signal_docker_src_files_path }}"
       pull: yes
-  when: "matrix_mautrix_signal_enabled|bool and matrix_mautrix_signal_container_self_build|bool"
+  when: "matrix_mautrix_signal_enabled|bool and (matrix_mautrix_signal_container_self_build|bool or matrix_mautrix_signal_pull_results is failed)"
   
-- name: Ensure Mautrix Signal image is pulled
-  docker_image:
-    name: "{{ matrix_mautrix_signal_docker_image }}"
-    source: "{{ 'pull' if ansible_version.major > 2 or ansible_version.minor > 7 else omit }}"
-    force_source: "{{ matrix_mautrix_signal_docker_image_force_pull if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
-    force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_mautrix_signal_docker_image_force_pull }}"
-  when: "matrix_mautrix_signal_enabled|bool and not matrix_mautrix_signal_container_self_build|bool"
-
 
 - name: Ensure Mautrix Signal Daemon image is pulled
   docker_image:
@@ -43,7 +47,29 @@
     source: "{{ 'pull' if ansible_version.major > 2 or ansible_version.minor > 7 else omit }}"
     force_source: "{{ matrix_mautrix_signal_daemon_docker_image_force_pull if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
     force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_mautrix_signal_daemon_docker_image_force_pull }}"
-  when: matrix_mautrix_signal_enabled|bool
+  when: matrix_mautrix_signal_enabled and not matrix_mautrix_signal_daemon_container_self_build|bool
+  register: matrix_mautrix_signal_daemon_pull_results
+  ignore_errors: yes
+
+- name: Ensure Mautrix Signal Daemon repository is present on self-build
+  git:
+    repo: "{{ matrix_mautrix_signal_daemon_docker_repo }}"
+    dest: "{{ matrix_mautrix_signal_daemon_docker_src_files_path }}"
+    force: "yes"
+  register: matrix_mautrix_signal_daemon_git_pull_results
+  when: "matrix_mautrix_signal_enabled|bool and (matrix_mautrix_signal_daemon_container_self_build|bool or matrix_mautrix_signal_daemon_pull_results is failed)"
+
+- name: Ensure Mautrix Signal Daemon image is built
+  docker_image:
+    name: "{{ matrix_mautrix_signal_daemon_docker_image }}"
+    source: build
+    force_source: "{{ matrix_mautrix_signal_daemon_git_pull_results.changed if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
+    force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_mailer_git_pull_results.changed }}"
+    build:
+      dockerfile: Dockerfile
+      path: "{{ matrix_mautrix_signal_daemon_docker_src_files_path }}"
+      pull: yes
+  when: "matrix_mautrix_signal_enabled|bool and (matrix_mautrix_signal_daemon_container_self_build|bool or matrix_mautrix_signal_daemon_pull_results is failed)"
 
 - name: Ensure Mautrix Signal paths exist
   file:

--- a/roles/matrix-bridge-mautrix-signal/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mautrix-signal/tasks/setup_install.yml
@@ -14,11 +14,8 @@
     source: "{{ 'pull' if ansible_version.major > 2 or ansible_version.minor > 7 else omit }}"
     force_source: "{{ matrix_mautrix_signal_docker_image_force_pull if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
     force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_mautrix_signal_docker_image_force_pull }}"
-#    pull:
-#        platform: "{{ matrix_architecture }}"
   when: "matrix_mautrix_signal_enabled|bool and not matrix_mautrix_signal_container_self_build|bool"
-  register: matrix_mautrix_signal_pull_results
-  ignore_errors: yes
+
 
 - name: Ensure Mautrix Signal repository is present on self-build
   git:
@@ -26,7 +23,7 @@
     dest: "{{ matrix_mautrix_signal_docker_src_files_path }}"
     force: "yes"
   register: matrix_mautrix_signal_git_pull_results
-  when: "matrix_mautrix_signal_enabled|bool and (matrix_mautrix_signal_container_self_build|bool or matrix_mautrix_signal_pull_results is failed)"
+  when: "matrix_mautrix_signal_enabled|bool and matrix_mautrix_signal_container_self_build|bool"
 
 - name: Ensure Mautrix Signal image is built
   docker_image:


### PR DESCRIPTION
I now autodetect compatible platforms of the mautrix-signal docker images via the manifest and added overlooked self-build functionality for the signal daemon.

Follow-up to  #1175