### PR TITLE
migrate from ntp to systemd-timesyncd for ubuntu & Archlinux

### DIFF
--- a/roles/matrix-base/defaults/main.yml
+++ b/roles/matrix-base/defaults/main.yml
@@ -80,8 +80,8 @@ matrix_host_command_openssl: "/usr/bin/env openssl"
 matrix_host_command_systemctl: "/usr/bin/env systemctl"
 matrix_host_command_sh: "/usr/bin/env sh"
 
-matrix_ntpd_package: "{{ 'systemd-timesyncd' if ansible_distribution == 'CentOS' and ansible_distribution_major_version > '7' else 'ntp' }}"
-matrix_ntpd_service: "{{ 'systemd-timesyncd' if ansible_distribution == 'CentOS' and ansible_distribution_major_version > '7' else ('ntpd' if ansible_os_family == 'RedHat' or ansible_distribution == 'Archlinux' else 'ntp') }}"
+matrix_ntpd_package: "{{ 'chrony' if ansible_distribution == 'CentOS' or ansible_distribution == 'Ubuntu' else 'ntp' }}"
+matrix_ntpd_service: "{{ 'chronyd' if ansible_distribution == 'CentOS' or ansible_distribution == 'Ubuntu' else ('ntpd' if ansible_os_family == 'RedHat' or ansible_distribution == 'Archlinux' else 'ntp') }}"
 
 matrix_homeserver_url: "https://{{ matrix_server_fqn_matrix }}"
 

--- a/roles/matrix-base/defaults/main.yml
+++ b/roles/matrix-base/defaults/main.yml
@@ -84,7 +84,7 @@ matrix_host_command_systemctl: "/usr/bin/env systemctl"
 matrix_host_command_sh: "/usr/bin/env sh"
 
 matrix_ntpd_package: "{{ 'systemd-timesyncd' if (ansible_distribution == 'CentOS' and ansible_distribution_major_version > '7') or (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version > '16') else 'ntp' }}"
-matrix_ntpd_service: "{{ 'systemd-timesyncd' if (ansible_distribution == 'CentOS' and ansible_distribution_major_version > '7') or (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version > '16') else ('ntpd' if ansible_os_family == 'RedHat' or ansible_distribution == 'Archlinux' else 'ntp') }}"
+matrix_ntpd_service: "{{ 'systemd-timesyncd' if (ansible_distribution == 'CentOS' and ansible_distribution_major_version > '7') or (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version > '16') or ansible_distribution == 'Archlinux' else ('ntpd' if ansible_os_family == 'RedHat' else 'ntp') }}"
 
 matrix_homeserver_url: "https://{{ matrix_server_fqn_matrix }}"
 

--- a/roles/matrix-base/defaults/main.yml
+++ b/roles/matrix-base/defaults/main.yml
@@ -83,8 +83,8 @@ matrix_host_command_openssl: "/usr/bin/env openssl"
 matrix_host_command_systemctl: "/usr/bin/env systemctl"
 matrix_host_command_sh: "/usr/bin/env sh"
 
-matrix_ntpd_package: "{{ 'chrony' if ansible_distribution == 'CentOS' or ansible_distribution == 'Ubuntu' else 'ntp' }}"
-matrix_ntpd_service: "{{ 'chronyd' if ansible_distribution == 'CentOS' or ansible_distribution == 'Ubuntu' else ('ntpd' if ansible_os_family == 'RedHat' or ansible_distribution == 'Archlinux' else 'ntp') }}"
+matrix_ntpd_package: "{{ 'systemd-timesyncd' if (ansible_distribution == 'CentOS' and ansible_distribution_major_version > '7') or (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version > '16') else 'ntp' }}"
+matrix_ntpd_service: "{{ 'systemd-timesyncd' if (ansible_distribution == 'CentOS' and ansible_distribution_major_version > '7') or (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version > '16') else ('ntpd' if ansible_os_family == 'RedHat' or ansible_distribution == 'Archlinux' else 'ntp') }}"
 
 matrix_homeserver_url: "https://{{ matrix_server_fqn_matrix }}"
 

--- a/roles/matrix-base/tasks/server_base/setup_archlinux.yml
+++ b/roles/matrix-base/tasks/server_base/setup_archlinux.yml
@@ -4,7 +4,7 @@
   pacman:
     name:
       - python-docker
-      - "{{ matrix_ntpd_package }}"
+      - systemd-timesyncd
       # TODO This needs to be verified. Which version do we need?
       - fuse3
       - python-dnspython


### PR DESCRIPTION
Facing time sync issue in ubuntu 20.04 https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/1029

- chrony availability and compatibility with mostly all OS.
- systemd-timesyncd is light weight and chrony more accurate, full featured.