### PR TITLE
Update main.yml for matrix-reminder-bot

### DIFF
--- a/roles/matrix-bot-matrix-reminder-bot/defaults/main.yml
+++ b/roles/matrix-bot-matrix-reminder-bot/defaults/main.yml
@@ -2,7 +2,7 @@
 # See: https://github.com/anoadragon453/matrix-reminder-bot
 
 matrix_bot_matrix_reminder_bot_enabled: true
-matrix_bot_matrix_reminder_bot_version: release-v0.2.0
+matrix_bot_matrix_reminder_bot_version: release-v0.2.1
 matrix_bot_matrix_reminder_bot_docker_image: "{{ matrix_container_global_registry_prefix }}anoa/matrix-reminder-bot:{{ matrix_bot_matrix_reminder_bot_version }}"
 matrix_bot_matrix_reminder_bot_docker_image_force_pull: "{{ matrix_bot_matrix_reminder_bot_docker_image.endswith(':latest') }}"
 


### PR DESCRIPTION
Resolves an issue with the bot version being incompatible with Synapse  v1.38+

Issue: https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/1191 

Upgrades the reminder bot to v.0.2.1 which resolves this known issue:  https://github.com/anoadragon453/matrix-reminder-bot/issues/86 

