### PR TITLE
Add back sqlite plugin database config option to maubot

### DIFF
--- a/roles/matrix-bot-maubot/templates/config/config.yaml.j2
+++ b/roles/matrix-bot-maubot/templates/config/config.yaml.j2
@@ -27,6 +27,9 @@ plugin_directories:
 
 # Configuration for storing plugin databases
 plugin_databases:
+  # Some plugins still require sqlite, so configure a path here.
+  # postgres will be used if supported.
+  sqlite: /data/dbs
   postgres: default
 
 server:

--- a/roles/matrix-bot-maubot/templates/systemd/matrix-bot-maubot.service.j2
+++ b/roles/matrix-bot-maubot/templates/systemd/matrix-bot-maubot.service.j2
@@ -31,7 +31,7 @@ ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-bot-maubot \
 			-p {{ matrix_bot_maubot_management_interface_http_bind_port }}:{{ matrix_bot_maubot_management_interface_port }}
 			{% endif %}
 			{{ matrix_bot_maubot_docker_image }} \
- 			python3 -m maubot -c /config/config.yaml
+ 			python3 -m maubot -c /config/config.yaml --no-update
 
 ExecStop=-{{ matrix_host_command_sh }} -c '{{ matrix_host_command_docker }} kill matrix-bot-maubot 2>/dev/null || true'
 ExecStop=-{{ matrix_host_command_sh }} -c '{{ matrix_host_command_docker }} rm matrix-bot-maubot 2>/dev/null || true'


### PR DESCRIPTION
I found that all my plugins (other than rss which supports postgres) broke because this config option was missing.

@moan0s