### PR TITLE
New version of Mautrix Signal bridge (version 0.2.0)

### DIFF
--- a/roles/matrix-bridge-mautrix-signal/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-signal/defaults/main.yml
@@ -1,16 +1,16 @@
 # mautrix-signal is a Matrix <-> Signal bridge
-# See: https://github.com/tulir/mautrix-signal
+# See: https://github.com/mautrix/signal
 
 matrix_mautrix_signal_enabled: true
 
 matrix_mautrix_signal_container_self_build: false
-matrix_mautrix_signal_docker_repo: "https://mau.dev/tulir/mautrix-signal.git"
+matrix_mautrix_signal_docker_repo: "https://mau.dev/mautrix/signal.git"
 matrix_mautrix_signal_docker_src_files_path: "{{ matrix_base_data_path }}/mautrix-signal/docker-src"
 
 matrix_mautrix_signal_version: latest
 matrix_mautrix_signal_daemon_version: latest
-# See: https://mau.dev/tulir/mautrix-signal/container_registry
-matrix_mautrix_signal_docker_image: "dock.mau.dev/tulir/mautrix-signal:{{ matrix_mautrix_signal_version }}"
+# See: https://mau.dev/mautrix/signal/container_registry
+matrix_mautrix_signal_docker_image: "dock.mau.dev/mautrix/signal:{{ matrix_mautrix_signal_version }}"
 matrix_mautrix_signal_docker_image_force_pull: "{{ matrix_mautrix_signal_docker_image.endswith(':latest') }}"
 
 matrix_mautrix_signal_daemon_container_self_build: false


### PR DESCRIPTION
The new version of the Mautrix Signal bridge is provided through a slightly changed GitLab location:

* old: 'dock.mau.dev/tulir/mautrix-signal'
* new: 'dock.mau.dev/mautrix/signal'


#1220 