### PR TITLE
Bump Slack Appservice to 1.11.0

### DIFF
--- a/roles/matrix-bridge-appservice-slack/defaults/main.yml
+++ b/roles/matrix-bridge-appservice-slack/defaults/main.yml
@@ -8,7 +8,7 @@ matrix_appservice_slack_container_image_self_build: false
 matrix_appservice_slack_docker_repo: "https://github.com/matrix-org/matrix-appservice-slack.git"
 matrix_appservice_slack_docker_src_files_path: "{{ matrix_base_data_path }}/appservice-slack/docker-src"
 
-matrix_appservice_slack_version: release-1.10.0
+matrix_appservice_slack_version: release-1.11.0
 matrix_appservice_slack_docker_image: "{{ matrix_container_global_registry_prefix }}matrixdotorg/matrix-appservice-slack:{{ matrix_appservice_slack_version }}"
 matrix_appservice_slack_docker_image_force_pull: "{{ matrix_appservice_slack_docker_image.endswith(':latest') }}"
 


### PR DESCRIPTION
Has some Threading-related improvements: https://github.com/matrix-org/matrix-appservice-slack/compare/1.10.0...1.11.0