### PR TITLE
added rc_invites configuration for synapse

### DIFF
--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -142,6 +142,19 @@ matrix_synapse_rc_joins:
     per_second: 0.01
     burst_count: 3
 
+
+matrix_synapse_rc_invites:
+  per_room:
+    per_second: 0.5
+    burst_count: 5
+  per_user:
+    per_second: 0.004
+    burst_count: 3
+  per_issuer:
+    per_second: 0.5
+    burst_count: 5
+
+
 matrix_synapse_rc_federation:
   window_size: 1000
   sleep_limit: 10

--- a/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -977,6 +977,8 @@ rc_joins: {{ matrix_synapse_rc_joins|to_json }}
 #    per_second: 0.003
 #    burst_count: 5
 #
+rc_invites: {{ matrix_synapse_rc_invites|to_json }}
+
 #rc_third_party_invite:
 #  per_second: 0.2
 #  burst_count: 10


### PR DESCRIPTION
Hello, I had to be able to change the rate limit for the invitation event on my server.
I needed to be able to add ~50+ members quickly.

Thus, I added the config for `matrix_synapse_rc_invites` the same way it was added for `matrix_synapse_rc_joins ` ( not sure why it wasn't added before ?) 

for the default values, I took them from here `https://github.com/matrix-org/synapse/blob/f4ab6a4a96ceb02e260a3d025ff6c1e6cfefe4ed/docs/usage/configuration/config_documentation.md`