### PR TITLE
fix: avoid yaml being wrapped at column 80 via to_nice_yaml

### DIFF
--- a/roles/matrix-bot-go-neb/tasks/setup_install.yml
+++ b/roles/matrix-bot-go-neb/tasks/setup_install.yml
@@ -25,7 +25,7 @@
 
 - name: Ensure go-neb config installed
   copy:
-    content: "{{ matrix_bot_go_neb_configuration|to_nice_yaml }}"
+    content: "{{ matrix_bot_go_neb_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_bot_go_neb_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-bot-matrix-reminder-bot/tasks/setup_install.yml
+++ b/roles/matrix-bot-matrix-reminder-bot/tasks/setup_install.yml
@@ -70,7 +70,7 @@
 
 - name: Ensure matrix-reminder-bot config installed
   copy:
-    content: "{{ matrix_bot_matrix_reminder_bot_configuration|to_nice_yaml }}"
+    content: "{{ matrix_bot_matrix_reminder_bot_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_bot_matrix_reminder_bot_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-bot-mjolnir/tasks/setup_install.yml
+++ b/roles/matrix-bot-mjolnir/tasks/setup_install.yml
@@ -47,7 +47,7 @@
 
 - name: Ensure matrix-bot-mjolnir config installed
   copy:
-    content: "{{ matrix_bot_mjolnir_configuration|to_nice_yaml }}"
+    content: "{{ matrix_bot_mjolnir_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_bot_mjolnir_config_path }}/production.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-bridge-appservice-discord/tasks/setup_install.yml
+++ b/roles/matrix-bridge-appservice-discord/tasks/setup_install.yml
@@ -69,7 +69,7 @@
 
 - name: Ensure AppService Discord config.yaml installed
   copy:
-    content: "{{ matrix_appservice_discord_configuration|to_nice_yaml }}"
+    content: "{{ matrix_appservice_discord_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_appservice_discord_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
@@ -77,7 +77,7 @@
 
 - name: Ensure AppService Discord registration.yaml installed
   copy:
-    content: "{{ matrix_appservice_discord_registration|to_nice_yaml }}"
+    content: "{{ matrix_appservice_discord_registration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_appservice_discord_config_path }}/registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-bridge-appservice-irc/tasks/setup_install.yml
+++ b/roles/matrix-bridge-appservice-irc/tasks/setup_install.yml
@@ -87,7 +87,7 @@
 
 - name: Ensure Matrix Appservice IRC config installed
   copy:
-    content: "{{ matrix_appservice_irc_configuration|to_nice_yaml }}"
+    content: "{{ matrix_appservice_irc_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_appservice_irc_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
@@ -171,7 +171,7 @@
 
 - name: Ensure Appservice IRC registration.yaml installed
   copy:
-    content: "{{ matrix_appservice_irc_registration|to_nice_yaml }}"
+    content: "{{ matrix_appservice_irc_registration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_appservice_irc_config_path }}/registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-bridge-appservice-slack/tasks/setup_install.yml
+++ b/roles/matrix-bridge-appservice-slack/tasks/setup_install.yml
@@ -61,7 +61,7 @@
 
 - name: Ensure Matrix Appservice Slack config installed
   copy:
-    content: "{{ matrix_appservice_slack_configuration|to_nice_yaml }}"
+    content: "{{ matrix_appservice_slack_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_appservice_slack_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
@@ -69,7 +69,7 @@
 
 - name: Ensure appservice-slack registration.yaml installed
   copy:
-    content: "{{ matrix_appservice_slack_registration|to_nice_yaml }}"
+    content: "{{ matrix_appservice_slack_registration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_appservice_slack_config_path }}/slack-registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-bridge-appservice-webhooks/tasks/setup_install.yml
+++ b/roles/matrix-bridge-appservice-webhooks/tasks/setup_install.yml
@@ -45,7 +45,7 @@
 
 - name: Ensure Matrix Appservice webhooks config is installed
   copy:
-    content: "{{ matrix_appservice_webhooks_configuration|to_nice_yaml }}"
+    content: "{{ matrix_appservice_webhooks_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_appservice_webhooks_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
@@ -69,7 +69,7 @@
 
 - name: Ensure appservice-webhooks registration.yaml installed
   copy:
-    content: "{{ matrix_appservice_webhooks_registration|to_nice_yaml }}"
+    content: "{{ matrix_appservice_webhooks_registration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_appservice_webhooks_config_path }}/webhooks-registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-bridge-beeper-linkedin/tasks/setup_install.yml
+++ b/roles/matrix-bridge-beeper-linkedin/tasks/setup_install.yml
@@ -67,7 +67,7 @@
 
 - name: Ensure beeper-linkedin config.yaml installed
   copy:
-    content: "{{ matrix_beeper_linkedin_configuration|to_nice_yaml }}"
+    content: "{{ matrix_beeper_linkedin_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_beeper_linkedin_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
@@ -75,7 +75,7 @@
 
 - name: Ensure beeper-linkedin registration.yaml installed
   copy:
-    content: "{{ matrix_beeper_linkedin_registration|to_nice_yaml }}"
+    content: "{{ matrix_beeper_linkedin_registration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_beeper_linkedin_config_path }}/registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-bridge-heisenbridge/tasks/setup_install.yml
+++ b/roles/matrix-bridge-heisenbridge/tasks/setup_install.yml
@@ -19,7 +19,7 @@
 
 - name: Ensure heisenbridge registration.yaml installed if provided
   copy:
-    content: "{{ matrix_heisenbridge_registration|to_nice_yaml }}"
+    content: "{{ matrix_heisenbridge_registration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_heisenbridge_base_path }}/registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-bridge-hookshot/tasks/setup_install.yml
+++ b/roles/matrix-bridge-hookshot/tasks/setup_install.yml
@@ -32,7 +32,7 @@
 
 - name: Ensure hookshot config.yml installed if provided
   copy:
-    content: "{{ matrix_hookshot_configuration|to_nice_yaml }}"
+    content: "{{ matrix_hookshot_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_hookshot_base_path }}/config.yml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
@@ -56,7 +56,7 @@
 
 - name: Ensure hookshot registration.yml installed if provided
   copy:
-    content: "{{ matrix_hookshot_registration|to_nice_yaml }}"
+    content: "{{ matrix_hookshot_registration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_hookshot_base_path }}/registration.yml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-bridge-mautrix-facebook/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mautrix-facebook/tasks/setup_install.yml
@@ -97,7 +97,7 @@
 
 - name: Ensure mautrix-facebook config.yaml installed
   copy:
-    content: "{{ matrix_mautrix_facebook_configuration|to_nice_yaml }}"
+    content: "{{ matrix_mautrix_facebook_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_facebook_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
@@ -105,7 +105,7 @@
 
 - name: Ensure mautrix-facebook registration.yaml installed
   copy:
-    content: "{{ matrix_mautrix_facebook_registration|to_nice_yaml }}"
+    content: "{{ matrix_mautrix_facebook_registration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_facebook_config_path }}/registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-bridge-mautrix-googlechat/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mautrix-googlechat/tasks/setup_install.yml
@@ -96,7 +96,7 @@
 
 - name: Ensure mautrix-googlechat config.yaml installed
   copy:
-    content: "{{ matrix_mautrix_googlechat_configuration|to_nice_yaml }}"
+    content: "{{ matrix_mautrix_googlechat_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_googlechat_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
@@ -104,7 +104,7 @@
 
 - name: Ensure mautrix-googlechat registration.yaml installed
   copy:
-    content: "{{ matrix_mautrix_googlechat_registration|to_nice_yaml }}"
+    content: "{{ matrix_mautrix_googlechat_registration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_googlechat_config_path }}/registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-bridge-mautrix-hangouts/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mautrix-hangouts/tasks/setup_install.yml
@@ -96,7 +96,7 @@
 
 - name: Ensure mautrix-hangouts config.yaml installed
   copy:
-    content: "{{ matrix_mautrix_hangouts_configuration|to_nice_yaml }}"
+    content: "{{ matrix_mautrix_hangouts_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_hangouts_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
@@ -104,7 +104,7 @@
 
 - name: Ensure mautrix-hangouts registration.yaml installed
   copy:
-    content: "{{ matrix_mautrix_hangouts_registration|to_nice_yaml }}"
+    content: "{{ matrix_mautrix_hangouts_registration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_hangouts_config_path }}/registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-bridge-mautrix-instagram/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mautrix-instagram/tasks/setup_install.yml
@@ -51,7 +51,7 @@
 
 - name: Ensure mautrix-instagram config.yaml installed
   copy:
-    content: "{{ matrix_mautrix_instagram_configuration|to_nice_yaml }}"
+    content: "{{ matrix_mautrix_instagram_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_instagram_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
@@ -59,7 +59,7 @@
 
 - name: Ensure mautrix-instagram registration.yaml installed
   copy:
-    content: "{{ matrix_mautrix_instagram_registration|to_nice_yaml }}"
+    content: "{{ matrix_mautrix_instagram_registration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_instagram_config_path }}/registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-bridge-mautrix-signal/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mautrix-signal/tasks/setup_install.yml
@@ -84,7 +84,7 @@
 
 - name: Ensure mautrix-signal config.yaml installed
   copy:
-    content: "{{ matrix_mautrix_signal_configuration|to_nice_yaml }}"
+    content: "{{ matrix_mautrix_signal_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_signal_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
@@ -92,7 +92,7 @@
 
 - name: Ensure mautrix-signal registration.yaml installed
   copy:
-    content: "{{ matrix_mautrix_signal_registration|to_nice_yaml }}"
+    content: "{{ matrix_mautrix_signal_registration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_signal_config_path }}/registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-bridge-mautrix-telegram/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mautrix-telegram/tasks/setup_install.yml
@@ -118,7 +118,7 @@
 
 - name: Ensure mautrix-telegram config.yaml installed
   copy:
-    content: "{{ matrix_mautrix_telegram_configuration|to_nice_yaml }}"
+    content: "{{ matrix_mautrix_telegram_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_telegram_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
@@ -126,7 +126,7 @@
 
 - name: Ensure mautrix-telegram registration.yaml installed
   copy:
-    content: "{{ matrix_mautrix_telegram_registration|to_nice_yaml }}"
+    content: "{{ matrix_mautrix_telegram_registration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_telegram_config_path }}/registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-bridge-mautrix-twitter/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mautrix-twitter/tasks/setup_install.yml
@@ -55,7 +55,7 @@
 
 - name: Ensure mautrix-twitter config.yaml installed
   copy:
-    content: "{{ matrix_mautrix_twitter_configuration|to_nice_yaml }}"
+    content: "{{ matrix_mautrix_twitter_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_twitter_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
@@ -63,7 +63,7 @@
 
 - name: Ensure mautrix-twitter registration.yaml installed
   copy:
-    content: "{{ matrix_mautrix_twitter_registration|to_nice_yaml }}"
+    content: "{{ matrix_mautrix_twitter_registration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_twitter_config_path }}/registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-bridge-mautrix-whatsapp/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mautrix-whatsapp/tasks/setup_install.yml
@@ -108,7 +108,7 @@
 
 - name: Ensure mautrix-whatsapp config.yaml installed
   copy:
-    content: "{{ matrix_mautrix_whatsapp_configuration|to_nice_yaml }}"
+    content: "{{ matrix_mautrix_whatsapp_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_whatsapp_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
@@ -116,7 +116,7 @@
 
 - name: Ensure mautrix-whatsapp registration.yaml installed
   copy:
-    content: "{{ matrix_mautrix_whatsapp_registration|to_nice_yaml }}"
+    content: "{{ matrix_mautrix_whatsapp_registration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_whatsapp_config_path }}/registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-bridge-mx-puppet-discord/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mx-puppet-discord/tasks/setup_install.yml
@@ -96,7 +96,7 @@
 
 - name: Ensure mx-puppet-discord config.yaml installed
   copy:
-    content: "{{ matrix_mx_puppet_discord_configuration|to_nice_yaml }}"
+    content: "{{ matrix_mx_puppet_discord_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mx_puppet_discord_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
@@ -104,7 +104,7 @@
 
 - name: Ensure mx-puppet-discord discord-registration.yaml installed
   copy:
-    content: "{{ matrix_mx_puppet_discord_registration|to_nice_yaml }}"
+    content: "{{ matrix_mx_puppet_discord_registration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mx_puppet_discord_config_path }}/registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-bridge-mx-puppet-groupme/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mx-puppet-groupme/tasks/setup_install.yml
@@ -96,7 +96,7 @@
 
 - name: Ensure mx-puppet-groupme config.yaml installed
   copy:
-    content: "{{ matrix_mx_puppet_groupme_configuration|to_nice_yaml }}"
+    content: "{{ matrix_mx_puppet_groupme_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mx_puppet_groupme_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
@@ -104,7 +104,7 @@
 
 - name: Ensure mx-puppet-groupme groupme-registration.yaml installed
   copy:
-    content: "{{ matrix_mx_puppet_groupme_registration|to_nice_yaml }}"
+    content: "{{ matrix_mx_puppet_groupme_registration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mx_puppet_groupme_config_path }}/registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-bridge-mx-puppet-instagram/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mx-puppet-instagram/tasks/setup_install.yml
@@ -79,7 +79,7 @@
 
 - name: Ensure mx-puppet-instagram config.yaml installed
   copy:
-    content: "{{ matrix_mx_puppet_instagram_configuration|to_nice_yaml }}"
+    content: "{{ matrix_mx_puppet_instagram_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mx_puppet_instagram_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
@@ -87,7 +87,7 @@
 
 - name: Ensure mx-puppet-instagram-registration.yaml installed
   copy:
-    content: "{{ matrix_mx_puppet_instagram_registration|to_nice_yaml }}"
+    content: "{{ matrix_mx_puppet_instagram_registration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mx_puppet_instagram_config_path }}/registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-bridge-mx-puppet-skype/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mx-puppet-skype/tasks/setup_install.yml
@@ -96,7 +96,7 @@
 
 - name: Ensure mx-puppet-skype config.yaml installed
   copy:
-    content: "{{ matrix_mx_puppet_skype_configuration|to_nice_yaml }}"
+    content: "{{ matrix_mx_puppet_skype_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mx_puppet_skype_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
@@ -104,7 +104,7 @@
 
 - name: Ensure mx-puppet-skype skype-registration.yaml installed
   copy:
-    content: "{{ matrix_mx_puppet_skype_registration|to_nice_yaml }}"
+    content: "{{ matrix_mx_puppet_skype_registration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mx_puppet_skype_config_path }}/registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-bridge-mx-puppet-slack/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mx-puppet-slack/tasks/setup_install.yml
@@ -96,7 +96,7 @@
 
 - name: Ensure mx-puppet-slack config.yaml installed
   copy:
-    content: "{{ matrix_mx_puppet_slack_configuration|to_nice_yaml }}"
+    content: "{{ matrix_mx_puppet_slack_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mx_puppet_slack_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
@@ -104,7 +104,7 @@
 
 - name: Ensure mx-puppet-slack slack-registration.yaml installed
   copy:
-    content: "{{ matrix_mx_puppet_slack_registration|to_nice_yaml }}"
+    content: "{{ matrix_mx_puppet_slack_registration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mx_puppet_slack_config_path }}/registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-bridge-mx-puppet-steam/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mx-puppet-steam/tasks/setup_install.yml
@@ -96,7 +96,7 @@
 
 - name: Ensure mx-puppet-steam config.yaml installed
   copy:
-    content: "{{ matrix_mx_puppet_steam_configuration|to_nice_yaml }}"
+    content: "{{ matrix_mx_puppet_steam_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mx_puppet_steam_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
@@ -104,7 +104,7 @@
 
 - name: Ensure mx-puppet-steam steam-registration.yaml installed
   copy:
-    content: "{{ matrix_mx_puppet_steam_registration|to_nice_yaml }}"
+    content: "{{ matrix_mx_puppet_steam_registration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mx_puppet_steam_config_path }}/registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-bridge-mx-puppet-twitter/tasks/setup_install.yml
+++ b/roles/matrix-bridge-mx-puppet-twitter/tasks/setup_install.yml
@@ -96,7 +96,7 @@
 
 - name: Ensure mx-puppet-twitter config.yaml installed
   copy:
-    content: "{{ matrix_mx_puppet_twitter_configuration|to_nice_yaml }}"
+    content: "{{ matrix_mx_puppet_twitter_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mx_puppet_twitter_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
@@ -104,7 +104,7 @@
 
 - name: Ensure mx-puppet-twitter twitter-registration.yaml installed
   copy:
-    content: "{{ matrix_mx_puppet_twitter_registration|to_nice_yaml }}"
+    content: "{{ matrix_mx_puppet_twitter_registration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mx_puppet_twitter_config_path }}/registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-bridge-sms/tasks/setup_install.yml
+++ b/roles/matrix-bridge-sms/tasks/setup_install.yml
@@ -19,7 +19,7 @@
 
 - name: Ensure matrix-sms-bridge application.yml installed
   copy:
-    content: "{{ matrix_sms_bridge_configuration|to_nice_yaml }}"
+    content: "{{ matrix_sms_bridge_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_sms_bridge_config_path }}/application.yml"
     mode: 0644
     owner: "{{ matrix_user_username }}"
@@ -27,7 +27,7 @@
 
 - name: Ensure matrix-sms-bridge registration.yaml installed
   copy:
-    content: "{{ matrix_sms_bridge_registration|to_nice_yaml }}"
+    content: "{{ matrix_sms_bridge_registration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_sms_bridge_config_path }}/registration.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-dendrite/tasks/dendrite/setup_install.yml
+++ b/roles/matrix-dendrite/tasks/dendrite/setup_install.yml
@@ -52,7 +52,7 @@
 
 - name: Ensure Dendrite configuration installed
   copy:
-    content: "{{ matrix_dendrite_configuration|to_nice_yaml }}"
+    content: "{{ matrix_dendrite_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_dendrite_config_dir_path }}/dendrite.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-dimension/tasks/setup_install.yml
+++ b/roles/matrix-dimension/tasks/setup_install.yml
@@ -78,7 +78,7 @@
 
 - name: Ensure Dimension config installed
   copy:
-    content: "{{ matrix_dimension_configuration|to_nice_yaml }}"
+    content: "{{ matrix_dimension_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_dimension_base_path }}/config.yaml"
     mode: 0640
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-ma1sd/tasks/setup_install.yml
+++ b/roles/matrix-ma1sd/tasks/setup_install.yml
@@ -104,7 +104,7 @@
 
 - name: Ensure ma1sd config installed
   copy:
-    content: "{{ matrix_ma1sd_configuration|to_nice_yaml }}"
+    content: "{{ matrix_ma1sd_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_ma1sd_config_path }}/ma1sd.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-prometheus/tasks/setup_install.yml
+++ b/roles/matrix-prometheus/tasks/setup_install.yml
@@ -31,7 +31,7 @@
 
 - name: Ensure prometheus.yml installed
   copy:
-    content: "{{ matrix_prometheus_configuration|to_nice_yaml }}"
+    content: "{{ matrix_prometheus_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_prometheus_config_path }}/prometheus.yml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-registration/tasks/setup_install.yml
+++ b/roles/matrix-registration/tasks/setup_install.yml
@@ -76,7 +76,7 @@
 
 - name: Ensure matrix-registration config installed
   copy:
-    content: "{{ matrix_registration_configuration|to_nice_yaml }}"
+    content: "{{ matrix_registration_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_registration_config_path }}/config.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-sygnal/tasks/setup_install.yml
+++ b/roles/matrix-sygnal/tasks/setup_install.yml
@@ -21,7 +21,7 @@
 
 - name: Ensure Sygnal config installed
   copy:
-    content: "{{ matrix_sygnal_configuration|to_nice_yaml }}"
+    content: "{{ matrix_sygnal_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_sygnal_config_path }}/sygnal.yaml"
     mode: 0640
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-synapse/tasks/synapse/setup_install.yml
+++ b/roles/matrix-synapse/tasks/synapse/setup_install.yml
@@ -84,7 +84,7 @@
 
 - name: Ensure Synapse homeserver config installed
   copy:
-    content: "{{ matrix_synapse_configuration|to_nice_yaml }}"
+    content: "{{ matrix_synapse_configuration|to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_synapse_config_dir_path }}/homeserver.yaml"
     mode: 0644
     owner: "{{ matrix_user_username }}"

--- a/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -1414,7 +1414,7 @@ account_threepid_delegates:
 #  - "#example:example.com"
 {% if matrix_synapse_auto_join_rooms|length > 0 %}
 auto_join_rooms:
-{{ matrix_synapse_auto_join_rooms|to_nice_yaml }}
+{{ matrix_synapse_auto_join_rooms|to_nice_yaml(indent=2, width=999999) }}
 {% endif %}
 
 # Where auto_join_rooms are specified, setting this flag ensures that the


### PR DESCRIPTION
The `to_nice_yaml` helper will by default wrap any string YAML values on the
first space after column 80. This can in worst case yield invalid YAML syntax.
More details in Ansible's documentation here:

https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#formatting-data-yaml-and-json

In short, you need to explicitly provide a custom width argument of a high
number of some kind to avoid the line wrapping.

---

I noticed this via the mautrix-whatsapp config file, which has the following
default value:

    displayname_template: '{{if .PushName}}{{.PushName}}{{else if .BusinessName}}{{.BusinessName}}{{else}}{{.JID}}{{end}} (WA)'

But it was being output into config.yaml as:

    displayname_template: '{{if .PushName}}{{.PushName}}{{else if .BusinessName}}{{.BusinessName}}{{else}}{{.JID}}{{end}}
        (WA)'