### PR TITLE
feat(mx-puppet-slack): add support for OAuth client ID/secret

### DIFF
--- a/docs/configuring-playbook-bridge-mx-puppet-slack.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-slack.md
@@ -1,20 +1,33 @@
 # Setting up MX Puppet Slack (optional)
 
-**Note**: bridging to [Slack](https://slack.com) can also happen via the [matrix-appservice-slack](configuring-playbook-bridge-appservice-slack.md) bridge supported by the playbook.
+**Note**: bridging to [Slack](https://slack.com) can also happen via the
+[matrix-appservice-slack](configuring-playbook-bridge-appservice-slack.md)
+bridge supported by the playbook.
 
 The playbook can install and configure
 [mx-puppet-slack](https://github.com/Sorunome/mx-puppet-slack) for you.
 
 See the project page to learn what it does and why it might be useful to you.
 
-To enable the [Slack](https://slack.com/) bridge just use the following
-playbook configuration:
+## Setup
 
+To enable the [Slack](https://slack.com/) bridge:
 
-```yaml
-matrix_mx_puppet_slack_enabled: true
-```
-
+1. Follow the
+   [OAuth credentials](https://github.com/Sorunome/mx-puppet-slack#option-2-oauth)
+   instructions to create a new Slack app, setting the redirect URL to
+   `https://matrix.YOUR_DOMAIN/slack/oauth`.
+2. Update your `vars.yml` with the following:
+    ```yaml
+    matrix_mx_puppet_slack_enabled: true
+    # Client ID must be quoted so YAML does not parse it as a float.
+    matrix_mx_puppet_slack_oauth_client_id: "<SLACK_APP_CLIENT_ID>"
+    matrix_mx_puppet_slack_oauth_client_secret: "<SLACK_APP_CLIENT_SECRET>"
+    ```
+3. Run playbooks with `setup-all` and `start` tags:
+    ```
+    ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+    ```
 
 ## Usage
 

--- a/roles/matrix-bridge-mx-puppet-slack/defaults/main.yml
+++ b/roles/matrix-bridge-mx-puppet-slack/defaults/main.yml
@@ -3,6 +3,9 @@
 
 matrix_mx_puppet_slack_enabled: true
 
+matrix_mx_puppet_slack_oauth_client_id: ''
+matrix_mx_puppet_slack_oauth_client_secret: ''
+
 matrix_mx_puppet_slack_container_image_self_build: false
 matrix_mx_puppet_slack_container_image_self_build_repo: "https://github.com/Sorunome/mx-puppet-slack.git"
 

--- a/roles/matrix-bridge-mx-puppet-slack/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mx-puppet-slack/templates/config.yaml.j2
@@ -18,6 +18,10 @@ bridge:
 # Slack OAuth settings. Create a slack app at https://api.slack.com/apps
 oauth:
   enabled: true
+  # Slack app credentials.
+  # N.B. This must be quoted so YAML does not parse it as a float.
+  clientId: '{{ matrix_mx_puppet_slack_oauth_client_id }}'
+  clientSecret: '{{ matrix_mx_puppet_slack_oauth_client_secret }}'
   # Path where to listen for OAuth redirect callbacks.
   redirectPath: {{ matrix_mx_puppet_slack_redirect_path }}
   # Set up proxying from https://your.domain/redirect_path to http://bindAddress:port/redirect_path,

--- a/roles/matrix-bridge-mx-puppet-slack/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mx-puppet-slack/templates/config.yaml.j2
@@ -21,7 +21,7 @@ oauth:
   # Slack app credentials.
   # N.B. This must be quoted so YAML does not parse it as a float.
   clientId: '{{ matrix_mx_puppet_slack_oauth_client_id }}'
-  clientSecret: '{{ matrix_mx_puppet_slack_oauth_client_secret }}'
+  clientSecret: {{ matrix_mx_puppet_slack_oauth_client_secret|to_json }}
   # Path where to listen for OAuth redirect callbacks.
   redirectPath: {{ matrix_mx_puppet_slack_redirect_path }}
   # Set up proxying from https://your.domain/redirect_path to http://bindAddress:port/redirect_path,


### PR DESCRIPTION
The OAuth credentials method seems to be the only viable way to
configure the mx-puppet-bridge now. Legacy tokens can no longer be
created, and the other methods (xoxs and xoxc tokens) come with warnings
about them being against Slack's terms of service.