### PR TITLE
specify which discord bridge to use; fix links

### DIFF
--- a/docs/configuring-playbook-bridge-appservice-discord.md
+++ b/docs/configuring-playbook-bridge-appservice-discord.md
@@ -1,8 +1,8 @@
 # Setting up Appservice Discord (optional)
 
 **Note**: bridging to [Discord](https://discordapp.com/) can also happen via the [mx-puppet-discord](configuring-playbook-bridge-mx-puppet-discord.md) and [mautrix-discord](configuring-playbook-bridge-mautrix-discord.md) bridges supported by the playbook.   
-For using as a Bot we are recommend the Appservice Discord bridge (the one being discussed here), because it supports plumbing.  
-For personal use we recommend the [mautrix-discord](configuring-playbook-bridge-mautrix-discord.md) bridge, because it is the most fully-featured and stable of the 3 Discord bridges supported by the playbook.
+- For using as a Bot we are recommend the Appservice Discord bridge (the one being discussed here), because it supports plumbing.  
+- For personal use we recommend the [mautrix-discord](configuring-playbook-bridge-mautrix-discord.md) bridge, because it is the most fully-featured and stable of the 3 Discord bridges supported by the playbook.
 
 The playbook can install and configure [matrix-appservice-discord](https://github.com/Half-Shot/matrix-appservice-discord) for you.
 

--- a/docs/configuring-playbook-bridge-appservice-discord.md
+++ b/docs/configuring-playbook-bridge-appservice-discord.md
@@ -1,7 +1,7 @@
 # Setting up Appservice Discord (optional)
 
-**Note**: bridging to [Discord](https://discordapp.com/) can also happen via the [mx-puppet-discord](configuring-playbook-bridge-mx-puppet-discord.md) and [mautrix-discord](docs/configuring-playbook-bridge-mautrix-discord.md) bridges supported by the playbook. 
-For using as a Bot we are recommend the Appservice Discord bridge (the one being discussed here), because it supports plumbing.
+**Note**: bridging to [Discord](https://discordapp.com/) can also happen via the [mx-puppet-discord](configuring-playbook-bridge-mx-puppet-discord.md) and [mautrix-discord](configuring-playbook-bridge-mautrix-discord.md) bridges supported by the playbook.   
+For using as a Bot we are recommend the Appservice Discord bridge (the one being discussed here), because it supports plumbing.  
 For personal use we recommend the [mautrix-discord](configuring-playbook-bridge-mautrix-discord.md) bridge, because it is the most fully-featured and stable of the 3 Discord bridges supported by the playbook.
 
 The playbook can install and configure [matrix-appservice-discord](https://github.com/Half-Shot/matrix-appservice-discord) for you.

--- a/docs/configuring-playbook-bridge-appservice-discord.md
+++ b/docs/configuring-playbook-bridge-appservice-discord.md
@@ -1,6 +1,8 @@
 # Setting up Appservice Discord (optional)
 
-**Note**: bridging to [Discord](https://discordapp.com/) can also happen via the [mx-puppet-discord](configuring-playbook-bridge-mx-puppet-discord.md) and [mautrix-discord](docs/configuring-playbook-bridge-mautrix-discord.md) bridges supported by the playbook. The [mautrix-discord](docs/configuring-playbook-bridge-mautrix-discord.md) bridge is the most fully-featured and stable of the 3 Discord bridges supported by the playbook, so it's the one we recommend.
+**Note**: bridging to [Discord](https://discordapp.com/) can also happen via the [mx-puppet-discord](configuring-playbook-bridge-mx-puppet-discord.md) and [mautrix-discord](docs/configuring-playbook-bridge-mautrix-discord.md) bridges supported by the playbook. 
+For using as a Bot we are recommend the Appservice Discord bridge (the one being discussed here), because it supports plumbing.
+For personal use we recommend the [mautrix-discord](configuring-playbook-bridge-mautrix-discord.md) bridge, because it is the most fully-featured and stable of the 3 Discord bridges supported by the playbook.
 
 The playbook can install and configure [matrix-appservice-discord](https://github.com/Half-Shot/matrix-appservice-discord) for you.
 

--- a/docs/configuring-playbook-bridge-mautrix-discord.md
+++ b/docs/configuring-playbook-bridge-mautrix-discord.md
@@ -1,6 +1,9 @@
 # Setting up Mautrix Discord (optional)
 
-**Note**: bridging to [Discord](https://discordapp.com/) can also happen via the [mx-puppet-discord](configuring-playbook-bridge-mx-puppet-discord.md) and [matrix-appservice-discord](configuring-playbook-bridge-appservice-discord.md) bridges supported by the playbook. The `mautrix-discord` bridge (the one being discussed here) is the most fully-featured and stable of the 3 Discord bridges supported by the playbook, so it's the one we recommend.
+**Note**: bridging to [Discord](https://discordapp.com/) can also happen via the [mx-puppet-discord](configuring-playbook-bridge-mx-puppet-discord.md) and [matrix-appservice-discord](configuring-playbook-bridge-appservice-discord.md) bridges supported by the playbook. 
+For using as a Bot we are recommend the [Appservice Discord](configuring-playbook-bridge-appservice-discord.md), because it supports plumbing.
+For personal use with a discord account we recommend the `mautrix-discord` bridge (the one being discussed here), because it is the most fully-featured and stable of the 3 Discord bridges supported by the playbook.
+The `mautrix-discord` bridge (the one being discussed here) is the most fully-featured and stable of the 3 Discord bridges supported by the playbook, so it's the one we recommend.
 
 The playbook can install and configure [mautrix-discord](https://github.com/mautrix/discord) for you.
 

--- a/docs/configuring-playbook-bridge-mautrix-discord.md
+++ b/docs/configuring-playbook-bridge-mautrix-discord.md
@@ -1,8 +1,8 @@
 # Setting up Mautrix Discord (optional)
 
 **Note**: bridging to [Discord](https://discordapp.com/) can also happen via the [mx-puppet-discord](configuring-playbook-bridge-mx-puppet-discord.md) and [matrix-appservice-discord](configuring-playbook-bridge-appservice-discord.md) bridges supported by the playbook.  
-For using as a Bot we are recommend the [Appservice Discord](configuring-playbook-bridge-appservice-discord.md), because it supports plumbing.  
-For personal use with a discord account we recommend the `mautrix-discord` bridge (the one being discussed here), because it is the most fully-featured and stable of the 3 Discord bridges supported by the playbook.
+- For using as a Bot we are recommend the [Appservice Discord](configuring-playbook-bridge-appservice-discord.md), because it supports plumbing.  
+- For personal use with a discord account we recommend the `mautrix-discord` bridge (the one being discussed here), because it is the most fully-featured and stable of the 3 Discord bridges supported by the playbook.
 The `mautrix-discord` bridge (the one being discussed here) is the most fully-featured and stable of the 3 Discord bridges supported by the playbook, so it's the one we recommend.
 
 The playbook can install and configure [mautrix-discord](https://github.com/mautrix/discord) for you.

--- a/docs/configuring-playbook-bridge-mautrix-discord.md
+++ b/docs/configuring-playbook-bridge-mautrix-discord.md
@@ -1,7 +1,7 @@
 # Setting up Mautrix Discord (optional)
 
 **Note**: bridging to [Discord](https://discordapp.com/) can also happen via the [mx-puppet-discord](configuring-playbook-bridge-mx-puppet-discord.md) and [matrix-appservice-discord](configuring-playbook-bridge-appservice-discord.md) bridges supported by the playbook.  
-- For using as a Bot we are recommend the [Appservice Discord](configuring-playbook-bridge-appservice-discord.md), because it supports plumbing.  
+- For using as a Bot we recommend the [Appservice Discord](configuring-playbook-bridge-appservice-discord.md), because it supports plumbing.  
 - For personal use with a discord account we recommend the `mautrix-discord` bridge (the one being discussed here), because it is the most fully-featured and stable of the 3 Discord bridges supported by the playbook.
 The `mautrix-discord` bridge (the one being discussed here) is the most fully-featured and stable of the 3 Discord bridges supported by the playbook, so it's the one we recommend.
 

--- a/docs/configuring-playbook-bridge-mautrix-discord.md
+++ b/docs/configuring-playbook-bridge-mautrix-discord.md
@@ -1,7 +1,7 @@
 # Setting up Mautrix Discord (optional)
 
-**Note**: bridging to [Discord](https://discordapp.com/) can also happen via the [mx-puppet-discord](configuring-playbook-bridge-mx-puppet-discord.md) and [matrix-appservice-discord](configuring-playbook-bridge-appservice-discord.md) bridges supported by the playbook. 
-For using as a Bot we are recommend the [Appservice Discord](configuring-playbook-bridge-appservice-discord.md), because it supports plumbing.
+**Note**: bridging to [Discord](https://discordapp.com/) can also happen via the [mx-puppet-discord](configuring-playbook-bridge-mx-puppet-discord.md) and [matrix-appservice-discord](configuring-playbook-bridge-appservice-discord.md) bridges supported by the playbook.  
+For using as a Bot we are recommend the [Appservice Discord](configuring-playbook-bridge-appservice-discord.md), because it supports plumbing.  
 For personal use with a discord account we recommend the `mautrix-discord` bridge (the one being discussed here), because it is the most fully-featured and stable of the 3 Discord bridges supported by the playbook.
 The `mautrix-discord` bridge (the one being discussed here) is the most fully-featured and stable of the 3 Discord bridges supported by the playbook, so it's the one we recommend.
 

--- a/docs/configuring-playbook-bridge-mx-puppet-discord.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-discord.md
@@ -1,7 +1,7 @@
 # Setting up MX Puppet Discord (optional)
 
 **Note**: bridging to [Discord](https://discordapp.com/) can also happen via the [matrix-appservice-discord](configuring-playbook-bridge-appservice-discord.md)and [mautrix-discord](configuring-playbook-bridge-mautrix-discord.md) bridges supported by the playbook.   
-- For using as a Bot we are recommend the [Appservice Discord](configuring-playbook-bridge-appservice-discord.md), because it supports plumbing.  
+- For using as a Bot we recommend the [Appservice Discord](configuring-playbook-bridge-appservice-discord.md), because it supports plumbing.  
 - For personal use with a discord account we recommend the [mautrix-discord](configuring-playbook-bridge-mautrix-discord.md) bridge, because it is the most fully-featured and stable of the 3 Discord bridges supported by the playbook.
 
 The playbook can install and configure

--- a/docs/configuring-playbook-bridge-mx-puppet-discord.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-discord.md
@@ -1,7 +1,7 @@
 # Setting up MX Puppet Discord (optional)
 
-**Note**: bridging to [Discord](https://discordapp.com/) can also happen via the [matrix-appservice-discord](configuring-playbook-bridge-appservice-discord.md)and [mautrix-discord](docs/configuring-playbook-bridge-mautrix-discord.md) bridges supported by the playbook. 
-For using as a Bot we are recommend the [Appservice Discord](configuring-playbook-bridge-appservice-discord.md), because it supports plumbing.
+**Note**: bridging to [Discord](https://discordapp.com/) can also happen via the [matrix-appservice-discord](configuring-playbook-bridge-appservice-discord.md)and [mautrix-discord](configuring-playbook-bridge-mautrix-discord.md) bridges supported by the playbook.   
+For using as a Bot we are recommend the [Appservice Discord](configuring-playbook-bridge-appservice-discord.md), because it supports plumbing.  
 For personal use with a discord account we recommend the [mautrix-discord](configuring-playbook-bridge-mautrix-discord.md) bridge, because it is the most fully-featured and stable of the 3 Discord bridges supported by the playbook.
 
 The playbook can install and configure

--- a/docs/configuring-playbook-bridge-mx-puppet-discord.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-discord.md
@@ -1,6 +1,8 @@
 # Setting up MX Puppet Discord (optional)
 
-**Note**: bridging to [Discord](https://discordapp.com/) can also happen via the [matrix-appservice-discord](configuring-playbook-bridge-appservice-discord.md)and [mautrix-discord](docs/configuring-playbook-bridge-mautrix-discord.md) bridges supported by the playbook. The [mautrix-discord](docs/configuring-playbook-bridge-mautrix-discord.md) bridge is the most fully-featured and stable of the 3 Discord bridges supported by the playbook, so it's the one we recommend.
+**Note**: bridging to [Discord](https://discordapp.com/) can also happen via the [matrix-appservice-discord](configuring-playbook-bridge-appservice-discord.md)and [mautrix-discord](docs/configuring-playbook-bridge-mautrix-discord.md) bridges supported by the playbook. 
+For using as a Bot we are recommend the [Appservice Discord](configuring-playbook-bridge-appservice-discord.md), because it supports plumbing.
+For personal use with a discord account we recommend the [mautrix-discord](configuring-playbook-bridge-mautrix-discord.md) bridge, because it is the most fully-featured and stable of the 3 Discord bridges supported by the playbook.
 
 The playbook can install and configure
 [mx-puppet-discord](https://github.com/matrix-discord/mx-puppet-discord) for you.

--- a/docs/configuring-playbook-bridge-mx-puppet-discord.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-discord.md
@@ -1,8 +1,8 @@
 # Setting up MX Puppet Discord (optional)
 
 **Note**: bridging to [Discord](https://discordapp.com/) can also happen via the [matrix-appservice-discord](configuring-playbook-bridge-appservice-discord.md)and [mautrix-discord](configuring-playbook-bridge-mautrix-discord.md) bridges supported by the playbook.   
-For using as a Bot we are recommend the [Appservice Discord](configuring-playbook-bridge-appservice-discord.md), because it supports plumbing.  
-For personal use with a discord account we recommend the [mautrix-discord](configuring-playbook-bridge-mautrix-discord.md) bridge, because it is the most fully-featured and stable of the 3 Discord bridges supported by the playbook.
+- For using as a Bot we are recommend the [Appservice Discord](configuring-playbook-bridge-appservice-discord.md), because it supports plumbing.  
+- For personal use with a discord account we recommend the [mautrix-discord](configuring-playbook-bridge-mautrix-discord.md) bridge, because it is the most fully-featured and stable of the 3 Discord bridges supported by the playbook.
 
 The playbook can install and configure
 [mx-puppet-discord](https://github.com/matrix-discord/mx-puppet-discord) for you.


### PR DESCRIPTION
The mautrix/discord bridge [isn't able to plumb](https://matrix.to/#/#discord:maunium.net/$94Ea7sM5eb86k_BQV6mq2XFDWiDoYuh2sHJvtcBs6qw?via=maunium.net&via=matrix.org&via=tchncs.de), 
[the developer of the bridge recommend appservice discord himself](https://matrix.to/#/#discord:maunium.net/$2buGUiAlg35kJvenaWqp6bBz0_1Yv3qv3Kfp5OM02po?via=maunium.net&via=matrix.org&via=tchncs.de).

Fixed the links which linked to https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/docs/docs/configuring-playbook-bridge-mautrix-discord.md