### PR TITLE
Upgrade Hookshot (1.3.0 -> 1.4.0) 

### DIFF
--- a/docs/configuring-playbook-bridge-hookshot.md
+++ b/docs/configuring-playbook-bridge-hookshot.md
@@ -22,18 +22,18 @@ Other configuration options are available via the `matrix_hookshot_configuration
 
 ### URLs for bridges setup
 
-All of the following endpoints are reachable on your `matrix.` subdomain (if the feature is enabled).
+Unless indicated otherwise, the following endpoints are reachable on your `matrix.` subdomain (if the feature is enabled).
 
-| Listener | default path | variable | used as |
+| listener | default path | variable | used as |
 |---|---|---|---|
-| webhooks | `/hookshot/webhooks/` | `matrix_hookshot_webhook_endpoint` | GitHub "Webhook URL" |
+| webhooks | `/hookshot/webhooks/` | `matrix_hookshot_webhook_endpoint` | generics, GitHub "Webhook URL", etc. |
 | github oauth | `/hookshot/webhooks/oauth` | `matrix_hookshot_github_oauth_endpoint` | GitHub "Callback URL" |
 | jira oauth | `/hookshot/webhooks/jira/oauth` | `matrix_hookshot_jira_oauth_endpoint` | JIRA OAuth |
 | figma endpoint | `/hookshot/webhooks/figma/webhook` | `matrix_hookshot_figma_endpoint` | Figma |
 | provisioning | `/hookshot/v1/` | `matrix_hookshot_provisioning_endpoint` | Dimension [provisioning](#provisioning-api) |
 | appservice | `/hookshot/_matrix/app/` | `matrix_hookshot_appservice_endpoint` | Matrix server |
-| metrics | `/hookshot/metrics/` | `matrix_hookshot_metrics_endpoint` | Prometheus |
-| widgets |  |  | not supported |
+| widgets | `/hookshot/widgetapi/` | `/matrix_hookshot_widgets_endpoint` | Widgets |
+| metrics | `/hookshot/metrics/` (on `stats.` subdomain) | `matrix_hookshot_metrics_endpoint` | Prometheus |
 
 See also `matrix_hookshot_matrix_nginx_proxy_configuration` in [init.yml](/roles/matrix-bridge-hookshot/tasks/init.yml).
 

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -678,7 +678,7 @@ matrix_hookshot_proxy_metrics_basic_auth_enabled: "{{ matrix_nginx_proxy_proxy_s
 
 matrix_hookshot_urlprefix_port_enabled: "{{ matrix_nginx_proxy_container_https_host_bind_port == 443 if matrix_nginx_proxy_https_enabled else matrix_nginx_proxy_container_https_host_bind_port == 80 }}"
 matrix_hookshot_urlprefix_port: ":{{ matrix_nginx_proxy_container_https_host_bind_port if matrix_nginx_proxy_https_enabled else matrix_nginx_proxy_container_http_host_bind_port }}"
-matrix_hookshot_urlprefix: "http{{ 's' if matrix_nginx_proxy_https_enabled else '' }}://{{ matrix_server_fqn_matrix }}{{ matrix_hookshot_urlprefix_port if matrix_hookshot_urlprefix_port_enabled else '' }}{{ matrix_hookshot_generic_endpoint }}"
+matrix_hookshot_urlprefix: "http{{ 's' if matrix_nginx_proxy_https_enabled else '' }}://{{ matrix_server_fqn_matrix }}{{ matrix_hookshot_urlprefix_port if matrix_hookshot_urlprefix_port_enabled else '' }}"
 
 ######################################################################
 #

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -676,9 +676,9 @@ matrix_hookshot_provisioning_enabled: "{{ matrix_hookshot_provisioning_secret an
 matrix_hookshot_proxy_metrics: "{{ matrix_nginx_proxy_proxy_synapse_metrics }}"
 matrix_hookshot_proxy_metrics_basic_auth_enabled: "{{ matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_enabled }}"
 
-matrix_hookshot_generic_urlprefix_port_enabled: "{{ matrix_nginx_proxy_container_https_host_bind_port == 443 if matrix_nginx_proxy_https_enabled else matrix_nginx_proxy_container_https_host_bind_port == 80 }}"
-matrix_hookshot_generic_urlprefix_port: ":{{ matrix_nginx_proxy_container_https_host_bind_port if matrix_nginx_proxy_https_enabled else matrix_nginx_proxy_container_http_host_bind_port }}"
-matrix_hookshot_generic_urlprefix: "http{{ 's' if matrix_nginx_proxy_https_enabled else '' }}://{{ matrix_server_fqn_matrix }}{{ matrix_hookshot_generic_urlprefix_port if matrix_hookshot_generic_urlprefix_port_enabled else '' }}{{ matrix_hookshot_generic_endpoint }}"
+matrix_hookshot_urlprefix_port_enabled: "{{ matrix_nginx_proxy_container_https_host_bind_port == 443 if matrix_nginx_proxy_https_enabled else matrix_nginx_proxy_container_https_host_bind_port == 80 }}"
+matrix_hookshot_urlprefix_port: ":{{ matrix_nginx_proxy_container_https_host_bind_port if matrix_nginx_proxy_https_enabled else matrix_nginx_proxy_container_http_host_bind_port }}"
+matrix_hookshot_urlprefix: "http{{ 's' if matrix_nginx_proxy_https_enabled else '' }}://{{ matrix_server_fqn_matrix }}{{ matrix_hookshot_urlprefix_port if matrix_hookshot_urlprefix_port_enabled else '' }}{{ matrix_hookshot_generic_endpoint }}"
 
 ######################################################################
 #

--- a/roles/matrix-bridge-hookshot/defaults/main.yml
+++ b/roles/matrix-bridge-hookshot/defaults/main.yml
@@ -61,7 +61,7 @@ matrix_hookshot_github_oauth_id: ''  # "Client ID" on the GitHub App page
 matrix_hookshot_github_oauth_secret: ''  # "Client Secret" on the GitHub App page
 # Default value of matrix_hookshot_github_oauth_endpoint: "/hookshot/webhooks/oauth"
 matrix_hookshot_github_oauth_endpoint: "{{ matrix_hookshot_webhook_endpoint }}/oauth"
-matrix_hookshot_github_oauth_uri: "https://{{ matrix_server_fqn_matrix }}{{ matrix_hookshot_github_oauth_endpoint }}"
+matrix_hookshot_github_oauth_uri: "{{ matrix_hookshot_urlprefix }}{{ matrix_hookshot_github_oauth_endpoint }}"
 # These are the default settings mentioned here and don't need to be modified: https://matrix-org.github.io/matrix-hookshot/usage/room_configuration/github_repo.html#configuration
 matrix_hookshot_github_ignore_hooks: "{}"
 matrix_hookshot_github_command_prefix: '!gh'
@@ -86,32 +86,10 @@ matrix_hookshot_gitlab_instances:
 matrix_hookshot_gitlab_secret: ''
 
 
-matrix_hookshot_jira_enabled: false
-# Get the these values from https://matrix-org.github.io/matrix-hookshot/setup/jira.html#jira-oauth
-matrix_hookshot_jira_secret: ''
-matrix_hookshot_jira_oauth_enabled: false
-matrix_hookshot_jira_oauth_id: ''
-matrix_hookshot_jira_oauth_secret: ''
-# Default value of matrix_hookshot_jira_oauth_endpoint: "/hookshot/webhooks/jira/oauth"
-matrix_hookshot_jira_oauth_endpoint: "{{ matrix_hookshot_webhook_endpoint }}/jira/oauth"
-matrix_hookshot_jira_oauth_uri: "{{ matrix_server_fqn_matrix }}{{ matrix_hookshot_jira_oauth_endpoint }}"
-
-
-# No need to change these
-matrix_hookshot_generic_enabled: true
-# Default value of matrix_hookshot_generic_endpoint: "/hookshot/webhooks"
-matrix_hookshot_generic_endpoint: "{{ matrix_hookshot_webhook_endpoint }}"
-# urlprefix gets updated with protocol & port in group_vars/matrix_servers
-matrix_hookshot_generic_urlprefix: "{{ matrix_server_fqn_matrix }}{{ matrix_hookshot_generic_endpoint }}"
-matrix_hookshot_generic_allow_js_transformation_functions: false
-# If you're also using matrix-appservice-webhooks, take care that these prefixes don't overlap
-matrix_hookshot_generic_user_id_prefix: '_webhooks_'
-
-
 matrix_hookshot_figma_enabled: false
 # Default value of matrix_hookshot_figma_endpoint: "/hookshot/webhooks/figma/webhook"
 matrix_hookshot_figma_endpoint: "{{ matrix_hookshot_webhook_endpoint }}/figma/webhook"
-matrix_hookshot_figma_publicUrl: "{{ matrix_server_fqn_matrix }}{{ matrix_hookshot_figma_endpoint }}"
+matrix_hookshot_figma_publicUrl: "{{ matrix_hookshot_urlprefix }}{{ matrix_hookshot_figma_endpoint }}"
 # To bridge figma webhooks, you need to configure one of multiple instances like this:
 # matrix_hookshot_figma_instances:
 #   your-instance:
@@ -120,12 +98,35 @@ matrix_hookshot_figma_publicUrl: "{{ matrix_server_fqn_matrix }}{{ matrix_hooksh
 #       passcode: your-webhook-passcode
 
 
+matrix_hookshot_jira_enabled: false
+# Get the these values from https://matrix-org.github.io/matrix-hookshot/setup/jira.html#jira-oauth
+matrix_hookshot_jira_secret: ''
+matrix_hookshot_jira_oauth_enabled: false
+matrix_hookshot_jira_oauth_id: ''
+matrix_hookshot_jira_oauth_secret: ''
+# Default value of matrix_hookshot_jira_oauth_endpoint: "/hookshot/webhooks/jira/oauth"
+matrix_hookshot_jira_oauth_endpoint: "{{ matrix_hookshot_webhook_endpoint }}/jira/oauth"
+matrix_hookshot_jira_oauth_uri: "{{ matrix_hookshot_urlprefix }}{{ matrix_hookshot_jira_oauth_endpoint }}"
+
+
+# No need to change these
+matrix_hookshot_generic_enabled: true
+# Default value of matrix_hookshot_generic_endpoint: "/hookshot/webhooks"
+matrix_hookshot_generic_endpoint: "{{ matrix_hookshot_webhook_endpoint }}"
+# urlprefix gets updated with protocol & port in group_vars/matrix_servers
+matrix_hookshot_generic_urlprefix: "{{ matrix_hookshot_urlprefix }}{{ matrix_hookshot_generic_endpoint }}"
+matrix_hookshot_generic_allow_js_transformation_functions: false
+# If you're also using matrix-appservice-webhooks, take care that these prefixes don't overlap
+matrix_hookshot_generic_user_id_prefix: '_webhooks_'
+
+
 # There is no need to edit ports. use matrix_hookshot_container_http_host_bind_ports below to expose ports instead.
 matrix_hookshot_provisioning_port: 9002
 matrix_hookshot_provisioning_secret: ''
 # Provisioning will be automatically enabled if dimension is enabled and you have provided a provisioning secret, unless you override it
 matrix_hookshot_provisioning_enabled: false
-matrix_hookshot_provisioning_endpoint: "{{ matrix_hookshot_public_endpoint }}/v1"
+matrix_hookshot_provisioning_internal: "/v1"
+matrix_hookshot_provisioning_endpoint: "{{ matrix_hookshot_public_endpoint }}{{ matrix_hookshot_provisioning_internal }}"
 
 # You can configure access to the bridge as documented here https://matrix-org.github.io/matrix-hookshot/setup.html#permissions
 # When empty, the default permissions are applied.

--- a/roles/matrix-bridge-hookshot/defaults/main.yml
+++ b/roles/matrix-bridge-hookshot/defaults/main.yml
@@ -10,7 +10,7 @@ matrix_hookshot_container_image_self_build: false
 matrix_hookshot_container_image_self_build_repo: "https://github.com/matrix-org/matrix-hookshot.git"
 matrix_hookshot_container_image_self_build_branch: "{{ 'main' if matrix_hookshot_version == 'latest' else matrix_hookshot_version }}"
 
-matrix_hookshot_version: 1.3.0
+matrix_hookshot_version: 1.4.0
 
 matrix_hookshot_docker_image: "{{ matrix_hookshot_docker_image_name_prefix }}halfshot/matrix-hookshot:{{ matrix_hookshot_version }}"
 matrix_hookshot_docker_image_name_prefix: "{{ 'localhost/' if matrix_hookshot_container_image_self_build else matrix_container_global_registry_prefix }}"
@@ -65,10 +65,11 @@ matrix_hookshot_github_oauth_uri: "{{ matrix_hookshot_urlprefix }}{{ matrix_hook
 # These are the default settings mentioned here and don't need to be modified: https://matrix-org.github.io/matrix-hookshot/usage/room_configuration/github_repo.html#configuration
 matrix_hookshot_github_ignore_hooks: "{}"
 matrix_hookshot_github_command_prefix: '!gh'
-matrix_hookshot_github_show_issue_room_link: false
+matrix_hookshot_github_showIssueRoomLink: false
 matrix_hookshot_github_pr_diff: "{enabled: false, maxLines: 5}"
 matrix_hookshot_github_including_labels: ''
 matrix_hookshot_github_excluding_labels: ''
+matrix_hookshot_github_hotlink_prefix: "#"
 
 
 matrix_hookshot_gitlab_enabled: true
@@ -127,6 +128,41 @@ matrix_hookshot_provisioning_secret: ''
 matrix_hookshot_provisioning_enabled: false
 matrix_hookshot_provisioning_internal: "/v1"
 matrix_hookshot_provisioning_endpoint: "{{ matrix_hookshot_public_endpoint }}{{ matrix_hookshot_provisioning_internal }}"
+
+
+matrix_hookshot_widgets_enabled: true
+matrix_hookshot_widgets_port: 9003
+matrix_hookshot_widgets_addToAdminRooms: false  # default off as it is a beta feature
+matrix_hookshot_widgets_roomSetupWidget_enabled: true
+matrix_hookshot_widgets_roomSetupWidget_addOnInvite: false
+# `disallowedIpRanges` describes which IP ranges should be disallowed when resolving homeserver IP addresses (for security reasons). Unless you know what you are doing, it is recommended to not include this key. The following IPs are blocked by default, unless you supply another list.
+# matrix_hookshot_widgets_disallowedIpRanges:
+#   - 127.0.0.0/8
+#   - 10.0.0.0/8
+#   - 172.16.0.0/12
+#   - 192.168.0.0/16
+#   - 100.64.0.0/10
+#   - 192.0.0.0/24
+#   - 169.254.0.0/16
+#   - 192.88.99.0/24
+#   - 198.18.0.0/15
+#   - 192.0.2.0/24
+#   - 198.51.100.0/24
+#   - 203.0.113.0/24
+#   - 224.0.0.0/4
+#   - ::1/128
+#   - fe80::/10
+#   - fc00::/7
+#   - 2001:db8::/32
+#   - ff00::/8
+#   - fec0::/10
+matrix_hookshot_widgets_disallowedIpRanges: ''
+matrix_hookshot_widgets_internal: "/widgetapi"
+# Default value of matrix_hookshot_widgets_endpoint: "/hookshot/widgetapi"
+matrix_hookshot_widgets_endpoint: "{{ matrix_hookshot_public_endpoint }}{{ matrix_hookshot_widgets_internal }}"
+matrix_hookshot_widgets_publicUrl: "{{ matrix_hookshot_urlprefix }}{{ matrix_hookshot_widgets_endpoint }}/v1/static"
+matrix_hookshot_widgets_branding_widgetTitle: "Hookshot Configuration"
+
 
 # You can configure access to the bridge as documented here https://matrix-org.github.io/matrix-hookshot/setup.html#permissions
 # When empty, the default permissions are applied.

--- a/roles/matrix-bridge-hookshot/tasks/init.yml
+++ b/roles/matrix-bridge-hookshot/tasks/init.yml
@@ -55,10 +55,10 @@
               {# Use the embedded DNS resolver in Docker containers to discover the service #}
               resolver 127.0.0.11 valid=5s;
               set $backend "{{ matrix_hookshot_container_url }}:{{ matrix_hookshot_provisioning_port }}";
-              proxy_pass http://$backend/v1/$1$is_args$args;
+              proxy_pass http://$backend{{ matrix_hookshot_provisioning_internal }}/$1$is_args$args;
             {% else %}
               {# Generic configuration for use outside of our container setup #}
-              proxy_pass http://127.0.0.1:{{ matrix_hookshot_provisioning_port }}/v1/$1$is_args$args;
+              proxy_pass http://127.0.0.1:{{ matrix_hookshot_provisioning_port }}{{ matrix_hookshot_provisioning_internal }}/$1$is_args$args;
             {% endif %}
             proxy_set_header Host $host;
           }

--- a/roles/matrix-bridge-hookshot/tasks/init.yml
+++ b/roles/matrix-bridge-hookshot/tasks/init.yml
@@ -63,6 +63,20 @@
             proxy_set_header Host $host;
           }
           {% endif %}
+          {% if matrix_hookshot_widgets_enabled %}
+          location ~ ^{{ matrix_hookshot_widgets_endpoint }}/(.*)$ {
+            {% if matrix_nginx_proxy_enabled|default(False) %}
+              {# Use the embedded DNS resolver in Docker containers to discover the service #}
+              resolver 127.0.0.11 valid=5s;
+              set $backend "{{ matrix_hookshot_container_url }}:{{ matrix_hookshot_widgets_port }}";
+              proxy_pass http://$backend{{ matrix_hookshot_widgets_internal }}/$1$is_args$args;
+            {% else %}
+              {# Generic configuration for use outside of our container setup #}
+              proxy_pass http://127.0.0.1:{{ matrix_hookshot_widgets_port }}{{ matrix_hookshot_widgets_internal }}/$1$is_args$args;
+            {% endif %}
+            proxy_set_header Host $host;
+          }
+          {% endif %}
           location ~ ^{{ matrix_hookshot_webhook_endpoint }}/(.*)$ {
             {% if matrix_nginx_proxy_enabled|default(False) %}
               {# Use the embedded DNS resolver in Docker containers to discover the service #}

--- a/roles/matrix-bridge-hookshot/templates/config.yml.j2
+++ b/roles/matrix-bridge-hookshot/templates/config.yml.j2
@@ -47,6 +47,13 @@ gitlab:
   webhook:
     secret: {{ matrix_hookshot_gitlab_secret|to_json }}
 {% endif %}
+{% if matrix_hookshot_figma_enabled %}
+figma:
+  # (Optional) Configure this to enable Figma support
+  #
+  publicUrl: {{ matrix_hookshot_figma_publicUrl }}
+  instances: {{ matrix_hookshot_figma_instances }}
+{% endif %}
 {% if matrix_hookshot_jira_enabled %}
 jira:
   # (Optional) Configure this to enable Jira support
@@ -68,13 +75,6 @@ generic:
   urlPrefix: {{ matrix_hookshot_generic_urlprefix }}
   allowJsTransformationFunctions: {{ matrix_hookshot_generic_allow_js_transformation_functions }}
   userIdPrefix: {{ matrix_hookshot_generic_user_id_prefix|to_json }}
-{% endif %}
-{% if matrix_hookshot_figma_enabled %}
-figma:
-  # (Optional) Configure this to enable Figma support
-  #
-  publicUrl: {{ matrix_hookshot_figma_publicUrl }}
-  instances: {{ matrix_hookshot_figma_instances }}
 {% endif %}
 {% if matrix_hookshot_provisioning_enabled %}
 provisioning:

--- a/roles/matrix-bridge-hookshot/templates/config.yml.j2
+++ b/roles/matrix-bridge-hookshot/templates/config.yml.j2
@@ -33,10 +33,12 @@ github:
     #
     ignoreHooks: {{ matrix_hookshot_github_ignore_hooks }}
     commandPrefix: "{{ matrix_hookshot_github_command_prefix }}"
-    showIssueRoomLink: {{ matrix_hookshot_github_show_issue_room_link }}
+    showIssueRoomLink: {{ matrix_hookshot_github_showIssueRoomLink }}
     prDiff: {{ matrix_hookshot_github_pr_diff }}
     includingLabels:{{ matrix_hookshot_github_including_labels }}
     excludingLabels: {{ matrix_hookshot_github_excluding_labels }}
+    hotlinkIssues:
+      prefix: "{{ matrix_hookshot_github_hotlink_prefix }}"
 {% endif %}
 {% if matrix_hookshot_gitlab_enabled %}
 gitlab:
@@ -100,6 +102,22 @@ logging:
   # (Optional) Logging settings. You can have a severity debug,info,warn,error
   #
   level: info
+{% if matrix_hookshot_widgets_enabled %}
+widgets:
+  # (Optional) EXPERIMENTAL support for complimentary widgets
+  #
+  addToAdminRooms: {{ matrix_hookshot_widgets_addToAdminRooms }}
+{% if matrix_hookshot_widgets_roomSetupWidget_enabled %}
+  roomSetupWidget:
+    addOnInvite: {{ matrix_hookshot_widgets_roomSetupWidget_addOnInvite }}
+{% endif %}
+{% if not matrix_hookshot_widgets_disallowedIpRanges is in [None, ''] %}
+  disallowedIpRanges: {{ matrix_hookshot_widgets_disallowedIpRanges }}
+{% endif %}
+  publicUrl: {{ matrix_hookshot_widgets_publicUrl }}
+  branding:
+    widgetTitle: {{ matrix_hookshot_widgets_branding_widgetTitle }}
+{% endif %}
 {% if matrix_hookshot_permissions %}
 permissions: {{ matrix_hookshot_permissions }}
 {% endif %}
@@ -124,4 +142,10 @@ listeners:
     bindAddress: 0.0.0.0
     resources:
       - provisioning
+{% endif %}
+{% if matrix_hookshot_widgets_enabled %}
+  - port: {{ matrix_hookshot_widgets_port }}
+    bindAddress: 0.0.0.0
+    resources:
+      - widgets
 {% endif %}


### PR DESCRIPTION
first addresses #1724

and on top upgrades hookshot to 1.4.0 https://github.com/matrix-org/matrix-hookshot/releases/tag/1.4.0, adding most importantly the new widgets feature.