### PR TITLE
Fix index in external_prometheus.yml.example.j2

### DIFF
--- a/roles/matrix-nginx-proxy/templates/prometheus/external_prometheus.yml.example.j2
+++ b/roles/matrix-nginx-proxy/templates/prometheus/external_prometheus.yml.example.j2
@@ -22,7 +22,7 @@ scrape_configs:
       - targets: ['{{ matrix_server_fqn_matrix }}:{{ matrix_nginx_proxy_container_https_host_bind_port if matrix_nginx_proxy_https_enabled else matrix_nginx_proxy_container_http_host_bind_port }}']
         labels:
           job: "master"
-          index: 1
+          index: "0"
 {% for worker in matrix_nginx_proxy_proxy_synapse_workers_enabled_list %}
   - job_name: 'synapse-{{ worker.type }}-{{ worker.instanceId }}'
     metrics_path: /_synapse-worker-{{ worker.type }}-{{ worker.instanceId }}/metrics
@@ -36,5 +36,5 @@ scrape_configs:
       - targets: ['{{ matrix_server_fqn_matrix }}:{{ matrix_nginx_proxy_container_https_host_bind_port if matrix_nginx_proxy_https_enabled else matrix_nginx_proxy_container_http_host_bind_port }}']
         labels:
           job: "{{ worker.type }}"
-          index: {{ worker.instanceId }}
+          index: "{{ worker.instanceId }}"
 {% endfor %}


### PR DESCRIPTION
For an unknown reason prometheus ignored the given "numeric" index and replaced it by 1. This made it not work properly, plus multiple workers of same types were not differentiable. With a "string" index, it works as intended.

before:
![image](https://user-images.githubusercontent.com/2803622/158862185-e204911d-ab7a-4f85-9d9e-09f7d7855be8.png)

after:
![image](https://user-images.githubusercontent.com/2803622/158862085-728caeb9-093e-4db9-84b6-048b2c149b72.png)
