### PR TITLE
Clarify reverse-proxying of well-known files with Caddy2

### DIFF
--- a/docs/configuring-well-known.md
+++ b/docs/configuring-well-known.md
@@ -116,8 +116,22 @@ server {
 **For Caddy 2**, it would be something like this:
 
 ```caddy
-reverse_proxy /.well-known/matrix/* https://matrix.DOMAIN {
-	header_up Host {http.reverse_proxy.upstream.hostport}
+DOMAIN.com {
+   @wellknown {
+         path /.well-known/matrix/*:x
+   }
+
+   handle @wellknown {
+      reverse_proxy https://matrix.DOMAIN.com {
+          header_up Host {http.reverse_proxy.upstream.hostport}
+      }
+   }
+    # Configration for the base domain goes here
+  # handle {
+  #    header -Server
+  #     encode zstd gzip
+  #    reverse_proxy localhost:4020
+  # }
 }
 ```
 

--- a/docs/configuring-well-known.md
+++ b/docs/configuring-well-known.md
@@ -46,7 +46,7 @@ If you decide to go this route, you don't need to read ahead in this document. W
 
 If you're managing the base domain by yourself somehow, you'll need to set up serving of some `/.well-known/matrix/*` files from it via HTTPS.
 
-To make things easy for you to set up, this playbook generates and hosts 2 well-known files on the Matrix domain's server (e.g. `https://matrix.example.com/.well-known/matrix/server` and `https://matrix.example.com/.well-known/matrix/client`), even though this is the wrong place to host them.
+To make things easy for you to set up, this playbook generates and hosts 2 well-known files on the Matrix domain's server. The files are generated at `/matrix/static-files/.well-known/matrix/` and hosted at `https://matrix.example.com/.well-known/matrix/server` and `https://matrix.example.com/.well-known/matrix/client`, even though this is the wrong place to host them.
 
 You have 3 options when it comes to installing the files on the base domain's server:
 

--- a/examples/caddy2/Caddyfile
+++ b/examples/caddy2/Caddyfile
@@ -214,3 +214,20 @@ element.DOMAIN.tld {
 #        }
 #  }
 #}
+DOMAIN.com {
+    @wellknown {
+        path /.well-known/matrix/*
+    }
+
+    handle @wellknown {
+        reverse_proxy https://matrix.DOMAIN.com {
+            header_up Host {http.reverse_proxy.upstream.hostport}
+        }
+    }
+    # Configration for the base domain goes here
+   # handle {
+   #    header -Server
+   #     encode zstd gzip
+   #    reverse_proxy localhost:4020
+   # }
+}


### PR DESCRIPTION
The suggestions for how to serve/reverse proxy .well-known files from base domain using Caddy 2 seems to be outdated. https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/docs/configuring-well-known.md#option-3-setting-up-reverse-proxying-of-the-well-known-files-from-the-base-domains-server-to-the-matrix-server

Instead what is suggested in this issue (https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/1442) should be used.