### PR TITLE
Use prebuilt ARM images for coturn / synapse-admin

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -1260,7 +1260,7 @@ matrix_corporal_matrix_registration_shared_secret: "{{ matrix_synapse_registrati
 
 matrix_coturn_enabled: true
 
-matrix_coturn_container_image_self_build: "{{ matrix_architecture != 'amd64' }}"
+matrix_coturn_container_image_self_build: "{{ matrix_architecture not in ['amd64', 'arm32', 'arm64'] }}"
 
 matrix_coturn_turn_external_ip_address: "{{ ansible_host }}"
 
@@ -2196,7 +2196,7 @@ matrix_synapse_admin_enabled: false
 # Synapse Admin's HTTP port to the local host.
 matrix_synapse_admin_container_http_host_bind_port: "{{ '' if matrix_nginx_proxy_enabled else '127.0.0.1:8766' }}"
 
-matrix_synapse_admin_container_image_self_build: "{{ matrix_architecture != 'amd64' }}"
+matrix_synapse_admin_container_image_self_build: "{{ matrix_architecture not in ['arm64', 'amd64'] }}"
 
 ######################################################################
 #


### PR DESCRIPTION
* synapse-admin arm64 builds available since 2021-12-17 v.0.8.4 [awesometechnologies/synapse-admin:0.8.5](https://hub.docker.com/layers/synapse-admin/awesometechnologies/synapse-admin/0.8.5/images/sha256-eb54b8660c4641641b8acd08fd2dfc94ecc3fc604860f9e8b286a38008e3f3b6?context=explore)

* coturn arm32/arm64 builds available since 2021-04-15 v.4.5.2-r0-alpine [coturn/coturn:4.5.2-r12](https://hub.docker.com/layers/coturn/coturn/coturn/4.5.2-r12/images/sha256-94887581bb1093085033be0494c3a651bd40034afba1867ddc78b8ba32dc2faf?context=explore)