### PR TITLE
Bump minimum supported Ubuntu version

### DIFF
--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -5,7 +5,7 @@ To install Matrix services using this Ansible playbook, you need:
 - (Recommended) An **x86** server ([What kind of server specs do I need?](faq.md#what-kind-of-server-specs-do-i-need)) running one of these operating systems:
   - **CentOS** (7 only for now; [8 is not yet supported](https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/300))
   - **Debian** (9/Stretch or newer)
-  - **Ubuntu** (16.04 or newer, although [20.04 may be problematic](ansible.md#supported-ansible-versions))
+  - **Ubuntu** (18.04 or newer, although [20.04 may be problematic](ansible.md#supported-ansible-versions))
   - **Archlinux**
 
 Generally, newer is better. We only strive to support released stable versions of distributions, not betas or pre-releases. This playbook can take over your whole server or co-exist with other services that you have there.


### PR DESCRIPTION
Ubuntu ended support for 16.04 in April and it looks like Docker no longer supports 16.04 either according to https://docs.docker.com/engine/install/ubuntu/#os-requirements

Fixes https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/1277