### PR TITLE
Update Synapse version from 1.42.0 to 1.43.0

### DIFF
--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -15,8 +15,8 @@ matrix_synapse_docker_image_name_prefix: "{{ 'localhost/' if matrix_synapse_cont
 # amd64 gets released first.
 # arm32 relies on self-building, so the same version can be built immediately.
 # arm64 users need to wait for a prebuilt image to become available.
-matrix_synapse_version: v1.42.0
-matrix_synapse_version_arm64: v1.42.0
+matrix_synapse_version: v1.43.0
+matrix_synapse_version_arm64: v1.43.0
 matrix_synapse_docker_image_tag: "{{ matrix_synapse_version if matrix_architecture in ['arm32', 'amd64'] else matrix_synapse_version_arm64 }}"
 matrix_synapse_docker_image_force_pull: "{{ matrix_synapse_docker_image.endswith(':latest') }}"
 


### PR DESCRIPTION
This upgrade should not need any special attention as the only addition that has an upgrade note is that Workers can now handle some spaces related tasks. This PR does not worry about making these changes. 

Making V9 default for Restricted rooms is a lovely upgrade from 1.43.0