### PR TITLE
feat(jitsi+arm64): Enable Jitsi on arm64

### DIFF
--- a/roles/matrix-jitsi/defaults/main.yml
+++ b/roles/matrix-jitsi/defaults/main.yml
@@ -70,7 +70,7 @@ matrix_jitsi_jibri_recorder_password: ''
 
 matrix_jitsi_enable_lobby: false
 
-matrix_jitsi_version: stable-7001
+matrix_jitsi_version: stable-7439-2
 matrix_jitsi_container_image_tag: "{{ matrix_jitsi_version }}"  # for backward-compatibility
 
 matrix_jitsi_web_docker_image: "{{ matrix_container_global_registry_prefix }}jitsi/web:{{ matrix_jitsi_container_image_tag }}"

--- a/roles/matrix-jitsi/tasks/init.yml
+++ b/roles/matrix-jitsi/tasks/init.yml
@@ -7,4 +7,4 @@
 - name: Fail if on an unsupported architecture
   fail:
     msg: "Jitsi only supports the amd64 architecture right now. See https://github.com/jitsi/docker-jitsi-meet/issues/1069 and https://github.com/jitsi/docker-jitsi-meet/issues/1214"
-  when: matrix_jitsi_enabled|bool and matrix_architecture != 'amd64'
+  when: matrix_jitsi_enabled|bool and matrix_architecture not in ['amd64', 'arm64']


### PR DESCRIPTION
Support for arm64 images tracked in jitsi/docker-jitsi-meet#1214 and added in jitsi/docker-jitsi-meet#1269

fixes spantaleev/matrix-docker-ansible-deploy#1889
