### PR TITLE
Update Postgres (CVE-2022-1552 + last 9.x update)

### DIFF
--- a/roles/matrix-postgres/defaults/main.yml
+++ b/roles/matrix-postgres/defaults/main.yml
@@ -22,12 +22,12 @@ matrix_postgres_architecture: amd64
 # > LOG:  startup process (PID 37) was terminated by signal 11: Segmentation fault
 matrix_postgres_docker_image_suffix: "{{ '-alpine' if matrix_postgres_architecture in ['amd64', 'arm64'] else '' }}"
 
-matrix_postgres_docker_image_v9: "{{ matrix_container_global_registry_prefix }}postgres:9.6.23{{ matrix_postgres_docker_image_suffix }}"
-matrix_postgres_docker_image_v10: "{{ matrix_container_global_registry_prefix }}postgres:10.20{{ matrix_postgres_docker_image_suffix }}"
-matrix_postgres_docker_image_v11: "{{ matrix_container_global_registry_prefix }}postgres:11.15{{ matrix_postgres_docker_image_suffix }}"
-matrix_postgres_docker_image_v12: "{{ matrix_container_global_registry_prefix }}postgres:12.10{{ matrix_postgres_docker_image_suffix }}"
-matrix_postgres_docker_image_v13: "{{ matrix_container_global_registry_prefix }}postgres:13.6{{ matrix_postgres_docker_image_suffix }}"
-matrix_postgres_docker_image_v14: "{{ matrix_container_global_registry_prefix }}postgres:14.2{{ matrix_postgres_docker_image_suffix }}"
+matrix_postgres_docker_image_v9: "{{ matrix_container_global_registry_prefix }}postgres:9.6.24{{ matrix_postgres_docker_image_suffix }}"
+matrix_postgres_docker_image_v10: "{{ matrix_container_global_registry_prefix }}postgres:10.21{{ matrix_postgres_docker_image_suffix }}"
+matrix_postgres_docker_image_v11: "{{ matrix_container_global_registry_prefix }}postgres:11.16{{ matrix_postgres_docker_image_suffix }}"
+matrix_postgres_docker_image_v12: "{{ matrix_container_global_registry_prefix }}postgres:12.11{{ matrix_postgres_docker_image_suffix }}"
+matrix_postgres_docker_image_v13: "{{ matrix_container_global_registry_prefix }}postgres:13.7{{ matrix_postgres_docker_image_suffix }}"
+matrix_postgres_docker_image_v14: "{{ matrix_container_global_registry_prefix }}postgres:14.3{{ matrix_postgres_docker_image_suffix }}"
 matrix_postgres_docker_image_latest: "{{ matrix_postgres_docker_image_v14 }}"
 
 # This variable is assigned at runtime. Overriding its value has no effect.


### PR DESCRIPTION
CVE: https://security-tracker.debian.org/tracker/CVE-2022-1552
Source: https://www.postgresql.org/about/news/postgresql-143-137-1211-1116-and-1021-released-2449/
Postgres 9.6 upgrade (**not a CVE fix, 9.x still vulnerable**): https://www.postgresql.org/docs/release/9.6.24/