### PR TITLE
Update Element self build repo URL

### DIFF
--- a/roles/matrix-client-element/defaults/main.yml
+++ b/roles/matrix-client-element/defaults/main.yml
@@ -3,7 +3,7 @@
 matrix_client_element_enabled: true
 
 matrix_client_element_container_image_self_build: false
-matrix_client_element_container_image_self_build_repo: "https://github.com/vector-im/riot-web.git"
+matrix_client_element_container_image_self_build_repo: "https://github.com/vector-im/element-web.git"
 # Controls whether to patch webpack.config.js when self-building, so that building can pass on low-memory systems (< 4 GB RAM):
 # - https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/1357
 # - https://github.com/vector-im/element-web/issues/19544


### PR DESCRIPTION
It forwards to the correct place but might as well just update it to the current URL.