### PR TITLE
Update Signal daeon 0.20.0 -> 0.21.0

### DIFF
--- a/roles/matrix-bridge-mautrix-signal/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-signal/defaults/main.yml
@@ -10,7 +10,7 @@ matrix_mautrix_signal_docker_repo_version: "{{ 'master' if matrix_mautrix_signal
 matrix_mautrix_signal_docker_src_files_path: "{{ matrix_base_data_path }}/mautrix-signal/docker-src"
 
 matrix_mautrix_signal_version: v0.3.0
-matrix_mautrix_signal_daemon_version: 0.20.0
+matrix_mautrix_signal_daemon_version: 0.21.0
 # See: https://mau.dev/mautrix/signal/container_registry
 matrix_mautrix_signal_docker_image: "dock.mau.dev/mautrix/signal:{{ matrix_mautrix_signal_version }}"
 matrix_mautrix_signal_docker_image_force_pull: "{{ matrix_mautrix_signal_docker_image.endswith(':latest') }}"


### PR DESCRIPTION
There is no docker tag in UI, but it exists:

```
docker pull registry.gitlab.com/signald/signald:0.21.0
0.21.0: Pulling from signald/signald
2f42a0d7a7b7: Pull complete 
81c2fb1b6074: Pull complete 
7e8b9a51d6b6: Pull complete 
f6ed8fd77301: Pull complete 
64e6fa036bdc: Pull complete 
5e98b5369603: Pull complete 
f2a9b80dd9fc: Pull complete 
Digest: sha256:201cf93efba689aa0319d2a480deea8ffb7dcdfbda31ea45932fccf4c7626ab9
Status: Downloaded newer image for registry.gitlab.com/signald/signald:0.21.0
registry.gitlab.com/signald/signald:0.21.0
```