### PR TITLE
Upgrade Hookshot (1.5.0 -> 1.6.1)

### DIFF
--- a/roles/matrix-bridge-hookshot/defaults/main.yml
+++ b/roles/matrix-bridge-hookshot/defaults/main.yml
@@ -10,7 +10,7 @@ matrix_hookshot_container_image_self_build: false
 matrix_hookshot_container_image_self_build_repo: "https://github.com/matrix-org/matrix-hookshot.git"
 matrix_hookshot_container_image_self_build_branch: "{{ 'main' if matrix_hookshot_version == 'latest' else matrix_hookshot_version }}"
 
-matrix_hookshot_version: 1.5.0
+matrix_hookshot_version: 1.6.1
 
 matrix_hookshot_docker_image: "{{ matrix_hookshot_docker_image_name_prefix }}halfshot/matrix-hookshot:{{ matrix_hookshot_version }}"
 matrix_hookshot_docker_image_name_prefix: "{{ 'localhost/' if matrix_hookshot_container_image_self_build else matrix_container_global_registry_prefix }}"


### PR DESCRIPTION
https://github.com/matrix-org/matrix-hookshot/releases/tag/1.6.1
https://github.com/matrix-org/matrix-hookshot/releases/tag/1.6.0

tl;dr:
- gitlab can be configured with commands and a widget
- rss/atom feed support
- docker image is now only 300MB instead of 1.3GB! :tada:

no api changes = easy upgrade