### PR TITLE
[Go-Skype] Change Docker Hub repository

### DIFF
--- a/roles/matrix-bridge-go-skype-bridge/defaults/main.yml
+++ b/roles/matrix-bridge-go-skype-bridge/defaults/main.yml
@@ -9,7 +9,7 @@ matrix_go_skype_bridge_container_image_self_build_repo: "https://github.com/kela
 matrix_go_skype_bridge_container_image_self_build_branch: "{{ 'master' if matrix_go_skype_bridge_version == 'latest' else matrix_go_skype_bridge_version }}"
 
 matrix_go_skype_bridge_version: latest
-matrix_go_skype_bridge_docker_image: "{{ matrix_go_skype_bridge_docker_image_name_prefix }}kelaresg/go-skype-bridge:{{ matrix_go_skype_bridge_version }}"
+matrix_go_skype_bridge_docker_image: "{{ matrix_go_skype_bridge_docker_image_name_prefix }}nodefyme/go-skype-bridge:{{ matrix_go_skype_bridge_version }}"
 matrix_go_skype_bridge_docker_image_name_prefix: "localhost/"
 matrix_go_skype_bridge_docker_image_force_pull: "{{ matrix_go_skype_bridge_docker_image.endswith(':latest') }}"
 


### PR DESCRIPTION
According to [this commit](https://github.com/kelaresg/go-skype-bridge/commit/59e27903cd6888399706ec5b7b1757411834990c), the docker hub account did change. This PR follow this update.

Also, this new image is automatically build (latest & release) for AMD64 and ARM64 :) Don't know how to apply those informations, but it can be handy :smile: 