### PR TITLE
Update howto-server-delegation.md

### DIFF
--- a/docs/howto-server-delegation.md
+++ b/docs/howto-server-delegation.md
@@ -82,8 +82,8 @@ Based on your setup, you have different ways to go about it:
 #
 # NOTE: these are in-container paths. `/matrix/ssl` on the host is mounted into the container
 # at the same path (`/matrix/ssl`) by default, so if that's the path you need, it would be seamless.
-matrix_nginx_proxy_proxy_matrix_federation_api_ssl_certificate: /matrix/ssl/config/live/matrix.<your-domain>/fullchain.pem
-matrix_nginx_proxy_proxy_matrix_federation_api_ssl_certificate_key: /matrix/ssl/config/live/matrix.<your-domain>/privkey.pem
+matrix_nginx_proxy_proxy_matrix_federation_api_ssl_certificate: /matrix/ssl/config/live/<your-domain>/fullchain.pem
+matrix_nginx_proxy_proxy_matrix_federation_api_ssl_certificate_key: /matrix/ssl/config/live/<your-domain>/privkey.pem
 ```
 
 If your files are not in `/matrix/ssl` but in some other location, you would need to mount them into the container:


### PR DESCRIPTION
The attached code for the "Serving the Federation API with your certificates and matrix-nginx-proxy" section suggests using the `matrix.<your-domain>` certificate for the federation API as opposed to the necessary `<your-domain>` certificate for the federation to work. This can cause some confusion to readers.