### PR TITLE
Adding logging configuration and default to the rest of the mautrixes…

### DIFF
--- a/roles/matrix-bridge-mautrix-googlechat/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-googlechat/defaults/main.yml
@@ -78,6 +78,9 @@ matrix_mautrix_googlechat_login_shared_secret: ''
 
 matrix_mautrix_googlechat_appservice_bot_username: googlechatbot
 
+# Specifies the default log level for all bridge loggers.
+matrix_mautrix_googlechat_logging_level: WARNING
+
 # Default configuration template which covers the generic use case.
 # You can customize it by controlling the various variables inside it.
 #

--- a/roles/matrix-bridge-mautrix-googlechat/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-googlechat/templates/config.yaml.j2
@@ -141,11 +141,11 @@ logging:
             formatter: colored
     loggers:
         mau:
-            level: WARNING
+            level: {{ matrix_mautrix_googlechat_logging_level|to_json }}
         hangups:
-            level: WARNING
+            level: {{ matrix_mautrix_googlechat_logging_level|to_json }}
         aiohttp:
-            level: WARNING
+            level: {{ matrix_mautrix_googlechat_logging_level|to_json }}
     root:
-        level: WARNING
+        level: {{ matrix_mautrix_googlechat_logging_level|to_json }}
         handlers: [console]

--- a/roles/matrix-bridge-mautrix-hangouts/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-hangouts/defaults/main.yml
@@ -75,6 +75,9 @@ matrix_mautrix_hangouts_login_shared_secret: ''
 
 matrix_mautrix_hangouts_appservice_bot_username: hangoutsbot
 
+# Specifies the default log level for all bridge loggers.
+matrix_mautrix_hangouts_logging_level: WARNING
+
 # Default configuration template which covers the generic use case.
 # You can customize it by controlling the various variables inside it.
 #

--- a/roles/matrix-bridge-mautrix-hangouts/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-hangouts/templates/config.yaml.j2
@@ -138,11 +138,11 @@ logging:
             formatter: colored
     loggers:
         mau:
-            level: WARNING
+            level: {{ matrix_mautrix_hangouts_logging_level|to_json }}
         hangups:
-            level: WARNING
+            level: {{ matrix_mautrix_hangouts_logging_level|to_json }}
         aiohttp:
-            level: WARNING
+            level: {{ matrix_mautrix_hangouts_logging_level|to_json }}
     root:
-        level: WARNING
+        level: {{ matrix_mautrix_hangouts_logging_level|to_json }}
         handlers: [console]

--- a/roles/matrix-bridge-mautrix-instagram/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-instagram/defaults/main.yml
@@ -68,6 +68,9 @@ matrix_mautrix_instagram_appservice_bot_username: instagrambot
 
 matrix_mautrix_instagram_bridge_presence: true
 
+# Specifies the default log level for all bridge loggers.
+matrix_mautrix_instagram_logging_level: WARNING
+
 # Default configuration template which covers the generic use case.
 # You can customize it by controlling the various variables inside it.
 #

--- a/roles/matrix-bridge-mautrix-instagram/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-instagram/templates/config.yaml.j2
@@ -135,7 +135,7 @@ bridge:
     # Whether or not the bridge should backfill chats when reconnecting.
     resync: true
     # Should even disconnected users be reconnected?
-    always: false  
+    always: false
   # End-to-bridge encryption support options. These require matrix-nio to be installed with pip
   # and login_shared_secret to be configured in order to get a device for the bridge bot.
   #
@@ -219,13 +219,13 @@ logging:
       formatter: colored
   loggers:
     mau:
-      level: WARNING
+      level: {{ matrix_mautrix_instagram_logging_level|to_json }}
     mauigpapi:
-      level: WARNING
+      level: {{ matrix_mautrix_instagram_logging_level|to_json }}
     paho:
-      level: WARNING
+      level: {{ matrix_mautrix_instagram_logging_level|to_json }}
     aiohttp:
-      level: WARNING
+      level: {{ matrix_mautrix_instagram_logging_level|to_json }}
   root:
-    level: WARNING
+    level: {{ matrix_mautrix_instagram_logging_level|to_json }}
     handlers: [console]

--- a/roles/matrix-bridge-mautrix-signal/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-signal/defaults/main.yml
@@ -57,6 +57,9 @@ matrix_mautrix_signal_homeserver_token: ''
 
 matrix_mautrix_signal_appservice_bot_username: signalbot
 
+# Specifies the default log level for all bridge loggers.
+matrix_mautrix_signal_logging_level: WARNING
+
 # Whether or not created rooms should have federation enabled.
 # If false, created portal rooms will never be federated.
 matrix_mautrix_signal_federate_rooms: true

--- a/roles/matrix-bridge-mautrix-signal/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-signal/templates/config.yaml.j2
@@ -266,9 +266,9 @@ logging:
             formatter: colored
     loggers:
         mau:
-            level: WARNING
+            level: {{ matrix_mautrix_signal_logging_level|to_json }}
         aiohttp:
-            level: WARNING
+            level: {{ matrix_mautrix_signal_logging_level|to_json }}
     root:
-        level: WARNING
+        level: {{ matrix_mautrix_signal_logging_level|to_json }}
         handlers: [console]

--- a/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
@@ -43,6 +43,9 @@ matrix_mautrix_telegram_appservice_public_external: 'https://{{ matrix_server_fq
 
 matrix_mautrix_telegram_appservice_bot_username: telegrambot
 
+# Specifies the default log level for all bridge loggers.
+matrix_mautrix_telegram_logging_level: WARNING
+
 # Whether or not created rooms should have federation enabled.
 # If false, created portal rooms will never be federated.
 matrix_mautrix_telegram_federate_rooms: true

--- a/roles/matrix-bridge-mautrix-telegram/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-telegram/templates/config.yaml.j2
@@ -404,11 +404,11 @@ logging:
             formatter: precise
     loggers:
         mau:
-            level: WARNING
+            level: {{ matrix_mautrix_telegram_logging_level|to_json }}
         telethon:
-            level: WARNING
+            level: {{ matrix_mautrix_telegram_logging_level|to_json }}
         aiohttp:
-            level: WARNING
+            level: {{ matrix_mautrix_telegram_logging_level|to_json }}
     root:
-        level: WARNING
+        level: {{ matrix_mautrix_telegram_logging_level|to_json }}
         handlers: [console]

--- a/roles/matrix-bridge-mautrix-twitter/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-twitter/defaults/main.yml
@@ -66,6 +66,9 @@ matrix_mautrix_twitter_bridge_login_shared_secret_map: "{{ {matrix_mautrix_twitt
 
 matrix_mautrix_twitter_appservice_bot_username: twitterbot
 
+# Specifies the default log level for all bridge loggers.
+matrix_mautrix_twitter_logging_level: WARNING
+
 # Default configuration template which covers the generic use case.
 # You can customize it by controlling the various variables inside it.
 #

--- a/roles/matrix-bridge-mautrix-twitter/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-twitter/templates/config.yaml.j2
@@ -198,9 +198,9 @@ logging:
             formatter: colored
     loggers:
         mau:
-            level: WARNING
+            level: {{ matrix_mautrix_twitter_logging_level|to_json }}
         aiohttp:
-            level: WARNING
+            level: {{ matrix_mautrix_twitter_logging_level|to_json }}
     root:
-        level: WARNING
+        level: {{ matrix_mautrix_twitter_logging_level|to_json }}
         handlers: [console]


### PR DESCRIPTION
… that don't have them

Put the default config below the botname, it was already defined in whatsapp with a different naming convention, so I just left it.