### PR TITLE
Updated: telegram to v0.11.1

### DIFF
--- a/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
@@ -7,13 +7,13 @@ matrix_telegram_lottieconverter_container_image_self_build: false
 matrix_telegram_lottieconverter_container_image_self_build_mask_arch: false
 matrix_telegram_lottieconverter_docker_repo: "https://mau.dev/tulir/lottieconverter.git"
 matrix_telegram_lottieconverter_docker_src_files_path: "{{ matrix_base_data_path }}/lotticonverter/docker-src"
-matrix_telegram_lottieconverter_docker_image: "dock.mau.dev/tulir/lottieconverter:alpine-3.14" # needs to be ajusted according to FROM clause of Dockerfile of mautrix-telegram
+matrix_telegram_lottieconverter_docker_image: "dock.mau.dev/tulir/lottieconverter:alpine-3.15" # needs to be ajusted according to FROM clause of Dockerfile of mautrix-telegram
 
 matrix_mautrix_telegram_container_image_self_build: false
 matrix_mautrix_telegram_docker_repo: "https://mau.dev/mautrix/telegram.git"
 matrix_mautrix_telegram_docker_src_files_path: "{{ matrix_base_data_path }}/mautrix-telegram/docker-src"
 
-matrix_mautrix_telegram_version: v0.10.2
+matrix_mautrix_telegram_version: v0.11.1
 # See: https://mau.dev/mautrix/telegram/container_registry
 matrix_mautrix_telegram_docker_image: "dock.mau.dev/mautrix/telegram:{{ matrix_mautrix_telegram_version }}"
 matrix_mautrix_telegram_docker_image_force_pull: "{{ matrix_mautrix_telegram_docker_image.endswith(':latest') }}"

--- a/roles/matrix-bridge-mautrix-telegram/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-telegram/templates/config.yaml.j2
@@ -225,17 +225,6 @@ bridge:
         #      notices from users listed here will be bridged.
         exceptions: []
 
-    # Some config options related to Telegram message deduplication.
-    # The default values are usually fine, but some debug messages/warnings might recommend you
-    # change these.
-    deduplication:
-        # Whether or not to check the database if the message about to be sent is a duplicate.
-        pre_db_check: false
-        # The number of latest events to keep when checking for duplicates.
-        # You might need to increase this on high-traffic bridge instances.
-        cache_queue_length: 20
-
-
     # The formats to use when sending messages to Telegram via the relay bot.
     #
     # Telegram doesn't have built-in emotes, so the m.emote format is also used for non-relaybot users.

--- a/roles/matrix-bridge-mautrix-telegram/templates/systemd/matrix-mautrix-telegram.service.j2
+++ b/roles/matrix-bridge-mautrix-telegram/templates/systemd/matrix-mautrix-telegram.service.j2
@@ -15,15 +15,6 @@ Type=simple
 Environment="HOME={{ matrix_systemd_unit_home_path }}"
 ExecStartPre=-{{ matrix_host_command_sh }} -c '{{ matrix_host_command_docker }} kill matrix-mautrix-telegram 2>/dev/null'
 ExecStartPre=-{{ matrix_host_command_sh }} -c '{{ matrix_host_command_docker }} rm matrix-mautrix-telegram 2>/dev/null'
-ExecStartPre={{ matrix_host_command_docker }} run --rm --name matrix-mautrix-telegram-db \
-			--log-driver=none \
-			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
-			--cap-drop=ALL \
-			--network={{ matrix_docker_network }} \
-			-v {{ matrix_mautrix_telegram_config_path }}:/config:z \
-			-v {{ matrix_mautrix_telegram_data_path }}:/data:z \
-			{{ matrix_mautrix_telegram_docker_image }} \
-			alembic -x config=/config/config.yaml upgrade head
 
 # Intentional delay, so that the homeserver (we likely depend on) can manage to start.
 ExecStartPre={{ matrix_host_command_sleep }} 5


### PR DESCRIPTION
Hi,
I've updated mautrix-telegram to v0.11.1 which seems to fix the problem regarding the database corruption when upgrading to v0.11.0 (`Fixed migrating pre-v0.11 legacy databases if the database schema had been corrupted (e.g. by using 3rd party tools for SQLite -> Postgres migration`).

I've also removed the deduplication settings from the config as they have been removed in the example config upstream as well. Lottieconverter has been updated to 3.15 so it matches the requirement of telegram.