### PR TITLE
Updates Certbot -> v1.19.0, nginx ->1.21.3-alpine

### DIFF
--- a/roles/matrix-nginx-proxy/defaults/main.yml
+++ b/roles/matrix-nginx-proxy/defaults/main.yml
@@ -1,5 +1,5 @@
 matrix_nginx_proxy_enabled: true
-matrix_nginx_proxy_version: 1.21.1-alpine
+matrix_nginx_proxy_version: 1.21.3-alpine
 
 # We use an official nginx image, which we fix-up to run unprivileged.
 # An alternative would be an `nginxinc/nginx-unprivileged` image, but
@@ -426,7 +426,7 @@ matrix_ssl_additional_domains_to_obtain_certificates_for: []
 
 # Controls whether to obtain production or staging certificates from Let's Encrypt.
 matrix_ssl_lets_encrypt_staging: false
-matrix_ssl_lets_encrypt_certbot_docker_image: "{{ matrix_container_global_registry_prefix }}certbot/certbot:{{ matrix_ssl_architecture }}-v1.18.0"
+matrix_ssl_lets_encrypt_certbot_docker_image: "{{ matrix_container_global_registry_prefix }}certbot/certbot:{{ matrix_ssl_architecture }}-v1.19.0"
 matrix_ssl_lets_encrypt_certbot_docker_image_force_pull: "{{ matrix_ssl_lets_encrypt_certbot_docker_image.endswith(':latest') }}"
 matrix_ssl_lets_encrypt_certbot_standalone_http_port: 2402
 matrix_ssl_lets_encrypt_support_email: ~


### PR DESCRIPTION
- [nginx:1.21.3-alpine](https://hub.docker.com/layers/nginx/library/nginx/1.21.3-alpine/images/sha256-826624c15f5e49e591d80f3e0c696f92a2d5967b989017572fe241edac294a2a?context=explore)
- [certbot/certbot:v1.19.0](https://hub.docker.com/layers/certbot/certbot/v1.19.0/images/sha256-ab3c3200b23c281c96b4acce1f95cc32fcacbe55dfd2d08d422bccb8ac4b1778?context=explore)
