### PR TITLE
Updated: matrix-googlechat to v0.3.1

### DIFF
--- a/roles/matrix-bridge-mautrix-googlechat/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-googlechat/defaults/main.yml
@@ -7,7 +7,7 @@ matrix_mautrix_googlechat_enabled: true
 matrix_mautrix_googlechat_container_image_self_build: false
 matrix_mautrix_googlechat_container_image_self_build_repo: "https://github.com/mautrix/googlechat.git"
 
-matrix_mautrix_googlechat_version: latest
+matrix_mautrix_googlechat_version: v0.3.1
 # See: https://mau.dev/mautrix/googlechat/container_registry
 matrix_mautrix_googlechat_docker_image: "{{ matrix_mautrix_googlechat_docker_image_name_prefix }}mautrix/googlechat:{{ matrix_mautrix_googlechat_version }}"
 matrix_mautrix_googlechat_docker_image_name_prefix: "{{ 'localhost/' if matrix_mautrix_googlechat_container_image_self_build else 'dock.mau.dev/' }}"


### PR DESCRIPTION
Since the release is only a little over a week old, we should still merge this, especially since there have been no commits made after this release was published (https://github.com/mautrix/googlechat/releases/tag/v0.3.1)