### PR TITLE
changed ExecStartPre in the systemd file(--name of docker container contained a typo) of mautrix-telegram

### DIFF
--- a/roles/matrix-bridge-mautrix-telegram/templates/systemd/matrix-mautrix-telegram.service.j2
+++ b/roles/matrix-bridge-mautrix-telegram/templates/systemd/matrix-mautrix-telegram.service.j2
@@ -15,7 +15,7 @@ Type=simple
 Environment="HOME={{ matrix_systemd_unit_home_path }}"
 ExecStartPre=-{{ matrix_host_command_sh }} -c '{{ matrix_host_command_docker }} kill matrix-mautrix-telegram 2>/dev/null'
 ExecStartPre=-{{ matrix_host_command_sh }} -c '{{ matrix_host_command_docker }} rm matrix-mautrix-telegram 2>/dev/null'
-ExecStartPre={{ matrix_host_command_docker }} run --rm --name matrix-mautrix-telegram-db \
+ExecStartPre={{ matrix_host_command_docker }} run --rm --name matrix-mautrix-telegram \
 			--log-driver=none \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \


### PR DESCRIPTION
removed "-db" from the third ExecStartPre= command (--name of the docker container), because this creates a container that is not getting removed by the previous ExecStartPre commands ^^

thanks for all the great work, signal and whatsapp bridges have been blazingly simple to install ;)

created this error:
```
$ sudo journalctl -u matrix-mautrix-telegram.service -f

Nov 20 19:01:20 webphp systemd[1]: Starting Matrix Mautrix Telegram bridge...
Nov 20 19:01:20 webphp matrix-mautrix-telegram[360889]: docker: Error response from daemon: Conflict. The container name "/matrix-mautrix-telegram-db" is already in use by container "e01ca...c5f8840d67986". You have to remove (or rename) that container to be able to reuse that name.
Nov 20 19:01:20 webphp matrix-mautrix-telegram[360889]: See 'docker run --help'.
Nov 20 19:01:20 webphp systemd[1]: matrix-mautrix-telegram.service: Control process exited, code=exited, status=125/n/a
Nov 20 19:01:20 webphp systemd[1]: matrix-mautrix-telegram.service: Failed with result 'exit-code'.
Nov 20 19:01:20 webphp systemd[1]: Failed to start Matrix Mautrix Telegram bridge.
Nov 20 19:01:50 webphp systemd[1]: matrix-mautrix-telegram.service: Scheduled restart job, restart counter is at 41.
```