### PR TITLE
Fixed not being able to start a jitsi conference on webinterface or element

### DIFF
--- a/roles/matrix-jitsi/templates/prosody/env.j2
+++ b/roles/matrix-jitsi/templates/prosody/env.j2
@@ -5,7 +5,7 @@ ENABLE_AV_MODERATION={{1 if matrix_jitsi_enable_av_moderation else 0}}
 ENABLE_BREAKOUT_ROOMS={{1 if matrix_jitsi_enable_breakout_rooms else 0}}
 ENABLE_GUESTS={{ 1 if matrix_jitsi_enable_guests else 0 }}
 ENABLE_LOBBY={{ 1 if matrix_jitsi_enable_lobby else 0 }}
-ENABLE_XMPP_WEBSOCKET
+ENABLE_XMPP_WEBSOCKET=0
 GLOBAL_CONFIG
 GLOBAL_MODULES
 JIBRI_RECORDER_USER={{ matrix_jitsi_jibri_recorder_user }}

--- a/roles/matrix-jitsi/templates/web/env.j2
+++ b/roles/matrix-jitsi/templates/web/env.j2
@@ -56,7 +56,7 @@ ENABLE_SUBDOMAINS
 ENABLE_TALK_WHILE_MUTED
 ENABLE_TCC
 ENABLE_TRANSCRIPTIONS={{ 1 if matrix_jitsi_enable_transcriptions else 0 }}
-ENABLE_XMPP_WEBSOCKET
+ENABLE_XMPP_WEBSOCKET=0
 ETHERPAD_PUBLIC_URL
 ETHERPAD_URL_BASE={{ (matrix_jitsi_etherpad_base + '/') if matrix_jitsi_etherpad_enabled else ''}}
 GOOGLE_ANALYTICS_ID


### PR DESCRIPTION
I am accessing my jitsi domain via webbrowser and in the preview screen everything seems fine, but when I click "join conference" nothing happens. After a few seconds I get an error saying "your connection was terminated. A new attempt will be started in 30 seconds".

Fix
https://community.jitsi.org/t/jitsi-meet-in-docker-container-websocket-error/88703/15

However I have no idea what this is actually doing. Additionally the last comment pointed out, that one should set 

ENABLE_SCTP=1
ENABLE_COLIBRI_WEBSOCKET=0
ENABLE_XMPP_WEBSOCKET=0

for chromium 97.0.4692.71 web browser in Ubuntu 18.04 to work.

So someone should double check this before merging.