### PR TITLE
Updated: mautrix-twitter to v0.1.3

### DIFF
--- a/roles/matrix-bridge-mautrix-twitter/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-twitter/defaults/main.yml
@@ -6,7 +6,7 @@ matrix_mautrix_twitter_enabled: true
 matrix_mautrix_twitter_container_image_self_build: false
 matrix_mautrix_twitter_container_image_self_build_repo: "https://github.com/mautrix/twitter.git"
 
-matrix_mautrix_twitter_version: latest
+matrix_mautrix_twitter_version: v0.1.3
 # See: https://mau.dev/tulir/mautrix-twitter/container_registry
 matrix_mautrix_twitter_docker_image: "{{ matrix_mautrix_twitter_docker_image_name_prefix }}mautrix/twitter:{{ matrix_mautrix_twitter_version }}"
 matrix_mautrix_twitter_docker_image_name_prefix: "{{ 'localhost/' if matrix_mautrix_twitter_container_image_self_build else 'dock.mau.dev/' }}"


### PR DESCRIPTION
Hi,
Mautrix-twitter has been bumped to https://github.com/mautrix/twitter/releases/tag/v0.1.3 two days ago. Since then nothing much has happened over at the repo.