### PR TITLE
Bridge mautrix signal and mautrix whatsapp encryption

### DIFF
--- a/roles/matrix-bridge-mautrix-signal/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-signal/defaults/main.yml
@@ -127,3 +127,7 @@ matrix_mautrix_signal_registration_yaml: "{{ lookup('template', 'templates/regis
 matrix_mautrix_signal_registration: "{{ matrix_mautrix_signal_registration_yaml|from_yaml }}"
 
 matrix_mautrix_signal_log_level: 'DEBUG'
+
+matrix_mautrix_signal_bridge_encryption_allow: false
+matrix_mautrix_signal_bridge_encryption_default: "{{ matrix_mautrix_signal_bridge_encryption_allow }}"
+matrix_mautrix_signal_bridge_encryption_key_sharing_allow: "{{ matrix_mautrix_signal_bridge_encryption_allow }}"

--- a/roles/matrix-bridge-mautrix-signal/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-signal/templates/config.yaml.j2
@@ -152,15 +152,15 @@ bridge:
     # this to work. See https://github.com/tulir/mautrix-telegram/wiki/End‐to‐bridge-encryption
     encryption:
         # Allow encryption, work in group chat rooms with e2ee enabled
-        allow: false
+        allow: {{ matrix_mautrix_signal_bridge_encryption_allow|to_json }}
         # Default to encryption, force-enable encryption in all portals the bridge creates
         # This will cause the bridge bot to be in private chats for the encryption to work properly.
-        default: false
+        default: {{ matrix_mautrix_signal_bridge_encryption_default|to_json }}
         # Options for automatic key sharing.
         key_sharing:
             # Enable key sharing? If enabled, key requests for rooms where users are in will be fulfilled.
             # You must use a client that supports requesting keys from other users to use this feature.
-            allow: false
+            allow: {{ matrix_mautrix_signal_bridge_encryption_key_sharing_allow|to_json }}
             # Require the requesting device to have a valid cross-signing signature?
             # This doesn't require that the bridge has verified the device, only that the user has verified it.
             # Not yet implemented.

--- a/roles/matrix-bridge-mautrix-whatsapp/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-whatsapp/defaults/main.yml
@@ -123,3 +123,8 @@ matrix_mautrix_whatsapp_registration_yaml: |
   de.sorunome.msc2409.push_ephemeral: true
 
 matrix_mautrix_whatsapp_registration: "{{ matrix_mautrix_whatsapp_registration_yaml|from_yaml }}"
+
+# Enable End-to-bridge encryption
+matrix_mautrix_whatsapp_bridge_encryption_allow: false
+matrix_mautrix_whatsapp_bridge_encryption_default: "{{ matrix_mautrix_whatsapp_bridge_encryption_allow }}"
+matrix_mautrix_whatsapp_bridge_encryption_key_sharing_allow: "{{ matrix_mautrix_whatsapp_bridge_encryption_allow }}"

--- a/roles/matrix-bridge-mautrix-whatsapp/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-whatsapp/templates/config.yaml.j2
@@ -158,16 +158,16 @@ bridge:
     # See https://docs.mau.fi/bridges/general/end-to-bridge-encryption.html for more info.
     encryption:
         # Allow encryption, work in group chat rooms with e2ee enabled
-        allow: false
+        allow: {{ matrix_mautrix_whatsapp_bridge_encryption_allow|to_json }}
         # Default to encryption, force-enable encryption in all portals the bridge creates
         # This will cause the bridge bot to be in private chats for the encryption to work properly.
         # It is recommended to also set private_chat_portal_meta to true when using this.
-        default: false
+        default: {{ matrix_mautrix_whatsapp_bridge_encryption_default|to_json }}
         # Options for automatic key sharing.
         key_sharing:
             # Enable key sharing? If enabled, key requests for rooms where users are in will be fulfilled.
             # You must use a client that supports requesting keys from other users to use this feature.
-            allow: false
+            allow: {{ matrix_mautrix_whatsapp_bridge_encryption_key_sharing_allow|to_json }}
             # Require the requesting device to have a valid cross-signing signature?
             # This doesn't require that the bridge has verified the device, only that the user has verified it.
             # Not yet implemented.


### PR DESCRIPTION
Hello,

This PR adds two new variables, one in each Signal & WhatsApp bridges, to be able to enable end-to-bridge encryption.

Closes #877