### PR TITLE
Optimize signal bridge startup order

### DIFF
--- a/roles/matrix-bridge-mautrix-signal/tasks/init.yml
+++ b/roles/matrix-bridge-mautrix-signal/tasks/init.yml
@@ -1,7 +1,7 @@
 ---
 
 - set_fact:
-    matrix_systemd_services_list: "{{ matrix_systemd_services_list + ['matrix-mautrix-signal.service', 'matrix-mautrix-signal-daemon.service'] }}"
+    matrix_systemd_services_list: "{{ matrix_systemd_services_list + ['matrix-mautrix-signal-daemon.service', 'matrix-mautrix-signal.service'] }}"
   when: matrix_mautrix_signal_enabled|bool
 
 # If the matrix-synapse role is not used, these variables may not exist.


### PR DESCRIPTION
bridge requires the daemon, so start it first