### PR TITLE
feat(etherpad): add optional admin web-UI access

### DIFF
--- a/docs/configuring-playbook-etherpad.md
+++ b/docs/configuring-playbook-etherpad.md
@@ -25,6 +25,23 @@ The Dimension administrator users can configure the default URL template. The Di
 If you wish to disable the Etherpad chat button, you can do it by appending `?showChat=false` to the end of the pad URL, or the template.
 Example: `https://dimension.<your-domain>/etherpad/p/$roomId_$padName?showChat=false`
 
+### Etherpad Admin access (optional)
+
+Etherpad comes with a admin web-UI which is disabled by default. You can enable it by setting a username and password in your configuration file (`inventory/host_vars/matrix.<your-domain>/vars.yml`):
+
+```yaml
+matrix_etherpad_admin_username: admin
+matrix_etherpad_admin_password: some-password
+```
+
+The admin web-UI should then be available on: `https://dimension.<your-domain>/etherpad/admin`
+
+### Managing / Deleting old pads
+
+If you want to manage and remove old unused pads from Etherpad, you will first need to able Admin access as described above.
+
+Then from the plugin manager page (`https://dimension.<your-domain>/etherpad/admin/plugins`), install the `adminpads2` plugin. Once installed, you should have a "Manage pads" section in the Admin web-UI.
+
 ## Known issues
 
 If your Etherpad widget fails to load, this might be due to Dimension generating a Pad name so long, the Etherpad app rejects it.

--- a/roles/matrix-etherpad/defaults/main.yml
+++ b/roles/matrix-etherpad/defaults/main.yml
@@ -41,6 +41,11 @@ matrix_etherpad_database_hostname: 'matrix-postgres'
 matrix_etherpad_database_port: 5432
 matrix_etherpad_database_name: 'matrix_etherpad'
 
+# If a admin username and password is set, the /admin web page will be
+# available.
+matrix_etherpad_admin_username: ''
+matrix_etherpad_admin_password: ''
+
 matrix_etherpad_database_connection_string: 'postgres://{{ matrix_etherpad_database_username }}:{{ matrix_etherpad_database_password }}@{{ matrix_etherpad_database_hostname }}:{{ matrix_etherpad_database_port }}/{{ matrix_etherpad_database_name }}'
 
 # Variables configuring the etherpad

--- a/roles/matrix-etherpad/templates/settings.json.j2
+++ b/roles/matrix-etherpad/templates/settings.json.j2
@@ -73,8 +73,8 @@
   },
 {% if matrix_etherpad_admin_username != "" and matrix_etherpad_admin_password != "" %}
   "users": {
-    "{{ matrix_etherpad_admin_username }}": {
-      "password": "{{ matrix_etherpad_admin_password }}",
+    {{ matrix_etherpad_admin_username|to_json }}: {
+      "password": {{ matrix_etherpad_admin_password|to_json }},
       "is_admin": true
     }
   },

--- a/roles/matrix-etherpad/templates/settings.json.j2
+++ b/roles/matrix-etherpad/templates/settings.json.j2
@@ -71,6 +71,14 @@
     "chatAndUsers": false,
     "lang": "en-gb"
   },
+{% if matrix_etherpad_admin_username != "" and matrix_etherpad_admin_password != "" %}
+  "users": {
+    "{{ matrix_etherpad_admin_username }}": {
+      "password": "{{ matrix_etherpad_admin_password }}",
+      "is_admin": true
+    }
+  },
+{% endif %}
   "padShortcutEnabled" : {
     "altF9": true,
     "altC": true,


### PR DESCRIPTION
Enables optional access to Etherpad's web-UI. This is useful for
managing Etherpad plugins.

Among other things, plugins makes it easy to manage/delete pads if you
install the adminpads2 plugin.

---

This seems to work for me on my server. User settings are based on the information in [`settings.json.template`](https://github.com/ether/etherpad-lite/blob/0af728ffeeba35cc7b264f3d9b8890469db1e861/settings.json.template?_pjax=%23js-repo-pjax-container%3Afirst-of-type%2C%20div%5Bitemtype%3D%22http%3A%2F%2Fschema.org%2FSoftwareSourceCode%22%5D%20main%3Afirst-of-type%2C%20%5Bdata-pjax-container%5D%3Afirst-of-type#L435-L473) in Etherpad's repo.