### PR TITLE
Allow workers to serve new v3 APIs

### DIFF
--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-synapse.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-synapse.conf.j2
@@ -120,7 +120,7 @@ server {
 			{% endfor %}
 			{% if matrix_nginx_proxy_synapse_presence_disabled %}
 			# FIXME: keep in sync with synapse workers documentation manually
-			location ~ ^/_matrix/client/(api/v1|r0|unstable)/presence/[^/]+/status {
+			location ~ ^/_matrix/client/(api/v1|r0|v3|unstable)/presence/[^/]+/status {
 				proxy_pass http://frontend_proxy_upstream$request_uri;
 				proxy_set_header Host $host;
 			}

--- a/roles/matrix-synapse/files/workers-doc-to-yaml.awk
+++ b/roles/matrix-synapse/files/workers-doc-to-yaml.awk
@@ -86,7 +86,7 @@ enable_parsing {
 
                 # FIXME: https://github.com/matrix-org/synapse/issues/7530
                 # https://github.com/spantaleev/matrix-docker-ansible-deploy/pull/456#issuecomment-719015911
-                if (api_endpoint_regex == "^/_matrix/client/(r0|unstable)/auth/.*/fallback/web$") {
+                if (api_endpoint_regex == "^/_matrix/client/(r0|v3|unstable)/auth/.*/fallback/web$") {
                     worker_stanza_append("  # FIXME: possible bug with SSO and multiple generic workers\n")
                     worker_stanza_append("  # see https://github.com/matrix-org/synapse/issues/7530\n")
                     worker_stanza_append("  # " api_endpoint_regex linefeed)

--- a/roles/matrix-synapse/vars/workers.yml
+++ b/roles/matrix-synapse/vars/workers.yml
@@ -5,10 +5,10 @@ matrix_synapse_workers_generic_worker_endpoints:
   # expressions:
 
   # Sync requests
-  - ^/_matrix/client/(v2_alpha|r0)/sync$
-  - ^/_matrix/client/(api/v1|v2_alpha|r0)/events$
-  - ^/_matrix/client/(api/v1|r0)/initialSync$
-  - ^/_matrix/client/(api/v1|r0)/rooms/[^/]+/initialSync$
+  - ^/_matrix/client/(v2_alpha|r0|v3)/sync$
+  - ^/_matrix/client/(api/v1|v2_alpha|r0|v3)/events$
+  - ^/_matrix/client/(api/v1|r0|v3)/initialSync$
+  - ^/_matrix/client/(api/v1|r0|v3)/rooms/[^/]+/initialSync$
 
   # Federation requests
   - ^/_matrix/federation/v1/event/
@@ -39,40 +39,40 @@ matrix_synapse_workers_generic_worker_endpoints:
   - ^/_matrix/federation/v1/send/
 
   # Client API requests
-  - ^/_matrix/client/(api/v1|r0|unstable)/createRoom$
-  - ^/_matrix/client/(api/v1|r0|unstable)/publicRooms$
-  - ^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/joined_members$
-  - ^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/context/.*$
-  - ^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/members$
-  - ^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/state$
+  - ^/_matrix/client/(api/v1|r0|v3|unstable)/createRoom$
+  - ^/_matrix/client/(api/v1|r0|v3|unstable)/publicRooms$
+  - ^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/joined_members$
+  - ^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/context/.*$
+  - ^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/members$
+  - ^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/state$
   - ^/_matrix/client/unstable/org.matrix.msc2946/rooms/.*/spaces$
   - ^/_matrix/client/unstable/org.matrix.msc2946/rooms/.*/hierarchy$
   - ^/_matrix/client/unstable/im.nheko.summary/rooms/.*/summary$
-  - ^/_matrix/client/(api/v1|r0|unstable)/account/3pid$
-  - ^/_matrix/client/(api/v1|r0|unstable)/devices$
-  - ^/_matrix/client/(api/v1|r0|unstable)/keys/query$
-  - ^/_matrix/client/(api/v1|r0|unstable)/keys/changes$
+  - ^/_matrix/client/(api/v1|r0|v3|unstable)/account/3pid$
+  - ^/_matrix/client/(api/v1|r0|v3|unstable)/devices$
+  - ^/_matrix/client/(api/v1|r0|v3|unstable)/keys/query$
+  - ^/_matrix/client/(api/v1|r0|v3|unstable)/keys/changes$
   - ^/_matrix/client/versions$
-  - ^/_matrix/client/(api/v1|r0|unstable)/voip/turnServer$
-  - ^/_matrix/client/(api/v1|r0|unstable)/joined_groups$
-  - ^/_matrix/client/(api/v1|r0|unstable)/publicised_groups$
-  - ^/_matrix/client/(api/v1|r0|unstable)/publicised_groups/
-  - ^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/event/
-  - ^/_matrix/client/(api/v1|r0|unstable)/joined_rooms$
-  - ^/_matrix/client/(api/v1|r0|unstable)/search$
+  - ^/_matrix/client/(api/v1|r0|v3|unstable)/voip/turnServer$
+  - ^/_matrix/client/(api/v1|r0|v3|unstable)/joined_groups$
+  - ^/_matrix/client/(api/v1|r0|v3|unstable)/publicised_groups$
+  - ^/_matrix/client/(api/v1|r0|v3|unstable)/publicised_groups/
+  - ^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/event/
+  - ^/_matrix/client/(api/v1|r0|v3|unstable)/joined_rooms$
+  - ^/_matrix/client/(api/v1|r0|v3|unstable)/search$
 
   # Registration/login requests
-  - ^/_matrix/client/(api/v1|r0|unstable)/login$
-  - ^/_matrix/client/(r0|unstable)/register$
+  - ^/_matrix/client/(api/v1|r0|v3|unstable)/login$
+  - ^/_matrix/client/(r0|v3|unstable)/register$
   - ^/_matrix/client/unstable/org.matrix.msc3231/register/org.matrix.msc3231.login.registration_token/validity$
 
   # Event sending requests
-  - ^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/redact
-  - ^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/send
-  - ^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/state/
-  - ^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/(join|invite|leave|ban|unban|kick)$
-  - ^/_matrix/client/(api/v1|r0|unstable)/join/
-  - ^/_matrix/client/(api/v1|r0|unstable)/profile/
+  - ^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/redact
+  - ^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/send
+  - ^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/state/
+  - ^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/(join|invite|leave|ban|unban|kick)$
+  - ^/_matrix/client/(api/v1|r0|v3|unstable)/join/
+  - ^/_matrix/client/(api/v1|r0|v3|unstable)/profile/
 
 
   # Additionally, the following REST endpoints can be handled for GET requests:
@@ -86,7 +86,7 @@ matrix_synapse_workers_generic_worker_endpoints:
   # for the room are in flight:
 
   # FIXME: ADDITIONAL CONDITIONS REQUIRED: to be enabled manually
-  # ^/_matrix/client/(api/v1|r0|unstable)/rooms/.*/messages$
+  # ^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/messages$
 
   # Additionally, the following endpoints should be included if Synapse is configured
   # to use SSO (you only need to include the ones for whichever SSO provider you're
@@ -94,7 +94,7 @@ matrix_synapse_workers_generic_worker_endpoints:
 
   # for all SSO providers
   # FIXME: ADDITIONAL CONDITIONS REQUIRED: to be enabled manually
-  # ^/_matrix/client/(api/v1|r0|unstable)/login/sso/redirect
+  # ^/_matrix/client/(api/v1|r0|v3|unstable)/login/sso/redirect
   # ^/_synapse/client/pick_idp$
   # ^/_synapse/client/pick_username
   # ^/_synapse/client/new_user_consent$
@@ -110,7 +110,7 @@ matrix_synapse_workers_generic_worker_endpoints:
 
   # CAS requests.
   # FIXME: ADDITIONAL CONDITIONS REQUIRED: to be enabled manually
-  # ^/_matrix/client/(api/v1|r0|unstable)/login/cas/ticket$
+  # ^/_matrix/client/(api/v1|r0|v3|unstable)/login/cas/ticket$
 
   # Ensure that all SSO logins go to a single process.
   # For multiple workers not handling the SSO endpoints properly, see
@@ -292,7 +292,7 @@ matrix_synapse_workers_user_dir_endpoints:
   # Handles searches in the user directory. It can handle REST endpoints matching
   # the following regular expressions:
 
-  - ^/_matrix/client/(api/v1|r0|unstable)/user_directory/search$
+  - ^/_matrix/client/(api/v1|r0|v3|unstable)/user_directory/search$
 
   # When using this worker you must also set `update_user_directory: False` in the
   # shared configuration file to stop the main synapse running background
@@ -303,13 +303,13 @@ matrix_synapse_workers_frontend_proxy_endpoints:
   # load from the main synapse. It can handle REST endpoints matching the following
   # regular expressions:
 
-  - ^/_matrix/client/(api/v1|r0|unstable)/keys/upload
+  - ^/_matrix/client/(api/v1|r0|v3|unstable)/keys/upload
 
   # If `use_presence` is False in the homeserver config, it can also handle REST
   # endpoints matching the following regular expressions:
 
   # FIXME: ADDITIONAL CONDITIONS REQUIRED: to be enabled manually
-  # ^/_matrix/client/(api/v1|r0|unstable)/presence/[^/]+/status
+  # ^/_matrix/client/(api/v1|r0|v3|unstable)/presence/[^/]+/status
 
   # This "stub" presence handler will pass through `GET` request but make the
   # `PUT` effectively a no-op.


### PR DESCRIPTION
Support for these APIs will probably be in Synapse 1.48.0 but this can get merged at any time.