### PR TITLE
Use prebuilt ARM images for Element

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -2094,7 +2094,7 @@ matrix_redis_enabled: "{{ matrix_synapse_workers_enabled }}"
 # If you wish to connect to your Matrix server by other means, you may wish to disable this.
 matrix_client_element_enabled: true
 
-matrix_client_element_container_image_self_build: "{{ matrix_architecture != 'amd64' }}"
+matrix_client_element_container_image_self_build: "{{ matrix_architecture not in ['arm64', 'amd64'] }}"
 
 # Normally, matrix-nginx-proxy is enabled and nginx can reach Element over the container network.
 # If matrix-nginx-proxy is not enabled, or you otherwise have a need for it, you can expose


### PR DESCRIPTION
* element-web arm64 builds available since 2022-08-03 v.1.11.2 [vectorim/element-web:v1.11.2](https://hub.docker.com/layers/element-web/vectorim/element-web/v1.11.2/images/sha256-776f82281936226d91cc1b3b587f4aa28fd46934b8045427ced7c72668eda223?context=explore)