### PR TITLE
mautrix-facebook, synapse: minor improvements

### DIFF
--- a/roles/matrix-bridge-mautrix-facebook/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-facebook/templates/config.yaml.j2
@@ -176,7 +176,7 @@ bridge:
     # Whether or not temporary disconnections should send notices to the notice room.
     # If this is false, disconnections will never send messages and connections will only send
     # messages if it was disconnected for more than resync_max_disconnected_time seconds.
-    temporary_disconnect_notices: true
+    temporary_disconnect_notices: false
     # Whether or not the bridge should try to "refresh" the connection if a normal reconnection
     # attempt fails.
     refresh_on_reconnection_fail: false

--- a/roles/matrix-synapse/templates/synapse/systemd/matrix-synapse.service.j2
+++ b/roles/matrix-synapse/templates/synapse/systemd/matrix-synapse.service.j2
@@ -43,7 +43,7 @@ ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-synapse \
 			{% if matrix_synapse_federation_enabled and matrix_synapse_tls_federation_listener_enabled and matrix_synapse_container_federation_api_tls_host_bind_port %}
 			-p {{ matrix_synapse_container_federation_api_tls_host_bind_port }}:{{ matrix_synapse_container_federation_api_tls_port }} \
 			{% endif %}
-			{% if matrix_synapse_federation_enabled and matrix_synapse_container_federation_api_plain_host_bind_port %}
+			{% if matrix_synapse_federation_enabled and matrix_synapse_federation_port_enabled and matrix_synapse_container_federation_api_plain_host_bind_port %}
 			-p {{ matrix_synapse_container_federation_api_plain_host_bind_port }}:{{ matrix_synapse_container_federation_api_plain_port }} \
 			{% endif %}
 			{% if matrix_synapse_metrics_enabled and matrix_synapse_container_metrics_api_host_bind_port %}


### PR DESCRIPTION
- bridge-mautrix-facebook: disable temporary disconnect notices
  mautrix/facebook#215

- synapse: do not expose plain federation port when it's disabled
  matrix_synapse_federation_port_enabled can be disabled by users, for example, when one wants to use the same port for client and federation requests (docs/configuring-playbook-federation.md).