### PR TITLE
Added: mautrix-signal 0.2.2 & signald 0.16.1

### DIFF
--- a/roles/matrix-bridge-mautrix-signal/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-signal/defaults/main.yml
@@ -7,8 +7,8 @@ matrix_mautrix_signal_container_image_self_build: false
 matrix_mautrix_signal_docker_repo: "https://mau.dev/mautrix/signal.git"
 matrix_mautrix_signal_docker_src_files_path: "{{ matrix_base_data_path }}/mautrix-signal/docker-src"
 
-matrix_mautrix_signal_version: latest
-matrix_mautrix_signal_daemon_version: latest
+matrix_mautrix_signal_version: v0.2.2
+matrix_mautrix_signal_daemon_version: 0.16.1
 # See: https://mau.dev/mautrix/signal/container_registry
 matrix_mautrix_signal_docker_image: "dock.mau.dev/mautrix/signal:{{ matrix_mautrix_signal_version }}"
 matrix_mautrix_signal_docker_image_force_pull: "{{ matrix_mautrix_signal_docker_image.endswith(':latest') }}"


### PR DESCRIPTION
Hi,
mautrix-signal had an update two days ago. There has been only a small commit since then which doesn't break things for latest tag users.

https://github.com/mautrix/signal/releases/tag/v0.2.2
https://gitlab.com/signald/signald/-/releases/0.16.1