### PR TITLE
Fix comments about `_database_*` variables

### DIFF
--- a/roles/matrix-bridge-appservice-discord/defaults/main.yml
+++ b/roles/matrix-bridge-appservice-discord/defaults/main.yml
@@ -48,7 +48,7 @@ matrix_appservice_discord_bridge_enableSelfServiceBridging: false
 #
 # To use Postgres:
 # - change the engine (`matrix_appservice_discord_database_engine: 'postgres'`)
-# - adjust your database credentials via the `matrix_appservice_discord_postgres_*` variables
+# - adjust your database credentials via the `matrix_appservice_discord_database_*` variables
 matrix_appservice_discord_database_engine: 'sqlite'
 
 matrix_appservice_discord_sqlite_database_path_local: "{{ matrix_appservice_discord_data_path }}/discord.db"

--- a/roles/matrix-bridge-mautrix-facebook/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-facebook/defaults/main.yml
@@ -42,7 +42,7 @@ matrix_mautrix_facebook_homeserver_token: ''
 # - plan your migration to Postgres, as this bridge does not support SQLite anymore (and neither will the playbook in the future).
 #
 # To use Postgres:
-# - adjust your database credentials via the `matrix_mautrix_facebook_postgres_*` variables
+# - adjust your database credentials via the `matrix_mautrix_facebook_database_*` variables
 matrix_mautrix_facebook_database_engine: 'postgres'
 
 matrix_mautrix_facebook_sqlite_database_path_local: "{{ matrix_mautrix_facebook_data_path }}/mautrix-facebook.db"

--- a/roles/matrix-bridge-mautrix-googlechat/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-googlechat/defaults/main.yml
@@ -47,7 +47,7 @@ matrix_mautrix_googlechat_homeserver_token: ''
 #
 # To use Postgres:
 # - change the engine (`matrix_mautrix_googlechat_database_engine: 'postgres'`)
-# - adjust your database credentials via the `matrix_mautrix_googlechat_postgres_*` variables
+# - adjust your database credentials via the `matrix_mautrix_googlechat_database_*` variables
 matrix_mautrix_googlechat_database_engine: 'sqlite'
 
 matrix_mautrix_googlechat_sqlite_database_path_local: "{{ matrix_mautrix_googlechat_data_path }}/mautrix-googlechat.db"

--- a/roles/matrix-bridge-mautrix-hangouts/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-hangouts/defaults/main.yml
@@ -47,7 +47,7 @@ matrix_mautrix_hangouts_homeserver_token: ''
 #
 # To use Postgres:
 # - change the engine (`matrix_mautrix_hangouts_database_engine: 'postgres'`)
-# - adjust your database credentials via the `matrix_mautrix_hangouts_postgres_*` variables
+# - adjust your database credentials via the `matrix_mautrix_hangouts_database_*` variables
 matrix_mautrix_hangouts_database_engine: 'sqlite'
 
 matrix_mautrix_hangouts_sqlite_database_path_local: "{{ matrix_mautrix_hangouts_data_path }}/mautrix-hangouts.db"

--- a/roles/matrix-bridge-mautrix-instagram/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-instagram/defaults/main.yml
@@ -37,7 +37,7 @@ matrix_mautrix_instagram_homeserver_token: ''
 # Database-related configuration fields.
 #
 # To use Postgres:
-# - adjust your database credentials via the `matrix_mautrix_instagram_postgres_*` variables
+# - adjust your database credentials via the `matrix_mautrix_instagram_database_*` variables
 matrix_mautrix_instagram_database_engine: 'postgres'
 
 matrix_mautrix_instagram_database_username: 'matrix_mautrix_instagram'

--- a/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
@@ -63,7 +63,7 @@ matrix_mautrix_telegram_homeserver_token: ''
 #
 # To use Postgres:
 # - change the engine (`matrix_mautrix_telegram_database_engine: 'postgres'`)
-# - adjust your database credentials via the `matrix_mautrix_telegram_postgres_*` variables
+# - adjust your database credentials via the `matrix_mautrix_telegram_database_*` variables
 matrix_mautrix_telegram_database_engine: 'sqlite'
 
 matrix_mautrix_telegram_sqlite_database_path_local: "{{ matrix_mautrix_telegram_data_path }}/mautrix-telegram.db"

--- a/roles/matrix-bridge-mautrix-whatsapp/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-whatsapp/defaults/main.yml
@@ -42,7 +42,7 @@ matrix_mautrix_whatsapp_appservice_bot_username: whatsappbot
 #
 # To use Postgres:
 # - change the engine (`matrix_mautrix_whatsapp_database_engine: 'postgres'`)
-# - adjust your database credentials via the `matrix_mautrix_whatsapp_postgres_*` variables
+# - adjust your database credentials via the `matrix_mautrix_whatsapp_database_*` variables
 matrix_mautrix_whatsapp_database_engine: 'sqlite'
 
 matrix_mautrix_whatsapp_sqlite_database_path_local: "{{ matrix_mautrix_whatsapp_data_path }}/mautrix-whatsapp.db"

--- a/roles/matrix-dimension/defaults/main.yml
+++ b/roles/matrix-dimension/defaults/main.yml
@@ -48,7 +48,7 @@ matrix_dimension_homeserver_federationUrl: ""
 #
 # To use Postgres:
 # - change the engine (`matrix_dimension_database_engine: 'postgres'`)
-# - adjust your database credentials via the `matrix_dimension_postgres_*` variables
+# - adjust your database credentials via the `matrix_dimension_database_*` variables
 matrix_dimension_database_engine: 'sqlite'
 
 matrix_dimension_sqlite_database_path_local: "{{ matrix_dimension_base_path }}/dimension.db"

--- a/roles/matrix-ma1sd/defaults/main.yml
+++ b/roles/matrix-ma1sd/defaults/main.yml
@@ -48,7 +48,7 @@ matrix_ma1sd_matrixorg_forwarding_enabled: false
 #
 # To use Postgres:
 # - change the engine (`matrix_ma1sd_database_engine: 'postgres'`)
-# - adjust your database credentials via the `matrix_ma1sd_postgres_*` variables
+# - adjust your database credentials via the `matrix_ma1sd_database_*` variables
 matrix_ma1sd_database_engine: 'sqlite'
 
 matrix_ma1sd_sqlite_database_path_local: "{{ matrix_ma1sd_data_path }}/ma1sd.db"

--- a/roles/matrix-registration/defaults/main.yml
+++ b/roles/matrix-registration/defaults/main.yml
@@ -38,7 +38,7 @@ matrix_registration_container_http_host_bind_port: ''
 #
 # To use Postgres:
 # - change the engine (`matrix_registration_database_engine: 'postgres'`)
-# - adjust your database credentials via the `matrix_registration_postgres_*` variables
+# - adjust your database credentials via the `matrix_registration_database_*` variables
 matrix_registration_database_engine: 'sqlite'
 
 matrix_registration_sqlite_database_path_local: "{{ matrix_registration_data_path }}/db.sqlite3"


### PR DESCRIPTION
Was renamed in 087dbe4ddc80ba6308e7ee98391ea475354e8860

It is unclear to me if there is anything you actually need to adjust with these variables. It looks like that is done automatically in `matrix_servers`.