### PR TITLE
Updated: beeper-linkedin to v0.5.2

### DIFF
--- a/roles/matrix-bridge-beeper-linkedin/defaults/main.yml
+++ b/roles/matrix-bridge-beeper-linkedin/defaults/main.yml
@@ -3,7 +3,7 @@
 
 matrix_beeper_linkedin_enabled: true
 
-matrix_beeper_linkedin_version: v0.5.1
+matrix_beeper_linkedin_version: v0.5.2
 
 # See: https://gitlab.com/beeper/linkedin/container_registry
 matrix_beeper_linkedin_docker_image: "{{ matrix_beeper_linkedin_docker_image_name_prefix }}beeper/linkedin:{{ matrix_beeper_linkedin_docker_image_tag }}"


### PR DESCRIPTION
Updates the beeper-linkedin image tag to v0.5.2.
Closes #1534