### PR TITLE
bridge-mautrix-facebook: add support for web-based login

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -299,6 +299,10 @@ matrix_mautrix_facebook_appservice_token: "{{ '%s' | format(matrix_homeserver_ge
 
 matrix_mautrix_facebook_homeserver_token: "{{ '%s' | format(matrix_homeserver_generic_secret_key) | password_hash('sha512', 'fb.hs.token') | to_uuid }}"
 
+matrix_mautrix_facebook_public_endpoint: "/{{ '%s' | format(matrix_homeserver_generic_secret_key) | password_hash('sha512', 'facebook') | to_uuid }}"
+
+matrix_mautrix_facebook_container_http_host_bind_port: "{{ '' if matrix_nginx_proxy_enabled else '127.0.0.1:9008' }}"
+
 matrix_mautrix_facebook_login_shared_secret: "{{ matrix_synapse_ext_password_provider_shared_secret_auth_shared_secret if matrix_synapse_ext_password_provider_shared_secret_auth_enabled else '' }}"
 
 matrix_mautrix_facebook_bridge_presence: "{{ matrix_synapse_presence_enabled if matrix_synapse_enabled else true }}"

--- a/roles/matrix-bridge-appservice-slack/tasks/init.yml
+++ b/roles/matrix-bridge-appservice-slack/tasks/init.yml
@@ -84,4 +84,4 @@
       Please make sure that you're proxying the `{{ something }}`
       URL endpoint to the matrix-appservice-slack container.
       You can expose the container's port using the `matrix_appservice_slack_container_http_host_bind_port` variable.
-  when: "matrix_appservice_slack_enabled|bool and matrix_nginx_proxy_enabled is not defined"
+  when: "matrix_appservice_slack_enabled|bool and not matrix_nginx_proxy_enabled|default(False)|bool"

--- a/roles/matrix-bridge-appservice-webhooks/tasks/init.yml
+++ b/roles/matrix-bridge-appservice-webhooks/tasks/init.yml
@@ -79,4 +79,4 @@
       Please make sure that you're proxying the `{{ matrix_appservice_webhooks_public_endpoint }}`
       URL endpoint to the matrix-appservice-webhooks container.
       You can expose the container's port using the `matrix_appservice_webhooks_container_http_host_bind_port` variable.
-  when: "matrix_appservice_webhooks_enabled|bool and matrix_nginx_proxy_enabled is not defined"
+  when: "matrix_appservice_webhooks_enabled|bool and not matrix_nginx_proxy_enabled|default(False)|bool"

--- a/roles/matrix-bridge-hookshot/tasks/init.yml
+++ b/roles/matrix-bridge-hookshot/tasks/init.yml
@@ -127,4 +127,4 @@
       Please make sure that you're proxying the `{{ matrix_hookshot_public_endpoint }}`
       URL endpoint to the matrix-hookshot container.
       You can expose the container's ports using the `matrix_hookshot_container_http_host_bind_ports` variable.
-  when: "matrix_hookshot_enabled|bool and matrix_nginx_proxy_enabled is not defined"
+  when: "matrix_hookshot_enabled|bool and not matrix_nginx_proxy_enabled|default(False)|bool"

--- a/roles/matrix-bridge-mautrix-facebook/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-facebook/defaults/main.yml
@@ -17,9 +17,16 @@ matrix_mautrix_facebook_config_path: "{{ matrix_mautrix_facebook_base_path }}/co
 matrix_mautrix_facebook_data_path: "{{ matrix_mautrix_facebook_base_path }}/data"
 matrix_mautrix_facebook_docker_src_files_path: "{{ matrix_mautrix_facebook_base_path }}/docker-src"
 
+# Whether or not the public-facing endpoints should be enabled (web-based login)
+matrix_mautrix_facebook_appservice_public_enabled: true
+
+# Mautrix Facebook public endpoint to log in to Facebook
+matrix_mautrix_facebook_public_endpoint: ''
+
 matrix_mautrix_facebook_homeserver_address: "{{ matrix_homeserver_container_url }}"
 matrix_mautrix_facebook_homeserver_domain: '{{ matrix_domain }}'
 matrix_mautrix_facebook_appservice_address: 'http://matrix-mautrix-facebook:29319'
+matrix_mautrix_facebook_appservice_public_external: 'https://{{ matrix_server_fqn_matrix }}{{ matrix_mautrix_facebook_public_endpoint }}'
 
 # A list of extra arguments to pass to the container
 matrix_mautrix_facebook_container_extra_arguments: []
@@ -36,6 +43,11 @@ matrix_mautrix_facebook_homeserver_token: ''
 # Whether or not created rooms should have federation enabled.
 # If false, created portal rooms will never be federated.
 matrix_mautrix_facebook_federate_rooms: true
+
+# Controls whether the matrix-mautrix-facebook container exposes its HTTP port.
+#
+# Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:9008"), or empty string to not expose.
+matrix_mautrix_facebook_container_http_host_bind_port: ''
 
 # Database-related configuration fields.
 #

--- a/roles/matrix-bridge-mautrix-facebook/tasks/init.yml
+++ b/roles/matrix-bridge-mautrix-facebook/tasks/init.yml
@@ -22,3 +22,51 @@
       +
       {{ ["/matrix-mautrix-facebook-registration.yaml"] }}
   when: matrix_mautrix_facebook_enabled|bool
+
+- block:
+    - name: Fail if matrix-nginx-proxy role already executed
+      fail:
+        msg: >-
+          Trying to append Mautrix Facebook's reverse-proxying configuration to matrix-nginx-proxy,
+          but it's pointless since the matrix-nginx-proxy role had already executed.
+          To fix this, please change the order of roles in your playbook,
+          so that the matrix-nginx-proxy role would run after the matrix-bridge-mautrix-facebook role.
+      when: matrix_nginx_proxy_role_executed|default(False)|bool
+
+    - name: Generate Mautrix Facebook proxying configuration for matrix-nginx-proxy
+      set_fact:
+        matrix_mautrix_facebook_matrix_nginx_proxy_configuration: |
+          location {{ matrix_mautrix_facebook_public_endpoint }} {
+          {% if matrix_nginx_proxy_enabled|default(False) %}
+              {# Use the embedded DNS resolver in Docker containers to discover the service #}
+              resolver 127.0.0.11 valid=5s;
+              set $backend "matrix-mautrix-facebook:29319";
+              proxy_pass http://$backend;
+          {% else %}
+              {# Generic configuration for use outside of our container setup #}
+              proxy_pass http://127.0.0.1:9008;
+          {% endif %}
+          }
+
+    - name: Register Mautrix Facebook proxying configuration with matrix-nginx-proxy
+      set_fact:
+        matrix_nginx_proxy_proxy_matrix_additional_server_configuration_blocks: |
+          {{
+            matrix_nginx_proxy_proxy_matrix_additional_server_configuration_blocks|default([])
+            +
+            [matrix_mautrix_facebook_matrix_nginx_proxy_configuration]
+          }}
+
+    - name: Warn about reverse-proxying if matrix-nginx-proxy not used
+      debug:
+        msg: >-
+          NOTE: You've enabled the Mautrix Facebook bridge but are not using the matrix-nginx-proxy
+          reverse proxy.
+          Please make sure that you're proxying the `{{ matrix_mautrix_facebook_public_endpoint }}`
+          URL endpoint to the matrix-mautrix-facebook container.
+          You can expose the container's port using the `matrix_mautrix_facebook_container_http_host_bind_port` variable.
+      when: "not matrix_nginx_proxy_enabled|default(False)|bool"
+
+  tags:
+    - always
+  when: matrix_mautrix_facebook_enabled|bool and matrix_mautrix_facebook_appservice_public_enabled|bool

--- a/roles/matrix-bridge-mautrix-facebook/tasks/validate_config.yml
+++ b/roles/matrix-bridge-mautrix-facebook/tasks/validate_config.yml
@@ -6,6 +6,7 @@
       You need to define a required configuration setting (`{{ item }}`).
   when: "vars[item] == ''"
   with_items:
+    - "matrix_mautrix_facebook_public_endpoint"
     - "matrix_mautrix_facebook_appservice_token"
     - "matrix_mautrix_facebook_homeserver_token"
 

--- a/roles/matrix-bridge-mautrix-facebook/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-facebook/templates/config.yaml.j2
@@ -32,16 +32,12 @@ appservice:
     # Public part of web server for out-of-Matrix interaction with the bridge.
     public:
         # Whether or not the public-facing endpoints should be enabled.
-        enabled: false
+        enabled: {{ matrix_mautrix_facebook_appservice_public_enabled|to_json }}
         # The prefix to use in the public-facing endpoints.
-        prefix: /public
+        prefix: {{ matrix_mautrix_facebook_public_endpoint|to_json }}
         # The base URL where the public-facing endpoints are available. The prefix is not added
         # implicitly.
-        external: https://example.com/public
-        # Shared secret for integration managers such as mautrix-manager.
-        # If set to "generate", a random string will be generated on the next startup.
-        # If null, integration manager access to the API will not be possible.
-        shared_secret: generate
+        external: {{ matrix_mautrix_facebook_appservice_public_external|to_json }}
 
     # The unique ID of this appservice.
     id: facebook

--- a/roles/matrix-bridge-mautrix-facebook/templates/systemd/matrix-mautrix-facebook.service.j2
+++ b/roles/matrix-bridge-mautrix-facebook/templates/systemd/matrix-mautrix-facebook.service.j2
@@ -24,6 +24,9 @@ ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-mautrix-facebo
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
 			--network={{ matrix_docker_network }} \
+			{% if matrix_mautrix_facebook_appservice_public_enabled and matrix_mautrix_facebook_container_http_host_bind_port %}
+			-p {{ matrix_mautrix_facebook_container_http_host_bind_port }}:29319 \
+			{% endif %}
 			-v {{ matrix_mautrix_facebook_config_path }}:/config:z \
 			-v {{ matrix_mautrix_facebook_data_path }}:/data:z \
 			{% for arg in matrix_mautrix_facebook_container_extra_arguments %}

--- a/roles/matrix-bridge-mautrix-googlechat/tasks/init.yml
+++ b/roles/matrix-bridge-mautrix-googlechat/tasks/init.yml
@@ -67,4 +67,4 @@
       Please make sure that you're proxying the `{{ matrix_mautrix_googlechat_public_endpoint }}`
       URL endpoint to the matrix-mautrix-googlechat container.
       You can expose the container's port using the `matrix_mautrix_googlechat_container_http_host_bind_port` variable.
-  when: "matrix_mautrix_googlechat_enabled|bool and (matrix_nginx_proxy_enabled is not defined or matrix_nginx_proxy_enabled|bool == false)"
+  when: "matrix_mautrix_googlechat_enabled|bool and not matrix_nginx_proxy_enabled|default(False)|bool"

--- a/roles/matrix-bridge-mautrix-hangouts/tasks/init.yml
+++ b/roles/matrix-bridge-mautrix-hangouts/tasks/init.yml
@@ -67,4 +67,4 @@
       Please make sure that you're proxying the `{{ matrix_mautrix_hangouts_public_endpoint }}`
       URL endpoint to the matrix-mautrix-hangouts container.
       You can expose the container's port using the `matrix_mautrix_hangouts_container_http_host_bind_port` variable.
-  when: "matrix_mautrix_hangouts_enabled|bool and (matrix_nginx_proxy_enabled is not defined or matrix_nginx_proxy_enabled|bool == false)"
+  when: "matrix_mautrix_hangouts_enabled|bool and not matrix_nginx_proxy_enabled|default(False)|bool"

--- a/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
@@ -28,6 +28,9 @@ matrix_mautrix_telegram_api_id: ''
 matrix_mautrix_telegram_api_hash: ''
 matrix_mautrix_telegram_bot_token: disabled
 
+# Whether or not the public-facing endpoints should be enabled (web-based login)
+matrix_mautrix_telegram_appservice_public_enabled: true
+
 # Mautrix telegram public endpoint to log in to telegram
 # Use an uuid so it's not easily discoverable.
 # Example: /741a0483-ba17-4682-9900-30bd7269f1cc

--- a/roles/matrix-bridge-mautrix-telegram/tasks/init.yml
+++ b/roles/matrix-bridge-mautrix-telegram/tasks/init.yml
@@ -56,16 +56,16 @@
             +
             [matrix_mautrix_telegram_matrix_nginx_proxy_configuration]
           }}
+    - name: Warn about reverse-proxying if matrix-nginx-proxy not used
+      debug:
+        msg: >-
+          NOTE: You've enabled the Mautrix Telegram bridge but are not using the matrix-nginx-proxy
+          reverse proxy.
+          Please make sure that you're proxying the `{{ matrix_mautrix_telegram_public_endpoint }}`
+          URL endpoint to the matrix-mautrix-telegram container.
+          You can expose the container's port using the `matrix_mautrix_telegram_container_http_host_bind_port` variable.
+      when: "not matrix_nginx_proxy_enabled|default(False)|bool"
+
   tags:
     - always
-  when: matrix_mautrix_telegram_enabled|bool
-
-- name: Warn about reverse-proxying if matrix-nginx-proxy not used
-  debug:
-    msg: >-
-      NOTE: You've enabled the Mautrix Telegram bridge but are not using the matrix-nginx-proxy
-      reverse proxy.
-      Please make sure that you're proxying the `{{ matrix_mautrix_telegram_public_endpoint }}`
-      URL endpoint to the matrix-mautrix-telegram container.
-      You can expose the container's port using the `matrix_mautrix_telegram_container_http_host_bind_port` variable.
-  when: "matrix_mautrix_telegram_enabled|bool and not matrix_nginx_proxy_enabled|default(False)|bool"
+  when: matrix_mautrix_telegram_enabled|bool and matrix_mautrix_telegram_appservice_public_enabled|bool

--- a/roles/matrix-bridge-mautrix-telegram/tasks/init.yml
+++ b/roles/matrix-bridge-mautrix-telegram/tasks/init.yml
@@ -68,4 +68,4 @@
       Please make sure that you're proxying the `{{ matrix_mautrix_telegram_public_endpoint }}`
       URL endpoint to the matrix-mautrix-telegram container.
       You can expose the container's port using the `matrix_mautrix_telegram_container_http_host_bind_port` variable.
-  when: "matrix_mautrix_telegram_enabled|bool and matrix_nginx_proxy_enabled is not defined"
+  when: "matrix_mautrix_telegram_enabled|bool and not matrix_nginx_proxy_enabled|default(False)|bool"

--- a/roles/matrix-bridge-mautrix-telegram/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-telegram/templates/config.yaml.j2
@@ -34,7 +34,7 @@ appservice:
     # the HS database.
     public:
         # Whether or not the public-facing endpoints should be enabled.
-        enabled: true
+        enabled: {{ matrix_mautrix_telegram_appservice_public_enabled|to_json }}
         # The prefix to use in the public-facing endpoints.
         prefix: {{ matrix_mautrix_telegram_public_endpoint|to_json }}
         # The base URL where the public-facing endpoints are available. The prefix is not added

--- a/roles/matrix-bridge-mautrix-telegram/templates/systemd/matrix-mautrix-telegram.service.j2
+++ b/roles/matrix-bridge-mautrix-telegram/templates/systemd/matrix-mautrix-telegram.service.j2
@@ -24,7 +24,7 @@ ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-mautrix-telegr
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
 			--network={{ matrix_docker_network }} \
-			{% if matrix_mautrix_telegram_container_http_host_bind_port %}
+			{% if matrix_mautrix_telegram_appservice_public_enabled and matrix_mautrix_telegram_container_http_host_bind_port %}
 			-p {{ matrix_mautrix_telegram_container_http_host_bind_port }}:8080 \
 			{% endif %}
 			-v {{ matrix_mautrix_telegram_config_path }}:/config:z \

--- a/roles/matrix-bridge-mx-puppet-slack/tasks/init.yml
+++ b/roles/matrix-bridge-mx-puppet-slack/tasks/init.yml
@@ -68,4 +68,4 @@
       Please make sure that you're proxying the `{{ matrix_mx_puppet_slack_redirect_path }}`
       URL endpoint to the matrix-mx-puppet-slack container.
       You can expose the container's port using the `matrix_appservice_slack_container_http_host_bind_port` variable.
-  when: "matrix_mx_puppet_slack_enabled|bool and matrix_nginx_proxy_enabled is not defined"
+  when: "matrix_mx_puppet_slack_enabled|bool and not matrix_nginx_proxy_enabled|default(False)|bool"

--- a/roles/matrix-bridge-mx-puppet-twitter/tasks/init.yml
+++ b/roles/matrix-bridge-mx-puppet-twitter/tasks/init.yml
@@ -68,4 +68,4 @@
       Please make sure that you're proxying the `{{ matrix_mx_puppet_twitter_redirect_path }}`
       URL endpoint to the matrix-mx-puppet-twitter container.
       You can expose the container's port using the `matrix_mx_puppet_twitter_container_http_host_bind_port` variable.
-  when: "matrix_mx_puppet_twitter_enabled|bool and matrix_nginx_proxy_enabled is not defined"
+  when: "matrix_mx_puppet_twitter_enabled|bool and not matrix_nginx_proxy_enabled|default(False)|bool"

--- a/roles/matrix-etherpad/tasks/init.yml
+++ b/roles/matrix-etherpad/tasks/init.yml
@@ -61,4 +61,4 @@
       Please make sure that you're proxying the `{{ matrix_etherpad_public_endpoint }}`
       URL endpoint to the matrix-etherpad container.
       You can expose the container's port using the `matrix_etherpad_container_http_host_bind_port` variable.
-  when: "matrix_etherpad_enabled|bool and matrix_nginx_proxy_enabled is not defined"
+  when: "matrix_etherpad_enabled|bool and not matrix_nginx_proxy_enabled|default(False)|bool"

--- a/roles/matrix-registration/tasks/init.yml
+++ b/roles/matrix-registration/tasks/init.yml
@@ -66,4 +66,4 @@
       Please make sure that you're proxying the `{{ matrix_registration_public_endpoint }}`
       URL endpoint to the matrix-registration container.
       You can expose the container's port using the `matrix_registration_container_http_host_bind_port` variable.
-  when: "matrix_registration_enabled|bool and matrix_nginx_proxy_enabled is not defined"
+  when: "matrix_registration_enabled|bool and not matrix_nginx_proxy_enabled|default(False)|bool"

--- a/roles/matrix-synapse-admin/tasks/init.yml
+++ b/roles/matrix-synapse-admin/tasks/init.yml
@@ -57,4 +57,4 @@
       Please make sure that you're proxying the `{{ matrix_synapse_admin_public_endpoint }}`
       URL endpoint to the matrix-synapse-admin container.
       You can expose the container's port using the `matrix_synapse_admin_container_http_host_bind_port` variable.
-  when: "matrix_synapse_admin_enabled|bool and matrix_nginx_proxy_enabled is not defined"
+  when: "matrix_synapse_admin_enabled|bool and not matrix_nginx_proxy_enabled|default(False)|bool"


### PR DESCRIPTION
This PR adds web login support for the Facebook bridge.
By default, it is on, as it does not seem to be a breaking change (the web login authentication method is optional, you can choose between this and the previously available "in-Matrix" login method when communicating with the bridge bot).