### PR TITLE
Archlinux: remove package systemd-timesyncd

### DIFF
--- a/roles/matrix-base/tasks/server_base/setup_archlinux.yml
+++ b/roles/matrix-base/tasks/server_base/setup_archlinux.yml
@@ -4,7 +4,6 @@
   pacman:
     name:
       - python-docker
-      - systemd-timesyncd
       # TODO This needs to be verified. Which version do we need?
       - fuse3
       - python-dnspython


### PR DESCRIPTION
#1192 lead to the following error for me on Archlinux:
`TASK [matrix-base : Install host dependencies] *******************************************************************************************************************************
fatal: [matrix.***.de]: FAILED! => changed=false 
  msg: |-
    failed to install systemd-timesyncd: error: target not found: systemd-timesyncd`

There is no package called `systemd-timesyncd` on Archlinux. The service is installed with the [`systemd`](https://archlinux.org/packages/core/x86_64/systemd/) package itself.

I suggest removing the `systemd-timesyncd` from https://github.com/sakkiii/matrix-docker-ansible-deploy/blob/2453876eb9a463eb6e327a9f771ea2a29b9cdc49/roles/matrix-base/tasks/server_base/setup_archlinux.yml#L7

I'm not sure whether we have to put the `- "{{ matrix_ntpd_package }}"` back in.