### PR TITLE
Add example configuration for Caddy v2

### DIFF
--- a/docs/configuring-playbook-synapse-admin.md
+++ b/docs/configuring-playbook-synapse-admin.md
@@ -65,7 +65,7 @@ matrix_synapse_admin_container_extra_arguments:
 
 ### Sample configuration for running behind Caddy v2
 
-Below is a sample configuration for using this playbook with a [Caddy](https://caddyserver.com/v2) 2.0 reverse proxy (non-default confiuratuon assuming `matrix-nginx-proxy` is disabled - `matrix_nginx_proxy_enabled: false`).
+Below is a sample configuration for using this playbook with a [Caddy](https://caddyserver.com/v2) 2.0 reverse proxy (non-default configuration where `matrix-nginx-proxy` is disabled - `matrix_nginx_proxy_enabled: false`).
 
 ```caddy
 # This is a basic configuration that will function the same as the default nginx proxy - exposing the synapse-admin panel to matrix.YOURSERVER.com/synapse-admin/

--- a/docs/configuring-playbook-synapse-admin.md
+++ b/docs/configuring-playbook-synapse-admin.md
@@ -65,12 +65,12 @@ matrix_synapse_admin_container_extra_arguments:
 
 ### Sample configuration for running behind Caddy v2
 
-Below is a sample configuration for using this playbook with a [Caddy](https://caddyserver.com/v2) 2.0 reverse proxy.
+Below is a sample configuration for using this playbook with a [Caddy](https://caddyserver.com/v2) 2.0 reverse proxy (non-default confiuratuon assuming `matrix-nginx-proxy` is disabled - `matrix_nginx_proxy_enabled: false`).
 
 ```caddy
-
-# This is a basic configuration that will function the same as the default nginx proxy - exposing the synapse admin panel to matrix.YOURSERVER.com/synapse-admin/
+# This is a basic configuration that will function the same as the default nginx proxy - exposing the synapse-admin panel to matrix.YOURSERVER.com/synapse-admin/
   handle_path /synapse-admin* {
         reverse_proxy localhost:8766  {
         }
   }
+```

--- a/docs/configuring-playbook-synapse-admin.md
+++ b/docs/configuring-playbook-synapse-admin.md
@@ -62,3 +62,15 @@ matrix_synapse_admin_container_extra_arguments:
     # The Synapse Admin container uses port 80 by default
     - '--label "traefik.http.services.matrix-synapse-admin.loadbalancer.server.port=80"'
 ```
+
+### Sample configuration for running behind Caddy v2
+
+Below is a sample configuration for using this playbook with a [Caddy](https://caddyserver.com/v2) 2.0 reverse proxy.
+
+```caddy
+
+# This is a basic configuration that will function the same as the default nginx proxy - exposing the synapse admin panel to matrix.YOURSERVER.com/synapse-admin/
+  handle_path /synapse-admin* {
+        reverse_proxy localhost:8766  {
+        }
+  }


### PR DESCRIPTION
Add a basic example how to get synapse-admin running behind Caddy v2 proxy.