### PR TITLE
HOTFIX: Update Matrix-Registration-Bot main.yml

### DIFF
--- a/roles/matrix-bot-matrix-registration-bot/defaults/main.yml
+++ b/roles/matrix-bot-matrix-registration-bot/defaults/main.yml
@@ -7,7 +7,7 @@ matrix_bot_matrix_registration_bot_container_image_self_build: false
 matrix_bot_matrix_registration_bot_docker_repo: "https://github.com/moan0s/matrix-registration-bot.git"
 matrix_bot_matrix_registration_bot_docker_src_files_path: "{{ matrix_bot_matrix_registration_bot_base_path }}/docker-src"
 
-matrix_bot_matrix_registration_bot_version: v1.1.5
+matrix_bot_matrix_registration_bot_version: latest
 matrix_bot_matrix_registration_bot_docker_image: "{{ matrix_container_global_registry_prefix }}moanos/matrix-registration-bot:{{ matrix_bot_matrix_registration_bot_version }}"
 matrix_bot_matrix_registration_bot_docker_image_force_pull: "{{ matrix_bot_matrix_registration_bot_docker_image.endswith(':latest') }}"
 


### PR DESCRIPTION
Line 10, which sets the tag to which docker version to pull was reverted from `v1.1.15` to latest. This gets the playbook working again when a user wants to use the matrix-registration-bot.

Closes #1847 