### PR TITLE
Synapse workers should respect X-Forwarded headers

### DIFF
--- a/roles/matrix-synapse/templates/synapse/worker.yaml.j2
+++ b/roles/matrix-synapse/templates/synapse/worker.yaml.j2
@@ -26,6 +26,7 @@ worker_listeners:
 {% if http_resources|length > 0 %}
   - type: http
     bind_addresses: ['::']
+    x_forwarded: true
     port: {{ matrix_synapse_worker_details.port }}
     resources:
       - names: {{ http_resources|to_json }}


### PR DESCRIPTION
Currently, Synapse workers ignore the X-Forwarded headers, which leads to internal Docker IP addresses randomly appearing in the device list of users.

This adds the `x_forwarded: true` option to the worker config, fixing the issue.