### PR TITLE
Update matrix-appservice-slack (1.5.0 -> 1.8.0)

### DIFF
--- a/roles/matrix-bridge-appservice-slack/defaults/main.yml
+++ b/roles/matrix-bridge-appservice-slack/defaults/main.yml
@@ -7,7 +7,7 @@ matrix_appservice_slack_container_self_build: false
 matrix_appservice_slack_docker_repo: "https://github.com/matrix-org/matrix-appservice-slack.git"
 matrix_appservice_slack_docker_src_files_path: "{{ matrix_base_data_path }}/appservice-slack/docker-src"
 
-matrix_appservice_slack_version: release-1.5.0
+matrix_appservice_slack_version: release-1.8.0
 matrix_appservice_slack_docker_image: "{{ matrix_container_global_registry_prefix }}matrixdotorg/matrix-appservice-slack:{{ matrix_appservice_slack_version }}"
 matrix_appservice_slack_docker_image_force_pull: "{{ matrix_appservice_slack_docker_image.endswith(':latest') }}"
 


### PR DESCRIPTION
I am not using this bridge and haven't tested this but multiple people have said 1.5.0 isn't working and 1.8.0 works for them so it seems to make sense to update.

https://github.com/matrix-org/matrix-appservice-slack/issues/618#issuecomment-929849093