### PR TITLE
Fix self-build error image names

### DIFF
--- a/roles/matrix-bridge-appservice-irc/tasks/init.yml
+++ b/roles/matrix-bridge-appservice-irc/tasks/init.yml
@@ -3,7 +3,7 @@
 # and https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/1ab507349c752042d26def3e95884f6df8886b74#commitcomment-51108407
 - name: Fail if trying to self-build on Ansible < 2.8
   ansible.builtin.fail:
-    msg: "To self-build the Element image, you should use Ansible 2.8 or higher. See docs/ansible.md"
+    msg: "To self-build the matrix-appservice-irc image, you should use Ansible 2.8 or higher. See docs/ansible.md"
   when: "ansible_version.major == 2 and ansible_version.minor < 8 and matrix_appservice_irc_container_image_self_build and matrix_appservice_irc_enabled"
 
 # If the matrix-synapse role is not used, `matrix_synapse_role_executed` won't exist.

--- a/roles/matrix-bridge-appservice-slack/tasks/init.yml
+++ b/roles/matrix-bridge-appservice-slack/tasks/init.yml
@@ -3,7 +3,7 @@
 # and https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/1ab507349c752042d26def3e95884f6df8886b74#commitcomment-51108407
 - name: Fail if trying to self-build on Ansible < 2.8
   ansible.builtin.fail:
-    msg: "To self-build the Element image, you should use Ansible 2.8 or higher. See docs/ansible.md"
+    msg: "To self-build the matrix-appservice-slack image, you should use Ansible 2.8 or higher. See docs/ansible.md"
   when: "ansible_version.major == 2 and ansible_version.minor < 8 and matrix_appservice_slack_container_image_self_build and matrix_appservice_slack_enabled"
 
 # If the matrix-synapse role is not used, `matrix_synapse_role_executed` won't exist.

--- a/roles/matrix-bridge-mautrix-facebook/tasks/init.yml
+++ b/roles/matrix-bridge-mautrix-facebook/tasks/init.yml
@@ -3,7 +3,7 @@
 # and https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/1ab507349c752042d26def3e95884f6df8886b74#commitcomment-51108407
 - name: Fail if trying to self-build on Ansible < 2.8
   ansible.builtin.fail:
-    msg: "To self-build the Element image, you should use Ansible 2.8 or higher. See docs/ansible.md"
+    msg: "To self-build the Mautrix-Facebook image, you should use Ansible 2.8 or higher. See docs/ansible.md"
   when: "ansible_version.major == 2 and ansible_version.minor < 8 and matrix_mautrix_facebook_container_image_self_build and matrix_mautrix_facebook_enabled"
 
 - ansible.builtin.set_fact:

--- a/roles/matrix-bridge-mautrix-googlechat/tasks/init.yml
+++ b/roles/matrix-bridge-mautrix-googlechat/tasks/init.yml
@@ -3,7 +3,7 @@
 # and https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/1ab507349c752042d26def3e95884f6df8886b74#commitcomment-51108407
 - name: Fail if trying to self-build on Ansible < 2.8
   ansible.builtin.fail:
-    msg: "To self-build the Element image, you should use Ansible 2.8 or higher. See docs/ansible.md"
+    msg: "To self-build the Mautrix-Google Chat image, you should use Ansible 2.8 or higher. See docs/ansible.md"
   when: "ansible_version.major == 2 and ansible_version.minor < 8 and matrix_mautrix_googlechat_container_image_self_build and matrix_mautrix_googlechat_enabled"
 
 - ansible.builtin.set_fact:

--- a/roles/matrix-bridge-mautrix-hangouts/tasks/init.yml
+++ b/roles/matrix-bridge-mautrix-hangouts/tasks/init.yml
@@ -3,7 +3,7 @@
 # and https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/1ab507349c752042d26def3e95884f6df8886b74#commitcomment-51108407
 - name: Fail if trying to self-build on Ansible < 2.8
   ansible.builtin.fail:
-    msg: "To self-build the Element image, you should use Ansible 2.8 or higher. See docs/ansible.md"
+    msg: "To self-build the Mautrix-Hangouts image, you should use Ansible 2.8 or higher. See docs/ansible.md"
   when: "ansible_version.major == 2 and ansible_version.minor < 8 and matrix_mautrix_hangouts_container_image_self_build and matrix_mautrix_hangouts_enabled"
 
 - ansible.builtin.set_fact:

--- a/roles/matrix-bridge-mautrix-instagram/tasks/init.yml
+++ b/roles/matrix-bridge-mautrix-instagram/tasks/init.yml
@@ -3,7 +3,7 @@
 # and https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/1ab507349c752042d26def3e95884f6df8886b74#commitcomment-51108407
 - name: Fail if trying to self-build on Ansible < 2.8
   ansible.builtin.fail:
-    msg: "To self-build the Element image, you should use Ansible 2.8 or higher. See docs/ansible.md"
+    msg: "To self-build the Mautrix-Instagram image, you should use Ansible 2.8 or higher. See docs/ansible.md"
   when: "ansible_version.major == 2 and ansible_version.minor < 8 and matrix_mautrix_instagram_container_image_self_build and matrix_mautrix_instagram_enabled"
 
 - ansible.builtin.set_fact:

--- a/roles/matrix-bridge-mautrix-telegram/tasks/init.yml
+++ b/roles/matrix-bridge-mautrix-telegram/tasks/init.yml
@@ -3,7 +3,7 @@
 # and https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/1ab507349c752042d26def3e95884f6df8886b74#commitcomment-51108407
 - name: Fail if trying to self-build on Ansible < 2.8
   ansible.builtin.fail:
-    msg: "To self-build the Element image, you should use Ansible 2.8 or higher. See docs/ansible.md"
+    msg: "To self-build the Mautrix-Telegram image, you should use Ansible 2.8 or higher. See docs/ansible.md"
   when: "ansible_version.major == 2 and ansible_version.minor < 8 and matrix_mautrix_telegram_container_image_self_build and matrix_mautrix_telegram_enabled"
 
 - ansible.builtin.set_fact:

--- a/roles/matrix-bridge-mx-puppet-discord/tasks/init.yml
+++ b/roles/matrix-bridge-mx-puppet-discord/tasks/init.yml
@@ -3,7 +3,7 @@
 # and https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/1ab507349c752042d26def3e95884f6df8886b74#commitcomment-51108407
 - name: Fail if trying to self-build on Ansible < 2.8
   ansible.builtin.fail:
-    msg: "To self-build the Element image, you should use Ansible 2.8 or higher. See docs/ansible.md"
+    msg: "To self-build the mx-puppet-discord image, you should use Ansible 2.8 or higher. See docs/ansible.md"
   when: "ansible_version.major == 2 and ansible_version.minor < 8 and matrix_mx_puppet_discord_container_image_self_build and matrix_mx_puppet_discord_enabled"
 
 - ansible.builtin.set_fact:

--- a/roles/matrix-bridge-mx-puppet-groupme/tasks/init.yml
+++ b/roles/matrix-bridge-mx-puppet-groupme/tasks/init.yml
@@ -3,7 +3,7 @@
 # and https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/1ab507349c752042d26def3e95884f6df8886b74#commitcomment-51108407
 - name: Fail if trying to self-build on Ansible < 2.8
   ansible.builtin.fail:
-    msg: "To self-build the Element image, you should use Ansible 2.8 or higher. See docs/ansible.md"
+    msg: "To self-build the mx-puppet-groupme image, you should use Ansible 2.8 or higher. See docs/ansible.md"
   when: "ansible_version.major == 2 and ansible_version.minor < 8 and matrix_mx_puppet_groupme_container_image_self_build and matrix_mx_puppet_groupme_enabled"
 
 - ansible.builtin.set_fact:

--- a/roles/matrix-bridge-mx-puppet-instagram/tasks/init.yml
+++ b/roles/matrix-bridge-mx-puppet-instagram/tasks/init.yml
@@ -3,7 +3,7 @@
 # and https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/1ab507349c752042d26def3e95884f6df8886b74#commitcomment-51108407
 - name: Fail if trying to self-build on Ansible < 2.8
   ansible.builtin.fail:
-    msg: "To self-build the Element image, you should use Ansible 2.8 or higher. See docs/ansible.md"
+    msg: "To self-build the mx-puppet-instagram image, you should use Ansible 2.8 or higher. See docs/ansible.md"
   when: "ansible_version.major == 2 and ansible_version.minor < 8 and matrix_mx_puppet_instagram_container_image_self_build and matrix_mx_puppet_instagram_enabled"
 
 - ansible.builtin.set_fact:

--- a/roles/matrix-bridge-mx-puppet-slack/tasks/init.yml
+++ b/roles/matrix-bridge-mx-puppet-slack/tasks/init.yml
@@ -3,7 +3,7 @@
 # and https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/1ab507349c752042d26def3e95884f6df8886b74#commitcomment-51108407
 - name: Fail if trying to self-build on Ansible < 2.8
   ansible.builtin.fail:
-    msg: "To self-build the Element image, you should use Ansible 2.8 or higher. See docs/ansible.md"
+    msg: "To self-build the mx-puppet-slack image, you should use Ansible 2.8 or higher. See docs/ansible.md"
   when: "ansible_version.major == 2 and ansible_version.minor < 8 and matrix_mx_puppet_slack_container_image_self_build and matrix_mx_puppet_slack_enabled"
 
 - ansible.builtin.set_fact:

--- a/roles/matrix-bridge-mx-puppet-steam/tasks/init.yml
+++ b/roles/matrix-bridge-mx-puppet-steam/tasks/init.yml
@@ -3,7 +3,7 @@
 # and https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/1ab507349c752042d26def3e95884f6df8886b74#commitcomment-51108407
 - name: Fail if trying to self-build on Ansible < 2.8
   ansible.builtin.fail:
-    msg: "To self-build the Element image, you should use Ansible 2.8 or higher. See docs/ansible.md"
+    msg: "To self-build the mx-puppet-steam image, you should use Ansible 2.8 or higher. See docs/ansible.md"
   when: "ansible_version.major == 2 and ansible_version.minor < 8 and matrix_mx_puppet_steam_container_image_self_build and matrix_mx_puppet_steam_enabled"
 
 - ansible.builtin.set_fact:

--- a/roles/matrix-bridge-mx-puppet-twitter/tasks/init.yml
+++ b/roles/matrix-bridge-mx-puppet-twitter/tasks/init.yml
@@ -3,7 +3,7 @@
 # and https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/1ab507349c752042d26def3e95884f6df8886b74#commitcomment-51108407
 - name: Fail if trying to self-build on Ansible < 2.8
   ansible.builtin.fail:
-    msg: "To self-build the Element image, you should use Ansible 2.8 or higher. See docs/ansible.md"
+    msg: "To self-build the mx-puppet-twitter image, you should use Ansible 2.8 or higher. See docs/ansible.md"
   when: "ansible_version.major == 2 and ansible_version.minor < 8 and matrix_mx_puppet_twitter_container_image_self_build and matrix_mx_puppet_twitter_enabled"
 
 - ansible.builtin.set_fact:

--- a/roles/matrix-corporal/tasks/init.yml
+++ b/roles/matrix-corporal/tasks/init.yml
@@ -3,7 +3,7 @@
 # and https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/1ab507349c752042d26def3e95884f6df8886b74#commitcomment-51108407
 - name: Fail if trying to self-build on Ansible < 2.8
   ansible.builtin.fail:
-    msg: "To self-build the Element image, you should use Ansible 2.8 or higher. See docs/ansible.md"
+    msg: "To self-build the Matrix Corporal image, you should use Ansible 2.8 or higher. See docs/ansible.md"
   when: "ansible_version.major == 2 and ansible_version.minor < 8 and matrix_corporal_container_image_self_build and matrix_corporal_enabled"
 
 - ansible.builtin.set_fact:

--- a/roles/matrix-coturn/tasks/init.yml
+++ b/roles/matrix-coturn/tasks/init.yml
@@ -3,7 +3,7 @@
 # and https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/1ab507349c752042d26def3e95884f6df8886b74#commitcomment-51108407
 - name: Fail if trying to self-build on Ansible < 2.8
   ansible.builtin.fail:
-    msg: "To self-build the Element image, you should use Ansible 2.8 or higher. See docs/ansible.md"
+    msg: "To self-build the coturn image, you should use Ansible 2.8 or higher. See docs/ansible.md"
   when: "ansible_version.major == 2 and ansible_version.minor < 8 and matrix_coturn_container_image_self_build and matrix_coturn_enabled"
 
 - ansible.builtin.set_fact:

--- a/roles/matrix-dynamic-dns/tasks/init.yml
+++ b/roles/matrix-dynamic-dns/tasks/init.yml
@@ -3,7 +3,7 @@
 # and https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/1ab507349c752042d26def3e95884f6df8886b74#commitcomment-51108407
 - name: Fail if trying to self-build on Ansible < 2.8
   ansible.builtin.fail:
-    msg: "To self-build the Element image, you should use Ansible 2.8 or higher. See docs/ansible.md"
+    msg: "To self-build the Dynamic DNS image, you should use Ansible 2.8 or higher. See docs/ansible.md"
   when: "ansible_version.major == 2 and ansible_version.minor < 8 and matrix_dynamic_dns_container_image_self_build and matrix_dynamic_dns_enabled"
 
 - ansible.builtin.set_fact:

--- a/roles/matrix-ma1sd/tasks/init.yml
+++ b/roles/matrix-ma1sd/tasks/init.yml
@@ -3,7 +3,7 @@
 # and https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/1ab507349c752042d26def3e95884f6df8886b74#commitcomment-51108407
 - name: Fail if trying to self-build on Ansible < 2.8
   ansible.builtin.fail:
-    msg: "To self-build the Element image, you should use Ansible 2.8 or higher. See docs/ansible.md"
+    msg: "To self-build the ma1sd image, you should use Ansible 2.8 or higher. See docs/ansible.md"
   when: "ansible_version.major == 2 and ansible_version.minor < 8 and matrix_ma1sd_container_image_self_build and matrix_ma1sd_enabled | bool"
 
 - ansible.builtin.set_fact:

--- a/roles/matrix-mailer/tasks/init.yml
+++ b/roles/matrix-mailer/tasks/init.yml
@@ -3,7 +3,7 @@
 # and https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/1ab507349c752042d26def3e95884f6df8886b74#commitcomment-51108407
 - name: Fail if trying to self-build on Ansible < 2.8
   ansible.builtin.fail:
-    msg: "To self-build the Element image, you should use Ansible 2.8 or higher. See docs/ansible.md"
+    msg: "To self-build the Matrix Mailer image, you should use Ansible 2.8 or higher. See docs/ansible.md"
   when: "ansible_version.major == 2 and ansible_version.minor < 8 and matrix_mailer_container_image_self_build and matrix_mailer_enabled"
 
 - ansible.builtin.set_fact:

--- a/roles/matrix-registration/tasks/init.yml
+++ b/roles/matrix-registration/tasks/init.yml
@@ -3,7 +3,7 @@
 # and https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/1ab507349c752042d26def3e95884f6df8886b74#commitcomment-51108407
 - name: Fail if trying to self-build on Ansible < 2.8
   ansible.builtin.fail:
-    msg: "To self-build the Element image, you should use Ansible 2.8 or higher. See docs/ansible.md"
+    msg: "To self-build the Matrix Registration image, you should use Ansible 2.8 or higher. See docs/ansible.md"
   when: "ansible_version.major == 2 and ansible_version.minor < 8 and matrix_registration_container_image_self_build and matrix_registration_enabled"
 
 - ansible.builtin.set_fact:

--- a/roles/matrix-synapse-admin/tasks/init.yml
+++ b/roles/matrix-synapse-admin/tasks/init.yml
@@ -3,7 +3,7 @@
 # and https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/1ab507349c752042d26def3e95884f6df8886b74#commitcomment-51108407
 - name: Fail if trying to self-build on Ansible < 2.8
   ansible.builtin.fail:
-    msg: "To self-build the Element image, you should use Ansible 2.8 or higher. See docs/ansible.md"
+    msg: "To self-build the Synapse Admin image, you should use Ansible 2.8 or higher. See docs/ansible.md"
   when: "ansible_version.major == 2 and ansible_version.minor < 8 and matrix_synapse_admin_container_image_self_build and matrix_synapse_admin_enabled"
 
 - ansible.builtin.set_fact:


### PR DESCRIPTION
Fixes self-build errors from an unsupported Ansible version that references only the Element image.