### PR TITLE
Allow editing of MXID/dispname templates for mautrix-telegram users

### DIFF
--- a/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
@@ -130,3 +130,8 @@ matrix_mautrix_telegram_registration_yaml: |
   de.sorunome.msc2409.push_ephemeral: true
 
 matrix_mautrix_telegram_registration: "{{ matrix_mautrix_telegram_registration_yaml|from_yaml }}"
+
+# Templates for defining MXID's and displaynames for users and rooms.
+matrix_mautrix_telegram_username_template: 'telegram_{userid}'
+matrix_mautrix_telegram_alias_template: 'telegram_{groupname}'
+matrix_mautrix_telegram_displayname_template: '{displayname} (Telegram)'

--- a/roles/matrix-bridge-mautrix-telegram/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-telegram/templates/config.yaml.j2
@@ -69,13 +69,16 @@ appservice:
 bridge:
     # Localpart template of MXIDs for Telegram users.
     # {userid} is replaced with the user ID of the Telegram user.
-    username_template: "telegram_{userid}"
+    # Default: telegram_{userid}
+    username_template: {{ matrix_mautrix_telegram_username_template|to_json }}
     # Localpart template of room aliases for Telegram portal rooms.
     # {groupname} is replaced with the name part of the public channel/group invite link ( https://t.me/{} )
-    alias_template: "telegram_{groupname}"
+    # Default: telegram_{groupname}
+    alias_template: {{ matrix_mautrix_telegram_alias_template|to_json }}
     # Displayname template for Telegram users.
     # {displayname} is replaced with the display name of the Telegram user.
-    displayname_template: "{displayname} (Telegram)"
+    # Default: {displayname} (Telegram)
+    displayname_template: {{ matrix_mautrix_telegram_displayname_template|to_json }}
 
     # Set the preferred order of user identifiers which to use in the Matrix puppet display name.
     # In the (hopefully unlikely) scenario that none of the given keys are found, the numeric user


### PR DESCRIPTION
Added defaults and edited config template for mautrix-telegram, allowing editing of MXID/displayname templates for bridged users.

This is primarily useful for removing the `(Telegram)` suffix from displaynames.

I have added the following config variables (defaults also shown):

```
matrix_mautrix_telegram_username_template: 'telegram_{userid}'
matrix_mautrix_telegram_alias_template: 'telegram_{groupname}'
matrix_mautrix_telegram_displayname_template: '{displayname} (Telegram)'
```

The defaults are the same as the current (hardcoded) config.

I have tested this on my deployment and can confirm that it works as intended.