### PR TITLE
Fix Facebook presence config key

### DIFF
--- a/roles/matrix-bridge-mautrix-facebook/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-facebook/templates/config.yaml.j2
@@ -106,7 +106,9 @@ bridge:
     # If using this for other servers than the bridge's server,
     # you must also set the URL in the double_puppet_server_map.
     login_shared_secret_map: {{ matrix_mautrix_facebook_bridge_login_shared_secret_map|to_json }}
-    presence: {{ matrix_mautrix_facebook_bridge_presence|to_json }}
+    # Should presence from Facebook be bridged? This doesn't use the same API as the Android app,
+    # so it might be more suspicious to Facebook.
+    presence_from_facebook: {{ matrix_mautrix_facebook_bridge_presence|to_json }}
     # Whether or not to update avatars when syncing all contacts at startup.
     update_avatar_initial_sync: true
     # End-to-bridge encryption support options. These require matrix-nio to be installed with pip


### PR DESCRIPTION
The presence config key has been changed in mautrix-facebook from `presence` to `presence_from_facebook`: https://github.com/mautrix/facebook/blame/master/mautrix_facebook/example-config.yaml#L157

Relevant upstream commit: https://github.com/mautrix/facebook/commit/a8e6f57bc94a17068086b4020477db508ea1639b

This PR updates the config key in the template.