### PR TITLE
Appservices for Dendrite

### DIFF
--- a/roles/matrix-bridge-appservice-discord/tasks/init.yml
+++ b/roles/matrix-bridge-appservice-discord/tasks/init.yml
@@ -11,8 +11,9 @@
     matrix_systemd_services_list: "{{ matrix_systemd_services_list + ['matrix-appservice-discord.service'] }}"
   when: matrix_appservice_discord_enabled | bool
 
-# If the matrix-synapse role is not used, these variables may not exist.
+
 - ansible.builtin.set_fact:
+    # If the matrix-synapse role is not used, these variables may not exist.
     matrix_synapse_container_extra_arguments: >
       {{
         matrix_synapse_container_extra_arguments | default([])
@@ -23,6 +24,21 @@
     matrix_synapse_app_service_config_files: >
       {{
         matrix_synapse_app_service_config_files | default([])
+        +
+        ["/matrix-appservice-discord-registration.yaml"]
+      }}
+
+    # If the matrix-dendrite role is not used, these variables may not exist.
+    matrix_dendrite_container_extra_arguments: >
+      {{
+        matrix_dendrite_container_extra_arguments | default([])
+        +
+        ["--mount type=bind,src={{ matrix_appservice_discord_config_path }}/registration.yaml,dst=/matrix-appservice-discord-registration.yaml,ro"]
+      }}
+
+    matrix_dendrite_app_service_config_files: >
+      {{
+        matrix_dendrite_app_service_config_files | default([])
         +
         ["/matrix-appservice-discord-registration.yaml"]
       }}

--- a/roles/matrix-bridge-mautrix-facebook/tasks/init.yml
+++ b/roles/matrix-bridge-mautrix-facebook/tasks/init.yml
@@ -10,8 +10,8 @@
     matrix_systemd_services_list: "{{ matrix_systemd_services_list + ['matrix-mautrix-facebook.service'] }}"
   when: matrix_mautrix_facebook_enabled | bool
 
-# If the matrix-synapse role is not used, these variables may not exist.
 - ansible.builtin.set_fact:
+    # If the matrix-synapse role is not used, these variables may not exist.
     matrix_synapse_container_extra_arguments: >
       {{
         matrix_synapse_container_extra_arguments | default([])
@@ -22,6 +22,20 @@
     matrix_synapse_app_service_config_files: >
       {{
         matrix_synapse_app_service_config_files | default([])
+        +
+        ["/matrix-mautrix-facebook-registration.yaml"]
+      }}
+    # If the matrix-dendrite role is not used, these variables may not exist.
+    matrix_dendrite_container_extra_arguments: >
+      {{
+        matrix_dendrite_container_extra_arguments | default([])
+        +
+        ["--mount type=bind,src={{ matrix_mautrix_facebook_config_path }}/registration.yaml,dst=/matrix-mautrix-facebook-registration.yaml,ro"]
+      }}
+
+    matrix_dendrite_app_service_config_files: >
+      {{
+        matrix_dendrite_app_service_config_files | default([])
         +
         ["/matrix-mautrix-facebook-registration.yaml"]
       }}

--- a/roles/matrix-bridge-mautrix-telegram/tasks/init.yml
+++ b/roles/matrix-bridge-mautrix-telegram/tasks/init.yml
@@ -10,8 +10,8 @@
     matrix_systemd_services_list: "{{ matrix_systemd_services_list + ['matrix-mautrix-telegram.service'] }}"
   when: matrix_mautrix_telegram_enabled | bool
 
-# If the matrix-synapse role is not used, these variables may not exist.
 - ansible.builtin.set_fact:
+    # If the matrix-synapse role is not used, these variables may not exist.
     matrix_synapse_container_extra_arguments: >
       {{
         matrix_synapse_container_extra_arguments | default([])
@@ -22,6 +22,21 @@
     matrix_synapse_app_service_config_files: >
       {{
         matrix_synapse_app_service_config_files | default([])
+        +
+        ["/matrix-mautrix-telegram-registration.yaml"]
+      }}
+
+    # If the matrix-dendrite role is not used, these variables may not exist.
+    matrix_dendrite_container_extra_arguments: >
+      {{
+        matrix_dendrite_container_extra_arguments | default([])
+        +
+        ["--mount type=bind,src={{ matrix_mautrix_telegram_config_path }}/registration.yaml,dst=/matrix-mautrix-telegram-registration.yaml,ro"]
+      }}
+
+    matrix_dendrite_app_service_config_files: >
+      {{
+        matrix_dendrite_app_service_config_files | default([])
         +
         ["/matrix-mautrix-telegram-registration.yaml"]
       }}

--- a/roles/matrix-bridge-mautrix-whatsapp/tasks/init.yml
+++ b/roles/matrix-bridge-mautrix-whatsapp/tasks/init.yml
@@ -3,8 +3,8 @@
     matrix_systemd_services_list: "{{ matrix_systemd_services_list + ['matrix-mautrix-whatsapp.service'] }}"
   when: matrix_mautrix_whatsapp_enabled | bool
 
-# If the matrix-synapse role is not used, these variables may not exist.
 - ansible.builtin.set_fact:
+    # If the matrix-synapse role is not used, these variables may not exist.
     matrix_synapse_container_extra_arguments: >
       {{
         matrix_synapse_container_extra_arguments | default([])
@@ -18,4 +18,19 @@
         +
         ["/matrix-mautrix-whatsapp-registration.yaml"]
       }}
+    # If the matrix-dendrite role is not used, these variables may not exist.
+    matrix_dendrite_container_extra_arguments: >
+      {{
+        matrix_dendrite_container_extra_arguments | default([])
+        +
+        ["--mount type=bind,src={{ matrix_mautrix_whatsapp_config_path }}/registration.yaml,dst=/matrix-mautrix-whatsapp-registration.yaml,ro"]
+      }}
+
+    matrix_dendrite_app_service_config_files: >
+      {{
+        matrix_dendrite_app_service_config_files | default([])
+        +
+        ["/matrix-mautrix-whatsapp-registration.yaml"]
+      }}
+
   when: matrix_mautrix_whatsapp_enabled | bool


### PR DESCRIPTION
D + A = M comes packaged with many appservices, but unfortunately these do not all automatically install on Dendrite. (See https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/1611)

@spantaleev said some time ago that it should be possible to automate appservice installation for Dendrite by re-using the tasks written for installing the appservices on Synapse. About [2-3 weeks ago](https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/1611#issuecomment-1205789473) I figured a nice way to do it:

```yml
- ansible.builtin.set_fact:
    matrix_systemd_services_list: "{{ matrix_systemd_services_list + ['matrix-mautrix-whatsapp.service'] }}"
  when: matrix_mautrix_whatsapp_enabled | bool

- ansible.builtin.set_fact:
    # If the matrix-synapse role is not used, these variables may not exist.
    matrix_synapse_container_extra_arguments: >
      {{
        matrix_synapse_container_extra_arguments | default([])
        +
        ["--mount type=bind,src={{ matrix_mautrix_whatsapp_config_path }}/registration.yaml,dst=/matrix-mautrix-whatsapp-registration.yaml,ro"]
      }}

    matrix_synapse_app_service_config_files: >
      {{
        matrix_synapse_app_service_config_files | default([])
        +
        ["/matrix-mautrix-whatsapp-registration.yaml"]
      }}

    # If the matrix-dendrite role is not used, these variables may not exist.
    matrix_dendrite_container_extra_arguments: >
      {{
        matrix_dendrite_container_extra_arguments | default([])
        +
        ["--mount type=bind,src={{ matrix_mautrix_whatsapp_config_path }}/registration.yaml,dst=/matrix-mautrix-whatsapp-registration.yaml,ro"]
      }}

    matrix_dendrite_app_service_config_files: >
      {{
        matrix_dendrite_app_service_config_files | default([])
        +
        ["/matrix-mautrix-whatsapp-registration.yaml"]
      }}

  when: matrix_mautrix_whatsapp_enabled | bool
```

This PR adds support for bridging WhatsApp, Telegram and Facebook (Experimental) using Mautrix, as well as the Discord appservice. I was originally planning to PR after having updated all appservices, but a combination of real life issues and bricking my server (while bridging to Facebook) have slowed me down. So now I think it's a better idea to PR in this early form with minimal coverage, and hopefully build on it from there.