### PR TITLE
Fix matrix-bridge-hookshot container image

### DIFF
--- a/roles/matrix-bridge-hookshot/defaults/main.yml
+++ b/roles/matrix-bridge-hookshot/defaults/main.yml
@@ -12,7 +12,7 @@ matrix_hookshot_container_image_self_build_branch: "{{ 'main' if matrix_hookshot
 
 matrix_hookshot_version: 1.3.0
 
-matrix_hookshot_docker_image: "{{ matrix_hookshot_docker_image_name_prefix }}mautrix/whatsapp:{{ matrix_mautrix_whatsapp_version }}"
+matrix_hookshot_docker_image: "{{ matrix_hookshot_docker_image_name_prefix }}halfshot/matrix-hookshot:{{ matrix_hookshot_version }}"
 matrix_hookshot_docker_image_name_prefix: "{{ 'localhost/' if matrix_hookshot_container_image_self_build else matrix_container_global_registry_prefix }}"
 matrix_hookshot_docker_image_force_pull: "{{ matrix_hookshot_docker_image.endswith(':latest') }}"
 


### PR DESCRIPTION
When [roles/matrix-bridge-hookshot/defaults/main.yml](https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/b3176957c3cf1e0797a8d1f1796d14b91ed3d1ca#diff-928f098aacc3d3a87d932d4c7d275d20444f42d8649fc1dd4ce7f1a380813f8fR15) was edited https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/b3176957c3cf1e0797a8d1f1796d14b91ed3d1ca.  The docker image was changed to `mautrix/whatsapp`.  I assume it was copy/pasted and then was not changed.  

This pull sets the image back to `halfshot/matrix-hookshot`