### PR TITLE
Upgrade Mjolnir from 1.1.20 to version 1.2.1

### DIFF
--- a/roles/matrix-bot-mjolnir/defaults/main.yml
+++ b/roles/matrix-bot-mjolnir/defaults/main.yml
@@ -10,8 +10,7 @@ matrix_bot_mjolnir_container_image_self_build_repo: "https://github.com/matrix-o
 
 matrix_bot_mjolnir_docker_image: "{{ matrix_bot_mjolnir_docker_image_name_prefix }}matrixdotorg/mjolnir:{{ matrix_bot_mjolnir_version }}"
 matrix_bot_mjolnir_docker_image_name_prefix: "{{ 'localhost/' if matrix_bot_mjolnir_container_image_self_build else matrix_container_global_registry_prefix }}"
-
-matrix_bot_mjolnir_docker_image_force_pull: "{{ matrix_bot_mjolnir_docker_image.endswith(':v1.2.1') }}"
+matrix_bot_mjolnir_docker_image_force_pull: "{{ matrix_bot_mjolnir_docker_image.endswith(':latest') }}"
 
 matrix_bot_mjolnir_base_path: "{{ matrix_base_data_path }}/mjolnir"
 matrix_bot_mjolnir_config_path: "{{ matrix_bot_mjolnir_base_path }}/config"

--- a/roles/matrix-bot-mjolnir/defaults/main.yml
+++ b/roles/matrix-bot-mjolnir/defaults/main.yml
@@ -3,7 +3,7 @@
 
 matrix_bot_mjolnir_enabled: true
 
-matrix_bot_mjolnir_version: "v1.1.20"
+matrix_bot_mjolnir_version: "v1.2.1"
 
 matrix_bot_mjolnir_container_image_self_build: false
 matrix_bot_mjolnir_container_image_self_build_repo: "https://github.com/matrix-org/mjolnir.git"
@@ -11,7 +11,7 @@ matrix_bot_mjolnir_container_image_self_build_repo: "https://github.com/matrix-o
 matrix_bot_mjolnir_docker_image: "{{ matrix_bot_mjolnir_docker_image_name_prefix }}matrixdotorg/mjolnir:{{ matrix_bot_mjolnir_version }}"
 matrix_bot_mjolnir_docker_image_name_prefix: "{{ 'localhost/' if matrix_bot_mjolnir_container_image_self_build else matrix_container_global_registry_prefix }}"
 
-matrix_bot_mjolnir_docker_image_force_pull: "{{ matrix_bot_mjolnir_docker_image.endswith(':latest') }}"
+matrix_bot_mjolnir_docker_image_force_pull: "{{ matrix_bot_mjolnir_docker_image.endswith(':v1.2.1') }}"
 
 matrix_bot_mjolnir_base_path: "{{ matrix_base_data_path }}/mjolnir"
 matrix_bot_mjolnir_config_path: "{{ matrix_bot_mjolnir_base_path }}/config"


### PR DESCRIPTION
https://hub.docker.com/r/matrixdotorg/mjolnir/tags

using the "latest" tag seems inefficient as it doesn't actually redirect to the latest release

In any case, the latest release is now 1.2.1

docker pull matrixdotorg/mjolnir:v1.2.1