### PR TITLE
add auto proxy synapse worker metrics

### DIFF
--- a/roles/matrix-nginx-proxy/defaults/main.yml
+++ b/roles/matrix-nginx-proxy/defaults/main.yml
@@ -222,7 +222,7 @@ matrix_nginx_proxy_proxy_matrix_client_api_forwarded_location_prefix_regexes: |
     +
     (['/_synapse/admin'] if matrix_nginx_proxy_proxy_matrix_client_api_forwarded_location_synapse_admin_api_enabled else [])
     +
-    (['/_synapse/metrics'] if matrix_nginx_proxy_proxy_synapse_metrics else [])
+    (['/_synapse.*/metrics'] if matrix_nginx_proxy_proxy_synapse_metrics else [])
   }}
 
 # Specifies where requests for the root URI (`/`) on the `matrix.` domain should be redirected.

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-synapse.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-synapse.conf.j2
@@ -153,6 +153,24 @@ server {
 	}
 	{% endif %}
 
+	{% if matrix_nginx_proxy_enabled and matrix_nginx_proxy_proxy_synapse_metrics %}
+		{% for worker in matrix_prometheus_scraper_synapse_workers_enabled_list %}
+			{% if worker.metrics_port != 0 %}
+				location /_synapse-worker-{{ worker.type }}-{{ worker.instanceId }}/metrics {
+					resolver 127.0.0.11 valid=5s;
+					set $backend "matrix-synapse-worker-{{ worker.type }}-{{ worker.instanceId }}:{{ worker.metrics_port }}";
+					proxy_pass http://$backend/_synapse/metrics;
+					proxy_set_header Host $host;
+
+					{% if matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_enabled %}
+						auth_basic "protected";
+						auth_basic_user_file /nginx-data/matrix-synapse-metrics-htpasswd;
+					{% endif %}
+				}
+			{% endif %}
+ 		{% endfor %}
+	{% endif %}
+
 	{# Everything else just goes to the API server ##}
 	location / {
 		{% if matrix_nginx_proxy_enabled %}


### PR DESCRIPTION
when matrix_nginx_proxy_proxy_synapse_metrics is enabled

resolves #898

relevant upstream docs: https://matrix-org.github.io/synapse/latest/metrics-howto.html#monitoring-workers

I feel that doing it this way fits the general style of how proxying is done best (first through matrix-domain, then matrix-synapse). The former is achieved by the added wildcard in `matrix_nginx_proxy_proxy_matrix_client_api_forwarded_location_prefix_regexes` for metrics. This is under the assumption that there are no other metrics that match this URI?
The latter is based on the loop in https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/d38c0e121b56e8ad6ba98c2ac5b39ff535656553/roles/matrix-prometheus/templates/prometheus.yml.j2#L38-L46
but only enabled when `matrix_nginx_proxy_enabled and matrix_nginx_proxy_proxy_synapse_metrics` are true, i.e. exactly when the main thread metrics are exposed.

I will add documentation for this if you greenlight this approach.

In prometheus.yml (on the Prometheus server) a config like this is needed (to be written manually):
```yaml
scrape_configs:
  - job_name: 'synapse'
    metrics_path: /_synapse/metrics
    scheme: https
    basic_auth:
      username: prometheus
      password_file: /etc/prometheus/password.pwd
    static_configs:
      - targets: ['matrix.DOMAIN:443']
        labels:
          job: "master"
          index: 1
  - job_name: 'synapse-generic_worker-1'
    metrics_path: /_synapse-worker-generic_worker-18111/metrics
    scheme: https
    basic_auth:
      username: prometheus
      password_file: /etc/prometheus/password.pwd
    static_configs:
      - targets: ['matrix.DOMAIN:443']
        labels:
          job: "generic_worker"
          index: 1
```
etc.
It's not perfect since from my understanding multiple `scrape_configs` are needed to set individual `metrics_path` where usually and in the upstream doc only several `static_configs` are used. Potentially we can generate that file on the server for the user/admin to copy to their Prometheus server.
However it ends up looking fine:
![image](https://user-images.githubusercontent.com/2803622/135917162-3a8b9b13-84eb-44d1-bd07-b2eefd1b24ef.png)
