### PR TITLE
changed SQLite file mount

### DIFF
--- a/roles/matrix-postgres/tasks/import_synapse_sqlite_db.yml
+++ b/roles/matrix-postgres/tasks/import_synapse_sqlite_db.yml
@@ -81,6 +81,6 @@
     --entrypoint=python
     --mount type=bind,src={{ matrix_synapse_config_dir_path }},dst=/data
     --mount type=bind,src={{ matrix_synapse_config_dir_path }},dst=/matrix-media-store-parent/media-store
-    --mount type=bind,src={{ server_path_homeserver_db }},dst=/{{ server_path_homeserver_db|basename }}
+    --mount type=bind,src={{ server_path_homeserver_db }},dst=/tmp/homeserver.db
     {{ matrix_synapse_docker_image }}
-    /usr/local/bin/synapse_port_db --sqlite-database /{{ server_path_homeserver_db|basename }} --postgres-config /data/homeserver.yaml
+    /usr/local/bin/synapse_port_db --sqlite-database /tmp/homeserver.db --postgres-config /data/homeserver.yaml


### PR DESCRIPTION
Mount wasn't working for a set of users it seems (https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/1922 and https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/775) and a dynamic file name is not needed for migration.