### PR TITLE
Fix bug that prevented user with external nginx from launch

### DIFF
--- a/docs/configuring-playbook-bot-maubot.md
+++ b/docs/configuring-playbook-bot-maubot.md
@@ -61,23 +61,3 @@ You can expand "Access token" to copy it.
 ![Obatining an admin access token with Element](assets/obtain_admin_access_token_element.png)
 
 **IMPORTANT**: once you copy the token, just close the Matrix client window/tab. Do not "log out", as that would invalidate the token.
-
-## External nginx
-
-To use the management interface with an [external nginx webserver](configuring-playbook-own-webserver.md) the configuration will default to
-a http bind port at `127.0.0.1:29316`. If you need to use a different interface add the following to your `vars.yml` (e.g. with `0.0.0.0`).
-
-
-```yaml
-# Controls whether the maubot container exposes its HTTP management interface port (tcp/29316 in the container).
-#
-# Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:29316"), or empty string to not expose.
-# If you'll be setting this at all, it should be defined in terms of `matrix_bot_maubot_management_interface_port`.
-# Example:
-# matrix_bot_maubot_management_interface_http_bind_port: "127.0.0.1:{{ matrix_bot_maubot_management_interface_port }}"
-matrix_bot_maubot_management_interface_http_bind_port: '0.0.0.0:{{ matrix_bot_maubot_management_interface_port }}'
-```
-
-
-
-

--- a/docs/configuring-playbook-bot-maubot.md
+++ b/docs/configuring-playbook-bot-maubot.md
@@ -62,8 +62,20 @@ You can expand "Access token" to copy it.
 
 **IMPORTANT**: once you copy the token, just close the Matrix client window/tab. Do not "log out", as that would invalidate the token.
 
+## External nginx
 
+To use the management interface with an [external nginx webserver](configuring-playbook-own-webserver.md) the configuration will default to
+a http bind port at `127.0.0.1:29316`. If you need to use a different interface add the following to your `vars.yml` (e.g. with `0.0.0.0`).
 
+```yaml
+# Controls whether the maubot container exposes its HTTP management interface port (tcp/29316 in the container).
+#
+# Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:29316"), or empty string to not expose.
+# If you'll be setting this at all, it should be defined in terms of `matrix_bot_maubot_management_interface_port`.
+# Example:
+# matrix_bot_maubot_management_interface_http_bind_port: "127.0.0.1:{{ matrix_bot_maubot_management_interface_port }}"
+matrix_bot_maubot_management_interface_http_bind_port: '0.0.0.0:{{ matrix_bot_maubot_management_interface_port }}'
+```
 
 
 

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -1125,6 +1125,8 @@ matrix_bot_maubot_registration_shared_secret: |-
     }[matrix_homeserver_implementation]
   }}
 
+matrix_bot_maubot_management_interface_http_bind_port: "{{ '' if matrix_nginx_proxy_enabled else ('127.0.0.1:' + matrix_bot_maubot_management_interface_port | string) }}"
+
 # Postgres is the default, except if not using `matrix_postgres` (internal postgres)
 matrix_bot_maubot_database_engine: "{{ 'postgres' if matrix_postgres_enabled else 'sqlite' }}"
 matrix_bot_maubot_database_password: "{{ '%s' | format(matrix_homeserver_generic_secret_key) | password_hash('sha512', 'mxpup.dsc.db') | to_uuid }}"

--- a/roles/matrix-bot-maubot/templates/systemd/matrix-bot-maubot.service.j2
+++ b/roles/matrix-bot-maubot/templates/systemd/matrix-bot-maubot.service.j2
@@ -28,7 +28,7 @@ ExecStart={{ matrix_host_command_docker }} run --rm --name matrix-bot-maubot \
 			{% endfor %}
 			--network={{ matrix_docker_network }} \
 			{% if matrix_bot_maubot_management_interface_http_bind_port %}
-			-p {{ matrix_bot_maubot_management_interface_http_bind_port }}:{{ matrix_bot_maubot_management_interface_port }}
+			-p {{ matrix_bot_maubot_management_interface_http_bind_port }}:{{ matrix_bot_maubot_management_interface_port }} \
 			{% endif %}
 			{{ matrix_bot_maubot_docker_image }} \
  			python3 -m maubot -c /config/config.yaml --no-update


### PR DESCRIPTION
The backslash was missing and prevented users from starting the bot