### PR TITLE
GoMatrixHosting v0.5.5

### DIFF
--- a/roles/matrix-awx/tasks/set_variables_ma1sd.yml
+++ b/roles/matrix-awx/tasks/set_variables_ma1sd.yml
@@ -29,12 +29,7 @@
     insertafter: '# Synapse Extension Start'
   with_dict:
     'matrix_synapse_ext_password_provider_rest_auth_enabled': 'true'
-    'matrix_synapse_ext_password_provider_rest_auth_endpoint': 'http://matrix-ma1sd:8090'
-  when: ext_matrix_ma1sd_auth_store == 'LDAP/AD'
-
-- name: Strip header from ma1sd configuration extension if using internal auth
-  set_fact:
-    ext_matrix_ma1sd_configuration_extension_yaml_parsed: "{{ ext_matrix_ma1sd_configuration_extension_yaml.splitlines() | reject('search', '^matrix_client_element_configuration_extension_json:') | list }}"
+    'matrix_synapse_ext_password_provider_rest_auth_endpoint': '"http://matrix-ma1sd:8090"'
   when: ext_matrix_ma1sd_auth_store == 'LDAP/AD'
 
 - name: Remove entire ma1sd configuration extension
@@ -52,22 +47,13 @@
     regexp: '^# Start ma1sd Extension# End ma1sd Extension'
     replace: '# Start ma1sd Extension\n# End ma1sd Extension'
 
-- name: Insert ma1sd configuration extension header if using external LDAP/AD with ma1sd
+- name: Insert/Update ma1sd configuration extension variables
   delegate_to: 127.0.0.1
-  lineinfile:
+  blockinfile:
     path: '{{ awx_cached_matrix_vars }}'
-    line: "matrix_ma1sd_configuration_extension_yaml: |"
+    marker: "# {mark} ma1sd ANSIBLE MANAGED BLOCK"
     insertafter: '# Start ma1sd Extension'
-  when: ext_matrix_ma1sd_auth_store == 'LDAP/AD'
-
-- name: Set ma1sd configuration extension if using external LDAP/AD with ma1sd
-  delegate_to: 127.0.0.1
-  lineinfile:
-    path: '{{ awx_cached_matrix_vars }}'
-    insertbefore: '# End ma1sd Extension'
-    line: '{{ item }}'
-  with_items: "{{ ext_matrix_ma1sd_configuration_extension_yaml_parsed }}"
-  when: ext_matrix_ma1sd_auth_store == 'LDAP/AD'
+    block: '{{ ext_matrix_ma1sd_configuration_extension_yaml }}'
 
 - name: Record ma1sd Custom variables locally on AWX
   delegate_to: 127.0.0.1
@@ -79,6 +65,7 @@
   with_dict:
     'ext_matrix_ma1sd_auth_store': '{{ ext_matrix_ma1sd_auth_store }}'
     'ext_matrix_ma1sd_configuration_extension_yaml': '{{ ext_matrix_ma1sd_configuration_extension_yaml.splitlines() | to_json }}'
+  no_log: True
 
 - name: Save new 'Configure ma1sd' survey.json to the AWX tower, template
   delegate_to: 127.0.0.1

--- a/roles/matrix-awx/tasks/set_variables_synapse.yml
+++ b/roles/matrix-awx/tasks/set_variables_synapse.yml
@@ -154,17 +154,6 @@
   with_items: "{{ ext_federation_whitelist_raw.splitlines() }}"
   when: ext_federation_whitelist_raw|length > 0
 
-- name: Record Synapse Custom variables locally on AWX
-  delegate_to: 127.0.0.1
-  lineinfile:
-    path: '{{ awx_cached_matrix_vars }}'
-    regexp: "^#? *{{ item.key | regex_escape() }}:"
-    line: "{{ item.key }}: {{ item.value }}"
-    insertafter: '# Custom Settings Start'
-  with_dict:
-    'ext_federation_whitelist_raw': '{{ ext_federation_whitelist_raw.splitlines() | to_json }}'
-    'ext_url_preview_accept_language_default': '{{ ext_url_preview_accept_language_default.splitlines() | to_json }}'
-
 - name: Set ext_recaptcha_public_key to a 'public-key' if undefined
   set_fact: ext_recaptcha_public_key="public-key"
   when: (ext_recaptcha_public_key is not defined) or (ext_recaptcha_public_key|length == 0)
@@ -184,6 +173,20 @@
     '  enable_registration_captcha': '{{ ext_enable_registration_captcha }}'
     '  recaptcha_public_key': '{{ ext_recaptcha_public_key }}'
     '  recaptcha_private_key': '{{ ext_recaptcha_private_key }}'
+
+- name: Record Synapse Custom variables locally on AWX
+  delegate_to: 127.0.0.1
+  lineinfile:
+    path: '{{ awx_cached_matrix_vars }}'
+    regexp: "^#? *{{ item.key | regex_escape() }}:"
+    line: "{{ item.key }}: {{ item.value }}"
+    insertafter: '# Custom Settings Start'
+  with_dict:
+    'ext_federation_whitelist_raw': '{{ ext_federation_whitelist_raw.splitlines() | to_json }}'
+    'ext_url_preview_accept_language_default': '{{ ext_url_preview_accept_language_default.splitlines() | to_json }}'
+    'ext_enable_registration_captcha': '{{ ext_enable_registration_captcha }}'
+    'ext_recaptcha_public_key': '"{{ ext_recaptcha_public_key }}"'
+    'ext_recaptcha_private_key': '"{{ ext_recaptcha_private_key }}"'
 
 - name: Save new 'Configure Synapse' survey.json to the AWX tower, template
   delegate_to: 127.0.0.1


### PR DESCRIPTION
- Set prometheus retention period as variable in create-awx-system.
- Fixed minor bugs relating to ma1sd/LDAP.
- Update the borg backup config to include the rest of /matrix and custom website folder, also fixed issue where re-provisioning blanks the recaptcha section of the 'Configure Synapse' survey, solves 'Create AWX System' issue [#16](https://gitlab.com/GoMatrixHosting/create-awx-system/-/issues/16).
- Set locale of all client servers to en_US to avoid 'Ansible Provision Server' issue [#11](https://gitlab.com/GoMatrixHosting/ansible-provision-server/-/issues/11).

Follow us on [GitLab](https://gitlab.com/GoMatrixHosting), or come say hello at [GoMatrixHosting](https://matrix.to/#/#general:gomatrixhosting.com)!