### PR TITLE
Updated: webhooks image tag to v1.0.3-01

### DIFF
--- a/roles/matrix-bridge-appservice-webhooks/defaults/main.yml
+++ b/roles/matrix-bridge-appservice-webhooks/defaults/main.yml
@@ -8,7 +8,7 @@ matrix_appservice_webhooks_container_image_self_build_repo: "https://github.com/
 matrix_appservice_webhooks_container_image_self_build_repo_version: "{{ 'master' if matrix_appservice_webhooks_version == 'latest' else matrix_appservice_webhooks_version }}"
 matrix_appservice_webhooks_container_image_self_build_repo_dockerfile_path: "Dockerfile"
 
-matrix_appservice_webhooks_version: v1.0.2-01
+matrix_appservice_webhooks_version: v1.0.3-01
 matrix_appservice_webhooks_docker_image: "{{ matrix_appservice_webhooks_docker_image_name_prefix }}redoonetworks/matrix-appservice-webhooks:{{ matrix_appservice_webhooks_version }}"
 matrix_appservice_webhooks_docker_image_name_prefix: "{{ 'localhost/' if matrix_appservice_webhooks_container_image_self_build else matrix_container_global_registry_prefix }}"
 matrix_appservice_webhooks_docker_image_force_pull: "{{ matrix_appservice_webhooks_docker_image.endswith(':latest') }}"


### PR DESCRIPTION
Updates the appservice-webhooks image tag to v1.0.3-01 which adds arm64 builds.
Closes #1533