### PR TITLE
Update configuring-playbook-bridge-mautrix-facebook.md

### DIFF
--- a/docs/configuring-playbook-bridge-mautrix-facebook.md
+++ b/docs/configuring-playbook-bridge-mautrix-facebook.md
@@ -24,10 +24,22 @@ If you would like to be able to administrate the bridge from your account it can
 matrix_mautrix_facebook_configuration_extension_yaml: |
   bridge:
     permissions:
-      '@YOUR_USERNAME:YOUR_DOMAIN': admin
+      '@YOUR_USERNAME:{{ matrix_domain }}': admin
 ```
 
-You may wish to look at `roles/matrix-bridge-mautrix-facebook/templates/config.yaml.j2` to find other things you would like to configure.
+Using both would look like
+
+```yaml
+matrix_mautrix_facebook_configuration_extension_yaml: |
+  bridge:
+    permissions:
+      '@YOUR_USERNAME:{{ matrix_domain }}': admin
+    encryption:
+      allow: true
+      default: true
+```
+
+You may wish to look at `roles/matrix-bridge-mautrix-facebook/templates/config.yaml.j2` and 'roles/matrix-bridge-mautrix-facebook/defaults/main.yml' to find other things you would like to configure.
 
 
 ## Set up Double Puppeting

--- a/docs/configuring-playbook-bridge-mautrix-facebook.md
+++ b/docs/configuring-playbook-bridge-mautrix-facebook.md
@@ -39,7 +39,7 @@ matrix_mautrix_facebook_configuration_extension_yaml: |
       default: true
 ```
 
-You may wish to look at `roles/matrix-bridge-mautrix-facebook/templates/config.yaml.j2` and 'roles/matrix-bridge-mautrix-facebook/defaults/main.yml' to find other things you would like to configure.
+You may wish to look at `roles/matrix-bridge-mautrix-facebook/templates/config.yaml.j2` and `roles/matrix-bridge-mautrix-facebook/defaults/main.yml` to find other things you would like to configure.
 
 
 ## Set up Double Puppeting


### PR DESCRIPTION
Adding the defaults in addition to template, switching YOUR_DOMAIN to {{ matrix_domain }}, and giving example of the two combined, as the playbook gives a warning about things being defined twice, so only using the last one in the vars.yml