### PR TITLE
Increase default async time for rust-synapse-compress-state

### DIFF
--- a/roles/matrix-synapse/tasks/rust-synapse-compress-state/main.yml
+++ b/roles/matrix-synapse/tasks/rust-synapse-compress-state/main.yml
@@ -11,17 +11,17 @@
 
 - name: Set matrix_synapse_rust_synapse_compress_state_find_rooms_command_wait_time, if not provided
   set_fact:
-    matrix_synapse_rust_synapse_compress_state_find_rooms_command_wait_time: 300
+    matrix_synapse_rust_synapse_compress_state_find_rooms_command_wait_time: 1800
   when: "matrix_synapse_rust_synapse_compress_state_find_rooms_command_wait_time|default('') == ''"
 
 - name: Set matrix_synapse_rust_synapse_compress_state_compress_room_time, if not provided
   set_fact:
-    matrix_synapse_rust_synapse_compress_state_compress_room_time: 1800
+    matrix_synapse_rust_synapse_compress_state_compress_room_time: 3600
   when: "matrix_synapse_rust_synapse_compress_state_compress_room_time|default('') == ''"
 
 - name: Set matrix_synapse_rust_synapse_compress_state_psql_import_time, if not provided
   set_fact:
-    matrix_synapse_rust_synapse_compress_state_psql_import_time: 1800
+    matrix_synapse_rust_synapse_compress_state_psql_import_time: 3600
   when: "matrix_synapse_rust_synapse_compress_state_psql_import_time|default('') == ''"
 
 - name: Set matrix_synapse_rust_synapse_compress_state_min_state_groups_required, if not provided


### PR DESCRIPTION
Increase the async timeout value defaults, as larger Matrix servers need more time to complete.

Not doing so can result in timeout errors such as;

```
ASYNC POLL on matrix.unredacted.org: jid=30536919578.3797072 started=1 finished=0
ASYNC FAILED on matrix.unredacted.org: jid=30536919578.3797072
fatal: [matrix.unredacted.org]: FAILED! => changed=false 
  ansible_job_id: '30536919578.3797072'
  child_pid: 3797076
  finished: 1
  msg: Timeout exceeded
  results_file: /root/.ansible_async/30536919578.3797072
  started: 1
  stderr: ''
  stderr_lines: <omitted>
  stdout: ''
  stdout_lines: <omitted>
```