### PR TITLE
Add encryption_enabled_by_default_for_room_type

### DIFF
--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -580,6 +580,8 @@ matrix_synapse_default_room_version: "6"
 # If not, you can also control its value manually.
 matrix_synapse_spam_checker: []
 
+matrix_synapse_encryption_enabled_by_default_for_room_type: off
+
 matrix_synapse_trusted_key_servers:
   - server_name: "matrix.org"
 

--- a/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -2651,7 +2651,7 @@ spam_checker: {{ matrix_synapse_spam_checker|to_json }}
 # Note that this option will only affect rooms created after it is set. It
 # will also not affect rooms created by other servers.
 #
-#encryption_enabled_by_default_for_room_type: invite
+encryption_enabled_by_default_for_room_type: {{ matrix_synapse_encryption_enabled_by_default_for_room_type }}
 
 
 # Uncomment to allow non-server-admin users to create groups on this server

--- a/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -2651,7 +2651,7 @@ spam_checker: {{ matrix_synapse_spam_checker|to_json }}
 # Note that this option will only affect rooms created after it is set. It
 # will also not affect rooms created by other servers.
 #
-encryption_enabled_by_default_for_room_type: {{ matrix_synapse_encryption_enabled_by_default_for_room_type }}
+encryption_enabled_by_default_for_room_type: {{ matrix_synapse_encryption_enabled_by_default_for_room_type|to_json }}
 
 
 # Uncomment to allow non-server-admin users to create groups on this server


### PR DESCRIPTION
This commit simply add encryption_enabled_by_default_for_room_type
variable.

Signed-off-by: Alejo Diaz <xlejo@protonmail.com>