### PR TITLE
Fixed preferred element domain for jitsi instance in .well-known clie…

### DIFF
--- a/roles/matrix-base/defaults/main.yml
+++ b/roles/matrix-base/defaults/main.yml
@@ -43,7 +43,7 @@ matrix_server_fqn_dimension: "dimension.{{ matrix_domain }}"
 matrix_server_fqn_bot_go_neb: "goneb.{{ matrix_domain }}"
 
 # This is where you access Jitsi.
-matrix_server_fqn_jitsi: "jitsi.{{ matrix_domain }}"
+matrix_server_fqn_jitsi: "https://jitsi.{{ matrix_domain }}"
 
 # This is where you access Grafana.
 matrix_server_fqn_grafana: "stats.{{ matrix_domain }}"


### PR DESCRIPTION
…nt file

Element will not recognize jitsi.domain.com instead it needs https://jitsi.domain.com in order to work correctly.