### PR TITLE
Slack appservice: Enable RTM by default

### DIFF
--- a/roles/matrix-bridge-appservice-slack/templates/config.yaml.j2
+++ b/roles/matrix-bridge-appservice-slack/templates/config.yaml.j2
@@ -9,8 +9,20 @@ homeserver:
     url: "{{ matrix_appservice_slack_homeserver_url }}"
     media_url: "{{ matrix_appservice_slack_homeserver_media_url }}"
 
+# Real Time Messaging API (RTM)
+# Optional if slack_hook_port and inbound_uri_prefix are defined, required otherwise.
+#
 rtm:
-    enable: true
+  # Use the RTM API to listen for requests, which does not require
+  # the bridge to listen on the hook port.
+  # You should leave this enabled, unless you plan to use the
+  # bridge exclusively for webhooks.
+  #
+  enable: true
+
+  # Logging level specific to RTM traffic.
+  #
+  log_level: "silent"
 
 {% if matrix_appservice_slack_database_engine == 'nedb' %}
 dbdir: "/data"

--- a/roles/matrix-bridge-appservice-slack/templates/config.yaml.j2
+++ b/roles/matrix-bridge-appservice-slack/templates/config.yaml.j2
@@ -9,6 +9,9 @@ homeserver:
     url: "{{ matrix_appservice_slack_homeserver_url }}"
     media_url: "{{ matrix_appservice_slack_homeserver_media_url }}"
 
+rtm:
+    enable: true
+
 {% if matrix_appservice_slack_database_engine == 'nedb' %}
 dbdir: "/data"
 {% else %}


### PR DESCRIPTION
It is very confusing to debug why messages only go from Matrix to Slack
but not from Slack to Matrix. RTM should be enabled by default, as
that's the recommended way to make this work.