### PR TITLE
Docs - Updating matrix_ssl_retrieval_method: manually-managed

### DIFF
--- a/docs/configuring-playbook-ssl-certificates.md
+++ b/docs/configuring-playbook-ssl-certificates.md
@@ -43,7 +43,6 @@ With such a configuration, the playbook would expect you to drop the SSL certifi
 
 - `<matrix_ssl_config_dir_path>/live/<domain>/fullchain.pem`
 - `<matrix_ssl_config_dir_path>/live/<domain>/privkey.pem`
-- `<matrix_ssl_config_dir_path>/live/<domain>/chain.pem`
 
 where `<domain>` refers to the domains that you need (usually `matrix.<your-domain>` and `element.<your-domain>`).
 


### PR DESCRIPTION
I don't think this is necessary, because you have the fullchain...

- `<matrix_ssl_config_dir_path>/live/<domain>/chain.pem`