### PR TITLE
Fix appservice-irc version

### DIFF
--- a/roles/matrix-bridge-appservice-irc/defaults/main.yml
+++ b/roles/matrix-bridge-appservice-irc/defaults/main.yml
@@ -7,7 +7,7 @@ matrix_appservice_irc_container_self_build: false
 matrix_appservice_irc_docker_repo: "https://github.com/matrix-org/matrix-appservice-irc.git"
 matrix_appservice_irc_docker_src_files_path: "{{ matrix_base_data_path }}/appservice-irc/docker-src"
 
-matrix_appservice_irc_version: release-v0.30.0
+matrix_appservice_irc_version: release-0.30.0
 matrix_appservice_irc_docker_image: "{{ matrix_container_global_registry_prefix }}matrixdotorg/matrix-appservice-irc:{{ matrix_appservice_irc_version }}"
 matrix_appservice_irc_docker_image_force_pull: "{{ matrix_appservice_irc_docker_image.endswith(':latest') }}"
 


### PR DESCRIPTION
Fix incorrect docker version tag for matrix-appservice-irc

This is the fix I mentioned in the matrix channel.

Looks like there is a bug in the irc bridge docker image tag, just tried to update and it complained the tag didn't exist: Error pulling image docker.io/matrixdotorg/matrix-appservice-irc:release-v0.30.0

On docker hub, the image tag looks to me release-0.30.0 (no v)
https://hub.docker.com/r/matrixdotorg/matrix-appservice-irc/tags?page=1&ordering=last_updated