### PR TITLE
avoid namespace collisions between webhook bridges

### DIFF
--- a/docs/configuring-playbook-bridge-hookshot.md
+++ b/docs/configuring-playbook-bridge-hookshot.md
@@ -45,3 +45,7 @@ The provisioning API will be enabled automatically if you set `matrix_dimension_
 ### Metrics
 
 If metrics are enabled, they will be automatically available in the builtin Prometheus and Grafana, but you need to set up your own Dashboard for now. If additionally metrics proxying for use with external Prometheus is enabled (`matrix_nginx_proxy_proxy_synapse_metrics`), hookshot metrics will also be available (at `matrix_hookshot_metrics_endpoint`, default `/hookshot/metrics`, on the stats subdomain) and with the same password. See also [the Prometheus and Grafana docs](../configuring-playbook-prometheus-grafana.md).
+
+### Collision with matrix-appservice-webhooks
+
+If you are also running [matrix-appservice-webhooks](configuring-playbook-bridge-appservice-webhooks.md), it reserves its namespace by the default setting `matrix_appservice_webhooks_user_prefix: '_webhook_'`. You should take care if you modify its or hookshot's prefix that they do not collide with each other's namespace (default `matrix_hookshot_generic_user_id_prefix: '_webhooks_'`).

--- a/roles/matrix-bridge-appservice-webhooks/defaults/main.yml
+++ b/roles/matrix-bridge-appservice-webhooks/defaults/main.yml
@@ -24,7 +24,7 @@ matrix_appservice_webhooks_public_endpoint: /appservice-webhooks
 matrix_appservice_webhooks_inbound_uri_prefix: "{{ matrix_homeserver_url }}{{ matrix_appservice_webhooks_public_endpoint }}"
 
 matrix_appservice_webhooks_bot_name: 'webhookbot'
-matrix_appservice_webhooks_user_prefix: '_webhook'
+matrix_appservice_webhooks_user_prefix: '_webhook_'
 
 # Controls the webhooks_PORT and MATRIX_PORT of the installation
 matrix_appservice_webhooks_matrix_port: 6789


### PR DESCRIPTION
I have this deployed and my appservice-webhooks webhooks keep working as before, it does not even create new ones, so it appears this upgrade path is clear.