### PR TITLE
Remove arch from beeper-linkedin tag

### DIFF
--- a/roles/matrix-bridge-beeper-linkedin/defaults/main.yml
+++ b/roles/matrix-bridge-beeper-linkedin/defaults/main.yml
@@ -10,7 +10,7 @@ matrix_beeper_linkedin_version: v0.5.3
 matrix_beeper_linkedin_docker_image: "{{ matrix_beeper_linkedin_docker_image_name_prefix }}beeper/linkedin:{{ matrix_beeper_linkedin_docker_image_tag }}"
 matrix_beeper_linkedin_docker_image_force_pull: "{{ matrix_beeper_linkedin_docker_image_tag.startswith('latest') }}"
 matrix_beeper_linkedin_docker_image_name_prefix: "{{ 'localhost/' if matrix_beeper_linkedin_container_image_self_build else 'ghcr.io/' }}"
-matrix_beeper_linkedin_docker_image_tag: "{{ 'latest' if matrix_beeper_linkedin_version == 'master' else matrix_beeper_linkedin_version }}-{{ matrix_architecture }}"
+matrix_beeper_linkedin_docker_image_tag: "{{ 'latest' if matrix_beeper_linkedin_version == 'master' else matrix_beeper_linkedin_version }}"
 
 matrix_beeper_linkedin_container_image_self_build: false
 matrix_beeper_linkedin_container_image_self_build_repo: "https://github.com/beeper/linkedin"


### PR DESCRIPTION
Fixes issue with beeper-linkedin tag introduced in https://github.com/spantaleev/matrix-docker-ansible-deploy/pull/2035 (sorry!). 
The new tag naming structure does not include the architecture.