### PR TITLE
Fix mautrix-telegram permissions

### DIFF
--- a/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
@@ -29,7 +29,7 @@ matrix_mautrix_telegram_command_prefix: "!tg"
 
 matrix_mautrix_telegram_bridge_permissions: |
   {{
-    {matrix_mautrix_telegram_homeserver_domain: 'user'}
+    {matrix_mautrix_telegram_homeserver_domain: 'full'}
     | combine({matrix_admin: 'admin'} if matrix_admin else {})
   }}
 


### PR DESCRIPTION
Because for telegram bridge there is a special `full` level to allow double-puppeting for users