### PR TITLE
Added Instagram version tag instead of latest

### DIFF
--- a/roles/matrix-bridge-mautrix-instagram/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-instagram/defaults/main.yml
@@ -6,7 +6,7 @@ matrix_mautrix_instagram_enabled: true
 matrix_mautrix_instagram_container_image_self_build: false
 matrix_mautrix_instagram_container_image_self_build_repo: "https://github.com/mautrix/instagram.git"
 
-matrix_mautrix_instagram_version: latest
+matrix_mautrix_instagram_version: v0.1.2
 # See: https://mau.dev/tulir/mautrix-instagram/container_registry
 matrix_mautrix_instagram_docker_image: "{{ matrix_mautrix_instagram_docker_image_name_prefix }}mautrix/instagram:{{ matrix_mautrix_instagram_version }}"
 matrix_mautrix_instagram_docker_image_name_prefix: "{{ 'localhost/' if matrix_mautrix_instagram_container_image_self_build else 'dock.mau.dev/' }}"


### PR DESCRIPTION
Hello,
I have added the version tag for this bridge as there has been a new release yesterday. This ensures that we don't break things in the future by using the latest tag, but can check if anything on our site needs to be changed.

https://github.com/mautrix/instagram/releases/tag/v0.1.2