### PR TITLE
Update Hydrogen from v0.2.25 to v0.2.26

### DIFF
--- a/roles/matrix-client-hydrogen/defaults/main.yml
+++ b/roles/matrix-client-hydrogen/defaults/main.yml
@@ -7,7 +7,7 @@ matrix_client_hydrogen_enabled: true
 matrix_client_hydrogen_container_image_self_build: true
 matrix_client_hydrogen_container_image_self_build_repo: "https://github.com/vector-im/hydrogen-web.git"
 
-matrix_client_hydrogen_version: v0.2.25
+matrix_client_hydrogen_version: v0.2.26
 matrix_client_hydrogen_docker_image: "{{ matrix_client_hydrogen_docker_image_name_prefix }}vectorim/hydrogen-web:{{ matrix_client_hydrogen_version }}"
 matrix_client_hydrogen_docker_image_name_prefix: "{{ 'localhost/' if matrix_client_hydrogen_container_image_self_build else matrix_container_global_registry_prefix }}"
 matrix_client_hydrogen_docker_image_force_pull: "{{ matrix_client_hydrogen_docker_image.endswith(':latest') }}"


### PR DESCRIPTION
This PR should be able to merge essentially instantly due to that all platforms self build hydrogen therefore we do not need to worry about docker image delay plus the release is 7 hours old at time of writing. 