### PR TITLE
Fixed mautrix-telegram selfbuild not working on non amd64 platforms

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -393,8 +393,8 @@ matrix_mautrix_telegram_enabled: false
 
 # Images are multi-arch (amd64 and arm64, but not arm32).
 matrix_mautrix_telegram_container_self_build: "{{ matrix_architecture not in ['arm64', 'amd64'] }}"
-matrix_lottieconverter_container_self_build: "{{ matrix_architecture not in ['arm64', 'amd64'] }}"
-matrix_lottieconverter_container_self_build_mask_arch: "{{ matrix_architecture != 'amd64' }}"
+matrix_telegram_lottieconverter_container_self_build: "{{ matrix_architecture not in ['arm64', 'amd64'] }}"
+matrix_telegram_lottieconverter_container_self_build_mask_arch: "{{ matrix_architecture != 'amd64' }}"
 
 matrix_mautrix_telegram_systemd_required_services_list: |
   {{

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -393,6 +393,8 @@ matrix_mautrix_telegram_enabled: false
 
 # Images are multi-arch (amd64 and arm64, but not arm32).
 matrix_mautrix_telegram_container_self_build: "{{ matrix_architecture not in ['arm64', 'amd64'] }}"
+matrix_lottieconverter_container_self_build: "{{ matrix_architecture not in ['arm64', 'amd64'] }}"
+matrix_lottieconverter_container_self_build_mask_arch: "{{ matrix_architecture != 'amd64' }}"
 
 matrix_mautrix_telegram_systemd_required_services_list: |
   {{

--- a/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
@@ -3,11 +3,11 @@
 
 matrix_mautrix_telegram_enabled: true
 
-matrix_lottieconverter_container_self_build: false
-matrix_lottieconverter_container_self_build_mask_arch: false
-matrix_lottieconverter_docker_repo: "https://mau.dev/tulir/lottieconverter.git"
-matrix_lottieconverter_docker_src_files_path: "{{ matrix_base_data_path }}/lotticonverter/docker-src"
-matrix_lottieconverter_docker_image: "dock.mau.dev/tulir/lottieconverter:alpine-3.14" # needs to be ajusted according to FROM clause of Dockerfile of mautrix-telegram
+matrix_telegram_lottieconverter_container_self_build: false
+matrix_telegram_lottieconverter_container_self_build_mask_arch: false
+matrix_telegram_lottieconverter_docker_repo: "https://mau.dev/tulir/lottieconverter.git"
+matrix_telegram_lottieconverter_docker_src_files_path: "{{ matrix_base_data_path }}/lotticonverter/docker-src"
+matrix_telegram_lottieconverter_docker_image: "dock.mau.dev/tulir/lottieconverter:alpine-3.14" # needs to be ajusted according to FROM clause of Dockerfile of mautrix-telegram
 
 matrix_mautrix_telegram_container_self_build: false
 matrix_mautrix_telegram_docker_repo: "https://mau.dev/tulir/mautrix-telegram.git"

--- a/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
@@ -3,6 +3,12 @@
 
 matrix_mautrix_telegram_enabled: true
 
+matrix_lottieconverter_container_self_build: false
+matrix_lottieconverter_container_self_build_mask_arch: false
+matrix_lottieconverter_docker_repo: "https://mau.dev/tulir/lottieconverter.git"
+matrix_lottieconverter_docker_src_files_path: "{{ matrix_base_data_path }}/lotticonverter/docker-src"
+matrix_lottieconverter_docker_image: "dock.mau.dev/tulir/lottieconverter:alpine-3.14" # needs to be ajusted according to FROM clause of Dockerfile of mautrix-telegram
+
 matrix_mautrix_telegram_container_self_build: false
 matrix_mautrix_telegram_docker_repo: "https://mau.dev/tulir/mautrix-telegram.git"
 matrix_mautrix_telegram_docker_src_files_path: "{{ matrix_base_data_path }}/mautrix-telegram/docker-src"

--- a/roles/matrix-bridge-mautrix-telegram/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mautrix-telegram/tasks/setup_install.yml
@@ -85,10 +85,6 @@
   when: "matrix_mautrix_telegram_container_self_build|bool"
   ignore_errors: yes
 
-- name: Ensure TARGETARCH is beeing masked
-  command: sed -i "3s/ARG/#ARG/" "{{ matrix_mautrix_telegram_docker_src_files_path }}/Dockerfile"
-  when: "matrix_telegram_lottieconverter_container_self_build_mask_arch|bool"
-  
 - name: Ensure matrix-mautrix-telegram Docker image is built
   docker_image:
     name: "{{ matrix_mautrix_telegram_docker_image }}"
@@ -99,13 +95,10 @@
       dockerfile: Dockerfile
       path: "{{ matrix_mautrix_telegram_docker_src_files_path }}"
       pull: "{{ not matrix_telegram_lottieconverter_container_self_build_mask_arch|bool }}"
+      args:
+        TARGETARCH: ""
   when: "matrix_mautrix_telegram_container_self_build|bool and matrix_mautrix_telegram_git_pull_results.changed"
 
-# Unmask so no git changes are beeing detected
-- name: Ensure TARGETARCH is beeing unmasked
-  command: sed -i "3s/#ARG/ARG/" "{{ matrix_mautrix_telegram_docker_src_files_path }}/Dockerfile"
-  when: "matrix_telegram_lottieconverter_container_self_build_mask_arch|bool"
-  
 - name: Check if an old database file already exists
   stat:
     path: "{{ matrix_mautrix_telegram_base_path }}/mautrix-telegram.db"

--- a/roles/matrix-bridge-mautrix-telegram/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mautrix-telegram/tasks/setup_install.yml
@@ -58,23 +58,23 @@
 
 - name: Ensure lottieconverter is present when self-building
   git:
-    repo: "{{ matrix_lottieconverter_docker_repo }}"
-    dest: "{{ matrix_lottieconverter_docker_src_files_path }}"
+    repo: "{{ matrix_telegram_lottieconverter_docker_repo }}"
+    dest: "{{ matrix_telegram_lottieconverter_docker_src_files_path }}"
     force: "yes"
-  register: matrix_lottieconverter_git_pull_results
-  when: "matrix_lottieconverter_container_self_build|bool and matrix_mautrix_telegram_container_self_build|bool"
+  register: matrix_telegram_lottieconverter_git_pull_results
+  when: "matrix_telegram_lottieconverter_container_self_build|bool and matrix_mautrix_telegram_container_self_build|bool"
 
 - name: Ensure lottieconverter Docker image is built
   docker_image:
-    name: "{{ matrix_lottieconverter_docker_image }}"
+    name: "{{ matrix_telegram_lottieconverter_docker_image }}"
     source: build
-    force_source: "{{ matrix_lottieconverter_git_pull_results.changed if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
-    force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_lottieconverter_git_pull_results.changed }}"
+    force_source: "{{ matrix_telegram_lottieconverter_git_pull_results.changed if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
+    force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_telegram_lottieconverter_git_pull_results.changed }}"
     build:
       dockerfile: Dockerfile
-      path: "{{ matrix_lottieconverter_docker_src_files_path }}"
+      path: "{{ matrix_telegram_lottieconverter_docker_src_files_path }}"
       pull: yes
-  when: "matrix_lottieconverter_container_self_build|bool and matrix_lottieconverter_git_pull_results.changed and matrix_mautrix_telegram_container_self_build|bool"
+  when: "matrix_telegram_lottieconverter_container_self_build|bool and matrix_telegram_lottieconverter_git_pull_results.changed and matrix_mautrix_telegram_container_self_build|bool"
 
 - name: Ensure matrix-mautrix-telegram repository is present when self-building
   git:
@@ -87,7 +87,7 @@
 
 - name: Ensure TARGETARCH is beeing masked
   command: sed -i "3s/ARG/#ARG/" "{{ matrix_mautrix_telegram_docker_src_files_path }}/Dockerfile"
-  when: "matrix_lottieconverter_container_self_build_mask_arch|bool"
+  when: "matrix_telegram_lottieconverter_container_self_build_mask_arch|bool"
   
 - name: Ensure matrix-mautrix-telegram Docker image is built
   docker_image:
@@ -98,13 +98,13 @@
     build:
       dockerfile: Dockerfile
       path: "{{ matrix_mautrix_telegram_docker_src_files_path }}"
-      pull: "{{ not matrix_lottieconverter_container_self_build_mask_arch|bool }}"
+      pull: "{{ not matrix_telegram_lottieconverter_container_self_build_mask_arch|bool }}"
   when: "matrix_mautrix_telegram_container_self_build|bool and matrix_mautrix_telegram_git_pull_results.changed"
 
 # Unmask so no git changes are beeing detected
 - name: Ensure TARGETARCH is beeing unmasked
   command: sed -i "3s/#ARG/ARG/" "{{ matrix_mautrix_telegram_docker_src_files_path }}/Dockerfile"
-  when: "matrix_lottieconverter_container_self_build_mask_arch|bool"
+  when: "matrix_telegram_lottieconverter_container_self_build_mask_arch|bool"
   
 - name: Check if an old database file already exists
   stat:

--- a/roles/matrix-bridge-mautrix-telegram/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mautrix-telegram/tasks/setup_install.yml
@@ -56,6 +56,26 @@
     force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_mautrix_telegram_docker_image_force_pull }}"
   when: "not matrix_mautrix_telegram_container_self_build|bool"
 
+- name: Ensure lottieconverter is present when self-building
+  git:
+    repo: "{{ matrix_lottieconverter_docker_repo }}"
+    dest: "{{ matrix_lottieconverter_docker_src_files_path }}"
+    force: "yes"
+  register: matrix_lottieconverter_git_pull_results
+  when: "matrix_lottieconverter_container_self_build|bool and matrix_mautrix_telegram_container_self_build|bool"
+
+- name: Ensure lottieconverter Docker image is built
+  docker_image:
+    name: "{{ matrix_lottieconverter_docker_image }}"
+    source: build
+    force_source: "{{ matrix_lottieconverter_git_pull_results.changed if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
+    force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_lottieconverter_git_pull_results.changed }}"
+    build:
+      dockerfile: Dockerfile
+      path: "{{ matrix_lottieconverter_docker_src_files_path }}"
+      pull: yes
+  when: "matrix_lottieconverter_container_self_build|bool and matrix_lottieconverter_git_pull_results.changed and matrix_mautrix_telegram_container_self_build|bool"
+
 - name: Ensure matrix-mautrix-telegram repository is present when self-building
   git:
     repo: "{{ matrix_mautrix_telegram_docker_repo }}"
@@ -63,7 +83,12 @@
     force: "yes"
   register: matrix_mautrix_telegram_git_pull_results
   when: "matrix_mautrix_telegram_container_self_build|bool"
+  ignore_errors: yes
 
+- name: Ensure TARGETARCH is beeing masked
+  command: sed -i "3s/ARG/#ARG/" "{{ matrix_mautrix_telegram_docker_src_files_path }}/Dockerfile"
+  when: "matrix_lottieconverter_container_self_build_mask_arch|bool"
+  
 - name: Ensure matrix-mautrix-telegram Docker image is built
   docker_image:
     name: "{{ matrix_mautrix_telegram_docker_image }}"
@@ -73,9 +98,14 @@
     build:
       dockerfile: Dockerfile
       path: "{{ matrix_mautrix_telegram_docker_src_files_path }}"
-      pull: yes
+      pull: "{{ not matrix_lottieconverter_container_self_build_mask_arch|bool }}"
   when: "matrix_mautrix_telegram_container_self_build|bool and matrix_mautrix_telegram_git_pull_results.changed"
 
+# Unmask so no git changes are beeing detected
+- name: Ensure TARGETARCH is beeing unmasked
+  command: sed -i "3s/#ARG/ARG/" "{{ matrix_mautrix_telegram_docker_src_files_path }}/Dockerfile"
+  when: "matrix_lottieconverter_container_self_build_mask_arch|bool"
+  
 - name: Check if an old database file already exists
   stat:
     path: "{{ matrix_mautrix_telegram_base_path }}/mautrix-telegram.db"

--- a/roles/matrix-bridge-mautrix-telegram/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mautrix-telegram/tasks/setup_install.yml
@@ -83,7 +83,6 @@
     force: "yes"
   register: matrix_mautrix_telegram_git_pull_results
   when: "matrix_mautrix_telegram_container_self_build|bool"
-  ignore_errors: yes
 
 - name: Ensure matrix-mautrix-telegram Docker image is built
   docker_image:


### PR DESCRIPTION
I added this changes because the docker [build file](https://mau.dev/tulir/mautrix-telegram/-/blob/c02f67e0d1dcabde598d65d346c63097e309d410/Dockerfile) contains an architecture constraint to only work for amd64 because the FROM image is amd64 only. Therefore, I mask the constraint and compile the [underlying image](https://mau.dev/tulir/lottieconverter.git) by myself and then compile the constraint mautrix-telegram image.