### PR TITLE
Fix synapse LDAP simple bind config

### DIFF
--- a/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -2521,8 +2521,10 @@ password_providers:
         uid: {{ matrix_synapse_ext_password_provider_ldap_attributes_uid|string|to_json }}
         mail: {{ matrix_synapse_ext_password_provider_ldap_attributes_mail|string|to_json }}
         name: {{ matrix_synapse_ext_password_provider_ldap_attributes_name|string|to_json }}
+{% if matrix_synapse_ext_password_provider_ldap_bind_dn %}
       bind_dn: {{ matrix_synapse_ext_password_provider_ldap_bind_dn|string|to_json }}
       bind_password: {{ matrix_synapse_ext_password_provider_ldap_bind_password|string|to_json }}
+{% endif %}
       filter: {{ matrix_synapse_ext_password_provider_ldap_filter|string|to_json }}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
When using LDAP simple bind, the `bind_dn` and `bind_password`
configuration values must not be present.

Fixes #1496