### PR TITLE
feat(telegram-bridge): add variable to enable encryption support

### DIFF
--- a/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
@@ -156,3 +156,8 @@ matrix_mautrix_telegram_registration: "{{ matrix_mautrix_telegram_registration_y
 matrix_mautrix_telegram_username_template: 'telegram_{userid}'
 matrix_mautrix_telegram_alias_template: 'telegram_{groupname}'
 matrix_mautrix_telegram_displayname_template: '{displayname} (Telegram)'
+
+# Enable End-to-bridge encryption
+matrix_mautrix_telegram_bridge_encryption_allow: false
+matrix_mautrix_telegram_bridge_encryption_default: "{{ matrix_mautrix_telegram_bridge_encryption_allow }}"
+matrix_mautrix_telegram_bridge_encryption_key_sharing_allow: "{{ matrix_mautrix_telegram_bridge_encryption_allow }}"

--- a/roles/matrix-bridge-mautrix-telegram/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-telegram/templates/config.yaml.j2
@@ -176,27 +176,29 @@ bridge:
             height: 256
             background: "020202"  # only for gif
             fps: 30               # only for webm
-    # End-to-bridge encryption support options. These require matrix-nio to be installed with pip
-    # and login_shared_secret to be configured in order to get a device for the bridge bot.
+    # End-to-bridge encryption support options.
     #
-    # Additionally, https://github.com/matrix-org/synapse/pull/5758 is required if using a normal
-    # application service.
+    # See https://docs.mau.fi/bridges/general/end-to-bridge-encryption.html for more info.
     encryption:
         # Allow encryption, work in group chat rooms with e2ee enabled
-        allow: false
+        allow: {{ matrix_mautrix_telegram_bridge_encryption_allow|to_json }}
         # Default to encryption, force-enable encryption in all portals the bridge creates
         # This will cause the bridge bot to be in private chats for the encryption to work properly.
-        default: false
-        # Database for the encryption data. Currently only supports Postgres and an in-memory
-        # store that's persisted as a pickle.
-        # If set to `default`, will use the appservice postgres database
-        # or a pickle file if the appservice database is sqlite.
-        #
-        # Format examples:
-        #   Pickle:   pickle:///filename.pickle
-        #   Postgres: postgres://username:password@hostname/dbname
+        default: {{ matrix_mautrix_telegram_bridge_encryption_default|to_json }}
+        # Database for the encryption data. If set to `default`, will use the appservice database.
         database: default
-
+        # Options for automatic key sharing.
+        key_sharing:
+            # Enable key sharing? If enabled, key requests for rooms where users are in will be fulfilled.
+            # You must use a client that supports requesting keys from other users to use this feature.
+            allow: {{ matrix_mautrix_telegram_bridge_encryption_key_sharing_allow|to_json }}
+            # Require the requesting device to have a valid cross-signing signature?
+            # This doesn't require that the bridge has verified the device, only that the user has verified it.
+            # Not yet implemented.
+            require_cross_signing: false
+            # Require devices to be verified by the bridge?
+            # Verification by the bridge is not yet implemented.
+            require_verification: true
     # Whether or not to explicitly set the avatar and room name for private
     # chat portal rooms. This will be implicitly enabled if encryption.default is true.
     private_chat_portal_meta: false


### PR DESCRIPTION
Hi,
this PR adds a variable to enable End-To-Bridge encryption for mautrix-telegram just like #1818.
It also updates the encryption configuration stanza to the latest stable upstream example config (which can be found here): https://github.com/mautrix/telegram/blob/v0.11.3/mautrix_telegram/example-config.yaml#L240-L259