### PR TITLE
Migrate mx-puppet-groupme to new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Using this playbook, you can get the following services configured on your serve
 
 - (optional) the [mx-puppet-discord](https://github.com/matrix-discord/mx-puppet-discord) bridge for [Discord](https://discordapp.com/) - see [docs/configuring-playbook-bridge-mx-puppet-discord.md](docs/configuring-playbook-bridge-mx-puppet-discord.md) for setup documentation
 
-- (optional) the [mx-puppet-groupme](https://gitlab.com/robintown/mx-puppet-groupme) bridge for [GroupMe](https://groupme.com/) - see [docs/configuring-playbook-bridge-mx-puppet-groupme.md](docs/configuring-playbook-bridge-mx-puppet-groupme.md) for setup documentation
+- (optional) the [mx-puppet-groupme](https://gitlab.com/xangelix-pub/matrix/mx-puppet-groupme) bridge for [GroupMe](https://groupme.com/) - see [docs/configuring-playbook-bridge-mx-puppet-groupme.md](docs/configuring-playbook-bridge-mx-puppet-groupme.md) for setup documentation
 
 - (optional) the [mx-puppet-steam](https://github.com/icewind1991/mx-puppet-steam) bridge for [Steam](https://steamapp.com/) - see [docs/configuring-playbook-bridge-mx-puppet-steam.md](docs/configuring-playbook-bridge-mx-puppet-steam.md) for setup documentation
 

--- a/docs/configuring-playbook-bridge-mx-puppet-groupme.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-groupme.md
@@ -1,7 +1,7 @@
 # Setting up MX Puppet GroupMe (optional)
 
 The playbook can install and configure
-[mx-puppet-groupme](https://gitlab.com/robintown/mx-puppet-groupme) for you.
+[mx-puppet-groupme](https://gitlab.com/xangelix-pub/matrix/mx-puppet-groupme) for you.
 
 See the project page to learn what it does and why it might be useful to you.
 

--- a/docs/container-images.md
+++ b/docs/container-images.md
@@ -76,7 +76,7 @@ These services are not part of our default installation, but can be enabled by [
 
 - [sorunome/mx-puppet-discord](https://hub.docker.com/r/sorunome/mx-puppet-discord) - the [mx-puppet-discord](https://github.com/matrix-discord/mx-puppet-discord) bridge to [Discord](https://discordapp.com) (optional)
 
-- [xangelix/mx-puppet-groupme](https://hub.docker.com/r/xangelix/mx-puppet-groupme) - the [mx-puppet-groupme](https://gitlab.com/robintown/mx-puppet-groupme) bridge to [GroupMe](https://groupme.com/) (optional)
+- [xangelix/mx-puppet-groupme](https://hub.docker.com/r/xangelix/mx-puppet-groupme) - the [mx-puppet-groupme](https://gitlab.com/xangelix-pub/matrix/mx-puppet-groupme) bridge to [GroupMe](https://groupme.com/) (optional)
 
 - [icewind1991/mx-puppet-steam](https://hub.docker.com/r/icewind1991/mx-puppet-steam) - the [mx-puppet-steam](https://github.com/icewind1991/mx-puppet-steam) bridge to [Steam](https://steampowered.com) (optional)
 

--- a/roles/matrix-bridge-mx-puppet-groupme/defaults/main.yml
+++ b/roles/matrix-bridge-mx-puppet-groupme/defaults/main.yml
@@ -1,11 +1,11 @@
 ---
 # Mx Puppet GroupMe is a Matrix <-> GroupMe bridge
-# Project source code URL: https://gitlab.com/robintown/mx-puppet-groupme
+# Project source code URL: https://gitlab.com/xangelix-pub/matrix/mx-puppet-groupme
 
 matrix_mx_puppet_groupme_enabled: true
 
 matrix_mx_puppet_groupme_container_image_self_build: false
-matrix_mx_puppet_groupme_container_image_self_build_repo: "https://gitlab.com/robintown/mx-puppet-groupme"
+matrix_mx_puppet_groupme_container_image_self_build_repo: "https://gitlab.com/xangelix-pub/matrix/mx-puppet-groupme"
 matrix_mx_puppet_groupme_container_image_self_build_repo_version: "{{ 'main' if matrix_mx_puppet_groupme_version == 'latest' else matrix_mx_puppet_groupme_version }}"
 
 # Controls whether the mx-puppet-groupme container exposes its HTTP port (tcp/8437 in the container).
@@ -13,9 +13,9 @@ matrix_mx_puppet_groupme_container_image_self_build_repo_version: "{{ 'main' if 
 # Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:8437"), or empty string to not expose.
 matrix_mx_puppet_groupme_container_http_host_bind_port: ''
 
-matrix_mx_puppet_groupme_version: latest
-matrix_mx_puppet_groupme_docker_image: "{{ matrix_mx_puppet_groupme_docker_image_name_prefix }}xangelix/mx-puppet-groupme:{{ matrix_mx_puppet_groupme_version }}"
-matrix_mx_puppet_groupme_docker_image_name_prefix: "{{ 'localhost/' if matrix_mx_puppet_groupme_container_image_self_build else matrix_container_global_registry_prefix }}"
+matrix_mx_puppet_groupme_version: 533cccc8
+matrix_mx_puppet_groupme_docker_image: "{{ matrix_mx_puppet_groupme_docker_image_name_prefix }}xangelix-pub/matrix/mx-puppet-groupme:{{ matrix_mx_puppet_groupme_version }}"
+matrix_mx_puppet_groupme_docker_image_name_prefix: "{{ 'localhost/' if matrix_mx_puppet_groupme_container_image_self_build else 'registry.gitlab.com/' }}"
 matrix_mx_puppet_groupme_docker_image_force_pull: "{{ matrix_mx_puppet_groupme_docker_image.endswith(':latest') }}"
 
 matrix_mx_puppet_groupme_base_path: "{{ matrix_base_data_path }}/mx-puppet-groupme"


### PR DESCRIPTION
mx-puppet-groupme is no longer maintained at [https://gitlab.com/robintown/mx-puppet-groupme](https://gitlab.com/robintown/mx-puppet-groupme), so I put up a new repo at [https://gitlab.com/xangelix-pub/matrix/mx-puppet-groupme](https://gitlab.com/xangelix-pub/matrix/mx-puppet-groupme).
So far, I have bumped the dependencies and made a few quick changes to fix the docker builds and mitigate security issues. I may later consider moving it to the new fork of mx-puppet-bridge and/or rewriting it in mautrix.