### PR TITLE
hookshot webhook listener moved to /webhook

### DIFF
--- a/roles/matrix-bridge-hookshot/tasks/init.yml
+++ b/roles/matrix-bridge-hookshot/tasks/init.yml
@@ -68,7 +68,7 @@
               {# Use the embedded DNS resolver in Docker containers to discover the service #}
               resolver 127.0.0.11 valid=5s;
               set $backend "{{ matrix_hookshot_container_url }}:{{ matrix_hookshot_webhook_port }}";
-              proxy_pass http://$backend/$1$is_args$args;
+              proxy_pass http://$backend/webhook/$1$is_args$args;
             {% else %}
               {# Generic configuration for use outside of our container setup #}
               proxy_pass http://127.0.0.1:{{ matrix_hookshot_webhook_port }}/$1$is_args$args;


### PR DESCRIPTION
fixes #1681, introduced in https://github.com/matrix-org/matrix-hookshot/pull/227