### PR TITLE
Update Hookshot 1.8.0 -> 1.8.1

### DIFF
--- a/roles/matrix-bridge-hookshot/defaults/main.yml
+++ b/roles/matrix-bridge-hookshot/defaults/main.yml
@@ -10,7 +10,7 @@ matrix_hookshot_container_image_self_build: false
 matrix_hookshot_container_image_self_build_repo: "https://github.com/matrix-org/matrix-hookshot.git"
 matrix_hookshot_container_image_self_build_branch: "{{ 'main' if matrix_hookshot_version == 'latest' else matrix_hookshot_version }}"
 
-matrix_hookshot_version: 1.8.0
+matrix_hookshot_version: 1.8.1
 
 matrix_hookshot_docker_image: "{{ matrix_hookshot_docker_image_name_prefix }}halfshot/matrix-hookshot:{{ matrix_hookshot_version }}"
 matrix_hookshot_docker_image_name_prefix: "{{ 'localhost/' if matrix_hookshot_container_image_self_build else matrix_container_global_registry_prefix }}"


### PR DESCRIPTION
No docker tag published yet, [keep an eye on it](https://hub.docker.com/r/halfshot/matrix-hookshot/tags?page=1&ordering=last_updated&name=1.8.1)