### PR TITLE
Updated signald docker image path

### DIFF
--- a/roles/matrix-bridge-mautrix-signal/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-signal/defaults/main.yml
@@ -17,7 +17,7 @@ matrix_mautrix_signal_daemon_container_self_build: false
 matrix_mautrix_signal_daemon_docker_repo: "https://mau.dev/maunium/signald.git"
 matrix_mautrix_signal_daemon_docker_src_files_path: "{{ matrix_base_data_path }}/mautrix-signald/docker-src"
 
-matrix_mautrix_signal_daemon_docker_image: "dock.mau.dev/maunium/signald:{{ matrix_mautrix_signal_daemon_version }}"
+matrix_mautrix_signal_daemon_docker_image: "docker.io/signald/signald:{{ matrix_mautrix_signal_daemon_version }}"
 matrix_mautrix_signal_daemon_docker_image_force_pull: "{{ matrix_mautrix_signal_daemon_docker_image.endswith(':latest') }}"
 
 matrix_mautrix_signal_base_path: "{{ matrix_base_data_path }}/mautrix-signal"


### PR DESCRIPTION
Recently, a vulnerability in log4j was discovered. Signald uses log4j. This PR updates the path of the signald docker image from the previously recommended, but now outdated docker image at mau.dev to the [now by @tulir recommended](https://docs.mau.fi/bridges/python/signal/setup-docker.html) docker image at docker.io.

Please merge this ASAP since there is a vulnerability on all servers running signald until the fixed image gets pulled.