### PR TITLE
Mautrix-Facebook repo location update, pin v0.3.1

### DIFF
--- a/roles/matrix-bridge-mautrix-facebook/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-facebook/defaults/main.yml
@@ -4,11 +4,10 @@
 matrix_mautrix_facebook_enabled: true
 
 matrix_mautrix_facebook_container_image_self_build: false
-matrix_mautrix_facebook_container_image_self_build_repo: "https://github.com/tulir/mautrix-facebook.git"
+matrix_mautrix_facebook_container_image_self_build_repo: "https://mau.dev/mautrix/facebook.git"
 
-matrix_mautrix_facebook_version: latest
-# See: https://mau.dev/tulir/mautrix-facebook/container_registry
-matrix_mautrix_facebook_docker_image: "{{ matrix_mautrix_facebook_docker_image_name_prefix }}tulir/mautrix-facebook:{{ matrix_mautrix_facebook_version }}"
+matrix_mautrix_facebook_version: v0.3.1
+matrix_mautrix_facebook_docker_image: "{{ matrix_mautrix_facebook_docker_image_name_prefix }}mautrix/facebook:{{ matrix_mautrix_facebook_version }}"
 matrix_mautrix_facebook_docker_image_name_prefix: "{{ 'localhost/' if matrix_mautrix_facebook_container_image_self_build else 'dock.mau.dev/' }}"
 matrix_mautrix_facebook_docker_image_force_pull: "{{ matrix_mautrix_facebook_docker_image.endswith(':latest') }}"
 


### PR DESCRIPTION
The Github link is just a redirect to Tulir's own GitLab, so I replaced the self-build link
The docker container repository was rearranged hierarchically (dock.mau.dev/tulir/mautrix-facebook -> dock.mau.dev/tulir/mautrix/facebook)
Tagged versions have been made available, thus :latest -> :v0.3.1