### PR TITLE
Upgrade Heisenbridge (1.7.0 -> 1.7.1)

### DIFF
--- a/roles/matrix-bridge-heisenbridge/defaults/main.yml
+++ b/roles/matrix-bridge-heisenbridge/defaults/main.yml
@@ -3,7 +3,7 @@
 
 matrix_heisenbridge_enabled: true
 
-matrix_heisenbridge_version: 1.7.0
+matrix_heisenbridge_version: 1.7.1
 matrix_heisenbridge_docker_image: "{{ matrix_container_global_registry_prefix }}hif1/heisenbridge:{{ matrix_heisenbridge_version }}"
 matrix_heisenbridge_docker_image_force_pull: "{{ matrix_heisenbridge_docker_image.endswith(':latest') }}"
 


### PR DESCRIPTION
This fixes a critical compatibility issue with Synapse 1.47.