### PR TITLE
dendrite: fix user-registration command

### DIFF
--- a/roles/matrix-dendrite/defaults/main.yml
+++ b/roles/matrix-dendrite/defaults/main.yml
@@ -83,7 +83,7 @@ matrix_dendrite_rate_limiting_threshold: 5
 matrix_dendrite_rate_limiting_cooloff_ms: 500
 
 # Controls whether people with access to the homeserver can register by themselves.
-matrix_dendrite_registration_disabled: false
+matrix_dendrite_registration_disabled: true
 
 # reCAPTCHA API for validating registration attempts
 matrix_dendrite_enable_registration_captcha: false

--- a/roles/matrix-dendrite/templates/dendrite/usr-local-bin/matrix-dendrite-create-account.j2
+++ b/roles/matrix-dendrite/templates/dendrite/usr-local-bin/matrix-dendrite-create-account.j2
@@ -2,7 +2,7 @@
 #!/bin/bash
 
 if [ $# -ne 2 ]; then
-	echo "Usage: "$0" <username> <password>"
+	echo "Usage: "$0" <username> <password> <admin access: 0 or 1>"
 	exit 1
 fi
 

--- a/roles/matrix-dendrite/templates/dendrite/usr-local-bin/matrix-dendrite-create-account.j2
+++ b/roles/matrix-dendrite/templates/dendrite/usr-local-bin/matrix-dendrite-create-account.j2
@@ -8,5 +8,10 @@ fi
 
 user=$1
 password=$2
+admin=$3
 
-docker exec matrix-dendrite create-account -config /data/dendrite.yaml -username "$user" -password "$password"
+if [ "$admin" -eq "1" ]; then
+	docker exec matrix-dendrite create-account -config /data/dendrite.yaml -username "$user" -password "$password" -admin -url http://localhost:{{ matrix_dendrite_http_bind_port }}
+else
+	docker exec matrix-dendrite create-account -config /data/dendrite.yaml -username "$user" -password "$password" -url http://localhost:{{ matrix_dendrite_http_bind_port }}
+fi


### PR DESCRIPTION
It currently fails with:
```
FATA[0003] Failed to create the account: unable to get nonce: Get "https://localhost:8448/_synapse/admin/v1/register": dial tcp 127.0.0.1:8448: connect: connection refused
```

Also go ahead and disable open registration by default to match the synapse defaults.