### PR TITLE
Remove a space from XMPP_INTERNAL_MUC_DOMAIN

### DIFF
--- a/roles/matrix-jitsi/templates/jvb/env.j2
+++ b/roles/matrix-jitsi/templates/jvb/env.j2
@@ -25,7 +25,7 @@ COLIBRI_REST_ENABLED
 SHUTDOWN_REST_ENABLED
 TZ={{ matrix_jitsi_timezone }}
 XMPP_AUTH_DOMAIN={{ matrix_jitsi_xmpp_auth_domain }}
-XMPP_INTERNAL_MUC_DOMAIN= {{ matrix_jitsi_xmpp_internal_muc_domain }}
+XMPP_INTERNAL_MUC_DOMAIN={{ matrix_jitsi_xmpp_internal_muc_domain }}
 XMPP_SERVER={{ matrix_jitsi_xmpp_server }}
 
 {{ matrix_jitsi_jvb_environment_variables_extension }}


### PR DESCRIPTION
The domain is invalid with space, so it shouldn't be here