### PR TITLE
Bump signald to 0.18.1

### DIFF
--- a/roles/matrix-bridge-mautrix-signal/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-signal/defaults/main.yml
@@ -9,7 +9,7 @@ matrix_mautrix_signal_docker_repo: "https://mau.dev/mautrix/signal.git"
 matrix_mautrix_signal_docker_src_files_path: "{{ matrix_base_data_path }}/mautrix-signal/docker-src"
 
 matrix_mautrix_signal_version: v0.3.0
-matrix_mautrix_signal_daemon_version: 0.18.0
+matrix_mautrix_signal_daemon_version: 0.18.1
 # See: https://mau.dev/mautrix/signal/container_registry
 matrix_mautrix_signal_docker_image: "dock.mau.dev/mautrix/signal:{{ matrix_mautrix_signal_version }}"
 matrix_mautrix_signal_docker_image_force_pull: "{{ matrix_mautrix_signal_docker_image.endswith(':latest') }}"
@@ -20,7 +20,7 @@ matrix_mautrix_signal_daemon_docker_src_files_path: "{{ matrix_base_data_path }}
 
 matrix_mautrix_signal_daemon_docker_image: "docker.io/signald/signald:{{ matrix_mautrix_signal_daemon_docker_image_tag }}"
 matrix_mautrix_signal_daemon_docker_image_force_pull: "{{ matrix_mautrix_signal_daemon_docker_image_tag.endswith(':latest') }}"
-matrix_mautrix_signal_daemon_docker_image_tag: "{{ matrix_mautrix_signal_daemon_version }}-non-root"
+matrix_mautrix_signal_daemon_docker_image_tag: "{{ matrix_mautrix_signal_daemon_version }}"
 
 matrix_mautrix_signal_base_path: "{{ matrix_base_data_path }}/mautrix-signal"
 matrix_mautrix_signal_config_path: "{{ matrix_mautrix_signal_base_path }}/bridge"


### PR DESCRIPTION
According to https://signald.org/articles/install/docker/#migrating-from-versions-before-0180,
This release only chowns files if the container is running as root. See also this upstream commit:
https://gitlab.com/signald/signald/-/commit/3bb7e8d2c128681473e324f811cff25e0883b88d