### PR TITLE
Add missing slash in url scheme for mediaUrl

### DIFF
--- a/roles/matrix-bridge-mx-puppet-discord/defaults/main.yml
+++ b/roles/matrix-bridge-mx-puppet-discord/defaults/main.yml
@@ -27,7 +27,7 @@ matrix_mx_puppet_discord_homeserver_address: "{{ matrix_homeserver_container_url
 matrix_mx_puppet_discord_homeserver_domain: '{{ matrix_domain }}'
 matrix_mx_puppet_discord_appservice_address: 'http://matrix-mx-puppet-discord:{{ matrix_mx_puppet_discord_appservice_port }}'
 
-matrix_mx_puppet_discord_bridge_mediaUrl: "https:/{{ matrix_server_fqn_matrix }}"
+matrix_mx_puppet_discord_bridge_mediaUrl: "https://{{ matrix_server_fqn_matrix }}"
 
 # "@user:server.com" to allow specific user
 # "@.*:yourserver.com" to allow users on a specific homeserver


### PR DESCRIPTION
The scheme portion of the URL for `matrix_mx_puppet_discord_bridge_mediaUrl` in `main.yml` for matrix-bridge-mx-puppet-discord is missing a slash and causes messages to fail when sending to discord if the matrix user has a profile picture configured.