### PR TITLE
Change back to working original mx-puppet-slack

### DIFF
--- a/roles/matrix-bridge-mx-puppet-discord/defaults/main.yml
+++ b/roles/matrix-bridge-mx-puppet-discord/defaults/main.yml
@@ -5,7 +5,7 @@
 matrix_mx_puppet_discord_enabled: true
 
 matrix_mx_puppet_discord_container_image_self_build: false
-matrix_mx_puppet_discord_container_image_self_build_repo: "https://gitlab.com/mx-puppet/discord/mx-puppet-discord"
+matrix_mx_puppet_discord_container_image_self_build_repo: "https://gitlab.com/mx-puppet/discord/mx-puppet-discord.git"
 matrix_mx_puppet_discord_container_image_self_build_version: "{{ 'main' if matrix_mx_puppet_discord_version == 'latest' else matrix_mx_puppet_discord_version }}"
 matrix_mx_puppet_discord_container_image_self_build_dockerfile_path: "Dockerfile"
 

--- a/roles/matrix-bridge-mx-puppet-slack/defaults/main.yml
+++ b/roles/matrix-bridge-mx-puppet-slack/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Mx Puppet Slack is a Matrix <-> Slack bridge
-# See: https://gitlab.com/beeper/mx-puppet-monorepo (originally based on https://github.com/Sorunome/mx-puppet-slack)
+# See: https://github.com/Sorunome/mx-puppet-slack
 
 matrix_mx_puppet_slack_enabled: true
 
@@ -8,17 +8,17 @@ matrix_mx_puppet_slack_oauth_client_id: ''
 matrix_mx_puppet_slack_oauth_client_secret: ''
 
 matrix_mx_puppet_slack_container_image_self_build: false
-matrix_mx_puppet_slack_container_image_self_build_repo: "https://gitlab.com/beeper/mx-puppet-monorepo.git"
+matrix_mx_puppet_slack_container_image_self_build_repo: "https://gitlab.com/mx-puppet/slack/mx-puppet-slack.git"
 matrix_mx_puppet_slack_container_image_self_build_version: "{{ 'main' if matrix_mx_puppet_slack_version == 'latest' else matrix_mx_puppet_slack_version }}"
-matrix_mx_puppet_slack_container_image_self_build_dockerfile_path: "docker/Dockerfile-slack"
+matrix_mx_puppet_slack_container_image_self_build_dockerfile_path: "Dockerfile"
 
 # Controls whether the mx-puppet-slack container exposes its HTTP port (tcp/8432 in the container).
 #
 # Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:8432"), or empty string to not expose.
 matrix_mx_puppet_slack_container_http_host_bind_port: ''
 
-matrix_mx_puppet_slack_version: latest
-matrix_mx_puppet_slack_docker_image: "{{ matrix_mx_puppet_slack_docker_image_name_prefix }}beeper/mx-puppet-monorepo/slack:{{ matrix_mx_puppet_slack_version }}"
+matrix_mx_puppet_slack_version: v0.1.1
+matrix_mx_puppet_slack_docker_image: "{{ matrix_mx_puppet_slack_docker_image_name_prefix }}mx-puppet/slack/mx-puppet-slack:{{ matrix_mx_puppet_slack_version }}"
 matrix_mx_puppet_slack_docker_image_name_prefix: "{{ 'localhost/' if matrix_mx_puppet_slack_container_image_self_build else 'registry.gitlab.com/' }}"
 matrix_mx_puppet_slack_docker_image_force_pull: "{{ matrix_mx_puppet_slack_docker_image.endswith(':latest') }}"
 


### PR DESCRIPTION
Now that v0.1.1 is out, which depends on the functional matrix-slack-parser it works again.