### PR TITLE
Add self-build for Dimension (arm64 support)

### DIFF
--- a/docs/self-building.md
+++ b/docs/self-building.md
@@ -18,6 +18,7 @@ List of roles where self-building the Docker image is currently possible:
 - `matrix-registration`
 - `matrix-coturn`
 - `matrix-corporal`
+- `matrix-dimension`
 - `matrix-ma1sd`
 - `matrix-mailer`
 - `matrix-bridge-appservice-irc`

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -1045,6 +1045,8 @@ matrix_coturn_container_additional_volumes: |
 
 matrix_dimension_enabled: false
 
+matrix_dimension_container_image_self_build: "{{ matrix_architecture != 'amd64' }}"
+
 # Normally, matrix-nginx-proxy is enabled and nginx can reach Dimension over the container network.
 # If matrix-nginx-proxy is not enabled, or you otherwise have a need for it, you can expose
 # the Dimension HTTP port to the local host.

--- a/roles/matrix-dimension/defaults/main.yml
+++ b/roles/matrix-dimension/defaults/main.yml
@@ -10,10 +10,16 @@ matrix_dimension_admins: []
 # Whether to allow Dimension widgets serve websites with invalid or self signed SSL certificates
 matrix_dimension_widgets_allow_self_signed_ssl_certificates: false
 
+matrix_dimension_container_image_self_build: false
+matrix_dimension_container_image_self_build_repo: "https://github.com/turt2live/matrix-dimension.git"
+matrix_dimension_container_image_self_build_branch: master
+
 matrix_dimension_base_path: "{{ matrix_base_data_path }}/dimension"
+matrix_dimension_docker_src_files_path: "{{ matrix_base_data_path }}/docker-src/dimension"
 
 matrix_dimension_version: latest
-matrix_dimension_docker_image: "{{ matrix_container_global_registry_prefix }}turt2live/matrix-dimension:{{ matrix_dimension_version }}"
+matrix_dimension_docker_image: "{{ matrix_dimension_docker_image_name_prefix }}turt2live/matrix-dimension:{{ matrix_dimension_version }}"
+matrix_dimension_docker_image_name_prefix: "{{ 'localhost/' if matrix_dimension_container_image_self_build else matrix_container_global_registry_prefix }}"
 matrix_dimension_docker_image_force_pull: "{{ matrix_dimension_docker_image.endswith(':latest') }}"
 
 # List of systemd services that matrix-dimension.service depends on.

--- a/roles/matrix-dimension/tasks/setup_install.yml
+++ b/roles/matrix-dimension/tasks/setup_install.yml
@@ -90,6 +90,29 @@
     source: "{{ 'pull' if ansible_version.major > 2 or ansible_version.minor > 7 else omit }}"
     force_source: "{{ matrix_dimension_docker_image_force_pull if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
     force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_dimension_docker_image_force_pull }}"
+  when: "not matrix_dimension_container_image_self_build|bool"
+  register: matrix_dimension_pull_results
+
+- name: Ensure dimension repository is present on self-build
+  git:
+    repo: "{{ matrix_dimension_container_image_self_build_repo }}"
+    dest: "{{ matrix_dimension_docker_src_files_path }}"
+    version: "{{ matrix_dimension_container_image_self_build_branch }}"
+    force: "yes"
+  when: "matrix_dimension_container_image_self_build|bool"
+  register: matrix_dimension_git_pull_results
+
+- name: Ensure Dimension Docker image is built
+  docker_image:
+    name: "{{ matrix_dimension_docker_image }}"
+    source: build
+    force_source: "{{ matrix_dimension_git_pull_results.changed if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
+    force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_dimension_git_pull_results.changed }}"
+    build:
+      dockerfile: Dockerfile
+      path: "{{ matrix_dimension_docker_src_files_path }}"
+      pull: yes
+  when: "matrix_dimension_container_image_self_build|bool"
 
 - name: Ensure matrix-dimension.service installed
   template:


### PR DESCRIPTION
Add a self-build option for the Dimension Dockerfile.
 - This helps further support running on arm64 hosts (i.e. [A1.Flex w/Oracle](https://matrix.org/docs/guides/free-small-matrix-server))

**NOTE:** A pre-built arm64 image does not currently exist for [matrix-dimension on Dockerhub](https://hub.docker.com/r/turt2live/matrix-dimension/tags)