### PR TITLE
Upgrade Heisenbridge (1.1.1 -> 1.2.0)

### DIFF
--- a/roles/matrix-bridge-heisenbridge/defaults/main.yml
+++ b/roles/matrix-bridge-heisenbridge/defaults/main.yml
@@ -3,7 +3,7 @@
 
 matrix_heisenbridge_enabled: true
 
-matrix_heisenbridge_version: 1.1.1
+matrix_heisenbridge_version: 1.2.0
 matrix_heisenbridge_docker_image: "{{ matrix_container_global_registry_prefix }}hif1/heisenbridge:{{ matrix_heisenbridge_version }}"
 matrix_heisenbridge_docker_image_force_pull: "{{ matrix_heisenbridge_docker_image.endswith(':latest') }}"
 


### PR DESCRIPTION
https://github.com/hifi/heisenbridge/releases/tag/v1.2.0