### PR TITLE
Use arm64 images for Cinny

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -2164,7 +2164,7 @@ matrix_client_hydrogen_self_check_validate_certificates: "{{ false if matrix_ssl
 
 matrix_client_cinny_enabled: false
 
-matrix_client_cinny_container_image_self_build: "{{ matrix_architecture != 'amd64' }}"
+matrix_client_cinny_container_image_self_build: "{{ matrix_architecture not in ['arm64', 'amd64'] }}"
 
 # Normally, matrix-nginx-proxy is enabled and nginx can reach Cinny over the container network.
 # If matrix-nginx-proxy is not enabled, or you otherwise have a need for it, you can expose


### PR DESCRIPTION
Cinny now builds arm64 docker images since [v2.0.4](https://hub.docker.com/layers/cinny/ajbura/cinny/v2.0.4/images/sha256-a7202136f8568eb0397a3d644725a8fb7dca230e08bcfc42040238bda0382057?context=explore).