### PR TITLE
Upgrade matrix-synapse-shared-secret-auth (1.0.2 -> 2.0)

### DIFF
--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -489,8 +489,16 @@ matrix_synapse_ext_password_provider_rest_auth_login_profile_name_autofill: fals
 # Enable this to activate the Shared Secret Auth password provider module.
 # See: https://github.com/devture/matrix-synapse-shared-secret-auth
 matrix_synapse_ext_password_provider_shared_secret_auth_enabled: false
-matrix_synapse_ext_password_provider_shared_secret_auth_download_url: "https://raw.githubusercontent.com/devture/matrix-synapse-shared-secret-auth/1.0.2/shared_secret_authenticator.py"
+matrix_synapse_ext_password_provider_shared_secret_auth_download_url: "https://raw.githubusercontent.com/devture/matrix-synapse-shared-secret-auth/2.0.2/shared_secret_authenticator.py"
 matrix_synapse_ext_password_provider_shared_secret_auth_shared_secret: ""
+matrix_synapse_ext_password_provider_shared_secret_auth_m_login_password_support_enabled: true
+# We'd like to enable this, but it causes trouble for Element: https://github.com/vector-im/element-web/issues/19605
+matrix_synapse_ext_password_provider_shared_secret_auth_com_devture_shared_secret_auth_support_enabled: false
+matrix_synapse_ext_password_provider_shared_secret_config: "{{ matrix_synapse_ext_password_provider_shared_secret_config_yaml|from_yaml }}"
+matrix_synapse_ext_password_provider_shared_secret_config_yaml: |
+  shared_secret: {{ matrix_synapse_ext_password_provider_shared_secret_auth_shared_secret|string|to_json }}
+  m_login_password_support_enabled: {{ matrix_synapse_ext_password_provider_shared_secret_auth_m_login_password_support_enabled|bool|to_json }}
+  com_devture_shared_secret_auth_support_enabled: {{ matrix_synapse_ext_password_provider_shared_secret_auth_com_devture_shared_secret_auth_support_enabled|to_json }}
 
 # Enable this to activate LDAP password provider
 matrix_synapse_ext_password_provider_ldap_enabled: false
@@ -573,6 +581,9 @@ matrix_synapse_default_room_version: "6"
 # If not, you can also control its value manually.
 matrix_synapse_spam_checker: []
 
+# Controls the Synapse `modules` list.
+# You can define your own list of modules here. See the `modules` syntax in `homeserver.yaml.j2`
+# Certain Synapse extensions that you can enable below auto-inject themselves into `matrix_synapse_modules` at runtime.
 matrix_synapse_modules: []
 
 matrix_synapse_encryption_enabled_by_default_for_room_type: "off"

--- a/roles/matrix-synapse/tasks/ext/shared-secret-auth/setup_install.yml
+++ b/roles/matrix-synapse/tasks/ext/shared-secret-auth/setup_install.yml
@@ -5,6 +5,11 @@
     msg: "Shared Secret Auth is enabled, but no secret has been set in matrix_synapse_ext_password_provider_shared_secret_auth_shared_secret"
   when: "matrix_synapse_ext_password_provider_shared_secret_auth_shared_secret == ''"
 
+- name: Fail if no Shared Secret Auth login types enabled
+  fail:
+    msg: "Shared Secret Auth is enabled, but none of the login types are"
+  when: "not (matrix_synapse_ext_password_provider_shared_secret_auth_m_login_password_support_enabled or matrix_synapse_ext_password_provider_shared_secret_auth_com_devture_shared_secret_auth_support_enabled)"
+
 - name: Download matrix-synapse-shared-secret-auth
   get_url:
     url: "{{ matrix_synapse_ext_password_provider_shared_secret_auth_download_url }}"
@@ -15,7 +20,17 @@
     group: "{{ matrix_user_groupname }}"
 
 - set_fact:
-    matrix_synapse_password_providers_enabled: true
+    matrix_synapse_modules: |
+      {{
+        matrix_synapse_modules|default([])
+        +
+        [
+          {
+            "module": "shared_secret_authenticator.SharedSecretAuthProvider",
+            "config": matrix_synapse_ext_password_provider_shared_secret_config
+          }
+        ]
+      }}
 
     matrix_synapse_container_extra_arguments: >
       {{ matrix_synapse_container_extra_arguments|default([]) }}

--- a/roles/matrix-synapse/tasks/init.yml
+++ b/roles/matrix-synapse/tasks/init.yml
@@ -3,7 +3,7 @@
 # and https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/1ab507349c752042d26def3e95884f6df8886b74#commitcomment-51108407
 - name: Fail if trying to self-build on Ansible < 2.8
   fail:
-    msg: "To self-build the Element image, you should use Ansible 2.8 or higher. See docs/ansible.md"
+    msg: "To self-build the Synapse image, you should use Ansible 2.8 or higher. See docs/ansible.md"
   when: "ansible_version.major == 2 and ansible_version.minor < 8 and matrix_synapse_container_image_self_build and matrix_synapse_enabled"
 
 # Unless `matrix_synapse_workers_enabled_list` is explicitly defined,

--- a/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -2586,11 +2586,6 @@ email:
 #        #filter: "(objectClass=posixAccount)"
 {% if matrix_synapse_password_providers_enabled %}
 password_providers:
-{% if matrix_synapse_ext_password_provider_shared_secret_auth_enabled %}
-  - module: "shared_secret_authenticator.SharedSecretAuthenticator"
-    config:
-      sharedSecret: {{ matrix_synapse_ext_password_provider_shared_secret_auth_shared_secret|string|to_json }}
-{% endif %}
 {% if matrix_synapse_ext_password_provider_rest_auth_enabled %}
   - module: "rest_auth_provider.RestAuthProvider"
     config:


### PR DESCRIPTION
It seems to work well (and is backward compatible by default),
but suffers from this issue with Element: https://github.com/vector-im/element-web/issues/19605