### PR TITLE
GoMatrixHosting v0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,5 +152,3 @@ When updating the playbook, refer to [the changelog](CHANGELOG.md) to catch up w
 ## Services by the community
 
 - [etke.cc](https://etke.cc) - matrix-docker-ansible-deploy and system stuff "as a service". That service will create your matrix homeserver on your domain and server (doesn't matter if it's cloud provider or on an old laptop in the corner of your room), (optional) maintains it (server's system updates, cleanup, security adjustments, tuning, etc.; matrix homeserver updates & maintenance) and (optional) provide full-featured email service for your domain
-
-- [GoMatrixHosting](https://gomatrixhosting.com) - matrix-docker-ansible-deploy "as a service" with [Ansible AWX](https://github.com/ansible/awx). Members can be assigned a server from DigitalOcean, or they can connect their on-premises server. This AWX system can manage the updates, configuration, import and export, backups, and monitoring on its own. For more information [see our GitLab group](https://gitlab.com/GoMatrixHosting) or come [visit us on Matrix](https://matrix.to/#/#general:gomatrixhosting.com).

--- a/docs/configuring-awx-system.md
+++ b/docs/configuring-awx-system.md
@@ -10,6 +10,7 @@ The AWX system is arranged into 'members' each with their own 'subscriptions'. A
 
 This system can manage the updates, configuration, import and export, backups and monitoring on its own. It is an extension of the popular deploy script [spantaleev/matrix-docker-ansible-deploy](https://github.com/spantaleev/matrix-docker-ansible-deploy).
 
+Warning: This system is about to undergo heavy revision, **we do not recommend using it at this time.**
 
 ## Other Required Playbooks
 

--- a/roles/matrix-awx/surveys/configure_mjolnir.json.j2
+++ b/roles/matrix-awx/surveys/configure_mjolnir.json.j2
@@ -1,0 +1,29 @@
+{
+  "name": "Configure Mjolnir",
+  "description": "Configure Mjolnir settings, Mjolnir is a moderation bot for Matrix.",
+  "spec": [
+    {
+      "question_name": "Enable Mjolnir",
+      "question_description": "Set if Mjolnir is enabled or not. Mjolnir is a moderation bot for Matrix.",
+      "required": true,
+      "min": null,
+      "max": null,
+      "default": "{{ matrix_bot_mjolnir_enabled | string | lower }}",
+      "choices": "true\nfalse",
+      "new_question": true,
+      "variable": "matrix_bot_mjolnir_enabled",
+      "type": "multiplechoice"
+    },
+    {
+      "question_name": "Mjolnir Management Room",
+      "question_description": "Sets the internal ID of the management room for Mjolnir. Example: '!wAeZaPCKvaCHcSqxAW:matrix.org'",
+      "required": true,
+      "min": null,
+      "max": null,
+      "default": "{{ matrix_bot_mjolnir_management_room }}",
+      "new_question": true,
+      "variable": "matrix_bot_mjolnir_management_room",
+      "type": "text"
+    }
+  ]
+}

--- a/roles/matrix-awx/tasks/main.yml
+++ b/roles/matrix-awx/tasks/main.yml
@@ -170,6 +170,15 @@
   tags:
     - setup-ma1sd
 
+# Additional playbook to set the variable file during Mjolnir Bot configuration
+- include_tasks:
+    file: "set_variables_mjolnir.yml"
+    apply:
+      tags: setup-bot-mjolnir
+  when: run_setup|bool and matrix_awx_enabled|bool
+  tags:
+    - setup-bot-mjolnir
+
 # Additional playbook to set the variable file during Corporal configuration
 - include_tasks:
     file: "set_variables_corporal.yml"

--- a/roles/matrix-awx/tasks/set_variables_dimension.yml
+++ b/roles/matrix-awx/tasks/set_variables_dimension.yml
@@ -14,7 +14,7 @@
 
 - name: Collect access token of @admin-dimension user
   shell: |
-    curl -X POST --header 'Content-Type: application/json' -d '{"identifier": {"type": "m.id.user","user": "admin-dimension"}, "password": "{{ awx_dimension_user_password }}", "type": "m.login.password"}' 'https://matrix.{{ matrix_domain }}/_matrix/client/r0/login' | jq -c '. | {access_token}' | sed 's/.*\":\"//' | sed 's/\"}//'
+    curl -X POST --header 'Content-Type: application/json' -d '{"identifier": {"type": "m.id.user","user": "admin-dimension"}, "password": "{{ awx_dimension_user_password }}", "type": "m.login.password"}' 'https://matrix.{{ matrix_domain }}/_matrix/client/r0/login' | jq '.access_token'
   register: awx_dimension_user_access_token
 
 - name: Record Synapse variables locally on AWX
@@ -26,7 +26,7 @@
     insertafter: '# Dimension Settings Start'
   with_dict:
     'matrix_dimension_enabled': '{{ matrix_dimension_enabled }}'
-    'matrix_dimension_access_token': '"{{ awx_dimension_user_access_token.stdout }}"'
+    'matrix_dimension_access_token': '"{{ awx_dimension_user_access_token.stdout[1:-1] }}"'
 
 - name: Set final users list if users are defined
   set_fact:

--- a/roles/matrix-awx/tasks/set_variables_ma1sd.yml
+++ b/roles/matrix-awx/tasks/set_variables_ma1sd.yml
@@ -38,22 +38,22 @@
   replace:
     path: '{{ awx_cached_matrix_vars }}'
     regexp: '^.*\n'
-    after: '# Start ma1sd Extension'
-    before: '# End ma1sd Extension'
+    after: '# ma1sd Extension Start'
+    before: '# ma1sd Extension End'
 
 - name: Replace conjoined ma1sd configuration extension limiters
   delegate_to: 127.0.0.1
   replace:
     path: '{{ awx_cached_matrix_vars }}'
-    regexp: '^# Start ma1sd Extension# End ma1sd Extension'
-    replace: '# Start ma1sd Extension\n# End ma1sd Extension'
+    regexp: '^# ma1sd Extension Start# ma1sd Extension End'
+    replace: '# ma1sd Extension Start\n# ma1sd Extension End'
 
 - name: Insert/Update ma1sd configuration extension variables
   delegate_to: 127.0.0.1
   blockinfile:
     path: '{{ awx_cached_matrix_vars }}'
     marker: "# {mark} ma1sd ANSIBLE MANAGED BLOCK"
-    insertafter: '# Start ma1sd Extension'
+    insertafter: '# ma1sd Extension Start'
     block: '{{ awx_matrix_ma1sd_configuration_extension_yaml }}'
 
 - name: Record ma1sd Custom variables locally on AWX

--- a/roles/matrix-awx/tasks/set_variables_mjolnir.yml
+++ b/roles/matrix-awx/tasks/set_variables_mjolnir.yml
@@ -1,0 +1,68 @@
+---
+
+- name: Include vars in matrix_vars.yml
+  include_vars:
+    file: '{{ awx_cached_matrix_vars }}'
+  no_log: true
+
+- name: Collect the internal IP of the matrix-synapse container
+  shell: |
+    /usr/bin/docker inspect --format '{''{range.NetworkSettings.Networks}''}{''{.IPAddress}''}{''{end}''}' matrix-synapse
+  register: matrix_synapse_ip
+
+- name: Collect access token of @admin-mjolnir user
+  shell: |
+    curl -X POST --header 'Content-Type: application/json' -d '{"identifier": {"type": "m.id.user","user": "admin-mjolnir"}, "password": "{{ awx_mjolnir_user_password }}", "type": "m.login.password"}' 'http://{{ matrix_synapse_ip.stdout }}:8008/_matrix/client/r0/login' | jq '.access_token'
+  register: awx_mjolnir_user_access_token
+  no_log: true
+
+- name: Record Mjolnir Bot variables locally on AWX
+  delegate_to: 127.0.0.1
+  lineinfile:
+    path: '{{ awx_cached_matrix_vars }}'
+    regexp: "^#? *{{ item.key | regex_escape() }}:"
+    line: "{{ item.key }}: {{ item.value }}"
+    insertafter: '# Mjolnir Settings Start'
+  with_dict:
+    'matrix_bot_mjolnir_enabled': '{{ matrix_bot_mjolnir_enabled }}'
+    'matrix_bot_mjolnir_access_token': '{{ awx_mjolnir_user_access_token.stdout[1:-1] }}'
+    'matrix_bot_mjolnir_management_room': '"{{ matrix_bot_mjolnir_management_room }}"'
+  no_log: true
+
+- name: Remove Synapse rate-limiting for admin-mjolnir user
+  shell: |
+    /usr/local/bin/matrix-postgres-cli-non-interactive --dbname=synapse --command="INSERT INTO ratelimit_override VALUES ('@admin-mjolnir:{{ matrix_domain }}', 0, 0);"
+  ignore_errors: true
+
+- name: Save new 'Configure Mjolnir' survey.json to the AWX tower, template
+  delegate_to: 127.0.0.1
+  template:
+    src: 'roles/matrix-awx/surveys/configure_mjolnir.json.j2'
+    dest: '/var/lib/awx/projects/clients/{{ member_id }}/{{ subscription_id }}/configure_mjolnir.json'
+
+- name: Copy new 'Configure Mjolnir' survey.json to target machine
+  copy:
+    src: '/var/lib/awx/projects/clients/{{ member_id }}/{{ subscription_id }}/configure_mjolnir.json'
+    dest: '/matrix/awx/configure_mjolnir.json'
+    mode: '0660'
+
+- name: Recreate 'Configure Mjolnir Bot' job template
+  delegate_to: 127.0.0.1
+  awx.awx.tower_job_template:
+    name: "{{ matrix_domain }} - 1 - Configure Mjolnir Bot"
+    description: "Configure Mjolnir settings, Mjolnir is a moderation bot for Matrix."
+    extra_vars: "{{ lookup('file', '/var/lib/awx/projects/clients/{{ member_id }}/{{ subscription_id }}/extra_vars.json') }}"
+    job_type: run
+    job_tags: "start,setup-bot-mjolnir"
+    inventory: "{{ member_id }}"
+    project: "{{ member_id }} - Matrix Docker Ansible Deploy"
+    playbook: setup.yml
+    credential: "{{ member_id }} - AWX SSH Key"
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', '/var/lib/awx/projects/clients/{{ member_id }}/{{ subscription_id }}/configure_mjolnir.json') }}"
+    become_enabled: true
+    state: present
+    verbosity: 1
+    tower_host: "https://{{ awx_host }}"
+    tower_oauthtoken: "{{ awx_session_token.ansible_facts.tower_token.token }}"
+    validate_certs: true

--- a/roles/matrix-bridge-mautrix-signal/tasks/init.yml
+++ b/roles/matrix-bridge-mautrix-signal/tasks/init.yml
@@ -1,7 +1,7 @@
 ---
 
 - set_fact:
-    matrix_systemd_services_list: "{{ matrix_systemd_services_list + ['matrix-mautrix-signal-daemon.service', 'matrix-mautrix-signal.service'] }}"
+    matrix_systemd_services_list: "{{ matrix_systemd_services_list + ['matrix-mautrix-signal.service', 'matrix-mautrix-signal-daemon.service'] }}"
   when: matrix_mautrix_signal_enabled|bool
 
 # If the matrix-synapse role is not used, these variables may not exist.

--- a/roles/matrix-postgres/tasks/setup_postgres.yml
+++ b/roles/matrix-postgres/tasks/setup_postgres.yml
@@ -85,6 +85,13 @@
     mode: 0755
   when: matrix_postgres_enabled|bool
 
+- name: Ensure matrix-postgres-cli-non-interactive script created
+  template:
+    src: "{{ role_path }}/templates/usr-local-bin/matrix-postgres-cli-non-interactive.j2"
+    dest: "{{ matrix_local_bin_path }}/matrix-postgres-cli-non-interactive"
+    mode: 0755
+  when: matrix_postgres_enabled|bool
+
 - name: Ensure matrix-change-user-admin-status script created
   template:
     src: "{{ role_path }}/templates/usr-local-bin/matrix-change-user-admin-status.j2"

--- a/roles/matrix-postgres/templates/usr-local-bin/matrix-postgres-cli-non-interactive.j2
+++ b/roles/matrix-postgres/templates/usr-local-bin/matrix-postgres-cli-non-interactive.j2
@@ -1,0 +1,12 @@
+#jinja2: lstrip_blocks: "True"
+#!/bin/bash
+
+docker run \
+	--rm \
+	--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
+	--cap-drop=ALL \
+	--env-file={{ matrix_postgres_base_path }}/env-postgres-psql \
+	--network {{ matrix_docker_network }} \
+	{{ matrix_postgres_docker_image_to_use }} \
+	psql -h {{ matrix_postgres_connection_hostname }} \
+	"$@"


### PR DESCRIPTION
GoMatrixHosting v0.7.0 🚀

- CENTOS 8 EOL fix, curse you RedHat!! See [#33](https://gitlab.com/GoMatrixHosting/create-awx-system/-/issues/33)
- Add Mjolnir Bot section. See [#20](https://gitlab.com/GoMatrixHosting/ansible-provision-server/-/issues/20)
- Unclog discord-appservice-bot so it now works behind the wireguard proxy. See [#8](https://gitlab.com/GoMatrixHosting/matrix-docker-ansible-deploy/-/issues/8)
- Update deploy script readme and docs to reflect recent changes to GoMatrixHosting. See [#1654](https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/1654)

Upgrade Notes v0.7.0 🚀

- Add the following section to every matrix_vars.yml file on AWX:
```
# Mjolnir Settings Start
matrix_bot_mjolnir_enabled: false
# Mjolnir Settings End
# Mjolnir Extension Start
matrix_bot_mjolnir_configuration_extension_yaml: |
  "homeserverUrl": "http://matrix-synapse:8008"
  "rawHomeserverUrl": "http://matrix-synapse:8008"
# Mjolnir Extension End
```
- Re-provision all servers.

Follow us on [GitLab](https://gitlab.com/GoMatrixHosting), or come say hello at GoMatrixHosting General!