### PR TITLE
run the playbook on multiple hosts with different credentials

### DIFF
--- a/docs/configuring-playbook.md
+++ b/docs/configuring-playbook.md
@@ -18,7 +18,7 @@ You can then follow these steps inside the playbook directory:
 
 1. edit the inventory hosts file (`inventory/hosts`) to your liking
 
-1. if you want to run multiple servers with different credentials, you can copy the sample inventory hosts yaml file for each of your hosts: (`cp examples/host.yml inventory/my_host1.yml` …) and use the [`ansible-all-hosts.sh`](inventory/scripts/ansible-all-hosts.sh) script [in then next step](installing.md).
+1. (optional, advaned) to run Ansible against multiple servers with different `sudo` credentials, you can copy the sample inventory hosts yaml file for each of your hosts: (`cp examples/host.yml inventory/my_host1.yml` …) and use the [`ansible-all-hosts.sh`](../inventory/scripts/ansible-all-hosts.sh) script [in then installation step](installing.md).
 
 For a basic Matrix installation, that's all you need.
 For a more custom setup, see the [Other configuration options](#other-configuration-options) below.

--- a/docs/configuring-playbook.md
+++ b/docs/configuring-playbook.md
@@ -18,6 +18,7 @@ You can then follow these steps inside the playbook directory:
 
 1. edit the inventory hosts file (`inventory/hosts`) to your liking
 
+1. if you want to run multiple servers with different credentials, you can copy the sample inventory hosts yaml file for each of your hosts: (`cp examples/host.yml inventory/my_host1.yml` …) and use the [`ansible-all-hosts.sh`](inventory/scripts/ansible-all-hosts.sh) script [in then next step](installing.md).
 
 For a basic Matrix installation, that's all you need.
 For a more custom setup, see the [Other configuration options](#other-configuration-options) below.

--- a/docs/configuring-playbook.md
+++ b/docs/configuring-playbook.md
@@ -18,7 +18,7 @@ You can then follow these steps inside the playbook directory:
 
 1. edit the inventory hosts file (`inventory/hosts`) to your liking
 
-1. (optional, advaned) to run Ansible against multiple servers with different `sudo` credentials, you can copy the sample inventory hosts yaml file for each of your hosts: (`cp examples/host.yml inventory/my_host1.yml` …) and use the [`ansible-all-hosts.sh`](../inventory/scripts/ansible-all-hosts.sh) script [in then installation step](installing.md).
+1. (optional, advanced) to run Ansible against multiple servers with different `sudo` credentials, you can copy the sample inventory hosts yaml file for each of your hosts: (`cp examples/host.yml inventory/my_host1.yml` …) and use the [`ansible-all-hosts.sh`](../inventory/scripts/ansible-all-hosts.sh) script [in the installation step](installing.md).
 
 For a basic Matrix installation, that's all you need.
 For a more custom setup, see the [Other configuration options](#other-configuration-options) below.

--- a/examples/host.yml
+++ b/examples/host.yml
@@ -1,0 +1,7 @@
+matrix_servers:
+  hosts:
+    matrix.<your domain>:
+      ansible_host: <your server's external ip address>
+      ansible_ssh_user: <your ssh user>
+      become: true
+      become_user: root

--- a/examples/host.yml
+++ b/examples/host.yml
@@ -1,4 +1,7 @@
 ---
+
+# This is a host file for usage with the `ansible-all-hosts.sh` script,
+# which runs Ansible against a bunch of hosts, each with its own `sudo` password.
 matrix_servers:
   hosts:
     matrix.<your domain>:

--- a/examples/host.yml
+++ b/examples/host.yml
@@ -1,3 +1,4 @@
+---
 matrix_servers:
   hosts:
     matrix.<your domain>:

--- a/inventory/scripts/ansible-all-hosts.sh
+++ b/inventory/scripts/ansible-all-hosts.sh
@@ -7,8 +7,8 @@
 #     ./inventory/scripts/ansible-all-hosts.sh self-check
 #
 
-# set inventory directory path
-inventory=$(dirname "$(readlink -f "$0")")/../../inventory
+# set playbook root path
+root=$(dirname "$(readlink -f "$0")")/../..
 
 # set default tags or get from first argument if any
 tags="${1:-setup-all,start}"
@@ -17,7 +17,7 @@ tags="${1:-setup-all,start}"
 declare -A pws
 
 # capture passwords for all hosts
-for host in "$inventory"/*.yml; do
+for host in "$root"/inventory/*.yml; do
     read -rp "sudo password for $(basename "$host"): " -s pw
     pws[$host]="$pw"
     echo
@@ -25,7 +25,7 @@ done
 
 # run ansible on all captured passwords/hosts
 for host in "${!pws[@]}"; do
-    ansible-playbook setup.yml \
+    ansible-playbook "$root"/setup.yml \
         --inventory-file "$host" \
         --extra-vars "ansible_become_pass=${pws[$host]}" \
         --tags="$tags"

--- a/inventory/scripts/ansible-all-hosts.sh
+++ b/inventory/scripts/ansible-all-hosts.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Run the playbook on multiple hosts with different credentials with this script
+# It defaults to ansible tags "setup-all,start". You can pass alternative tags
+# to this script as arguments, e.g.
+#
+#     ./inventory/scripts/ansible-all-hosts.sh self-check
+#
+
+# set inventory directory path
+inventory=$(dirname "$(readlink -f "$0")")/../../inventory
+
+# set default tags or get from first argument if any
+tags="${1:-setup-all,start}"
+
+# init password array
+declare -A pws
+
+# capture passwords for all hosts
+for host in "$inventory"/*.yml; do
+    read -rp "sudo password for $(basename "$host"): " -s pw
+    pws[$host]="$pw"
+    echo
+done
+
+# run ansible on all captured passwords/hosts
+for host in "${!pws[@]}"; do
+    ansible-playbook setup.yml \
+        --inventory-file "$host" \
+        --extra-vars "ansible_become_pass=${pws[$host]}" \
+        --tags="$tags"
+done


### PR DESCRIPTION
This is a bash script to run the playbook on multiple hosts with different credentials.

It first iterates over any `inventory/<my host>.yml` to get all the sudo passwords, and then runs the playbook on each host afterwards. The PR includes an example host file and documentation. The host file comes with yaml syntax, so that the for loop in the bash script can use the asterisk wildcard syntax: `inventory/*.yml`.

I am aware that running playbooks on multiple hosts can be done using [default ansible methods](https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html#using-multiple-inventory-sources). Though, this playbook ought to be usable as a standalone configuration imho.

Feel free to rephrase, extend, alter or reject anything of this contribution. Just wanted to share the work I did for my own use case.