### PR TITLE
Fix string "null" in status_endpoint

### DIFF
--- a/roles/matrix-bridge-mautrix-whatsapp/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-whatsapp/templates/config.yaml.j2
@@ -10,7 +10,7 @@ homeserver:
     # The URL to push real-time bridge status to.
     # If set, the bridge will make POST requests to this URL whenever a user's whatsapp connection state changes.
     # The bridge will use the appservice as_token to authorize requests.
-    status_endpoint: "null"
+    status_endpoint: null
 
 appservice:
     # The address that the homeserver can use to connect to this appservice.


### PR DESCRIPTION
Hello,
after taling to "tulir" in the matrix-mautrix-whatsapp room, we found out that the "null" string in status_endpoint is causing this WARN:

```
Failed to update bridge state: failed to send request: Post "null": unsupported protocol scheme "", retrying in 64 seconds
```

He told us that to fix that, any of these changes must be done to the config:

```
status_endpoint:
status_endpoint: ""
status_endpoint: null
```

Hope this helps.