### PR TITLE
Updated: registration to v0.9.1

### DIFF
--- a/roles/matrix-registration/defaults/main.yml
+++ b/roles/matrix-registration/defaults/main.yml
@@ -12,7 +12,7 @@ matrix_registration_config_path: "{{ matrix_registration_base_path }}/config"
 matrix_registration_data_path: "{{ matrix_registration_base_path }}/data"
 matrix_registration_docker_src_files_path: "{{ matrix_registration_base_path }}/docker-src"
 
-matrix_registration_version: "v0.7.2"
+matrix_registration_version: "v0.9.1"
 
 matrix_registration_docker_image: "{{ matrix_registration_docker_image_name_prefix }}zeratax/matrix-registration:{{ matrix_registration_version }}"
 matrix_registration_docker_image_name_prefix: "{{ 'localhost/' if matrix_registration_container_image_self_build else matrix_container_global_registry_prefix }}"

--- a/roles/matrix-registration/templates/config.yaml.j2
+++ b/roles/matrix-registration/templates/config.yaml.j2
@@ -1,13 +1,15 @@
 server_location: {{ matrix_registration_server_location|to_json }}
 server_name: {{ matrix_registration_server_name|to_json }}
-shared_secret: {{ matrix_registration_shared_secret|to_json }}
-admin_secret: {{ matrix_registration_admin_secret|to_json }}
-riot_instance: {{ matrix_registration_riot_instance|to_json }}
+registration_shared_secret: {{ matrix_registration_shared_secret|to_json }}
+admin_api_shared_secret: {{ matrix_registration_admin_secret|to_json }}
+client_redirect: {{ matrix_registration_riot_instance|to_json }}
+base_url: {{ matrix_registration_base_url|to_json }}
 db: {{ matrix_registration_db|to_json }}
 host: '0.0.0.0'
 port: 5000
 rate_limit: ["100 per day", "10 per minute"]
 allow_cors: false
+ip_logging: false
 logging:
   disable_existing_loggers: False
   version: 1
@@ -28,4 +30,3 @@ logging:
 # password requirements
 password:
   min_length: 8
-base_url: {{ matrix_registration_base_url|to_json }}


### PR DESCRIPTION
Updates the registration image tag to v0.9.1. I've also updated the config file to match the changes in the upstream one (https://github.com/ZerataX/matrix-registration/blob/master/config.sample.yaml). I'd be happy if one could have a look at it.
Closes #1541