### PR TITLE
Make synapse htpasswd file path configurable

### DIFF
--- a/roles/matrix-nginx-proxy/defaults/main.yml
+++ b/roles/matrix-nginx-proxy/defaults/main.yml
@@ -221,6 +221,7 @@ matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_enabled: false
 # e.g. `htpasswd -c mypass.htpasswd prometheus` and enter `mysecurepw` when prompted yields `prometheus:$apr1$wZhqsn.U$7LC3kMmjUbjNAZjyMyvYv/`
 # The part after `prometheus:` is needed here. matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_key: "$apr1$wZhqsn.U$7LC3kMmjUbjNAZjyMyvYv/"
 matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_key: ""
+matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_path: "/nginx-data/matrix-synapse-metrics-htpasswd"
 
 # The addresses where the Matrix Client API is.
 # Certain extensions (like matrix-corporal) may override this in order to capture all traffic.

--- a/roles/matrix-nginx-proxy/defaults/main.yml
+++ b/roles/matrix-nginx-proxy/defaults/main.yml
@@ -221,7 +221,7 @@ matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_enabled: false
 # e.g. `htpasswd -c mypass.htpasswd prometheus` and enter `mysecurepw` when prompted yields `prometheus:$apr1$wZhqsn.U$7LC3kMmjUbjNAZjyMyvYv/`
 # The part after `prometheus:` is needed here. matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_key: "$apr1$wZhqsn.U$7LC3kMmjUbjNAZjyMyvYv/"
 matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_key: ""
-matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_path: "/nginx-data/matrix-synapse-metrics-htpasswd"
+matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_path: "{{ matrix_nginx_proxy_data_path_in_container if matrix_nginx_proxy_enabled else matrix_nginx_proxy_data_path }}/matrix-synapse-metrics-htpasswd"
 
 # The addresses where the Matrix Client API is.
 # Certain extensions (like matrix-corporal) may override this in order to capture all traffic.

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-synapse.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-synapse.conf.j2
@@ -161,7 +161,7 @@ server {
 
 		{% if matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_enabled %}
 			auth_basic "protected";
-			auth_basic_user_file /nginx-data/matrix-synapse-metrics-htpasswd;
+			auth_basic_user_file {{ matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_path }};
 		{% endif %}
 	}
 	{% endif %}
@@ -177,7 +177,7 @@ server {
 
 					{% if matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_enabled %}
 						auth_basic "protected";
-						auth_basic_user_file /nginx-data/matrix-synapse-metrics-htpasswd;
+						auth_basic_user_file {{ matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_path }};
 					{% endif %}
 				}
 			{% endif %}


### PR DESCRIPTION
When setting `matrix_nginx_proxy_enabled: false` and enabling authentication on the metrics endpoint, the htpasswd file is hardcoded to the nginx-proxy container dir.
This changes the hardcoded value to a variable so the path can be updated.

Added a new variable in the nginx-proxy defaults `matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_path` pointing to the currently hardcoded value