### PR TITLE
Remove deprecated community options

### DIFF
--- a/docs/configuring-playbook-bridge-mautrix-facebook.md
+++ b/docs/configuring-playbook-bridge-mautrix-facebook.md
@@ -70,31 +70,6 @@ If you run into trouble, check the [Troubleshooting](#troubleshooting) section b
 After successfully enabling bridging, you may wish to [set up Double Puppeting](#set-up-double-puppeting), if you haven't already done so.
 
 
-## Set up community-grouping
-
-This is an **optional feature** that you may wish to enable.
-
-The Facebook bridge can create a Matrix community for you, which would contain all your chats and contacts.
-
-For this to work, the bridge's bot needs to have permissions to create communities (also referred to as groups).
-Since the bot is a non-admin user, you need to enable such group-creation for non-privileged users in [Synapse's settings](configuring-playbook-synapse.md).
-
-Here's an example configuration:
-
-```yaml
-matrix_synapse_configuration_extension_yaml: |
-  enable_group_creation: true
-  group_creation_prefix: "unofficial/"
-
-matrix_mautrix_facebook_configuration_extension_yaml: |
-  bridge:
-    community_template: "unofficial/facebook_{localpart}={server}"
-```
-
-Once the bridge is restarted, it would create a community and invite you to it. You need to accept the community invitation manually.
-If you don't see all your contacts, you may wish to send a `sync` message to the bot.
-
-
 ## Troubleshooting
 
 ### Facebook rejecting login attempts and forcing you to change password

--- a/roles/matrix-bridge-mautrix-facebook/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-facebook/templates/config.yaml.j2
@@ -66,12 +66,6 @@ bridge:
     # Localpart template of MXIDs for Facebook users.
     # {userid} is replaced with the user ID of the Facebook user.
     username_template: "facebook_{userid}"
-    # Localpart template for per-user room grouping community IDs.
-    # The bridge will create these communities and add all of the specific user's portals to the community.
-    # {localpart} is the MXID localpart and {server} is the MXID server part of the user.
-    #
-    # `facebook_{localpart}={server}` is a good value.
-    community_template: null
     # Displayname template for Facebook users.
     # {displayname} is replaced with the display name of the Facebook user
     #               as defined below in displayname_preference.

--- a/roles/matrix-bridge-mautrix-instagram/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-instagram/templates/config.yaml.j2
@@ -46,12 +46,6 @@ appservice:
   bot_displayname: Instagram bridge bot
   bot_avatar: mxc://maunium.net/JxjlbZUlCPULEeHZSwleUXQv
 
-  # Community ID for bridged users (changes registration file) and rooms.
-  # Must be created manually.
-  #
-  # Example: "+instagram:example.com". Set to false to disable.
-  community_id: false
-
   # Whether or not to receive ephemeral events via appservice transactions.
   # Requires MSC2409 support (i.e. Synapse 1.22+).
   # You should disable bridge -> sync_with_custom_puppets when this is enabled.

--- a/roles/matrix-bridge-mautrix-signal/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-signal/templates/config.yaml.j2
@@ -56,12 +56,6 @@ appservice:
     bot_displayname: Signal bridge bot
     bot_avatar: mxc://maunium.net/wPJgTQbZOtpBFmDNkiNEMDUp
 
-    # Community ID for bridged users (changes registration file) and rooms.
-    # Must be created manually.
-    #
-    # Example: "+signal:example.com". Set to false to disable.
-    community_id: false
-
     # Whether or not to receive ephemeral events via appservice transactions.
     # Requires MSC2409 support (i.e. Synapse 1.22+).
     # You should disable bridge -> sync_with_custom_puppets when this is enabled.

--- a/roles/matrix-bridge-mautrix-twitter/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-twitter/templates/config.yaml.j2
@@ -54,12 +54,6 @@ appservice:
     bot_displayname: Twitter bridge bot
     bot_avatar: mxc://maunium.net/HVHcnusJkQcpVcsVGZRELLCn
 
-    # Community ID for bridged users (changes registration file) and rooms.
-    # Must be created manually.
-    #
-    # Example: "+twitter:example.com". Set to false to disable.
-    community_id: false
-
     # Whether or not to receive ephemeral events via appservice transactions.
     # Requires MSC2409 support (i.e. Synapse 1.22+).
     # You should disable bridge -> sync_with_custom_puppets when this is enabled.


### PR DESCRIPTION
"Community" support

- has been removed from mautrix/facebook in v0.3.3:
  https://github.com/mautrix/facebook/commit/31cac6fb5e75667d272bf0daae094578add09a1f

- has been removed from mautrix/signal in v0.2.2:
  https://github.com/mautrix/signal/commit/1f27a608a661118e17e2ef89412fd7ee2735b15c

- will be removed in the next mautrix/instagram release:
  https://github.com/mautrix/instagram/commit/e2ae1ca503e7ab05e1f9dd703c26e4a5a2d4e517

- will be removed in the next mautrix/twitter release:
  https://github.com/mautrix/twitter/commit/3893075265fc78021be773acc58203619ffaa067

"Spaces" support is currently not implemented. See also in mautrix/telegram#365, mautrix/facebook#216