### PR TITLE
Port 80 for IPv6

### DIFF
--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-base-domain.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-base-domain.conf.j2
@@ -36,6 +36,7 @@
 
 server {
 	listen {{ 8080 if matrix_nginx_proxy_enabled else 80 }};
+	listen [::]:{{ 8080 if matrix_nginx_proxy_enabled else 80 }};
 
 	server_name {{ matrix_nginx_proxy_base_domain_hostname }};
 	server_tokens off;

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-bot-go-neb.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-bot-go-neb.conf.j2
@@ -33,6 +33,8 @@
 
 server {
 	listen {{ 8080 if matrix_nginx_proxy_enabled else 80 }};
+	listen [::]:{{ 8080 if matrix_nginx_proxy_enabled else 80 }};
+
 	server_name {{ matrix_nginx_proxy_proxy_bot_go_neb_hostname }};
 
 	server_tokens off;
@@ -83,7 +85,7 @@ server {
 		ssl_stapling_verify on;
 		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_proxy_bot_go_neb_hostname }}/chain.pem;
 	{% endif %}
-	
+
 	{% if matrix_nginx_proxy_ssl_session_tickets_off %}
 		ssl_session_tickets off;
 	{% endif %}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-client-element.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-client-element.conf.j2
@@ -41,6 +41,8 @@
 
 server {
 	listen {{ 8080 if matrix_nginx_proxy_enabled else 80 }};
+	listen [::]:{{ 8080 if matrix_nginx_proxy_enabled else 80 }};
+
 
 	server_name {{ matrix_nginx_proxy_proxy_element_hostname }};
 

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-client-hydrogen.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-client-hydrogen.conf.j2
@@ -39,6 +39,8 @@
 
 server {
 	listen {{ 8080 if matrix_nginx_proxy_enabled else 80 }};
+	listen [::]:{{ 8080 if matrix_nginx_proxy_enabled else 80 }};
+
 
 	server_name {{ matrix_nginx_proxy_proxy_hydrogen_hostname }};
 

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-dimension.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-dimension.conf.j2
@@ -36,6 +36,8 @@
 
 server {
 	listen {{ 8080 if matrix_nginx_proxy_enabled else 80 }};
+	listen [::]:{{ 8080 if matrix_nginx_proxy_enabled else 80 }};
+
 	server_name {{ matrix_nginx_proxy_proxy_dimension_hostname }};
 
 	server_tokens off;
@@ -86,7 +88,7 @@ server {
 		ssl_stapling_verify on;
 		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_proxy_dimension_hostname }}/chain.pem;
 	{% endif %}
-	
+
 	{% if matrix_nginx_proxy_ssl_session_tickets_off %}
 		ssl_session_tickets off;
 	{% endif %}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
@@ -161,6 +161,8 @@
 
 server {
 	listen {{ 8080 if matrix_nginx_proxy_enabled else 80 }};
+	listen [::]:{{ 8080 if matrix_nginx_proxy_enabled else 80 }};
+
 	server_name {{ matrix_nginx_proxy_proxy_matrix_hostname }};
 
 	server_tokens off;

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-grafana.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-grafana.conf.j2
@@ -43,6 +43,8 @@
 
 server {
 	listen {{ 8080 if matrix_nginx_proxy_enabled else 80 }};
+	listen [::]:{{ 8080 if matrix_nginx_proxy_enabled else 80 }};
+
 
 	server_name {{ matrix_nginx_proxy_proxy_grafana_hostname }};
 
@@ -94,12 +96,12 @@ server {
 		ssl_stapling_verify on;
 		ssl_trusted_certificate {{ matrix_ssl_config_dir_path }}/live/{{ matrix_nginx_proxy_proxy_grafana_hostname }}/chain.pem;
 	{% endif %}
-	
+
 	{% if matrix_nginx_proxy_ssl_session_tickets_off %}
 		ssl_session_tickets off;
 	{% endif %}
 	ssl_session_cache {{ matrix_nginx_proxy_ssl_session_cache }};
-	ssl_session_timeout {{ matrix_nginx_proxy_ssl_session_timeout }};	
+	ssl_session_timeout {{ matrix_nginx_proxy_ssl_session_timeout }};
 
 	{{ render_vhost_directives() }}
 }

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-jitsi.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-jitsi.conf.j2
@@ -78,6 +78,8 @@
 
 server {
 	listen {{ 8080 if matrix_nginx_proxy_enabled else 80 }};
+	listen [::]:{{ 8080 if matrix_nginx_proxy_enabled else 80 }};
+
 	server_name {{ matrix_nginx_proxy_proxy_jitsi_hostname }};
 
 	server_tokens off;

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-riot-web.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-riot-web.conf.j2
@@ -24,6 +24,8 @@
 
 server {
 	listen {{ 8080 if matrix_nginx_proxy_enabled else 80 }};
+	listen [::]:{{ 8080 if matrix_nginx_proxy_enabled else 80 }};
+
 
 	server_name {{ matrix_nginx_proxy_proxy_riot_compat_redirect_hostname }};
 

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-sygnal.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-sygnal.conf.j2
@@ -35,6 +35,8 @@
 
 server {
 	listen {{ 8080 if matrix_nginx_proxy_enabled else 80 }};
+	listen [::]:{{ 8080 if matrix_nginx_proxy_enabled else 80 }};
+
 	server_name {{ matrix_nginx_proxy_proxy_sygnal_hostname }};
 
 	server_tokens off;


### PR DESCRIPTION
If you use a external certbot because of an external reverse proxy, the server has to be reached via ipv6 on port80.