### PR TITLE
signald: 0.18.5 -> 0.20.0

### DIFF
--- a/roles/matrix-bridge-mautrix-signal/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-signal/defaults/main.yml
@@ -9,7 +9,7 @@ matrix_mautrix_signal_docker_repo: "https://mau.dev/mautrix/signal.git"
 matrix_mautrix_signal_docker_src_files_path: "{{ matrix_base_data_path }}/mautrix-signal/docker-src"
 
 matrix_mautrix_signal_version: v0.3.0
-matrix_mautrix_signal_daemon_version: 0.18.5
+matrix_mautrix_signal_daemon_version: 0.20.0
 # See: https://mau.dev/mautrix/signal/container_registry
 matrix_mautrix_signal_docker_image: "dock.mau.dev/mautrix/signal:{{ matrix_mautrix_signal_version }}"
 matrix_mautrix_signal_docker_image_force_pull: "{{ matrix_mautrix_signal_docker_image.endswith(':latest') }}"


### PR DESCRIPTION
https://gitlab.com/signald/signald/-/blob/main/releases/0.19.0.md
https://gitlab.com/signald/signald/-/blob/main/releases/0.19.1.md
https://gitlab.com/signald/signald/-/blob/main/releases/0.20.0.md

Notable changes in version `0.19.0`
- All critical data now stored in database
  - Avatars, group images, attachments, etc are still stored on the disk for now
  - None of these need to be kept around for signald to continue working
- New command line flag `--migrate-data` tells signald to preform all required data migrations and exit

I'm not sure if we'd like to automate this or add a hint to CHANGELOG.md about it?