### PR TITLE
Update for changing the federation port into the documentation

### DIFF
--- a/docs/configuring-playbook-federation.md
+++ b/docs/configuring-playbook-federation.md
@@ -47,3 +47,20 @@ matrix_synapse_federation_port_enabled: false
 # This removes the `8448` virtual host from the matrix-nginx-proxy reverse-proxy server.
 matrix_nginx_proxy_proxy_matrix_federation_api_enabled: false
 ```
+
+## Changing the federation port from 8448 to a different port to use a CDN that only accepts 443/80 ports
+
+Why? This change could be useful for people running small Synapse instances on small severs/VPSes to avoid being impacted by a simple DOS/DDOS when bandwidth, RAM, an CPU resources are limited and if your hosting provider does not provide a DOS/DDOS protection.
+
+The following changes in the configuration file (`inventory/host_vars/matrix.<your-domain>/vars.yml`) will allow this and make it possible to proxy the federation through a CDN such as CloudFlare or any other:
+
+```
+matrix_synapse_http_listener_resource_names: ["client","federation"]
+# Any port can be used but in this case we use 443
+matrix_federation_public_port: 443
+matrix_synapse_federation_port_enabled: false
+# Note tht the following change might not be "required per se" but probably will be due to the proxying of the traffic through the CDN proxy servers (CloudFlare for instance). The security impact of doing this should be minimal as your CDN itself will encrypt the traffic no matter what on their proxy servers. You could however first try and see if federation works while setting the following to true.
+matrix_synapse_tls_federation_listener_enabled: false
+```
+
+**Use this at you own risk as all the possible side-effects of doing this are not fully known. However, it has been tested and works fine and passes all the tests on <https://federationtester.matrix.org/> without issues.**


### PR DESCRIPTION
This is a proposed to add to the documentation information about how to change the Synapse federation port using the ansible playbook in order to allow  use with third party services such as CDNs not accepting port 8448.