### PR TITLE
Update prometheus node exporter (1.1.2 -> 1.2.0)

### DIFF
--- a/roles/matrix-prometheus-node-exporter/defaults/main.yml
+++ b/roles/matrix-prometheus-node-exporter/defaults/main.yml
@@ -3,7 +3,7 @@
 
 matrix_prometheus_node_exporter_enabled: false
 
-matrix_prometheus_node_exporter_version: v1.1.2
+matrix_prometheus_node_exporter_version: v1.2.0
 matrix_prometheus_node_exporter_docker_image: "{{ matrix_container_global_registry_prefix }}prom/node-exporter:{{ matrix_prometheus_node_exporter_version }}"
 matrix_prometheus_node_exporter_docker_image_force_pull: "{{ matrix_prometheus_node_exporter_docker_image.endswith(':latest') }}"
 


### PR DESCRIPTION

- https://github.com/prometheus/node_exporter/releases/tag/v1.2.0