### PR TITLE
Ansible 2.10 & AWX 19.4 compatibility

### DIFF
--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - name: community.general.docker_network

--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -1,3 +1,4 @@
 ---
 collections:
   - name: community.general
+  - name: community.docker  

--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -1,3 +1,3 @@
 ---
 collections:
-  - name: community.general.docker_network
+  - name: community.general


### PR DESCRIPTION
I know there is an extended AWX implementation within this repository, but we use the repository since beginning in AWX without any extra functions.

Unfortunately we was forced to upgrade to latest, k8s only, AWX 19.4 and run into some problems, because I suppose a latest ansible version is used in images. In other issues this also was mentioned, related to ansible-base: (example #1363)

**Our problem:**
> ERROR! couldn't resolve module/action 'docker_network'. This often indicates a misspelling, missing collection, or incorrect module path.

Is it possible to merge this collections/requirements.yaml file into the repository, so latest Ansible and also AWX come back to compatibility without adjustments? 
I'm not fully sure if this create problems with existing AWX integration, but I think not. Because also their this collections are needed.

Also I'm not fully sure if "community.general" is really needed, because "community.docker" should be extracted from general collection, but it also not hurts.