### PR TITLE
fix hookshot provisioning url in nginx

### DIFF
--- a/roles/matrix-bridge-hookshot/tasks/init.yml
+++ b/roles/matrix-bridge-hookshot/tasks/init.yml
@@ -55,10 +55,10 @@
               {# Use the embedded DNS resolver in Docker containers to discover the service #}
               resolver 127.0.0.11 valid=5s;
               set $backend "{{ matrix_hookshot_container_url }}:{{ matrix_hookshot_provisioning_port }}";
-              proxy_pass http://$backend/$1;
+              proxy_pass http://$backend/v1/$1;
             {% else %}
               {# Generic configuration for use outside of our container setup #}
-              proxy_pass http://127.0.0.1:{{ matrix_hookshot_provisioning_port }}/$1;
+              proxy_pass http://127.0.0.1:{{ matrix_hookshot_provisioning_port }}/v1/$1;
             {% endif %}
             proxy_set_header Host $host;
           }

--- a/roles/matrix-bridge-hookshot/tasks/init.yml
+++ b/roles/matrix-bridge-hookshot/tasks/init.yml
@@ -55,10 +55,10 @@
               {# Use the embedded DNS resolver in Docker containers to discover the service #}
               resolver 127.0.0.11 valid=5s;
               set $backend "{{ matrix_hookshot_container_url }}:{{ matrix_hookshot_provisioning_port }}";
-              proxy_pass http://$backend/v1/$1;
+              proxy_pass http://$backend/v1/$1$is_args$args;
             {% else %}
               {# Generic configuration for use outside of our container setup #}
-              proxy_pass http://127.0.0.1:{{ matrix_hookshot_provisioning_port }}/v1/$1;
+              proxy_pass http://127.0.0.1:{{ matrix_hookshot_provisioning_port }}/v1/$1$is_args$args;
             {% endif %}
             proxy_set_header Host $host;
           }


### PR DESCRIPTION
Hello, this PR should fix Hookshot container not receiving API calls with the right path because nginx proxy was stripping the /v1 from it.

Thanks