### PR TITLE
Fix Dendrite extra arguments getting lost

### DIFF
--- a/roles/matrix-dendrite/templates/dendrite/systemd/matrix-dendrite.service.j2
+++ b/roles/matrix-dendrite/templates/dendrite/systemd/matrix-dendrite.service.j2
@@ -46,13 +46,13 @@ ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-dendrite \
 			{% endfor %}
 			{{ matrix_dendrite_docker_image }} \
 			-config /data/dendrite.yaml \
+			{{ matrix_dendrite_process_extra_arguments|join(' ') }} \
 			{% if matrix_dendrite_http_bind_address %}
 			-http-bind-address {{ matrix_dendrite_http_bind_address }}
 			{% endif %}
 			{% if matrix_dendrite_https_bind_address %}
 			-https-bind-address {{ matrix_dendrite_https_bind_address }}
 			{% endif %}
-			{{ matrix_dendrite_process_extra_arguments|join(' ') }}
 
 ExecStop=-{{ matrix_host_command_sh }} -c '{{ matrix_host_command_docker }} kill matrix-dendrite 2>/dev/null || true'
 ExecStop=-{{ matrix_host_command_sh }} -c '{{ matrix_host_command_docker }} rm matrix-dendrite 2>/dev/null || true'


### PR DESCRIPTION
This PR moves the `matrix_dendrite_process_extra_arguments` line up so that it doesn't get lost, and adds a trailing backslash.

## Motivation
Without this PR, anything below the `..._bind_address` lines gets lost.  I ran into this bug because I needed to enable the "Really enable open registration" option on a server in a test environment.  But even after I added it to the `_extra_arguments` variable, Dendrite still wasn't seeing it.

## Alternatives
One possible approach would be to do figure out whether we have any extra args for the process or not.  And if we do, then add the trailing \ after the `_bind_address` lines.

Instead, here I just move the `_extra_arguments` line up so that it's no longer the last one.  Then everything is easy -- we always have the \ after the `_extra_arguments` line, and we never need one after `_bind_address`.