### PR TITLE
HOTFIX: matrix-registration-bot, fixed systemd template that caused setup error

### DIFF
--- a/docs/configuring-playbook-bot-matrix-registration-bot.md
+++ b/docs/configuring-playbook-bot-matrix-registration-bot.md
@@ -63,7 +63,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 
 ## Usage
 
-To use the bot, create a **non-encrypted** room and invite `@bot.matrix-reminder-bot:DOMAIN` (where `YOUR_DOMAIN` is your base domain, not the `matrix.` domain).
+To use the bot, create a **non-encrypted** room and invite `@bot.matrix-registration-bot:DOMAIN` (where `YOUR_DOMAIN` is your base domain, not the `matrix.` domain).
 
 In this room send `help` and the bot will reply with all options.
 

--- a/roles/matrix-bot-matrix-registration-bot/templates/systemd/matrix-bot-matrix-registration-bot.service.j2
+++ b/roles/matrix-bot-matrix-registration-bot/templates/systemd/matrix-bot-matrix-registration-bot.service.j2
@@ -25,7 +25,6 @@ ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-bot-matrix-reg
 			--mount type=bind,src={{ matrix_bot_matrix_registration_bot_config_path }},dst=/config,ro \
 			--mount type=bind,src={{ matrix_bot_matrix_registration_bot_data_path }},dst=/data \
 			--network={{ matrix_docker_network }} \
-			--env-file={{ matrix_bot_matrix_registration_bot_config_path }}/env \
 			{{ matrix_bot_matrix_registration_bot_docker_image }}
 
 ExecStop=-{{ matrix_host_command_sh }} -c '{{ matrix_host_command_docker }} kill matrix-bot-matrix-registration-bot 2>/dev/null || true'


### PR DESCRIPTION
Sorry to request to pull into master, but a hotfix is needed. I have removed a line in [matrix-bot-matrix-registration-bot.service.j2](https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/roles/matrix-bot-matrix-registration-bot/templates/systemd/matrix-bot-matrix-registration-bot.service.j2). 

If this line is left open, docker will crash when it tries to open a file that doesn't exist. Looks like this may have been left over from something. I have tested this and I was able to install it on my own server. Once this line was removed, I had no issues.

I also noticed a documentation error that referenced the wrong bot. I corrected this too.