### PR TITLE
add etherpad to nginx wanted services

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -1483,7 +1483,7 @@ matrix_nginx_proxy_systemd_wanted_services_list: |
     +
     (['matrix-bot-go-neb.service'] if matrix_bot_go_neb_enabled else [])
     +
-    (['matrix-etherpad.service'] if matrix_etherpad_enabled else [])
+    (['matrix-etherpad.service'] if matrix_etherpad_enabled and matrix_dimension_enabled else [])
   }}
 
 matrix_ssl_domains_to_obtain_certificates_for: |

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -1482,6 +1482,8 @@ matrix_nginx_proxy_systemd_wanted_services_list: |
     (['matrix-jitsi.service'] if matrix_jitsi_enabled else [])
     +
     (['matrix-bot-go-neb.service'] if matrix_bot_go_neb_enabled else [])
+    +
+    (['matrix-etherpad.service'] if matrix_etherpad_enabled else [])
   }}
 
 matrix_ssl_domains_to_obtain_certificates_for: |


### PR DESCRIPTION
it's required if enabled by the dimension config here:
https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/6eb8fb83925af055483ca797e31b5d803135e61f/roles/matrix-etherpad/tasks/init.yml#L42-L49

see also #1517