### PR TITLE
Updated: Mautrix Telegram to v0.11.0 & alpine 3.15

### DIFF
--- a/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
@@ -7,13 +7,13 @@ matrix_telegram_lottieconverter_container_self_build: false
 matrix_telegram_lottieconverter_container_self_build_mask_arch: false
 matrix_telegram_lottieconverter_docker_repo: "https://mau.dev/tulir/lottieconverter.git"
 matrix_telegram_lottieconverter_docker_src_files_path: "{{ matrix_base_data_path }}/lotticonverter/docker-src"
-matrix_telegram_lottieconverter_docker_image: "dock.mau.dev/tulir/lottieconverter:alpine-3.14" # needs to be ajusted according to FROM clause of Dockerfile of mautrix-telegram
+matrix_telegram_lottieconverter_docker_image: "dock.mau.dev/tulir/lottieconverter:alpine-3.15" # needs to be ajusted according to FROM clause of Dockerfile of mautrix-telegram
 
 matrix_mautrix_telegram_container_self_build: false
 matrix_mautrix_telegram_docker_repo: "https://mau.dev/mautrix/telegram.git"
 matrix_mautrix_telegram_docker_src_files_path: "{{ matrix_base_data_path }}/mautrix-telegram/docker-src"
 
-matrix_mautrix_telegram_version: v0.10.2
+matrix_mautrix_telegram_version: v0.11.0
 # See: https://mau.dev/mautrix/telegram/container_registry
 matrix_mautrix_telegram_docker_image: "dock.mau.dev/mautrix/telegram:{{ matrix_mautrix_telegram_version }}"
 matrix_mautrix_telegram_docker_image_force_pull: "{{ matrix_mautrix_telegram_docker_image.endswith(':latest') }}"


### PR DESCRIPTION
Hello,
I have updated mautrix-telegram to version v0.11.0. I also changed the lottieconverter docker image to use the alpine-3.15 tag, since the mautrix-telegram dockerfile currently does this.

Feel free to leave some feedback 😄 