### PR TITLE
Update telemetry documentation to more closely match upstream

### DIFF
--- a/docs/configuring-playbook-telemetry.md
+++ b/docs/configuring-playbook-telemetry.md
@@ -3,8 +3,7 @@
 By default, this playbook configures your Matrix homeserver to not send any telemetry data anywhere.
 
 The [matrix.org](https://matrix.org) team would really appreciate it if you could help the project out by reporting
-anonymized usage statistics from your homeserver. Only very [basic aggregate
-data](#usage-statistics-being-submitted) (e.g. number of users) will be reported, but it helps track the
+usage statistics from your homeserver. Enabling usage statistics helps track the
 growth of the Matrix community, and helps to make Matrix a success.
 
 
@@ -19,28 +18,5 @@ matrix_synapse_report_stats: true
 
 ## Usage statistics being submitted
 
-If statistics reporting is enabled, the information that gets submitted to the matrix.org team [according to the source code](https://github.com/matrix-org/synapse/blob/master/synapse/app/homeserver.py) is:
-
-- your homeserver's domain name
-
-- uptime of the homeserver program
-
-- [Python](https://www.python.org/) version powering your homeserver
-
-- total number of users on your home server (including bridged users)
-
-- total number of native Matrix users on your home server
-
-- total number of rooms on your homeserver
-
-- total number of daily active users on your homeserver
-
-- total number of daily active rooms on your homeserver
-
-- total number of messages sent per day
-
-- cache setting information
-
-- CPU and memory statistics for the homeserver program
-
-- database engine type and version
+See [Synapse's documentation](https://github.com/matrix-org/synapse/blob/develop/docs/usage/administration/monitoring/reporting_homeserver_usage_statistics.md#available-statistics)
+for a list of the individual parameters that are reported.

--- a/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -1587,11 +1587,11 @@ metrics_flags:
     #
     #known_servers: true
 
-# Whether or not to report anonymized homeserver usage statistics.
+# Whether or not to report homeserver usage statistics.
 #
 report_stats: {{ matrix_synapse_report_stats|to_json }}
 
-# The endpoint to report the anonymized homeserver usage statistics to.
+# The endpoint to report homeserver usage statistics to.
 # Defaults to https://matrix.org/report-usage-stats/push
 #
 #report_stats_endpoint: https://example.com/report-usage-stats/push


### PR DESCRIPTION
Synapse no longer describes the stats as anonymized since the `server_name` is included.
https://github.com/matrix-org/synapse/pull/13321