### PR TITLE
add retires to all get_url actions

### DIFF
--- a/roles/matrix-base/defaults/main.yml
+++ b/roles/matrix-base/defaults/main.yml
@@ -71,6 +71,10 @@ matrix_container_global_registry_prefix: "docker.io/"
 matrix_container_retries_count: 10
 matrix_container_retries_delay: 10
 
+# Each get_url will retry on failed attempt 10 times with delay of 10 seconds between each attempt.
+matrix_geturl_retries_count: 10
+matrix_geturl_retries_delay: 10
+
 matrix_user_username: "matrix"
 matrix_user_groupname: "matrix"
 

--- a/roles/matrix-grafana/tasks/setup.yml
+++ b/roles/matrix-grafana/tasks/setup.yml
@@ -70,6 +70,10 @@
     group: "{{ matrix_user_groupname }}"
   with_items: "{{ matrix_grafana_dashboard_download_urls_all }}"
   when: matrix_grafana_enabled|bool
+  register: result
+  retries: "{{ matrix_geturl_retries_count }}"
+  delay: "{{ matrix_geturl_retries_delay }}"
+  until: result is not failed
 
 - name: Ensure matrix-grafana.service installed
   template:

--- a/roles/matrix-prometheus/tasks/setup_install.yml
+++ b/roles/matrix-prometheus/tasks/setup_install.yml
@@ -32,6 +32,10 @@
     owner: "{{ matrix_user_username }}"
     group: "{{ matrix_user_groupname }}"
   when: "matrix_prometheus_scraper_synapse_rules_enabled|bool"
+  register: result
+  retries: "{{ matrix_geturl_retries_count }}"
+  delay: "{{ matrix_geturl_retries_delay }}"
+  until: result is not failed
 
 - name: Ensure prometheus.yml installed
   copy:

--- a/roles/matrix-synapse/tasks/ext/encryption-disabler/setup_install.yml
+++ b/roles/matrix-synapse/tasks/ext/encryption-disabler/setup_install.yml
@@ -8,6 +8,10 @@
     mode: 0440
     owner: "{{ matrix_user_username }}"
     group: "{{ matrix_user_groupname }}"
+  register: result
+  retries: "{{ matrix_geturl_retries_count }}"
+  delay: "{{ matrix_geturl_retries_delay }}"
+  until: result is not failed
 
 - set_fact:
     matrix_synapse_modules: |

--- a/roles/matrix-synapse/tasks/ext/rest-auth/setup_install.yml
+++ b/roles/matrix-synapse/tasks/ext/rest-auth/setup_install.yml
@@ -13,6 +13,10 @@
     mode: 0440
     owner: "{{ matrix_user_username }}"
     group: "{{ matrix_user_groupname }}"
+  register: result
+  retries: "{{ matrix_geturl_retries_count }}"
+  delay: "{{ matrix_geturl_retries_delay }}"
+  until: result is not failed
 
 - set_fact:
     matrix_synapse_password_providers_enabled: true

--- a/roles/matrix-synapse/tasks/ext/shared-secret-auth/setup_install.yml
+++ b/roles/matrix-synapse/tasks/ext/shared-secret-auth/setup_install.yml
@@ -18,6 +18,10 @@
     mode: 0440
     owner: "{{ matrix_user_username }}"
     group: "{{ matrix_user_groupname }}"
+  register: result
+  retries: "{{ matrix_geturl_retries_count }}"
+  delay: "{{ matrix_geturl_retries_delay }}"
+  until: result is not failed
 
 - set_fact:
     matrix_synapse_modules: |


### PR DESCRIPTION
This PR adds automatic retries to all `get_url` actions to avoid errors like this one:

```
Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>
```

The same was done to docker pulls before