### PR TITLE
Upgrade to Synaspe v 1.41.1 (Security Update)

### DIFF
--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -15,8 +15,8 @@ matrix_synapse_docker_image_name_prefix: "{{ 'localhost/' if matrix_synapse_cont
 # amd64 gets released first.
 # arm32 relies on self-building, so the same version can be built immediately.
 # arm64 users need to wait for a prebuilt image to become available.
-matrix_synapse_version: v1.41.0
-matrix_synapse_version_arm64: v1.41.0
+matrix_synapse_version: v1.41.1
+matrix_synapse_version_arm64: v1.41.1
 matrix_synapse_docker_image_tag: "{{ matrix_synapse_version if matrix_architecture in ['arm32', 'amd64'] else matrix_synapse_version_arm64 }}"
 matrix_synapse_docker_image_force_pull: "{{ matrix_synapse_docker_image.endswith(':latest') }}"
 


### PR DESCRIPTION
Synapse 1.41.1 Patches 2 exploits that can reveal information about rooms an user is not supposed to have access to information about.