### PR TITLE
Updated Hangouts configuration readme.

### DIFF
--- a/docs/configuring-playbook-bridge-mautrix-hangouts.md
+++ b/docs/configuring-playbook-bridge-mautrix-hangouts.md
@@ -1,3 +1,5 @@
+# The [Mautrix Hangouts Bridge](https://mau.dev/mautrix/hangouts) is no longer maintained.  It has changed to a [Google Chat Bridge](https://github.com/mautrix/googlechat). Setup instructions for the Google Chat Bridge can be [found here](configuring-playbook-bridge-mautrix-googlechat.md). 
+
 # Setting up Mautrix Hangouts (optional)
 
 The playbook can install and configure [mautrix-hangouts](https://github.com/mautrix/hangouts) for you.


### PR DESCRIPTION
Also indicates that the Mautrix googlechat bridge is a replacement for hangouts.