### PR TITLE
[STEAM] Move Docker source repository to a fixed version

### DIFF
--- a/docs/self-building.md
+++ b/docs/self-building.md
@@ -33,6 +33,7 @@ List of roles where self-building the Docker image is currently possible:
 - `matrix-bridge-mautrix-signal`
 - `matrix-bridge-mautrix-whatsapp`
 - `matrix-bridge-mx-puppet-skype`
+- `matrix-bridge-mx-puppet-steam`
 - `matrix-bot-mjolnir`
 - `matrix-bot-honoroit`
 - `matrix-bot-matrix-reminder-bot`

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -908,7 +908,7 @@ matrix_mx_puppet_discord_database_password: "{{ '%s' | format(matrix_homeserver_
 # We don't enable bridges by default.
 matrix_mx_puppet_steam_enabled: false
 
-matrix_mx_puppet_steam_container_image_self_build: "{{ matrix_architecture != 'amd64' }}"
+matrix_mx_puppet_steam_container_image_self_build: "{{ matrix_architecture not in ['arm64', 'amd64'] }}"
 
 matrix_mx_puppet_steam_systemd_required_services_list: |
   {{
@@ -1552,11 +1552,11 @@ matrix_ssl_domains_to_obtain_certificates_for: |
   }}
 
 matrix_ssl_architecture: "{{
-	{
-		'amd64': 'amd64',
-		'arm32': 'arm32v6',
-		'arm64': 'arm64v8',
-	}[matrix_architecture]
+  {
+    'amd64': 'amd64',
+    'arm32': 'arm32v6',
+    'arm64': 'arm64v8',
+  }[matrix_architecture]
 }}"
 
 matrix_ssl_pre_obtaining_required_service_name: "{{ 'matrix-dynamic-dns' if matrix_dynamic_dns_enabled else '' }}"

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -1552,11 +1552,11 @@ matrix_ssl_domains_to_obtain_certificates_for: |
   }}
 
 matrix_ssl_architecture: "{{
-  {
-    'amd64': 'amd64',
-    'arm32': 'arm32v6',
-    'arm64': 'arm64v8',
-  }[matrix_architecture]
+	{
+		'amd64': 'amd64',
+		'arm32': 'arm32v6',
+		'arm64': 'arm64v8',
+	}[matrix_architecture]
 }}"
 
 matrix_ssl_pre_obtaining_required_service_name: "{{ 'matrix-dynamic-dns' if matrix_dynamic_dns_enabled else '' }}"

--- a/roles/matrix-bridge-mx-puppet-steam/defaults/main.yml
+++ b/roles/matrix-bridge-mx-puppet-steam/defaults/main.yml
@@ -5,7 +5,7 @@
 matrix_mx_puppet_steam_enabled: true
 
 matrix_mx_puppet_steam_container_image_self_build: false
-matrix_mx_puppet_steam_container_image_self_build_repo: "https://github.com/icewind1991/mx-puppet-steam.git"
+matrix_mx_puppet_steam_container_image_self_build_repo: "https://github.com/tilosp/mx-puppet-steam.git"
 
 # Controls whether the mx-puppet-steam container exposes its HTTP port (tcp/8432 in the container).
 #


### PR DESCRIPTION
Current icewind1991 source is broken (the main problem is a package name which changed since the latest commit in Alpine's repo). A [PR is waiting from tilosp](https://github.com/icewind1991/mx-puppet-steam/pull/27) and fix that error.

A great side effect is that this new Dockerfile built and works on arm64 (tested for months now on my RP4) :)

This PR is bringing this 2 features (change build source + self-buildable for arm64)