### PR TITLE
Updated Honoroit with fallback reply-to mode

### DIFF
--- a/roles/matrix-bot-honoroit/defaults/main.yml
+++ b/roles/matrix-bot-honoroit/defaults/main.yml
@@ -7,7 +7,7 @@ matrix_bot_honoroit_container_image_self_build: false
 matrix_bot_honoroit_docker_repo: "https://gitlab.com/etke.cc/honoroit.git"
 matrix_bot_honoroit_docker_src_files_path: "{{ matrix_base_data_path }}/honoroit/docker-src"
 
-matrix_bot_honoroit_version: v0.9.1
+matrix_bot_honoroit_version: v0.9.2
 matrix_bot_honoroit_docker_image: "{{ matrix_bot_honoroit_docker_image_name_prefix }}honoroit:{{ matrix_bot_honoroit_version }}"
 matrix_bot_honoroit_docker_image_name_prefix: "{{ 'localhost/' if matrix_bot_honoroit_container_image_self_build else 'registry.gitlab.com/etke.cc/' }}"
 matrix_bot_honoroit_docker_image_force_pull: "{{ matrix_bot_honoroit_docker_image.endswith(':latest') }}"


### PR DESCRIPTION
Honoroit updated to v0.9.2

By default Element doesn't support threads yet. To mitigate that, fallback reply-to mode was added, so now you can interract with honoroit just replying to previous messages, to avoid [such frustrations](https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/1518#issuecomment-1008263296). That method considered as temporary workaround, so performance will be pretty poor on large reply-to chains, but that's better than nothing.