### PR TITLE
expose smtp_user and smtp_pass to ansible configs (role: matrix-synapse)

### DIFF
--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -473,6 +473,8 @@ matrix_synapse_turn_allow_guests: False
 matrix_synapse_email_enabled: false
 matrix_synapse_email_smtp_host: ""
 matrix_synapse_email_smtp_port: 587
+matrix_synapse_email_smtp_user: ""
+matrix_synapse_email_smtp_pass: ""
 matrix_synapse_email_smtp_require_transport_security: false
 matrix_synapse_email_notif_from: "Matrix <matrix@{{ matrix_domain }}>"
 matrix_synapse_email_client_base_url: "https://{{ matrix_server_fqn_element }}"

--- a/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -2338,9 +2338,8 @@ email:
 
   # Username/password for authentication to the SMTP server. By default, no
   # authentication is attempted.
-  #
-  #smtp_user: "exampleusername"
-  #smtp_pass: "examplepassword"
+  smtp_user: {{ matrix_synapse_email_smtp_user|string|to_json }}
+  smtp_pass: {{ matrix_synapse_email_smtp_pass|string|to_json }}
 
   # Uncomment the following to require TLS transport security for SMTP.
   # By default, Synapse will connect over plain text, and will then switch to


### PR DESCRIPTION
Hello,

currently to configure synapse email sending you need to add smtp username and password through synapse additional configuration var/block, but all other smtp connection-related vars already exposed via role vars.

This PR adds missing `smtp_user` and `smtp_pass` to synapse role defaults