### PR TITLE
Updated: sygnal to v0.11.0

### DIFF
--- a/roles/matrix-sygnal/defaults/main.yml
+++ b/roles/matrix-sygnal/defaults/main.yml
@@ -7,7 +7,7 @@ matrix_sygnal_base_path: "{{ matrix_base_data_path }}/sygnal"
 matrix_sygnal_config_path: "{{ matrix_sygnal_base_path }}/config"
 matrix_sygnal_data_path: "{{ matrix_sygnal_base_path }}/data"
 
-matrix_sygnal_version: v0.10.1
+matrix_sygnal_version: v0.11.0
 matrix_sygnal_docker_image: "{{ matrix_container_global_registry_prefix }}matrixdotorg/sygnal:{{ matrix_sygnal_version }}"
 matrix_sygnal_docker_image_force_pull: "{{ matrix_sygnal_docker_image.endswith(':latest') }}"
 


### PR DESCRIPTION
Updates the sygnal image tag to v0.11.0. No config changes have been made upstream
Closes #1542