### PR TITLE
Fix base domain 8443 port redirect  if / is absent

### DIFF
--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-base-domain.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-base-domain.conf.j2
@@ -39,6 +39,7 @@ server {
 
 	server_name {{ matrix_nginx_proxy_base_domain_hostname }};
 	server_tokens off;
+	absolute_redirect off;
 
 	{% if matrix_nginx_proxy_https_enabled %}
 		location /.well-known/acme-challenge {
@@ -68,6 +69,7 @@ server {
 
 	server_name {{ matrix_nginx_proxy_base_domain_hostname }};
 	server_tokens off;
+	absolute_redirect off;
 
 	ssl_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_base_domain_hostname }}/fullchain.pem;
 	ssl_certificate_key {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_base_domain_hostname }}/privkey.pem;


### PR DESCRIPTION
Fix nginx (docker) 8443 port redirection on base domain if trailing slash (/) is missing at the end of URLs

I hosted a static site on the dir /matrix/nginx-proxy/data/matrix-domain/

For the URLs other then https://base-domain.tld if the trialing / at the end is absent like this (https://base-domain.tld/posts) then it gets redirected to the 8443 port  as the posts folder has index.html which the server picks only if there is trialing / at the end of URL (like this https://base-domain.tld/posts/)

To fix the problem I added absolute_redirect off; in the roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-base-domain.conf.j2 file within server configurations then the problem is fixed. 

Please update matrix-base-domain.conf.j2 if this solution is appropriate or give some suggestions.
![port redirection](https://user-images.githubusercontent.com/58697145/126597492-8c414e9d-0e7a-45df-8bbd-44863885938d.png)

Thanks