### PR TITLE
Multi-IP coturn

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -1144,7 +1144,7 @@ matrix_coturn_enabled: true
 
 matrix_coturn_container_image_self_build: "{{ matrix_architecture != 'amd64' }}"
 
-matrix_coturn_turn_external_ip_address: "{{ ansible_host }}"
+matrix_coturn_turn_external_ip_address: ["{{ ansible_host }}"]
 
 matrix_coturn_turn_static_auth_secret: "{{ '%s' | format(matrix_homeserver_generic_secret_key) | password_hash('sha512', 'coturn.sas') | to_uuid }}"
 

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -1145,7 +1145,6 @@ matrix_coturn_enabled: true
 matrix_coturn_container_image_self_build: "{{ matrix_architecture != 'amd64' }}"
 
 matrix_coturn_turn_external_ip_address: "{{ ansible_host }}"
-matrix_coturn_turn_external_ip_addresses: [ "{{ matrix_coturn_turn_external_ip_address }}" ]
 
 matrix_coturn_turn_static_auth_secret: "{{ '%s' | format(matrix_homeserver_generic_secret_key) | password_hash('sha512', 'coturn.sas') | to_uuid }}"
 

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -1144,7 +1144,8 @@ matrix_coturn_enabled: true
 
 matrix_coturn_container_image_self_build: "{{ matrix_architecture != 'amd64' }}"
 
-matrix_coturn_turn_external_ip_address: ["{{ ansible_host }}"]
+matrix_coturn_turn_external_ip_address: "{{ ansible_host }}"
+matrix_coturn_turn_external_ip_addresses: [ "{{ matrix_coturn_turn_external_ip_address }}" ]
 
 matrix_coturn_turn_static_auth_secret: "{{ '%s' | format(matrix_homeserver_generic_secret_key) | password_hash('sha512', 'coturn.sas') | to_uuid }}"
 

--- a/roles/matrix-coturn/defaults/main.yml
+++ b/roles/matrix-coturn/defaults/main.yml
@@ -65,7 +65,7 @@ matrix_coturn_turn_static_auth_secret: ""
 
 # The external IP address of the machine where Coturn is.
 matrix_coturn_turn_external_ip_address: ''
-matrix_coturn_turn_external_ip_addresses: []
+matrix_coturn_turn_external_ip_addresses: [ "{{ matrix_coturn_turn_external_ip_address }}" ]
 
 matrix_coturn_allowed_peer_ips: []
 matrix_coturn_denied_peer_ips: []

--- a/roles/matrix-coturn/defaults/main.yml
+++ b/roles/matrix-coturn/defaults/main.yml
@@ -64,7 +64,7 @@ matrix_coturn_turn_udp_max_port: 49172
 matrix_coturn_turn_static_auth_secret: ""
 
 # The external IP address of the machine where Coturn is.
-matrix_coturn_turn_external_ip_address: ''
+matrix_coturn_turn_external_ip_address: []
 
 matrix_coturn_allowed_peer_ips: []
 matrix_coturn_denied_peer_ips: []

--- a/roles/matrix-coturn/defaults/main.yml
+++ b/roles/matrix-coturn/defaults/main.yml
@@ -64,7 +64,8 @@ matrix_coturn_turn_udp_max_port: 49172
 matrix_coturn_turn_static_auth_secret: ""
 
 # The external IP address of the machine where Coturn is.
-matrix_coturn_turn_external_ip_address: []
+matrix_coturn_turn_external_ip_address: ''
+matrix_coturn_turn_external_ip_addresses: []
 
 matrix_coturn_allowed_peer_ips: []
 matrix_coturn_denied_peer_ips: []

--- a/roles/matrix-coturn/defaults/main.yml
+++ b/roles/matrix-coturn/defaults/main.yml
@@ -65,7 +65,7 @@ matrix_coturn_turn_static_auth_secret: ""
 
 # The external IP address of the machine where Coturn is.
 matrix_coturn_turn_external_ip_address: ''
-matrix_coturn_turn_external_ip_addresses: [ "{{ matrix_coturn_turn_external_ip_address }}" ]
+matrix_coturn_turn_external_ip_addresses: ["{{ matrix_coturn_turn_external_ip_address }}"]
 
 matrix_coturn_allowed_peer_ips: []
 matrix_coturn_denied_peer_ips: []

--- a/roles/matrix-coturn/templates/turnserver.conf.j2
+++ b/roles/matrix-coturn/templates/turnserver.conf.j2
@@ -5,7 +5,7 @@ realm=turn.{{ matrix_server_fqn_matrix }}
 
 min-port={{ matrix_coturn_turn_udp_min_port }}
 max-port={{ matrix_coturn_turn_udp_max_port }}
-{% for ip in matrix_coturn_turn_external_ip_address %}
+{% for ip in matrix_coturn_turn_external_ip_addresses %}
 external-ip={{ ip }}
 {% endfor %}
 

--- a/roles/matrix-coturn/templates/turnserver.conf.j2
+++ b/roles/matrix-coturn/templates/turnserver.conf.j2
@@ -5,7 +5,9 @@ realm=turn.{{ matrix_server_fqn_matrix }}
 
 min-port={{ matrix_coturn_turn_udp_min_port }}
 max-port={{ matrix_coturn_turn_udp_max_port }}
-external-ip={{ matrix_coturn_turn_external_ip_address }}
+{% for ip in matrix_coturn_turn_external_ip_address %}
+external-ip={{ ip }}
+{% endfor %}
 
 log-file=stdout
 pidfile=/var/tmp/turnserver.pid


### PR DESCRIPTION
Add support for multiple external turn IP addresses, this allows for better comptability with dualstack ipv4/ipv6 hosts, and is supported as per the documentation (point 6 here: https://matrix-org.github.io/synapse/latest/turn-howto.html#configuration)