### PR TITLE
"Federate rooms" switch for mautrix bridges

### DIFF
--- a/roles/matrix-bridge-mautrix-facebook/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-facebook/defaults/main.yml
@@ -33,6 +33,9 @@ matrix_mautrix_facebook_systemd_wanted_services_list: []
 matrix_mautrix_facebook_appservice_token: ''
 matrix_mautrix_facebook_homeserver_token: ''
 
+# Whether or not created rooms should have federation enabled.
+# If false, created portal rooms will never be federated.
+matrix_mautrix_facebook_federate_rooms: true
 
 # Database-related configuration fields.
 #

--- a/roles/matrix-bridge-mautrix-facebook/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-facebook/templates/config.yaml.j2
@@ -141,6 +141,9 @@ bridge:
     delivery_receipts: false
     # Whether to allow inviting arbitrary mxids to portal rooms
     allow_invites: false
+    # Whether or not created rooms should have federation enabled.
+    # If false, created portal rooms will never be federated.
+    federate_rooms: {{ matrix_mautrix_facebook_federate_rooms|to_json }}
     # Settings for backfilling messages from Facebook.
     backfill:
         # Whether or not the Facebook users of logged in Matrix users should be

--- a/roles/matrix-bridge-mautrix-googlechat/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-googlechat/defaults/main.yml
@@ -41,6 +41,9 @@ matrix_mautrix_googlechat_systemd_wanted_services_list: []
 matrix_mautrix_googlechat_appservice_token: ''
 matrix_mautrix_googlechat_homeserver_token: ''
 
+# Whether or not created rooms should have federation enabled.
+# If false, created portal rooms will never be federated.
+matrix_mautrix_googlechat_federate_rooms: true
 
 # Database-related configuration fields.
 #

--- a/roles/matrix-bridge-mautrix-googlechat/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-googlechat/templates/config.yaml.j2
@@ -93,6 +93,9 @@ bridge:
         # This will cause the bridge bot to be in private chats for the encryption to work properly.
         default: false
 
+    # Whether or not created rooms should have federation enabled.
+    # If false, created portal rooms will never be federated.
+    federate_rooms: {{ matrix_mautrix_googlechat_federate_rooms|to_json }}
     # Public website and API configs
     web:
         # Auth server config

--- a/roles/matrix-bridge-mautrix-instagram/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-instagram/defaults/main.yml
@@ -34,6 +34,9 @@ matrix_mautrix_instagram_systemd_wanted_services_list: []
 matrix_mautrix_instagram_appservice_token: ''
 matrix_mautrix_instagram_homeserver_token: ''
 
+# Whether or not created rooms should have federation enabled.
+# If false, created portal rooms will never be federated.
+matrix_mautrix_instagram_federate_rooms: true
 
 # Database-related configuration fields.
 #

--- a/roles/matrix-bridge-mautrix-instagram/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-instagram/templates/config.yaml.j2
@@ -110,7 +110,7 @@ bridge:
   update_avatar_initial_sync: true
   # Whether or not created rooms should have federation enabled.
   # If false, created portal rooms will never be federated.
-  federate_rooms: true
+  federate_rooms: {{ matrix_mautrix_instagram_federate_rooms|to_json }}
   # Settings for backfilling messages from Instagram.
   backfill:
     # Whether or not the Instagram users of logged in Matrix users should be

--- a/roles/matrix-bridge-mautrix-signal/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-signal/defaults/main.yml
@@ -56,6 +56,10 @@ matrix_mautrix_signal_homeserver_token: ''
 
 matrix_mautrix_signal_appservice_bot_username: signalbot
 
+# Whether or not created rooms should have federation enabled.
+# If false, created portal rooms will never be federated.
+matrix_mautrix_signal_federate_rooms: true
+
 # Database-related configuration fields
 #
 # This bridge only supports postgres.

--- a/roles/matrix-bridge-mautrix-signal/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-signal/templates/config.yaml.j2
@@ -147,7 +147,7 @@ bridge:
         {{ matrix_mautrix_signal_homeserver_domain }}: {{ matrix_mautrix_signal_login_shared_secret|to_json }}
     # Whether or not created rooms should have federation enabled.
     # If false, created portal rooms will never be federated.
-    federate_rooms: true
+    federate_rooms: {{ matrix_mautrix_signal_federate_rooms|to_json }}
     # End-to-bridge encryption support options. You must install the e2be optional dependency for
     # this to work. See https://github.com/tulir/mautrix-telegram/wiki/End‐to‐bridge-encryption
     encryption:

--- a/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
@@ -40,6 +40,10 @@ matrix_mautrix_telegram_appservice_public_external: 'https://{{ matrix_server_fq
 
 matrix_mautrix_telegram_appservice_bot_username: telegrambot
 
+# Whether or not created rooms should have federation enabled.
+# If false, created portal rooms will never be federated.
+matrix_mautrix_telegram_federate_rooms: true
+
 # Controls whether the matrix-mautrix-telegram container exposes its HTTP port (tcp/8080 in the container).
 #
 # Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:9006"), or empty string to not expose.

--- a/roles/matrix-bridge-mautrix-telegram/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-telegram/templates/config.yaml.j2
@@ -160,7 +160,7 @@ bridge:
     parallel_file_transfer: false
     # Whether or not created rooms should have federation enabled.
     # If false, created portal rooms will never be federated.
-    federate_rooms: true
+    federate_rooms: {{ matrix_mautrix_telegram_federate_rooms|to_json }}
     # Settings for converting animated stickers.
     animated_sticker:
         # Format to which animated stickers should be converted.

--- a/roles/matrix-bridge-mautrix-twitter/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-twitter/defaults/main.yml
@@ -34,6 +34,9 @@ matrix_mautrix_twitter_systemd_wanted_services_list: []
 matrix_mautrix_twitter_appservice_token: ''
 matrix_mautrix_twitter_homeserver_token: ''
 
+# Whether or not created rooms should have federation enabled.
+# If false, created portal rooms will never be federated.
+matrix_mautrix_twitter_federate_rooms: true
 
 # Database-related configuration fields.
 #

--- a/roles/matrix-bridge-mautrix-twitter/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-twitter/templates/config.yaml.j2
@@ -105,7 +105,7 @@ bridge:
     login_shared_secret_map: {{ matrix_mautrix_twitter_bridge_login_shared_secret_map|to_json }}
     # Whether or not created rooms should have federation enabled.
     # If false, created portal rooms will never be federated.
-    federate_rooms: true
+    federate_rooms: {{ matrix_mautrix_twitter_federate_rooms|to_json }}
     # Settings for backfilling messages from Twitter.
     #
     # Missed message backfilling is currently based on receiving them from the Twitter polling API,

--- a/roles/matrix-bridge-mautrix-whatsapp/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-whatsapp/defaults/main.yml
@@ -37,6 +37,10 @@ matrix_mautrix_whatsapp_homeserver_token: ''
 
 matrix_mautrix_whatsapp_appservice_bot_username: whatsappbot
 
+# Whether or not created rooms should have federation enabled.
+# If false, created portal rooms will never be federated.
+matrix_mautrix_whatsapp_federate_rooms: true
+
 # Database-related configuration fields.
 #
 # To use SQLite, stick to these defaults.

--- a/roles/matrix-bridge-mautrix-whatsapp/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-whatsapp/templates/config.yaml.j2
@@ -136,7 +136,7 @@ bridge:
     allow_user_invite: false
     # Whether or not created rooms should have federation enabled.
     # If false, created portal rooms will never be federated.
-    federate_rooms: true
+    federate_rooms: {{ matrix_mautrix_whatsapp_federate_rooms|to_json }}
 
     # The prefix for commands. Only required in non-management rooms.
     command_prefix: "!wa"


### PR DESCRIPTION
This PR makes it configurable whether portal rooms created by mautrix bridges will be federatable or not.

Note: Rooms cannot transition from unfederated to federated after creation.