### PR TITLE
caddy example fixes

### DIFF
--- a/examples/caddy/matrix-synapse
+++ b/examples/caddy/matrix-synapse
@@ -5,7 +5,7 @@ https://matrix.DOMAIN {
 
 	root /matrix/static-files
 
-	header {
+	header / {
 		Access-Control-Allow-Origin *
 		Strict-Transport-Security "mag=age=31536000;"
 		X-Frame-Options "DENY"
@@ -13,10 +13,10 @@ https://matrix.DOMAIN {
 	}
 
 	# Identity server traffic
-	proxy /_matrix/identity matrix-msisd:8090 {
+	proxy /_matrix/identity matrix-ma1sd:8090 {
 		transparent
 	}
-	proxy /_matrix/client/r0/user_directory/search matrix-msisd:8090 {
+	proxy /_matrix/client/r0/user_directory/search matrix-ma1sd:8090 {
 		transparent
 	}
 


### PR DESCRIPTION
- caddy v1 requires a path in the header directive
- msisd has been replaced in favour of ma1sd