### PR TITLE
Automatically enable admin api access via nginx

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -1495,7 +1495,7 @@ matrix_nginx_proxy_proxy_matrix_client_api_client_max_body_size_mb: |-
     }[matrix_homeserver_implementation]|int
   }}
 
-matrix_nginx_proxy_proxy_matrix_client_api_forwarded_location_synapse_admin_api_enabled: "{{ matrix_synapse_admin_enabled }} or {{ matrix_bot_matrix_registration_bot_enabled }}"
+matrix_nginx_proxy_proxy_matrix_client_api_forwarded_location_synapse_admin_api_enabled: "{{ matrix_synapse_admin_enabled or matrix_bot_matrix_registration_bot_enabled }}"
 
 matrix_nginx_proxy_proxy_matrix_client_redirect_root_uri_to_domain: "{{ matrix_server_fqn_element if matrix_client_element_enabled else '' }}"
 

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -1495,7 +1495,7 @@ matrix_nginx_proxy_proxy_matrix_client_api_client_max_body_size_mb: |-
     }[matrix_homeserver_implementation]|int
   }}
 
-matrix_nginx_proxy_proxy_matrix_client_api_forwarded_location_synapse_admin_api_enabled: "{{ matrix_synapse_admin_enabled }}"
+matrix_nginx_proxy_proxy_matrix_client_api_forwarded_location_synapse_admin_api_enabled: "{{ matrix_synapse_admin_enabled }} or {{ matrix_bot_matrix_registration_bot_enabled }}"
 
 matrix_nginx_proxy_proxy_matrix_client_redirect_root_uri_to_domain: "{{ matrix_server_fqn_element if matrix_client_element_enabled else '' }}"
 


### PR DESCRIPTION
This was a bug preventing the bot from interacting with the admin API (404). It now configures nginx so that the admin API is accessible from the outside, as synapse admin does too