### PR TITLE
Feature/signal config

### DIFF
--- a/docs/configuring-playbook-bridge-mautrix-signal.md
+++ b/docs/configuring-playbook-bridge-mautrix-signal.md
@@ -27,8 +27,8 @@ matrix_mautrix_signal_configuration_extension_yaml: |
   bridge:
     permissions:
       '@YOUR_USERNAME:YOUR_DOMAIN': admin
-      '*': user
-      YOUR_DOMAIN: relay
+      YOUR_DOMAIN: user
+      '*': relay
 ```
 
 You may wish to look at `roles/matrix-bridge-mautrix-signal/templates/config.yaml.j2` to find more information on the permissions settings and other options you would like to configure.

--- a/docs/configuring-playbook-bridge-mautrix-signal.md
+++ b/docs/configuring-playbook-bridge-mautrix-signal.md
@@ -23,14 +23,36 @@ Use `!signal unset-relay` to deactivate.
 By default, any user on your homeserver will be able to use the bridge.
 If you enable the relay bot functionality, it will relay every user's messages in a portal room - no matter which homeserver they're from.
 
-If you would like to have a more specific setting of the permissions you can set the permissions as follows (example). For more details see also [mautrix-bridge documentation](https://docs.mau.fi/bridges/python/signal/relay-mode.html)
+Different levels of permission can be granted to users:
+
+* relay - Allowed to be relayed through the bridge, no access to commands;
+* user - Use the bridge with puppeting;
+* admin - Use and administer the bridge.
+
+The permissions are following the sequence: nothing < relay < user < admin.
+
+The default permissions are set as follows:
+```yaml
+permissions:
+  '*': relay
+  YOUR_DOMAIN: user
+```
+
+If you want to augment the preset permissions, you might want to set the additional permissions with the following settings in your `vars.yml` file:
 ```yaml
 matrix_mautrix_signal_configuration_extension_yaml: |
   bridge:
     permissions:
       '@YOUR_USERNAME:YOUR_DOMAIN': admin
-      YOUR_DOMAIN: user
-      '*': relay
+```
+
+This will add the admin permission to the specific user, while keepting the default permissions.
+
+In case you want to replace the default permissions settings **completely**, populate the following item within your `vars.yml` file:
+```yaml
+matrix_mautrix_signal_bridge_permissions: |
+  '@ADMIN:YOUR_DOMAIN': admin
+  '@USER:YOUR_DOMAIN' : user
 ```
 
 You may wish to look at `roles/matrix-bridge-mautrix-signal/templates/config.yaml.j2` to find more information on the permissions settings and other options you would like to configure.

--- a/docs/configuring-playbook-bridge-mautrix-signal.md
+++ b/docs/configuring-playbook-bridge-mautrix-signal.md
@@ -20,7 +20,8 @@ matrix_mautrix_signal_relaybot_enabled: true
 ```
 If you want to activate the relay bot in a room, use `!signal set-relay`.
 Use `!signal unset-relay` to deactivate.
-Additionally the permissions for the bridge grant user rights to all base domain users in case the relay bot is disabled, or relay rights in case the relay bot is enabled.
+By default, any user on your homeserver will be able to use the bridge.
+If you enable the relay bot functionality, it will relay every user's messages in a portal room - no matter which homeserver they're from.
 
 If you would like to have a more specific setting of the permissions you can set the permissions as follows (example). For more details see also [mautrix-bridge documentation](https://docs.mau.fi/bridges/python/signal/relay-mode.html)
 ```yaml

--- a/docs/configuring-playbook-bridge-mautrix-signal.md
+++ b/docs/configuring-playbook-bridge-mautrix-signal.md
@@ -18,7 +18,8 @@ The relay bot functionality is off by default. If you would like to enable the r
 ```yaml
 matrix_mautrix_signal_relaybot_enabled: true
 ```
-
+If you want to activate the relay bot in a room, use `!signal set-relay`.
+Use `!signal unset-relay` to deactivate.
 Additionally the permissions for the bridge grant user rights to all base domain users in case the relay bot is disabled, or relay rights in case the relay bot is enabled.
 
 If you would like to have a more specific setting of the permissions you can set the permissions as follows (example). For more details see also [mautrix-bridge documentation](https://docs.mau.fi/bridges/python/signal/relay-mode.html)

--- a/docs/configuring-playbook-bridge-mautrix-signal.md
+++ b/docs/configuring-playbook-bridge-mautrix-signal.md
@@ -12,6 +12,27 @@ Use the following playbook configuration:
 matrix_mautrix_signal_enabled: true
 ```
 
+There are some additional things you may wish to configure about the bridge before you continue.
+
+The relay bot functionality is off by default. If you would like to enable the relay bot, add the following to your `vars.yml` file:
+```yaml
+matrix_mautrix_signal_relaybot_enabled: true
+```
+
+Additionally the permissions for the bridge grant user rights to all base domain users in case the relay bot is disabled, or relay rights in case the relay bot is enabled.
+
+If you would like to have a more specific setting of the permissions you can set the permissions as follows (example). For more details see also [mautrix-bridge documentation](https://docs.mau.fi/bridges/python/signal/relay-mode.html)
+```yaml
+matrix_mautrix_signal_configuration_extension_yaml: |
+  bridge:
+    permissions:
+      '@YOUR_USERNAME:YOUR_DOMAIN': admin
+      '*': user
+      YOUR_DOMAIN: relay
+```
+
+You may wish to look at `roles/matrix-bridge-mautrix-signal/templates/config.yaml.j2` to find more information on the permissions settings and other options you would like to configure.
+
 ## Set up Double Puppeting
 
 If you'd like to use [Double Puppeting](https://github.com/tulir/mautrix-signal/wiki/Authentication#double-puppeting) (hint: you most likely do), you have 2 ways of going about it.

--- a/roles/matrix-bridge-mautrix-signal/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-signal/defaults/main.yml
@@ -81,6 +81,19 @@ matrix_mautrix_signal_login_shared_secret: ''
 # Enable bridge relay bot functionality
 matrix_mautrix_signal_relaybot_enabled: false
 
+# Permissions for using the bridge.
+# Permitted values:
+#      relay - Allowed to be relayed through the bridge, no access to commands.
+#       user - Use the bridge with puppeting.
+#      admin - Use and administrate the bridge.
+# Permitted keys:
+#        * - All Matrix users
+#   domain - All users on that homeserver
+#     mxid - Specific user
+matrix_mautrix_signal_bridge_permissions: |
+  '*': relay
+  '{{ matrix_mautrix_signal_homeserver_domain }}': user
+
 # Default configuration template which covers the generic use case.
 # You can customize it by controlling the various variables inside it.
 #

--- a/roles/matrix-bridge-mautrix-signal/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-signal/defaults/main.yml
@@ -78,6 +78,9 @@ matrix_mautrix_signal_appservice_database: "{{
 # Can be set to enable automatic double-puppeting via Shared Secret Auth (https://github.com/devture/matrix-synapse-shared-secret-auth).
 matrix_mautrix_signal_login_shared_secret: ''
 
+# Enable bridge relay bot functionality
+matrix_mautrix_signal_relaybot_enabled: false
+
 # Default configuration template which covers the generic use case.
 # You can customize it by controlling the various variables inside it.
 #
@@ -93,6 +96,21 @@ matrix_mautrix_signal_configuration_extension_yaml: |
   #
   # If you need something more special, you can take full control by
   # completely redefining `matrix_mautrix_signal_configuration_yaml`.
+  #
+  # Permissions for using the bridge.
+  # Permitted values:
+  #      relay - Allowed to be relayed through the bridge, no access to commands.
+  #       user - Use the bridge with puppeting.
+  #      admin - Use and administrate the bridge.
+  # Permitted keys:
+  #        * - All Matrix users
+  #   domain - All users on that homeserver
+  #     mxid - Specific user
+  #
+  bridge:
+    permissions:
+      {{ matrix_mautrix_signal_homeserver_domain }}: "{{ "relay" if matrix_mautrix_signal_relaybot_enabled else "user" }}"
+
 
 matrix_mautrix_signal_configuration_extension: "{{ matrix_mautrix_signal_configuration_extension_yaml|from_yaml if matrix_mautrix_signal_configuration_extension_yaml|from_yaml is mapping else {} }}"
 

--- a/roles/matrix-bridge-mautrix-signal/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-signal/defaults/main.yml
@@ -96,21 +96,6 @@ matrix_mautrix_signal_configuration_extension_yaml: |
   #
   # If you need something more special, you can take full control by
   # completely redefining `matrix_mautrix_signal_configuration_yaml`.
-  #
-  # Permissions for using the bridge.
-  # Permitted values:
-  #      relay - Allowed to be relayed through the bridge, no access to commands.
-  #       user - Use the bridge with puppeting.
-  #      admin - Use and administrate the bridge.
-  # Permitted keys:
-  #        * - All Matrix users
-  #   domain - All users on that homeserver
-  #     mxid - Specific user
-  #
-  bridge:
-    permissions:
-      {{ matrix_mautrix_signal_homeserver_domain }}: "{{ "relay" if matrix_mautrix_signal_relaybot_enabled else "user" }}"
-
 
 matrix_mautrix_signal_configuration_extension: "{{ matrix_mautrix_signal_configuration_extension_yaml|from_yaml if matrix_mautrix_signal_configuration_extension_yaml|from_yaml is mapping else {} }}"
 

--- a/roles/matrix-bridge-mautrix-signal/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-signal/defaults/main.yml
@@ -70,9 +70,9 @@ matrix_mautrix_signal_database_name: 'matrix_mautrix_signal'
 matrix_mautrix_signal_database_connection_string: 'postgres://{{ matrix_mautrix_signal_database_username }}:{{ matrix_mautrix_signal_database_password }}@{{ matrix_mautrix_signal_database_hostname }}:{{ matrix_mautrix_signal_database_port }}/{{ matrix_mautrix_signal_database_name }}'
 
 matrix_mautrix_signal_appservice_database: "{{
- 	{
- 		'postgres': matrix_mautrix_signal_database_connection_string,
- 	}[matrix_mautrix_signal_database_engine]
+  {
+    'postgres': matrix_mautrix_signal_database_connection_string,
+  }[matrix_mautrix_signal_database_engine]
  }}"
 
 # Can be set to enable automatic double-puppeting via Shared Secret Auth (https://github.com/devture/matrix-synapse-shared-secret-auth).

--- a/roles/matrix-bridge-mautrix-signal/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-signal/templates/config.yaml.j2
@@ -188,10 +188,9 @@ bridge:
     #        * - All Matrix users
     #   domain - All users on that homeserver
     #     mxid - Specific user
-    #permissions: 
-    #
-    # Remark: permissions will be set in the defaults/main.yml file of this role 
-    # (see matrix_mautrix_signal_configuration_extension_yaml)
+    permissions: 
+        *: relay
+        '{{ matrix_mautrix_signal_homeserver_domain }}': user
 
     relay:
         # Whether or not relay mode should be allowed. If allowed, `!signal set-relay` can be used to turn any

--- a/roles/matrix-bridge-mautrix-signal/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-signal/templates/config.yaml.j2
@@ -190,7 +190,7 @@ bridge:
     #     mxid - Specific user
     permissions: 
         '{{ matrix_mautrix_signal_homeserver_domain }}': user
-        *: relay
+        '*': relay
 
     relay:
         # Whether or not relay mode should be allowed. If allowed, `!signal set-relay` can be used to turn any

--- a/roles/matrix-bridge-mautrix-signal/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-signal/templates/config.yaml.j2
@@ -189,8 +189,7 @@ bridge:
     #   domain - All users on that homeserver
     #     mxid - Specific user
     permissions: 
-        '{{ matrix_mautrix_signal_homeserver_domain }}': user
-        '*': relay
+        {{ matrix_mautrix_signal_bridge_permissions|from_yaml }}
 
     relay:
         # Whether or not relay mode should be allowed. If allowed, `!signal set-relay` can be used to turn any

--- a/roles/matrix-bridge-mautrix-signal/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-signal/templates/config.yaml.j2
@@ -189,8 +189,8 @@ bridge:
     #   domain - All users on that homeserver
     #     mxid - Specific user
     permissions: 
-        *: relay
         '{{ matrix_mautrix_signal_homeserver_domain }}': user
+        *: relay
 
     relay:
         # Whether or not relay mode should be allowed. If allowed, `!signal set-relay` can be used to turn any

--- a/roles/matrix-bridge-mautrix-signal/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-signal/templates/config.yaml.j2
@@ -188,14 +188,13 @@ bridge:
     #        * - All Matrix users
     #   domain - All users on that homeserver
     #     mxid - Specific user
-    permissions:
-      '{{ matrix_mautrix_signal_homeserver_domain }}': relay
-      '{{ matrix_mautrix_signal_homeserver_domain }}': user
+    permissions: 
+        {{ matrix_mautrix_signal_homeserver_domain }}: user
 
     relay:
         # Whether or not relay mode should be allowed. If allowed, `!signal set-relay` can be used to turn any
         # authenticated user into a relaybot for that chat.
-        enabled: true
+        enabled: {{ matrix_mautrix_signal_relaybot_enabled }}
         # The formats to use when sending messages to Signal via a relay user.
         #
         # Available variables:

--- a/roles/matrix-bridge-mautrix-signal/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-signal/templates/config.yaml.j2
@@ -188,8 +188,10 @@ bridge:
     #        * - All Matrix users
     #   domain - All users on that homeserver
     #     mxid - Specific user
-    permissions: 
-        {{ matrix_mautrix_signal_homeserver_domain }}: user
+    #permissions: 
+    #
+    # Remark: permissions will be set in the defaults/main.yml file of this role 
+    # (see matrix_mautrix_signal_configuration_extension_yaml)
 
     relay:
         # Whether or not relay mode should be allowed. If allowed, `!signal set-relay` can be used to turn any


### PR DESCRIPTION
The recent changes for the relay bot functionality has been enabled within the template file for the signal bridge. These changes now exposes the relay bot enable/disable as a configuration item.

Additionally, the permissions are set for the base domain users depending on whether the relay bot is switched on or off. 

Documentation augmented in case admins need a more detailed permissions setup.