### PR TITLE
Update the docker image version for mautrix-telegram

### DIFF
--- a/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
@@ -13,7 +13,7 @@ matrix_mautrix_telegram_container_self_build: false
 matrix_mautrix_telegram_docker_repo: "https://mau.dev/mautrix/telegram.git"
 matrix_mautrix_telegram_docker_src_files_path: "{{ matrix_base_data_path }}/mautrix-telegram/docker-src"
 
-matrix_mautrix_telegram_version: v0.9.0
+matrix_mautrix_telegram_version: v0.10.1
 # See: https://mau.dev/mautrix/telegram/container_registry
 matrix_mautrix_telegram_docker_image: "dock.mau.dev/mautrix/telegram:{{ matrix_mautrix_telegram_version }}"
 matrix_mautrix_telegram_docker_image_force_pull: "{{ matrix_mautrix_telegram_docker_image.endswith(':latest') }}"


### PR DESCRIPTION
See #1239  . Just tested, and the installation works without issues.