### PR TITLE
Endpoint changes for Client and media API due to migration to 1.41.0

### DIFF
--- a/roles/matrix-synapse/vars/workers.yml
+++ b/roles/matrix-synapse/vars/workers.yml
@@ -37,6 +37,7 @@ matrix_synapse_workers_generic_worker_endpoints:
   - ^/_matrix/federation/v1/send/
 
   # Client API requests
+  - ^/_matrix/client/(api/v1|r0|unstable)/createRoom$
   - ^/_matrix/client/(api/v1|r0|unstable)/publicRooms$
   - ^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/joined_members$
   - ^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/context/.*$
@@ -253,10 +254,12 @@ matrix_synapse_workers_media_repository_endpoints:
   - ^/_synapse/admin/v1/user/.*/media.*$
   - ^/_synapse/admin/v1/media/.*$
   - ^/_synapse/admin/v1/quarantine_media/.*$
+  - ^/_synapse/admin/v1/users/.*/media$
 
   # You should also set `enable_media_repo: False` in the shared configuration
   # file to stop the main synapse running background jobs related to managing the
-  # media repository.
+  # media repository. Note that doing so will prevent the main process from being
+  # able to handle the above endpoints.
 
   # In the `media_repository` worker configuration file, configure the http listener to
   # expose the `media` resource. For example:


### PR DESCRIPTION
Changes after executing the `workers-doc-to-yaml.sh` bash script to retrieve new endpoints