### PR TITLE
matrix-bot-honoroit: disable self-build by default, update to v0.9.1

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -986,7 +986,7 @@ matrix_bot_honoroit_systemd_required_services_list: |
 # Postgres is the default, except if not using `matrix_postgres` (internal postgres)
 matrix_bot_honoroit_database_engine: "{{ 'postgres' if matrix_postgres_enabled else 'sqlite' }}"
 matrix_bot_honoroit_database_password: "{{ '%s' | format(matrix_homeserver_generic_secret_key) | password_hash('sha512', 'honoroit.bot.db') | to_uuid }}"
-matrix_bot_honoroit_container_image_self_build: false
+matrix_bot_honoroit_container_image_self_build: "{{ matrix_architecture not in ['amd64', 'arm32', 'arm64'] }}"
 
 ######################################################################
 #

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -986,7 +986,7 @@ matrix_bot_honoroit_systemd_required_services_list: |
 # Postgres is the default, except if not using `matrix_postgres` (internal postgres)
 matrix_bot_honoroit_database_engine: "{{ 'postgres' if matrix_postgres_enabled else 'sqlite' }}"
 matrix_bot_honoroit_database_password: "{{ '%s' | format(matrix_homeserver_generic_secret_key) | password_hash('sha512', 'honoroit.bot.db') | to_uuid }}"
-matrix_bot_honoroit_container_image_self_build: "{{ matrix_architecture != 'amd64' }}"
+matrix_bot_honoroit_container_image_self_build: false
 
 ######################################################################
 #

--- a/roles/matrix-bot-honoroit/defaults/main.yml
+++ b/roles/matrix-bot-honoroit/defaults/main.yml
@@ -7,7 +7,7 @@ matrix_bot_honoroit_container_image_self_build: false
 matrix_bot_honoroit_docker_repo: "https://gitlab.com/etke.cc/honoroit.git"
 matrix_bot_honoroit_docker_src_files_path: "{{ matrix_base_data_path }}/honoroit/docker-src"
 
-matrix_bot_honoroit_version: v0.9.0
+matrix_bot_honoroit_version: v0.9.1
 matrix_bot_honoroit_docker_image: "{{ matrix_bot_honoroit_docker_image_name_prefix }}honoroit:{{ matrix_bot_honoroit_version }}"
 matrix_bot_honoroit_docker_image_name_prefix: "{{ 'localhost/' if matrix_bot_honoroit_container_image_self_build else 'registry.gitlab.com/etke.cc/' }}"
 matrix_bot_honoroit_docker_image_force_pull: "{{ matrix_bot_honoroit_docker_image.endswith(':latest') }}"


### PR DESCRIPTION
Hi there,

To mitigate #1518 and prevent such issues in future, multiarch support was added both to the base image and to the honoroit image.

Both images support arm32, arm64 and amd64 architectures now, so no need for automatic self-building (of course, that's still possible, but default value changed to `false`).

These changes already available for the `latest` image tag, but as it works as expected, pinned release added as well.