### PR TITLE
missing uppercase in instagram's bot name

### DIFF
--- a/roles/matrix-bridge-mautrix-instagram/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-instagram/templates/config.yaml.j2
@@ -43,7 +43,7 @@ appservice:
   bot_username: {{ matrix_mautrix_instagram_appservice_bot_username|to_json }}
   # Display name and avatar for bot. Set to "remove" to remove display name/avatar, leave empty
   # to leave display name/avatar as-is.
-  bot_displayname: instagram bridge bot
+  bot_displayname: Instagram bridge bot
   bot_avatar: mxc://maunium.net/JxjlbZUlCPULEeHZSwleUXQv
 
   # Community ID for bridged users (changes registration file) and rooms.


### PR DESCRIPTION
Very minor inconsistency fix.
![SS_20 12 2021_16:57:34](https://user-images.githubusercontent.com/78233840/146837966-4169e256-6bcf-49fe-aa30-31d5ef845765.png)

