### PR TITLE
Change borg backup service file to type=simple

### DIFF
--- a/roles/matrix-backup-borg/templates/systemd/matrix-backup-borg.service.j2
+++ b/roles/matrix-backup-borg/templates/systemd/matrix-backup-borg.service.j2
@@ -11,7 +11,7 @@ Wants={{ service }}
 DefaultDependencies=no
 
 [Service]
-Type=oneshot
+Type=simple
 Environment="HOME={{ matrix_systemd_unit_home_path }}"
 ExecStartPre=-{{ matrix_host_command_sh }} -c '{{ matrix_host_command_docker }} kill matrix-backup-borg 2>/dev/null || true'
 ExecStartPre=-{{ matrix_host_command_sh }} -c '{{ matrix_host_command_docker }} rm matrix-backup-borg 2>/dev/null || true'


### PR DESCRIPTION
This change is to prevent the playbook hanging on: https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/aef2c4c32e8fb8249bde15066df6075cfaf95454/roles/matrix-common-after/tasks/start.yml#L18

It seems that setting the service type to `oneshot` caused the unit to sit at activating and never reach started which then won't satisfy the check in the start tasks.
The [systemd.service man](https://www.freedesktop.org/software/systemd/man/systemd.service.html) seems to imply with oneshot it would:
> directly transition from "activating" to "deactivating" or "dead" 
which I imagine would cause it fail after completing the backup.

`Type=simple` seems to be the choice in other systemd files in the playbook, so this would be following that.