### PR TITLE
Added selfbuild functionality to matrix-reminder-bot

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -811,6 +811,7 @@ matrix_bot_matrix_reminder_bot_systemd_required_services_list: |
 # Postgres is the default, except if not using `matrix_postgres` (internal postgres)
 matrix_bot_matrix_reminder_bot_database_engine: "{{ 'postgres' if matrix_postgres_enabled else 'sqlite' }}"
 matrix_bot_matrix_reminder_bot_database_password: "{{ matrix_synapse_macaroon_secret_key | password_hash('sha512', 'reminder.bot.db') | to_uuid }}"
+matrix_bot_matrix_reminder_bot_container_self_build: "{{ matrix_architecture != 'amd64' }}"
 
 ######################################################################
 #

--- a/roles/matrix-bot-matrix-reminder-bot/defaults/main.yml
+++ b/roles/matrix-bot-matrix-reminder-bot/defaults/main.yml
@@ -2,6 +2,11 @@
 # See: https://github.com/anoadragon453/matrix-reminder-bot
 
 matrix_bot_matrix_reminder_bot_enabled: true
+
+matrix_bot_matrix_reminder_bot_container_self_build: false
+matrix_bot_matrix_reminder_bot_docker_repo: "https://github.com/anoadragon453/matrix-reminder-bot.git"
+matrix_bot_matrix_reminder_bot_docker_src_files_path: "{{ matrix_base_data_path }}/matrix-reminder-bot/docker-src"
+
 matrix_bot_matrix_reminder_bot_version: release-v0.2.1
 matrix_bot_matrix_reminder_bot_docker_image: "{{ matrix_container_global_registry_prefix }}anoa/matrix-reminder-bot:{{ matrix_bot_matrix_reminder_bot_version }}"
 matrix_bot_matrix_reminder_bot_docker_image_force_pull: "{{ matrix_bot_matrix_reminder_bot_docker_image.endswith(':latest') }}"

--- a/roles/matrix-bot-matrix-reminder-bot/tasks/setup_install.yml
+++ b/roles/matrix-bot-matrix-reminder-bot/tasks/setup_install.yml
@@ -37,6 +37,7 @@
     - { path: "{{ matrix_bot_matrix_reminder_bot_config_path }}", when: true }
     - { path: "{{ matrix_bot_matrix_reminder_bot_data_path }}", when: true }
     - { path: "{{ matrix_bot_matrix_reminder_bot_data_store_path }}", when: true }
+    - { path: "{{ matrix_bot_matrix_reminder_bot_docker_src_files_path }}", when: true}
   when: "item.when|bool"
 
 - name: Ensure matrix-reminder-bot image is pulled
@@ -45,6 +46,27 @@
     source: "{{ 'pull' if ansible_version.major > 2 or ansible_version.minor > 7 else omit }}"
     force_source: "{{ matrix_bot_matrix_reminder_bot_docker_image_force_pull if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
     force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_bot_matrix_reminder_bot_docker_image_force_pull }}"
+  when: "matrix_bot_matrix_reminder_bot_enabled|bool and not matrix_bot_matrix_reminder_bot_container_self_build|bool"
+
+- name: Ensure matrix-reminder-bot repository is present on self-build
+  git:
+    repo: "{{ matrix_bot_matrix_reminder_bot_docker_repo }}"
+    dest: "{{ matrix_bot_matrix_reminder_bot_docker_src_files_path }}"
+    force: "yes"
+  register: matrix_bot_matrix_reminder_bot_git_pull_results
+  when: "matrix_bot_matrix_reminder_bot_enabled|bool and matrix_bot_matrix_reminder_bot_container_self_build|bool"
+
+- name: Ensure matrix-reminder-bot image is built
+  docker_image:
+    name: "{{ matrix_bot_matrix_reminder_bot_docker_image }}"
+    source: build
+    force_source: "{{ matrix_bot_matrix_reminder_bot_git_pull_results.changed if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
+    force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_mailer_git_pull_results.changed }}"
+    build:
+      dockerfile: docker/Dockerfile
+      path: "{{ matrix_bot_matrix_reminder_bot_docker_src_files_path }}"
+      pull: yes
+  when: "matrix_bot_matrix_reminder_bot_enabled|bool and matrix_bot_matrix_reminder_bot_container_self_build|bool"
 
 - name: Ensure matrix-reminder-bot config installed
   copy:

--- a/roles/matrix-bot-matrix-reminder-bot/tasks/setup_install.yml
+++ b/roles/matrix-bot-matrix-reminder-bot/tasks/setup_install.yml
@@ -46,7 +46,7 @@
     source: "{{ 'pull' if ansible_version.major > 2 or ansible_version.minor > 7 else omit }}"
     force_source: "{{ matrix_bot_matrix_reminder_bot_docker_image_force_pull if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
     force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_bot_matrix_reminder_bot_docker_image_force_pull }}"
-  when: "matrix_bot_matrix_reminder_bot_enabled|bool and not matrix_bot_matrix_reminder_bot_container_self_build|bool"
+  when: "not matrix_bot_matrix_reminder_bot_container_self_build|bool"
 
 - name: Ensure matrix-reminder-bot repository is present on self-build
   git:
@@ -54,7 +54,7 @@
     dest: "{{ matrix_bot_matrix_reminder_bot_docker_src_files_path }}"
     force: "yes"
   register: matrix_bot_matrix_reminder_bot_git_pull_results
-  when: "matrix_bot_matrix_reminder_bot_enabled|bool and matrix_bot_matrix_reminder_bot_container_self_build|bool"
+  when: "matrix_bot_matrix_reminder_bot_container_self_build|bool"
 
 - name: Ensure matrix-reminder-bot image is built
   docker_image:
@@ -66,7 +66,7 @@
       dockerfile: docker/Dockerfile
       path: "{{ matrix_bot_matrix_reminder_bot_docker_src_files_path }}"
       pull: yes
-  when: "matrix_bot_matrix_reminder_bot_enabled|bool and matrix_bot_matrix_reminder_bot_container_self_build|bool"
+  when: "matrix_bot_matrix_reminder_bot_container_self_build|bool"
 
 - name: Ensure matrix-reminder-bot config installed
   copy:


### PR DESCRIPTION
I added self-build functionality to the reminder-bot similar to #1175 and #1180.  The reminder bot is now working on a Raspberry Pi 4.