### PR TITLE
Add hookshot self build for arm64 and amd64

### DIFF
--- a/docs/self-building.md
+++ b/docs/self-building.md
@@ -22,6 +22,7 @@ List of roles where self-building the Docker image is currently possible:
 - `matrix-dimension`
 - `matrix-ma1sd`
 - `matrix-mailer`
+- `matrix-bridge-hookshot`
 - `matrix-bridge-appservice-irc`
 - `matrix-bridge-appservice-slack`
 - `matrix-bridge-appservice-webhooks`

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -671,6 +671,8 @@ matrix_heisenbridge_systemd_wanted_services_list: |
 # We don't enable bridges by default.
 matrix_hookshot_enabled: false
 
+matrix_hookshot_container_image_self_build: "{{ matrix_architecture not in ['arm64', 'amd64'] }}"
+
 matrix_hookshot_appservice_token: "{{ '%s' | format(matrix_homeserver_generic_secret_key) | password_hash('sha512', 'hookshot.as.tok') | to_uuid }}"
 
 matrix_hookshot_homeserver_token: "{{ '%s' | format(matrix_homeserver_generic_secret_key) | password_hash('sha512', 'hookshot.hs.tok') | to_uuid }}"

--- a/roles/matrix-bridge-hookshot/defaults/main.yml
+++ b/roles/matrix-bridge-hookshot/defaults/main.yml
@@ -5,11 +5,20 @@
 
 matrix_hookshot_enabled: true
 
+
+matrix_hookshot_container_image_self_build: false
+matrix_hookshot_container_image_self_build_repo: "https://github.com/matrix-org/matrix-hookshot.git"
+matrix_hookshot_container_image_self_build_branch: "{{ 'main' if matrix_hookshot_version == 'latest' else matrix_hookshot_version }}"
+
 matrix_hookshot_version: 1.3.0
-matrix_hookshot_docker_image: "{{ matrix_container_global_registry_prefix }}halfshot/matrix-hookshot:{{ matrix_hookshot_version }}"
+
+matrix_hookshot_docker_image: "{{ matrix_hookshot_docker_image_name_prefix }}mautrix/whatsapp:{{ matrix_mautrix_whatsapp_version }}"
+matrix_hookshot_docker_image_name_prefix: "{{ 'localhost/' if matrix_hookshot_container_image_self_build else matrix_container_global_registry_prefix }}"
 matrix_hookshot_docker_image_force_pull: "{{ matrix_hookshot_docker_image.endswith(':latest') }}"
 
 matrix_hookshot_base_path: "{{ matrix_base_data_path }}/hookshot"
+
+matrix_hookshot_docker_src_files_path: "{{ matrix_hookshot_base_path }}/docker-src"
 
 matrix_hookshot_homeserver_address: "{{ matrix_homeserver_container_url }}"
 matrix_hookshot_container_url: 'matrix-hookshot'

--- a/roles/matrix-bridge-hookshot/tasks/setup_install.yml
+++ b/roles/matrix-bridge-hookshot/tasks/setup_install.yml
@@ -9,9 +9,9 @@
     mode: 0750
     owner: "{{ matrix_user_username }}"
     group: "{{ matrix_user_groupname }}"
-  with_items: 
-    - { path: "{{ matrix_hookshot_base_path }}", when: true }
-    - { path: "{{ matrix_hookshot_docker_src_files_path }}", when: "{{ matrix_hookshot_container_image_self_build }}" }
+  with_items:
+    - {path: "{{ matrix_hookshot_base_path }}", when: true}
+    - {path: "{{ matrix_hookshot_docker_src_files_path }}", when: "{{ matrix_hookshot_container_image_self_build }}"}
   when: item.when|bool
 
 - name: Ensure hookshot image is pulled
@@ -44,7 +44,7 @@
     build:
       dockerfile: Dockerfile
       path: "{{ matrix_hookshot_docker_src_files_path }}"
-      pull: yes
+      pull: true
   when: "matrix_hookshot_container_image_self_build|bool"
 
 - name: Check if hookshot passkey exists

--- a/roles/matrix-bridge-hookshot/tasks/setup_install.yml
+++ b/roles/matrix-bridge-hookshot/tasks/setup_install.yml
@@ -2,26 +2,50 @@
 
 - import_tasks: "{{ role_path }}/../matrix-base/tasks/util/ensure_openssl_installed.yml"
 
+- name: Ensure hookshot paths exist
+  file:
+    path: "{{ item.path }}"
+    state: directory
+    mode: 0750
+    owner: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
+  with_items: 
+    - { path: "{{ matrix_hookshot_base_path }}", when: true }
+    - { path: "{{ matrix_hookshot_docker_src_files_path }}", when: "{{ matrix_hookshot_container_image_self_build }}" }
+  when: item.when|bool
+
 - name: Ensure hookshot image is pulled
   docker_image:
     name: "{{ matrix_hookshot_docker_image }}"
     source: "{{ 'pull' if ansible_version.major > 2 or ansible_version.minor > 7 else omit }}"
     force_source: "{{ matrix_hookshot_docker_image_force_pull if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
     force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_hookshot_docker_image_force_pull }}"
+  when: not matrix_hookshot_container_image_self_build
   register: result
   retries: "{{ matrix_container_retries_count }}"
   delay: "{{ matrix_container_retries_delay }}"
   until: result is not failed
 
-- name: Ensure hookshot paths exist
-  file:
-    path: "{{ item }}"
-    state: directory
-    mode: 0750
-    owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_groupname }}"
-  with_items:
-    - "{{ matrix_hookshot_base_path }}"
+- name: Ensure hookshot repository is present on self-build
+  git:
+    repo: "{{ matrix_hookshot_container_image_self_build_repo }}"
+    dest: "{{ matrix_hookshot_docker_src_files_path }}"
+    version: "{{ matrix_hookshot_container_image_self_build_branch }}"
+    force: "yes"
+  register: matrix_hookshot_git_pull_results
+  when: "matrix_hookshot_container_image_self_build|bool"
+
+- name: Ensure hookshot Docker image is built
+  docker_image:
+    name: "{{ matrix_hookshot_docker_image }}"
+    source: build
+    force_source: "{{ matrix_hookshot_git_pull_results.changed if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
+    force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_hookshot_git_pull_results.changed }}"
+    build:
+      dockerfile: Dockerfile
+      path: "{{ matrix_hookshot_docker_src_files_path }}"
+      pull: yes
+  when: "matrix_hookshot_container_image_self_build|bool"
 
 - name: Check if hookshot passkey exists
   stat:


### PR DESCRIPTION
As commented  in [#1505](https://github.com/spantaleev/matrix-docker-ansible-deploy/pull/1505#issuecomment-1027725206), Hookshot is buildable for arm64 and works (at least on my RP4 since I commented it). Also, this PR should close #1592 

PS : First time I do some Ansible, feel free to point out all my possible mistakes 👍