### PR TITLE
Support trusting the upstream server when it says the protocol is HTTPS

### DIFF
--- a/docs/configuring-playbook-own-webserver.md
+++ b/docs/configuring-playbook-own-webserver.md
@@ -108,6 +108,9 @@ matrix_nginx_proxy_container_federation_host_bind_port: '127.0.0.1:8449'
 # Since we don't obtain any certificates (`matrix_ssl_retrieval_method: none` above), it won't work by default.
 # An alternative is to tweak some of: `matrix_coturn_tls_enabled`, `matrix_coturn_tls_cert_path` and `matrix_coturn_tls_key_path`.
 matrix_coturn_enabled: false
+
+# Trust the reverse proxy to send the correct `X-Forwarded-Proto` header as it is handling the SSL connection.
+matrix_nginx_proxy_trust_forwarded_proto: true
 ```
 
 With this, nginx would still be in use, but it would not bother with anything SSL related or with taking up public ports.

--- a/roles/matrix-etherpad/tasks/init.yml
+++ b/roles/matrix-etherpad/tasks/init.yml
@@ -15,7 +15,7 @@
   - name: Generate Etherpad proxying configuration for matrix-nginx-proxy
     set_fact:
       matrix_etherpad_matrix_nginx_proxy_configuration: |
-        rewrite ^{{ matrix_etherpad_public_endpoint }}$ $scheme://$server_name{{ matrix_etherpad_public_endpoint }}/ permanent;
+        rewrite ^{{ matrix_etherpad_public_endpoint }}$ {{ matrix_nginx_proxy_x_forwarded_header_value }}://$server_name{{ matrix_etherpad_public_endpoint }}/ permanent;
 
         location {{ matrix_etherpad_public_endpoint }}/ {
         {% if matrix_nginx_proxy_enabled|default(False) %}
@@ -27,7 +27,7 @@
           proxy_http_version 1.1;  # recommended with keepalive connections
           proxy_pass_header Server;
           proxy_set_header Host $host;
-          proxy_set_header X-Forwarded-Proto $scheme; # for EP to set secure cookie flag when https is used
+          proxy_set_header X-Forwarded-Proto {{ matrix_nginx_proxy_x_forwarded_header_value }}; # for EP to set secure cookie flag when https is used
           # WebSocket proxying - from http://nginx.org/en/docs/http/websocket.html
           proxy_set_header Upgrade $http_upgrade;
           proxy_set_header Connection $connection_upgrade;

--- a/roles/matrix-etherpad/tasks/init.yml
+++ b/roles/matrix-etherpad/tasks/init.yml
@@ -15,7 +15,7 @@
   - name: Generate Etherpad proxying configuration for matrix-nginx-proxy
     set_fact:
       matrix_etherpad_matrix_nginx_proxy_configuration: |
-        rewrite ^{{ matrix_etherpad_public_endpoint }}$ {{ matrix_nginx_proxy_x_forwarded_header_value }}://$server_name{{ matrix_etherpad_public_endpoint }}/ permanent;
+        rewrite ^{{ matrix_etherpad_public_endpoint }}$ {{ matrix_nginx_proxy_x_forwarded_proto_value }}://$server_name{{ matrix_etherpad_public_endpoint }}/ permanent;
 
         location {{ matrix_etherpad_public_endpoint }}/ {
         {% if matrix_nginx_proxy_enabled|default(False) %}
@@ -27,7 +27,7 @@
           proxy_http_version 1.1;  # recommended with keepalive connections
           proxy_pass_header Server;
           proxy_set_header Host $host;
-          proxy_set_header X-Forwarded-Proto {{ matrix_nginx_proxy_x_forwarded_header_value }}; # for EP to set secure cookie flag when https is used
+          proxy_set_header X-Forwarded-Proto {{ matrix_nginx_proxy_x_forwarded_proto_value }}; # for EP to set secure cookie flag when https is used
           # WebSocket proxying - from http://nginx.org/en/docs/http/websocket.html
           proxy_set_header Upgrade $http_upgrade;
           proxy_set_header Connection $connection_upgrade;

--- a/roles/matrix-nginx-proxy/defaults/main.yml
+++ b/roles/matrix-nginx-proxy/defaults/main.yml
@@ -40,6 +40,12 @@ matrix_nginx_proxy_container_extra_arguments: []
 # - services are served directly from the HTTP vhost
 matrix_nginx_proxy_https_enabled: true
 
+# Controls whether matrix-nginx-proxy trusts an upstream server's X-Forwarded-Proto header
+#
+# Required if you disable HTTPS for the container (see `matrix_nginx_proxy_https_enabled`) and have an upstream server handle it instead.
+matrix_nginx_proxy_trust_forwarded_proto: false
+matrix_nginx_proxy_x_forwarded_header_value: "{{ '$http_x_forwarded_proto' if matrix_nginx_proxy_trust_forwarded_proto else '$scheme' }}"
+
 # Controls whether the matrix-nginx-proxy container exposes its HTTP port (tcp/8080 in the container).
 #
 # Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:80"), or empty string to not expose.

--- a/roles/matrix-nginx-proxy/defaults/main.yml
+++ b/roles/matrix-nginx-proxy/defaults/main.yml
@@ -44,7 +44,7 @@ matrix_nginx_proxy_https_enabled: true
 #
 # Required if you disable HTTPS for the container (see `matrix_nginx_proxy_https_enabled`) and have an upstream server handle it instead.
 matrix_nginx_proxy_trust_forwarded_proto: false
-matrix_nginx_proxy_x_forwarded_header_value: "{{ '$http_x_forwarded_proto' if matrix_nginx_proxy_trust_forwarded_proto else '$scheme' }}"
+matrix_nginx_proxy_x_forwarded_proto_value: "{{ '$http_x_forwarded_proto' if matrix_nginx_proxy_trust_forwarded_proto else '$scheme' }}"
 
 # Controls whether the matrix-nginx-proxy container exposes its HTTP port (tcp/8080 in the container).
 #

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
@@ -59,7 +59,7 @@
 
 		proxy_set_header Host $host;
 		proxy_set_header X-Forwarded-For $remote_addr;
-		proxy_set_header X-Forwarded-Proto {{ matrix_nginx_proxy_x_forwarded_header_value }};
+		proxy_set_header X-Forwarded-Proto {{ matrix_nginx_proxy_x_forwarded_proto_value }};
 	}
 	{% endif %}
 
@@ -77,7 +77,7 @@
 
 		proxy_set_header Host $host;
 		proxy_set_header X-Forwarded-For $remote_addr;
-		proxy_set_header X-Forwarded-Proto {{ matrix_nginx_proxy_x_forwarded_header_value }};
+		proxy_set_header X-Forwarded-Proto {{ matrix_nginx_proxy_x_forwarded_proto_value }};
 	}
 	{% endif %}
 
@@ -112,7 +112,7 @@
 
 		proxy_set_header Host $host;
 		proxy_set_header X-Forwarded-For $remote_addr;
-		proxy_set_header X-Forwarded-Proto {{ matrix_nginx_proxy_x_forwarded_header_value }};
+		proxy_set_header X-Forwarded-Proto {{ matrix_nginx_proxy_x_forwarded_proto_value }};
 	}
 	{% endif %}
 
@@ -137,7 +137,7 @@
 
 		proxy_set_header Host $host;
 		proxy_set_header X-Forwarded-For $remote_addr;
-		proxy_set_header X-Forwarded-Proto {{ matrix_nginx_proxy_x_forwarded_header_value }};
+		proxy_set_header X-Forwarded-Proto {{ matrix_nginx_proxy_x_forwarded_proto_value }};
 
 		client_body_buffer_size 25M;
 		client_max_body_size {{ matrix_nginx_proxy_proxy_matrix_client_api_client_max_body_size_mb }}M;
@@ -152,7 +152,7 @@
 	#}
 	location ~* ^/$ {
 		{% if matrix_nginx_proxy_proxy_matrix_client_redirect_root_uri_to_domain %}
-			return 302 {{ matrix_nginx_proxy_x_forwarded_header_value }}://{{ matrix_nginx_proxy_proxy_matrix_client_redirect_root_uri_to_domain }}$request_uri;
+			return 302 {{ matrix_nginx_proxy_x_forwarded_proto_value }}://{{ matrix_nginx_proxy_proxy_matrix_client_redirect_root_uri_to_domain }}$request_uri;
 		{% else %}
 			rewrite ^/$ /_matrix/static/ last;
 		{% endif %}
@@ -283,7 +283,7 @@ server {
 
 		proxy_set_header Host $host;
 		proxy_set_header X-Forwarded-For $remote_addr;
-		proxy_set_header X-Forwarded-Proto {{ matrix_nginx_proxy_x_forwarded_header_value }};
+		proxy_set_header X-Forwarded-Proto {{ matrix_nginx_proxy_x_forwarded_proto_value }};
 
 		client_body_buffer_size 25M;
 		client_max_body_size {{ matrix_nginx_proxy_proxy_matrix_federation_api_client_max_body_size_mb }}M;

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
@@ -20,13 +20,13 @@
 	{% if matrix_nginx_proxy_floc_optout_enabled %}
 		add_header Permissions-Policy interest-cohort=() always;
 	{% endif %}
-	
+
 	{% if matrix_nginx_proxy_hsts_preload_enabled %}
 		add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
 	{% else %}
 		add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 	{% endif %}
-	
+
 	add_header X-XSS-Protection "{{ matrix_nginx_proxy_xss_protection }}";
 
 	location /.well-known/matrix {
@@ -59,7 +59,7 @@
 
 		proxy_set_header Host $host;
 		proxy_set_header X-Forwarded-For $remote_addr;
-		proxy_set_header X-Forwarded-Proto $scheme;
+		proxy_set_header X-Forwarded-Proto {{ matrix_nginx_proxy_x_forwarded_header_value }};
 	}
 	{% endif %}
 
@@ -77,7 +77,7 @@
 
 		proxy_set_header Host $host;
 		proxy_set_header X-Forwarded-For $remote_addr;
-		proxy_set_header X-Forwarded-Proto $scheme;
+		proxy_set_header X-Forwarded-Proto {{ matrix_nginx_proxy_x_forwarded_header_value }};
 	}
 	{% endif %}
 
@@ -112,7 +112,7 @@
 
 		proxy_set_header Host $host;
 		proxy_set_header X-Forwarded-For $remote_addr;
-		proxy_set_header X-Forwarded-Proto $scheme;
+		proxy_set_header X-Forwarded-Proto {{ matrix_nginx_proxy_x_forwarded_header_value }};
 	}
 	{% endif %}
 
@@ -137,7 +137,7 @@
 
 		proxy_set_header Host $host;
 		proxy_set_header X-Forwarded-For $remote_addr;
-		proxy_set_header X-Forwarded-Proto $scheme;
+		proxy_set_header X-Forwarded-Proto {{ matrix_nginx_proxy_x_forwarded_header_value }};
 
 		client_body_buffer_size 25M;
 		client_max_body_size {{ matrix_nginx_proxy_proxy_matrix_client_api_client_max_body_size_mb }}M;
@@ -152,7 +152,7 @@
 	#}
 	location ~* ^/$ {
 		{% if matrix_nginx_proxy_proxy_matrix_client_redirect_root_uri_to_domain %}
-			return 302 $scheme://{{ matrix_nginx_proxy_proxy_matrix_client_redirect_root_uri_to_domain }}$request_uri;
+			return 302 {{ matrix_nginx_proxy_x_forwarded_header_value }}://{{ matrix_nginx_proxy_proxy_matrix_client_redirect_root_uri_to_domain }}$request_uri;
 		{% else %}
 			rewrite ^/$ /_matrix/static/ last;
 		{% endif %}
@@ -215,12 +215,12 @@ server {
 		ssl_stapling_verify on;
 		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_proxy_matrix_hostname }}/chain.pem;
 	{% endif %}
-	
+
 	{% if matrix_nginx_proxy_ssl_session_tickets_off %}
 		ssl_session_tickets off;
 	{% endif %}
 	ssl_session_cache {{ matrix_nginx_proxy_ssl_session_cache }};
-	ssl_session_timeout {{ matrix_nginx_proxy_ssl_session_timeout }};	
+	ssl_session_timeout {{ matrix_nginx_proxy_ssl_session_timeout }};
 
 	{{ render_vhost_directives() }}
 }
@@ -262,7 +262,7 @@ server {
 			ssl_stapling_verify on;
 			ssl_trusted_certificate {{ matrix_nginx_proxy_proxy_matrix_federation_api_ssl_trusted_certificate }};
 		{% endif %}
-		
+
 		{% if matrix_nginx_proxy_ssl_session_tickets_off %}
 			ssl_session_tickets off;
 		{% endif %}
@@ -283,7 +283,7 @@ server {
 
 		proxy_set_header Host $host;
 		proxy_set_header X-Forwarded-For $remote_addr;
-		proxy_set_header X-Forwarded-Proto $scheme;
+		proxy_set_header X-Forwarded-Proto {{ matrix_nginx_proxy_x_forwarded_header_value }};
 
 		client_body_buffer_size 25M;
 		client_max_body_size {{ matrix_nginx_proxy_proxy_matrix_federation_api_client_max_body_size_mb }}M;

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-jitsi.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-jitsi.conf.j2
@@ -71,7 +71,7 @@
 		proxy_set_header Connection "upgrade";
 		proxy_set_header Upgrade $http_upgrade;
 		proxy_set_header X-Forwarded-For $remote_addr;
-		proxy_set_header X-Forwarded-Proto $scheme;
+		proxy_set_header X-Forwarded-Proto {{ matrix_nginx_proxy_x_forwarded_header_value }};
 		tcp_nodelay on;
 	}
 {% endmacro %}
@@ -128,7 +128,7 @@ server {
 		ssl_stapling_verify on;
 		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_proxy_jitsi_hostname }}/chain.pem;
 	{% endif %}
-	
+
 	{% if matrix_nginx_proxy_ssl_session_tickets_off %}
 		ssl_session_tickets off;
 	{% endif %}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-jitsi.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-jitsi.conf.j2
@@ -71,7 +71,7 @@
 		proxy_set_header Connection "upgrade";
 		proxy_set_header Upgrade $http_upgrade;
 		proxy_set_header X-Forwarded-For $remote_addr;
-		proxy_set_header X-Forwarded-Proto {{ matrix_nginx_proxy_x_forwarded_header_value }};
+		proxy_set_header X-Forwarded-Proto {{ matrix_nginx_proxy_x_forwarded_proto_value }};
 		tcp_nodelay on;
 	}
 {% endmacro %}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-sygnal.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-sygnal.conf.j2
@@ -29,7 +29,7 @@
 
 		proxy_set_header Host $host;
 		proxy_set_header X-Forwarded-For $remote_addr;
-		proxy_set_header X-Forwarded-Proto {{ matrix_nginx_proxy_x_forwarded_header_value }};
+		proxy_set_header X-Forwarded-Proto {{ matrix_nginx_proxy_x_forwarded_proto_value }};
 	}
 {% endmacro %}
 

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-sygnal.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-sygnal.conf.j2
@@ -29,7 +29,7 @@
 
 		proxy_set_header Host $host;
 		proxy_set_header X-Forwarded-For $remote_addr;
-		proxy_set_header X-Forwarded-Proto $scheme;
+		proxy_set_header X-Forwarded-Proto {{ matrix_nginx_proxy_x_forwarded_header_value }};
 	}
 {% endmacro %}
 
@@ -85,7 +85,7 @@ server {
 		ssl_stapling_verify on;
 		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_proxy_sygnal_hostname }}/chain.pem;
 	{% endif %}
-	
+
 	{% if matrix_nginx_proxy_ssl_session_tickets_off %}
 		ssl_session_tickets off;
 	{% endif %}

--- a/roles/matrix-registration/tasks/init.yml
+++ b/roles/matrix-registration/tasks/init.yml
@@ -22,8 +22,8 @@
   - name: Generate matrix-registration proxying configuration for matrix-nginx-proxy
     set_fact:
       matrix_registration_matrix_nginx_proxy_configuration: |
-        rewrite ^{{ matrix_registration_public_endpoint }}$ {{ matrix_nginx_proxy_x_forwarded_header_value }}://$server_name{{ matrix_registration_public_endpoint }}/ permanent;
-        rewrite ^{{ matrix_registration_public_endpoint }}/$ {{ matrix_nginx_proxy_x_forwarded_header_value }}://$server_name{{ matrix_registration_public_endpoint }}/register redirect;
+        rewrite ^{{ matrix_registration_public_endpoint }}$ {{ matrix_nginx_proxy_x_forwarded_proto_value }}://$server_name{{ matrix_registration_public_endpoint }}/ permanent;
+        rewrite ^{{ matrix_registration_public_endpoint }}/$ {{ matrix_nginx_proxy_x_forwarded_proto_value }}://$server_name{{ matrix_registration_public_endpoint }}/register redirect;
 
         location ~ ^{{ matrix_registration_public_endpoint }}/(.*) {
         {% if matrix_nginx_proxy_enabled|default(False) %}

--- a/roles/matrix-registration/tasks/init.yml
+++ b/roles/matrix-registration/tasks/init.yml
@@ -22,8 +22,8 @@
   - name: Generate matrix-registration proxying configuration for matrix-nginx-proxy
     set_fact:
       matrix_registration_matrix_nginx_proxy_configuration: |
-        rewrite ^{{ matrix_registration_public_endpoint }}$ $scheme://$server_name{{ matrix_registration_public_endpoint }}/ permanent;
-        rewrite ^{{ matrix_registration_public_endpoint }}/$ $scheme://$server_name{{ matrix_registration_public_endpoint }}/register redirect;
+        rewrite ^{{ matrix_registration_public_endpoint }}$ {{ matrix_nginx_proxy_x_forwarded_header_value }}://$server_name{{ matrix_registration_public_endpoint }}/ permanent;
+        rewrite ^{{ matrix_registration_public_endpoint }}/$ {{ matrix_nginx_proxy_x_forwarded_header_value }}://$server_name{{ matrix_registration_public_endpoint }}/register redirect;
 
         location ~ ^{{ matrix_registration_public_endpoint }}/(.*) {
         {% if matrix_nginx_proxy_enabled|default(False) %}

--- a/roles/matrix-synapse-admin/tasks/init.yml
+++ b/roles/matrix-synapse-admin/tasks/init.yml
@@ -22,7 +22,7 @@
   - name: Generate Synapse Admin proxying configuration for matrix-nginx-proxy
     set_fact:
       matrix_synapse_admin_matrix_nginx_proxy_configuration: |
-        rewrite ^{{ matrix_synapse_admin_public_endpoint }}$ {{ matrix_nginx_proxy_x_forwarded_header_value }}://$server_name{{ matrix_synapse_admin_public_endpoint }}/ permanent;
+        rewrite ^{{ matrix_synapse_admin_public_endpoint }}$ {{ matrix_nginx_proxy_x_forwarded_proto_value }}://$server_name{{ matrix_synapse_admin_public_endpoint }}/ permanent;
 
         location ~ ^{{ matrix_synapse_admin_public_endpoint }}/(.*) {
         {% if matrix_nginx_proxy_enabled|default(False) %}

--- a/roles/matrix-synapse-admin/tasks/init.yml
+++ b/roles/matrix-synapse-admin/tasks/init.yml
@@ -22,7 +22,7 @@
   - name: Generate Synapse Admin proxying configuration for matrix-nginx-proxy
     set_fact:
       matrix_synapse_admin_matrix_nginx_proxy_configuration: |
-        rewrite ^{{ matrix_synapse_admin_public_endpoint }}$ $scheme://$server_name{{ matrix_synapse_admin_public_endpoint }}/ permanent;
+        rewrite ^{{ matrix_synapse_admin_public_endpoint }}$ {{ matrix_nginx_proxy_x_forwarded_header_value }}://$server_name{{ matrix_synapse_admin_public_endpoint }}/ permanent;
 
         location ~ ^{{ matrix_synapse_admin_public_endpoint }}/(.*) {
         {% if matrix_nginx_proxy_enabled|default(False) %}


### PR DESCRIPTION
This replaces `$scheme` with the contents of the `X-Forwarded-Proto` when enabled.

Not 100% certain on the variables. Creating `matrix_nginx_proxy_trust_forwarded_proto` means that you can have a completely HTTP matrix server, which I don't know if that's supported or not. Or I can move `matrix_nginx_proxy_x_forwarded_proto_value` to `roles/matrix-nginx-proxy/tasks/init.yml` and have it key off `matrix_nginx_proxy_https_enabled` instead?

I think this resolves #1132 but I'm not 100% certain people's problems there are the same as mine.