### PR TITLE
Update beeper-linkedin v0.5.2 -> v0.5.3 (repo change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Using this playbook, you can get the following services configured on your serve
 
 - (optional) the [mautrix-signal](https://github.com/mautrix/signal) bridge for bridging your Matrix server to [Signal](https://www.signal.org/)
 
-- (optional) the [beeper-linkedin](https://gitlab.com/beeper/linkedin) bridge for bridging your Matrix server to [LinkedIn](https://www.linkedin.com/)
+- (optional) the [beeper-linkedin](https://github.com/beeper/linkedin) bridge for bridging your Matrix server to [LinkedIn](https://www.linkedin.com/)
 
 - (optional) the [matrix-appservice-irc](https://github.com/matrix-org/matrix-appservice-irc) bridge for bridging your Matrix server to [IRC](https://wikipedia.org/wiki/Internet_Relay_Chat)
 

--- a/docs/configuring-playbook-bridge-beeper-linkedin.md
+++ b/docs/configuring-playbook-bridge-beeper-linkedin.md
@@ -1,8 +1,8 @@
 # Setting up Beeper Linkedin (optional)
 
-The playbook can install and configure [beeper-linkedin](https://gitlab.com/beeper/linkedin) for you, for bridging to [LinkedIn](https://www.linkedin.com/) Messaging. This bridge is based on the mautrix-python framework and can be configured in a similar way to the other mautrix bridges
+The playbook can install and configure [beeper-linkedin](https://github.com/beeper/linkedin) for you, for bridging to [LinkedIn](https://www.linkedin.com/) Messaging. This bridge is based on the mautrix-python framework and can be configured in a similar way to the other mautrix bridges
 
-See the project's [documentation](https://gitlab.com/beeper/linkedin/-/blob/master/README.md) to learn what it does and why it might be useful to you.
+See the project's [documentation](https://github.com/beeper/linkedin/blob/master/README.md) to learn what it does and why it might be useful to you.
 
 ```yaml
 matrix_beeper_linkedin_enabled: true

--- a/roles/matrix-bridge-beeper-linkedin/defaults/main.yml
+++ b/roles/matrix-bridge-beeper-linkedin/defaults/main.yml
@@ -1,19 +1,19 @@
 ---
 # beeper-linkedin is a Matrix <-> LinkedIn bridge
-# Project source code URL: https://gitlab.com/beeper/linkedin
+# Project source code URL: https://github.com/beeper/linkedin
 
 matrix_beeper_linkedin_enabled: true
 
 matrix_beeper_linkedin_version: v0.5.3
 
-# See: https://gitlab.com/beeper/linkedin/container_registry
+# See: https://github.com/beeper/linkedin/pkgs/container/linkedin
 matrix_beeper_linkedin_docker_image: "{{ matrix_beeper_linkedin_docker_image_name_prefix }}beeper/linkedin:{{ matrix_beeper_linkedin_docker_image_tag }}"
 matrix_beeper_linkedin_docker_image_force_pull: "{{ matrix_beeper_linkedin_docker_image_tag.startswith('latest') }}"
 matrix_beeper_linkedin_docker_image_name_prefix: "{{ 'localhost/' if matrix_beeper_linkedin_container_image_self_build else 'ghcr.io/' }}"
 matrix_beeper_linkedin_docker_image_tag: "{{ 'latest' if matrix_beeper_linkedin_version == 'master' else matrix_beeper_linkedin_version }}-{{ matrix_architecture }}"
 
 matrix_beeper_linkedin_container_image_self_build: false
-matrix_beeper_linkedin_container_image_self_build_repo: "https://gitlab.com/beeper/linkedin"
+matrix_beeper_linkedin_container_image_self_build_repo: "https://github.com/beeper/linkedin"
 matrix_beeper_linkedin_container_image_self_build_branch: "{{ matrix_beeper_linkedin_version }}"
 
 matrix_beeper_linkedin_base_path: "{{ matrix_base_data_path }}/beeper-linkedin"

--- a/roles/matrix-bridge-beeper-linkedin/defaults/main.yml
+++ b/roles/matrix-bridge-beeper-linkedin/defaults/main.yml
@@ -4,12 +4,12 @@
 
 matrix_beeper_linkedin_enabled: true
 
-matrix_beeper_linkedin_version: v0.5.2
+matrix_beeper_linkedin_version: v0.5.3
 
 # See: https://gitlab.com/beeper/linkedin/container_registry
 matrix_beeper_linkedin_docker_image: "{{ matrix_beeper_linkedin_docker_image_name_prefix }}beeper/linkedin:{{ matrix_beeper_linkedin_docker_image_tag }}"
 matrix_beeper_linkedin_docker_image_force_pull: "{{ matrix_beeper_linkedin_docker_image_tag.startswith('latest') }}"
-matrix_beeper_linkedin_docker_image_name_prefix: "{{ 'localhost/' if matrix_beeper_linkedin_container_image_self_build else 'registry.gitlab.com/' }}"
+matrix_beeper_linkedin_docker_image_name_prefix: "{{ 'localhost/' if matrix_beeper_linkedin_container_image_self_build else 'ghcr.io/' }}"
 matrix_beeper_linkedin_docker_image_tag: "{{ 'latest' if matrix_beeper_linkedin_version == 'master' else matrix_beeper_linkedin_version }}-{{ matrix_architecture }}"
 
 matrix_beeper_linkedin_container_image_self_build: false

--- a/roles/matrix-bridge-beeper-linkedin/tasks/setup_install.yml
+++ b/roles/matrix-bridge-beeper-linkedin/tasks/setup_install.yml
@@ -46,7 +46,7 @@
       register: matrix_beeper_linkedin_git_pull_results
 
     # Building the container image (using the default Dockerfile) requires that a docker-requirements.txt file be generated.
-    # See: https://gitlab.com/beeper/linkedin/-/blob/94442db17ccb9769b377cdb8e4bf1cb3955781d7/.gitlab-ci.yml#L30-40
+    # See: https://github.com/beeper/linkedin/blob/94442db17ccb9769b377cdb8e4bf1cb3955781d7/.gitlab-ci.yml#L30-40
     - name: Ensure docker-requirements.txt is generated before building Beeper LinkedIn Docker Image
       ansible.builtin.command:
         cmd: |


### PR DESCRIPTION
beeper-linkedin has moved to GitHub at https://github.com/beeper/linkedin and a new version has been published, v0.5.3.