### PR TITLE
mx_puppet_slack: Add support for stripHomeservers config option

### DIFF
--- a/roles/matrix-bridge-mx-puppet-slack/defaults/main.yml
+++ b/roles/matrix-bridge-mx-puppet-slack/defaults/main.yml
@@ -111,3 +111,5 @@ matrix_mx_puppet_slack_registration_yaml: |
   de.sorunome.msc2409.push_ephemeral: true
 
 matrix_mx_puppet_slack_registration: "{{ matrix_mx_puppet_slack_registration_yaml|from_yaml }}"
+
+matrix_mx_puppet_slack_stripHomeservers: ''

--- a/roles/matrix-bridge-mx-puppet-slack/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mx-puppet-slack/templates/config.yaml.j2
@@ -13,7 +13,12 @@ bridge:
   loginSharedSecretMap:
     {{ matrix_domain }}: {{ matrix_mx_puppet_slack_login_shared_secret }}
   {% endif %}
-
+  {% if matrix_mx_puppet_slack_stripHomeservers != '' %}
+  stripHomeservers:
+    {% for stripHomeserver in matrix_mx_puppet_slack_stripHomeservers %}
+    - {{ stripHomeserver }};
+    {% endfor %}
+  {% endif %}
 
 # Slack OAuth settings. Create a slack app at https://api.slack.com/apps
 oauth:


### PR DESCRIPTION
This option helps prevent continuous notification spam as slack users mention each other while the bridge, user, and puppeted slack user are on the same homeserver.