### PR TITLE
matrix_mailer default false

### DIFF
--- a/roles/matrix-mailer/defaults/main.yml
+++ b/roles/matrix-mailer/defaults/main.yml
@@ -1,4 +1,4 @@
-matrix_mailer_enabled: true
+matrix_mailer_enabled: false
 
 matrix_mailer_base_path: "{{ matrix_base_data_path }}/mailer"
 


### PR DESCRIPTION
- disable default (already an optional component)
- User must configure matrix_mailer_enabled along with other required parameters 