### PR TITLE
Add support for creation of Jitsi internal authentication users in vars.yml

### DIFF
--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -48,10 +48,12 @@ matrix_jitsi_enable_auth: true
 matrix_jitsi_enable_guests: true
 matrix_jitsi_prosody_auth_internal_accounts:
   - username: "jitsi-moderator"
-    password: "some-password"
-  - username: "other-user"
-    password: "some-other-password"
+    password: "secret-password"
+  - username: "another-user"
+    password: "another-password"
 ```
+
+**Caution:** Accounts added here and subsquently removed will not be automatically removed from the Prosody server until user account cleaning is integrated into the playbook.
 
 **If you get an error** like this: "Error: Account creation/modification not supported.", it's likely that you had previously installed Jitsi without auth/guest support. In such a case, you should look into [Rebuilding your Jitsi installation](#rebuilding-your-jitsi-installation).
 

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -41,12 +41,20 @@ If you're fine with such an open Jitsi instance, please skip to [Apply changes](
 
 If you would like to control who is allowed to open meetings on your new Jitsi instance, then please follow this step to enable Jitsi's authentication and guests mode. With authentication enabled, all meeting rooms have to be opened by a registered user, after which guests are free to join. If a registered host is not yet present, guests are put on hold in individual waiting rooms.
 
-Add these two lines to your `inventory/host_vars/matrix.DOMAIN/vars.yml` configuration:
+Add these lines to your `inventory/host_vars/matrix.DOMAIN/vars.yml` configuration:
 
 ```yaml
 matrix_jitsi_enable_auth: true
 matrix_jitsi_enable_guests: true
+matrix_jitsi_prosody_auth_internal_accounts:
+  - username: "jitsi-moderator"
+    password: "some-password"
+  - username: "other-user"
+    password: "some-other-password"
 ```
+
+**If you get an error** like this: "Error: Account creation/modification not supported.", it's likely that you had previously installed Jitsi without auth/guest support. In such a case, you should look into [Rebuilding your Jitsi installation](#rebuilding-your-jitsi-installation).
+
 
 ### (Optional) LDAP authentication
 
@@ -121,19 +129,6 @@ You may want to **limit the maximum video resolution**, to save up resources on 
 ## Apply changes
 
 Then re-run the playbook: `ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start`
-
-## Required if configuring Jitsi with internal authentication: register new users
-
-Until this gets integrated into the playbook, we need to register new users / meeting hosts for Jitsi manually.
-Please SSH into your matrix host machine and execute the following command targeting the `matrix-jitsi-prosody` container:
-
-```bash
-docker exec matrix-jitsi-prosody prosodyctl --config /config/prosody.cfg.lua register <USERNAME> meet.jitsi <PASSWORD>
-```
-
-Run this command for each user you would like to create, replacing `<USERNAME>` and `<PASSWORD>` accordingly. After you've finished, please exit the host.
-
-**If you get an error** like this: "Error: Account creation/modification not supported.", it's likely that you had previously installed Jitsi without auth/guest support. In such a case, you should look into [Rebuilding your Jitsi installation](#rebuilding-your-jitsi-installation).
 
 
 ## Usage

--- a/roles/matrix-jitsi/defaults/main.yml
+++ b/roles/matrix-jitsi/defaults/main.yml
@@ -232,30 +232,6 @@ matrix_jitsi_jvb_brewery_muc: jvbbrewery
 matrix_jitsi_jvb_rtp_udp_port: 10000
 matrix_jitsi_jvb_rtp_tcp_port: 4443
 
-# JWT Auth
-matrix_jitsi_auth_jwt_id: jitsi
-matrix_jitsi_auth_jwt_secret: ''
-matrix_jitsi_auth_jwt_accepted_issuers: ''
-matrix_jitsi_authjwt_allow_empty: false
-
-# Jigasi SIP Gateway Configuration - Not Fully Implemented
-matrix_jitsi_jigasi_auth_user: ''
-matrix_jitsi_jigasi_auth_password: ''
-#JIGASI_SIP_URI: '' # SIP URI for incoming / outgoing calls test@sip2sip.info
-#JIGASI_SIP_PASSWORD: ''  # Password for the specified SIP account  passw0rd
-#JIGASI_SIP_SERVER SIP: '' # server (use the SIP account domain if in doubt) sip2sip.info
-#JIGASI_SIP_PORT SIP: '5060' # server port 5060
-#JIGASI_SIP_TRANSPORT: 'UDP'  # SIP transport UDP
-#DIALIN_NUMBERS_URL: 'https://jitsi.chs.chat/dial-in.json' # URL to the JSON with all Dial-In numbers. Example: https://meet.example.com/dialin.json
-#CONFCODE_URL: '' # URL to the API for checking/generating Dial-In codes. Example: https://jitsi-api.jitsi.net/conferenceMapper
-#GC_PROJECT_ID:  # project_id from Google Cloud Credentials
-#GC_PRIVATE_KEY_ID:  # private_key_id from Google Cloud Credentials
-#GC_PRIVATE_KEY:  # private_key from Google Cloud Credentials
-#GC_CLIENT_EMAIL:  # client_email from Google Cloud Credentials
-#GC_CLIENT_ID:  # client_id from Google Cloud Credentials
-#GC_CLIENT_CERT_URL:  # client_x509_cert_url from Google Cloud Credentials
-
-
 # Custom configuration to be injected into `custom-sip-communicator.properties`, passed to Jitsi JVB.
 # This configuration gets appended to the final configuration that Jitsi JVB uses.
 #

--- a/roles/matrix-jitsi/defaults/main.yml
+++ b/roles/matrix-jitsi/defaults/main.yml
@@ -9,12 +9,22 @@ matrix_jitsi_enable_transcriptions: false
 matrix_jitsi_enable_p2p: true
 matrix_jitsi_enable_av_moderation: true
 
-# Authentication type, must be one of internal, jwt or ldap. Currently only
-# internal and ldap are supported by this playbook.
+# Authentication type, must be one of internal, jwt or ldap.
+# Currently only internal and ldap mechanisms are supported by this playbook.
 matrix_jitsi_auth_type: internal
-matrix_jitsi_prosody_auth_internal_accounts:
-  - username: "jitsti-moderator"
-    password: ""
+
+# A list of Jitsi (Prosody) accounts to create using the internal authentication mechanism.
+#
+# Accounts added here and subsquently removed will not be automatically removed
+# from the Prosody server until user account cleaning is integrated into the playbook.
+#
+# Example:
+# matrix_jitsi_prosody_auth_internal_accounts:
+#  - username: "jitsi-moderator"
+#    password: "secret-password"
+#  - username: "another-user"
+#    password: "another-password"
+matrix_jitsi_prosody_auth_internal_accounts: []
 
 # Configuration options for LDAP authentication. For details see upstream:
 #   https://github.com/jitsi/docker-jitsi-meet#authentication-using-ldap.
@@ -44,17 +54,16 @@ matrix_jitsi_xmpp_guest_domain: guest.meet.jitsi
 matrix_jitsi_xmpp_muc_domain: muc.meet.jitsi
 matrix_jitsi_xmpp_internal_muc_domain: internal-muc.meet.jitsi
 matrix_jitsi_xmpp_modules: ''
-matrix_jitsi_xmpp_muc_modules: ''
-matrix_jitsi_xmpp_muc_modules_internal: ''
 
 matrix_jitsi_recorder_domain: recorder.meet.jitsi
-matrix_jitsi_jibri_recorder_user: recorder
-matrix_jitsi_jibri_recorder_password: ''
+
 
 matrix_jitsi_jibri_brewery_muc: jibribrewery
 matrix_jitsi_jibri_pending_timeout: 90
 matrix_jitsi_jibri_xmpp_user: jibri
 matrix_jitsi_jibri_xmpp_password: ''
+matrix_jitsi_jibri_recorder_user: recorder
+matrix_jitsi_jibri_recorder_password: ''
 
 matrix_jitsi_enable_lobby: false
 

--- a/roles/matrix-jitsi/defaults/main.yml
+++ b/roles/matrix-jitsi/defaults/main.yml
@@ -12,6 +12,9 @@ matrix_jitsi_enable_av_moderation: true
 # Authentication type, must be one of internal, jwt or ldap. Currently only
 # internal and ldap are supported by this playbook.
 matrix_jitsi_auth_type: internal
+matrix_jitsi_prosody_auth_internal_accounts:
+  - username: "jitsti-moderator"
+    password: ""
 
 # Configuration options for LDAP authentication. For details see upstream:
 #   https://github.com/jitsi/docker-jitsi-meet#authentication-using-ldap.
@@ -41,16 +44,17 @@ matrix_jitsi_xmpp_guest_domain: guest.meet.jitsi
 matrix_jitsi_xmpp_muc_domain: muc.meet.jitsi
 matrix_jitsi_xmpp_internal_muc_domain: internal-muc.meet.jitsi
 matrix_jitsi_xmpp_modules: ''
+matrix_jitsi_xmpp_muc_modules: ''
+matrix_jitsi_xmpp_muc_modules_internal: ''
 
 matrix_jitsi_recorder_domain: recorder.meet.jitsi
-
+matrix_jitsi_jibri_recorder_user: recorder
+matrix_jitsi_jibri_recorder_password: ''
 
 matrix_jitsi_jibri_brewery_muc: jibribrewery
 matrix_jitsi_jibri_pending_timeout: 90
 matrix_jitsi_jibri_xmpp_user: jibri
 matrix_jitsi_jibri_xmpp_password: ''
-matrix_jitsi_jibri_recorder_user: recorder
-matrix_jitsi_jibri_recorder_password: ''
 
 matrix_jitsi_enable_lobby: false
 
@@ -205,7 +209,6 @@ matrix_jitsi_jicofo_component_secret: ''
 matrix_jitsi_jicofo_auth_user: focus
 matrix_jitsi_jicofo_auth_password: ''
 
-
 matrix_jitsi_jvb_docker_image: "{{ matrix_container_global_registry_prefix }}jitsi/jvb:{{ matrix_jitsi_container_image_tag }}"
 matrix_jitsi_jvb_docker_image_force_pull: "{{ matrix_jitsi_jvb_docker_image.endswith(':latest') }}"
 
@@ -228,6 +231,30 @@ matrix_jitsi_jvb_stun_servers: ['meet-jit-si-turnrelay.jitsi.net:443']
 matrix_jitsi_jvb_brewery_muc: jvbbrewery
 matrix_jitsi_jvb_rtp_udp_port: 10000
 matrix_jitsi_jvb_rtp_tcp_port: 4443
+
+# JWT Auth
+matrix_jitsi_auth_jwt_id: jitsi
+matrix_jitsi_auth_jwt_secret: ''
+matrix_jitsi_auth_jwt_accepted_issuers: ''
+matrix_jitsi_authjwt_allow_empty: false
+
+# Jigasi SIP Gateway Configuration - Not Fully Implemented
+matrix_jitsi_jigasi_auth_user: ''
+matrix_jitsi_jigasi_auth_password: ''
+#JIGASI_SIP_URI: '' # SIP URI for incoming / outgoing calls test@sip2sip.info
+#JIGASI_SIP_PASSWORD: ''  # Password for the specified SIP account  passw0rd
+#JIGASI_SIP_SERVER SIP: '' # server (use the SIP account domain if in doubt) sip2sip.info
+#JIGASI_SIP_PORT SIP: '5060' # server port 5060
+#JIGASI_SIP_TRANSPORT: 'UDP'  # SIP transport UDP
+#DIALIN_NUMBERS_URL: 'https://jitsi.chs.chat/dial-in.json' # URL to the JSON with all Dial-In numbers. Example: https://meet.example.com/dialin.json
+#CONFCODE_URL: '' # URL to the API for checking/generating Dial-In codes. Example: https://jitsi-api.jitsi.net/conferenceMapper
+#GC_PROJECT_ID:  # project_id from Google Cloud Credentials
+#GC_PRIVATE_KEY_ID:  # private_key_id from Google Cloud Credentials
+#GC_PRIVATE_KEY:  # private_key from Google Cloud Credentials
+#GC_CLIENT_EMAIL:  # client_email from Google Cloud Credentials
+#GC_CLIENT_ID:  # client_id from Google Cloud Credentials
+#GC_CLIENT_CERT_URL:  # client_x509_cert_url from Google Cloud Credentials
+
 
 # Custom configuration to be injected into `custom-sip-communicator.properties`, passed to Jitsi JVB.
 # This configuration gets appended to the final configuration that Jitsi JVB uses.

--- a/roles/matrix-jitsi/tasks/setup_jitsi_prosody.yml
+++ b/roles/matrix-jitsi/tasks/setup_jitsi_prosody.yml
@@ -4,7 +4,7 @@
 # Tasks related to setting up jitsi-prosody
 #
 
-- name: Ensure Matrix jitsi-prosody path exists
+- name: Ensure Matrix jitsi-prosody environment exists
   file:
     path: "{{ item.path }}"
     state: directory
@@ -32,7 +32,7 @@
     mode: 0640
   when: matrix_jitsi_enabled|bool
 
-- name: Ensure matrix-jitsi-prosody.service is installed
+- name: Ensure matrix-jitsi-prosody.service file is installed
   template:
     src: "{{ role_path }}/templates/prosody/matrix-jitsi-prosody.service.j2"
     dest: "{{ matrix_systemd_path }}/matrix-jitsi-prosody.service"
@@ -58,7 +58,7 @@
 # Tasks related to getting rid of jitsi-prosody (if it was previously enabled)
 #
 
-- name: Ensure matrix-jitsi-prosody service file exists
+- name: Ensure matrix-jitsi-prosody.service file exists
   stat:
     path: "{{ matrix_systemd_path }}/matrix-jitsi-prosody.service"
   register: matrix_jitsi_prosody_service_stat
@@ -73,7 +73,7 @@
   register: stopping_result
   when: "not matrix_jitsi_enabled|bool and matrix_jitsi_prosody_service_stat.stat.exists"
 
-- name: Ensure matrix-jitsi-prosody service file doesn't exist
+- name: Ensure matrix-jitsi-prosody.service file doesn't exist
   file:
     path: "{{ matrix_systemd_path }}/matrix-jitsi-prosody.service"
     state: absent

--- a/roles/matrix-jitsi/tasks/setup_jitsi_prosody.yml
+++ b/roles/matrix-jitsi/tasks/setup_jitsi_prosody.yml
@@ -25,14 +25,14 @@
     force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_jitsi_prosody_docker_image_force_pull }}"
   when: matrix_jitsi_enabled|bool
 
-- name: Ensure jitsi-prosody environment variables file created
+- name: Ensure jitsi-prosody environment variables file is created
   template:
     src: "{{ role_path }}/templates/prosody/env.j2"
     dest: "{{ matrix_jitsi_prosody_base_path }}/env"
     mode: 0640
   when: matrix_jitsi_enabled|bool
 
-- name: Ensure matrix-jitsi-prosody.service installed
+- name: Ensure matrix-jitsi-prosody.service is installed
   template:
     src: "{{ role_path }}/templates/prosody/matrix-jitsi-prosody.service.j2"
     dest: "{{ matrix_systemd_path }}/matrix-jitsi-prosody.service"
@@ -40,16 +40,25 @@
   register: matrix_jitsi_prosody_systemd_service_result
   when: matrix_jitsi_enabled|bool
 
-- name: Ensure systemd reloaded after matrix-jitsi-prosody.service installation
+- name: Ensure systemd service is reloaded after matrix-jitsi-prosody.service installation
   service:
     daemon_reload: yes
   when: "matrix_jitsi_enabled and matrix_jitsi_prosody_systemd_service_result.changed"
+
+
+- name: Ensure authentication is properly configured
+  include_tasks:
+    file: "{{ role_path }}/tasks/util/setup_jitsi_auth.yml"
+  when:
+    - matrix_jitsi_enabled|bool
+    - matrix_jitsi_enable_auth|bool
+
 
 #
 # Tasks related to getting rid of jitsi-prosody (if it was previously enabled)
 #
 
-- name: Check existence of matrix-jitsi-prosody service
+- name: Ensure matrix-jitsi-prosody service file exists
   stat:
     path: "{{ matrix_systemd_path }}/matrix-jitsi-prosody.service"
   register: matrix_jitsi_prosody_service_stat
@@ -64,13 +73,13 @@
   register: stopping_result
   when: "not matrix_jitsi_enabled|bool and matrix_jitsi_prosody_service_stat.stat.exists"
 
-- name: Ensure matrix-jitsi-prosody.service doesn't exist
+- name: Ensure matrix-jitsi-prosody service file doesn't exist
   file:
     path: "{{ matrix_systemd_path }}/matrix-jitsi-prosody.service"
     state: absent
   when: "not matrix_jitsi_enabled|bool and matrix_jitsi_prosody_service_stat.stat.exists"
 
-- name: Ensure systemd reloaded after matrix-jitsi-prosody.service removal
+- name: Ensure systemd is reloaded after matrix-jitsi-prosody.service removal
   service:
     daemon_reload: yes
   when: "not matrix_jitsi_enabled|bool and matrix_jitsi_prosody_service_stat.stat.exists"

--- a/roles/matrix-jitsi/tasks/setup_jitsi_prosody.yml
+++ b/roles/matrix-jitsi/tasks/setup_jitsi_prosody.yml
@@ -45,7 +45,6 @@
     daemon_reload: yes
   when: "matrix_jitsi_enabled and matrix_jitsi_prosody_systemd_service_result.changed"
 
-
 - name: Ensure authentication is properly configured
   include_tasks:
     file: "{{ role_path }}/tasks/util/setup_jitsi_auth.yml"

--- a/roles/matrix-jitsi/tasks/util/setup_jitsi_auth.yml
+++ b/roles/matrix-jitsi/tasks/util/setup_jitsi_auth.yml
@@ -1,30 +1,43 @@
 ---
-
 #
-# Tasks related to setting up Jitsi authentication mechanisms
+# Start Necessary Services
 #
 
 - name: Ensure matrix-jitsi-prosody container is running
   systemd:
     state: started
     name: matrix-jitsi-prosody
+  register: matrix_jitsi_prosody_start_result
 
-- name: Ensire Jitsi internal authentication users are created
+
+#
+# Tasks related to configuring Jitsi internal authentication
+#
+
+- name: Ensure Jitsi internal authentication users are configured
   shell: "docker exec matrix-jitsi-prosody prosodyctl --config /config/prosody.cfg.lua register {{ item.username | quote }} meet.jitsi {{ item.password | quote }}"
   with_items: "{{ matrix_jitsi_prosody_auth_internal_accounts }}"
   when:
     - matrix_jitsi_auth_type == "internal"
+    - matrix_jitsi_prosody_auth_internal_accounts|length > 0
 
 
 #
-# Configure other authentication mechanisms below
+# Tasks related to configuring other Jitsi authentication mechanisms
+#
+
+
+
+#
+# Tasks related to cleaning after Jitsi authentication configuration
 #
 
 
 #
-# End
+# Stop Necessary Services
 #
-- name: Ensure matrix-jitsi-prosody container is stopped
+- name: Ensure matrix-jitsi-prosody container is stopped if necessary
   systemd:
     state: stopped
     name: matrix-jitsi-prosody
+  when: matrix_jitsi_prosody_start_result.changed|bool

--- a/roles/matrix-jitsi/tasks/util/setup_jitsi_auth.yml
+++ b/roles/matrix-jitsi/tasks/util/setup_jitsi_auth.yml
@@ -1,0 +1,30 @@
+---
+
+#
+# Tasks related to setting up Jitsi authentication mechanisms
+#
+
+- name: Ensure matrix-jitsi-prosody container is running
+  systemd:
+    state: started
+    name: matrix-jitsi-prosody
+
+- name: Ensire Jitsi internal authentication users are created
+  shell: "docker exec matrix-jitsi-prosody prosodyctl --config /config/prosody.cfg.lua register {{ item.username | quote }} meet.jitsi {{ item.password | quote }}"
+  with_items: "{{ matrix_jitsi_prosody_auth_internal_accounts }}"
+  when:
+    - matrix_jitsi_auth_type == "internal"
+
+
+#
+# Configure other authentication mechanisms below
+#
+
+
+#
+# End
+#
+- name: Ensure matrix-jitsi-prosody container is stopped
+  systemd:
+    state: stopped
+    name: matrix-jitsi-prosody

--- a/roles/matrix-jitsi/tasks/validate_config.yml
+++ b/roles/matrix-jitsi/tasks/validate_config.yml
@@ -23,16 +23,14 @@
 - name: Fail if a Jitsi internal authentication account is not defined
   fail:
     msg: >-
-      Each Jitsi user in `matrix_jitsi_prosody_auth_internal_accounts` needs to have a non-empty `username`/`password`.
-
-      Please ensure you have defined at least one user and password when using internal authentication.
+      At least one Jitsi user needs to be defined in `matrix_jitsi_prosody_auth_internal_accounts` when using internal authentication.
       
       If you're setting up Jitsi for the first time, you may have missed a step.
       Refer to our setup instructions (docs/configuring-playbook-jitsi.md).
   when:
     - matrix_jitsi_enable_auth|bool
     - matrix_jitsi_auth_type == 'internal'
-    - matrix_jitsi_prosody_auth_internal_accounts == ''
+    - matrix_jitsi_prosody_auth_internal_accounts|length == 0
 
 
 - name: (Deprecation) Catch and report renamed settings

--- a/roles/matrix-jitsi/tasks/validate_config.yml
+++ b/roles/matrix-jitsi/tasks/validate_config.yml
@@ -34,10 +34,10 @@
       it means that your installation is most likely using default passwords previously defined by the playbook.
       These defaults are insecure. Jitsi should be rebuilt with secure values.
       Refer to the "Rebuilding your Jitsi installation" section in our setup instructions (docs/configuring-playbook-jitsi.md).
-  when: 
-    - matrix_jitsi_auth_type == "internal"
-    - item.username == ''
-    - item.password == ''
+  when:
+    - matrix_jitsi_enable_auth|bool
+    - matrix_jitsi_auth_type == 'internal'
+    - matrix_jitsi_prosody_auth_internal_accounts|length == '0'
   with_items: "{{ matrix_jitsi_prosody_auth_internal_accounts }}"
 
 

--- a/roles/matrix-jitsi/tasks/validate_config.yml
+++ b/roles/matrix-jitsi/tasks/validate_config.yml
@@ -3,14 +3,14 @@
 - name: Fail if required Jitsi settings not defined
   fail:
     msg: >-
-      You need to define a required configuration setting (`{{ item }}`) for using Jitsi.
+      You need to define a required configuration setting (`{{ item }}`) to properly configure Jitsi.
 
       If you're setting up Jitsi for the first time, you may have missed a step.
       Refer to our setup instructions (docs/configuring-playbook-jitsi.md).
 
-      If you had setup Jitsi successfully before and it's just now that you're observing this failure,
-      it means that your installation may be using some default passwords that the playbook used to define until now.
-      This is not secure and we urge you to rebuild your Jitsi setup.
+      If you had previously setup Jitsi successfully and are only now facing this error,
+      it means that your installation is most likely using default passwords previously defined by the playbook.
+      These defaults are insecure. Jitsi should be rebuilt with secure values.
       Refer to the "Rebuilding your Jitsi installation" section in our setup instructions (docs/configuring-playbook-jitsi.md).
   when: "vars[item] == ''"
   with_items:
@@ -18,6 +18,28 @@
     - "matrix_jitsi_jibri_recorder_password"
     - "matrix_jitsi_jicofo_auth_password"
     - "matrix_jitsi_jvb_auth_password"
+
+
+- name: Fail if Jitsi internal authentication settings not defined
+  fail:
+    msg: >-
+      You must define the (`{{ item.username }}`) and (`{{ item.password }}`) configuration settings to properly configure an account using Jitsi's internal authentication.
+
+      Please ensure you have defined at least one user and password when using internal authentication.
+      
+      If you're setting up Jitsi for the first time, you may have missed a step.
+      Refer to our setup instructions (docs/configuring-playbook-jitsi.md).
+
+      If you had previously setup Jitsi successfully and are only now facing this error,
+      it means that your installation is most likely using default passwords previously defined by the playbook.
+      These defaults are insecure. Jitsi should be rebuilt with secure values.
+      Refer to the "Rebuilding your Jitsi installation" section in our setup instructions (docs/configuring-playbook-jitsi.md).
+  when: 
+    - matrix_jitsi_auth_type == "internal"
+    - item.username == ''
+    - item.password == ''
+  with_items: "{{ matrix_jitsi_prosody_auth_internal_accounts }}"
+
 
 - name: (Deprecation) Catch and report renamed settings
   fail:

--- a/roles/matrix-jitsi/tasks/validate_config.yml
+++ b/roles/matrix-jitsi/tasks/validate_config.yml
@@ -20,25 +20,19 @@
     - "matrix_jitsi_jvb_auth_password"
 
 
-- name: Fail if Jitsi internal authentication settings not defined
+- name: Fail if a Jitsi internal authentication account is not defined
   fail:
     msg: >-
-      You must define the (`{{ item.username }}`) and (`{{ item.password }}`) configuration settings to properly configure an account using Jitsi's internal authentication.
+      Each Jitsi user in `matrix_jitsi_prosody_auth_internal_accounts` needs to have a non-empty `username`/`password`.
 
       Please ensure you have defined at least one user and password when using internal authentication.
       
       If you're setting up Jitsi for the first time, you may have missed a step.
       Refer to our setup instructions (docs/configuring-playbook-jitsi.md).
-
-      If you had previously setup Jitsi successfully and are only now facing this error,
-      it means that your installation is most likely using default passwords previously defined by the playbook.
-      These defaults are insecure. Jitsi should be rebuilt with secure values.
-      Refer to the "Rebuilding your Jitsi installation" section in our setup instructions (docs/configuring-playbook-jitsi.md).
   when:
     - matrix_jitsi_enable_auth|bool
     - matrix_jitsi_auth_type == 'internal'
-    - matrix_jitsi_prosody_auth_internal_accounts|length == '0'
-  with_items: "{{ matrix_jitsi_prosody_auth_internal_accounts }}"
+    - matrix_jitsi_prosody_auth_internal_accounts == ''
 
 
 - name: (Deprecation) Catch and report renamed settings


### PR DESCRIPTION
This allows the playbook to create Jitsi internal authentication users without manual intervention. I'm not extremely familiar with Ansible, but it seems to work as intended and includes support for multiple user accounts.