### PR TITLE
Fix empty body for GET requests in hookshot-bridge 

### DIFF
--- a/roles/matrix-bridge-hookshot/tasks/init.yml
+++ b/roles/matrix-bridge-hookshot/tasks/init.yml
@@ -68,10 +68,10 @@
               {# Use the embedded DNS resolver in Docker containers to discover the service #}
               resolver 127.0.0.11 valid=5s;
               set $backend "{{ matrix_hookshot_container_url }}:{{ matrix_hookshot_webhook_port }}";
-              proxy_pass http://$backend/$1;
+              proxy_pass http://$backend/$1$is_args$args;
             {% else %}
               {# Generic configuration for use outside of our container setup #}
-              proxy_pass http://127.0.0.1:{{ matrix_hookshot_webhook_port }}/$1;
+              proxy_pass http://127.0.0.1:{{ matrix_hookshot_webhook_port }}/$1$is_args$args;
             {% endif %}
             proxy_set_header Host $host;
           }


### PR DESCRIPTION
add `$is_args$args` to proxy pass URL params in GET requests 
following the NGINX docs https://nginx.org/en/docs/http/ngx_http_core_module.html#var_args 

based on discussions in https://github.com/matrix-org/matrix-hookshot/issues/208