### PR TITLE
Run `workers-doc-to-yaml.sh`

### DIFF
--- a/roles/matrix-synapse/vars/workers.yml
+++ b/roles/matrix-synapse/vars/workers.yml
@@ -5,10 +5,10 @@ matrix_synapse_workers_generic_worker_endpoints:
   # expressions:
 
   # Sync requests
-  - ^/_matrix/client/(v2_alpha|r0)/sync$
-  - ^/_matrix/client/(api/v1|v2_alpha|r0)/events$
-  - ^/_matrix/client/(api/v1|r0)/initialSync$
-  - ^/_matrix/client/(api/v1|r0)/rooms/[^/]+/initialSync$
+  - ^/_matrix/client/(v2_alpha|r0|v3)/sync$
+  - ^/_matrix/client/(api/v1|v2_alpha|r0|v3)/events$
+  - ^/_matrix/client/(api/v1|r0|v3)/initialSync$
+  - ^/_matrix/client/(api/v1|r0|v3)/rooms/[^/]+/initialSync$
 
   # Federation requests
   - ^/_matrix/federation/v1/event/
@@ -63,7 +63,7 @@ matrix_synapse_workers_generic_worker_endpoints:
 
   # Registration/login requests
   - ^/_matrix/client/(api/v1|r0|v3|unstable)/login$
-  - ^/_matrix/client/(r0|unstable)/register$
+  - ^/_matrix/client/(r0|v3|unstable)/register$
   - ^/_matrix/client/unstable/org.matrix.msc3231/register/org.matrix.msc3231.login.registration_token/validity$
 
   # Event sending requests


### PR DESCRIPTION
1472958e25c729f3fb9f6c018c2df947bcae97aa reverted some of the v3 changes. I'm not sure why. Running the `workers-doc-to-yaml.sh` script right now puts them back 🤷‍♂️.