### PR TITLE
set homeserver_url to matrix_domain when nginx-proxy disabled and workers enabled

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -21,7 +21,7 @@ matrix_identity_server_url: "{{ ('https://' + matrix_server_fqn_matrix) if matri
 
 # If Synapse workers are enabled and matrix-nginx-proxy is disabled, certain APIs may not work over 'http://matrix-synapse:8008'.
 # This is because we explicitly disable them for the main Synapse process.
-matrix_homeserver_container_url: "{{ 'http://matrix-nginx-proxy:12080' if matrix_nginx_proxy_enabled else 'http://matrix-synapse:8008' }}"
+matrix_homeserver_container_url: "{{ 'http://matrix-nginx-proxy:12080' if matrix_nginx_proxy_enabled else 'https://' + matrix_domain }}"
 
 ######################################################################
 #


### PR DESCRIPTION
Trying to set mautrix-signal bridge, I could not `link` to a new device. This was because the bridge could not connect to the homeserver endpoint  with `matrix-nginx-proxy` disabled and `workers` enabled. 
Setting the `homeserver.address` to `https:matrix_domain` solved my issue