### PR TITLE
Added missing X-Forwarded-Proto header

### DIFF
--- a/examples/apache/matrix-synapse.conf
+++ b/examples/apache/matrix-synapse.conf
@@ -32,6 +32,7 @@
 	ProxyPreserveHost On
 	ProxyRequests Off
 	ProxyVia On
+	RequestHeader set "X-Forwarded-Proto" expr=%{REQUEST_SCHEME}
 
 	# Keep some URIs free for different proxy/location
 	ProxyPassMatch ^/.well-known/matrix/client !
@@ -111,6 +112,7 @@ Listen 8448
 	ProxyPreserveHost On
 	ProxyRequests Off
 	ProxyVia On
+	RequestHeader set "X-Forwarded-Proto" expr=%{REQUEST_SCHEME}
 
 	# Proxy all remaining traffic to the Synapse port
 	# Beware: In this example the local traffic goes to the local synapse server at 127.0.0.1


### PR DESCRIPTION
Added missing X-Forwarded-Proto header according to the example here: https://github.com/matrix-org/synapse/blob/3fffb71254d052c54d7a6eabae8534480f021adc/docs/reverse_proxy.md