### PR TITLE
Correctly check number of arguments when creating a dendrite account

### DIFF
--- a/roles/matrix-dendrite/templates/dendrite/usr-local-bin/matrix-dendrite-create-account.j2
+++ b/roles/matrix-dendrite/templates/dendrite/usr-local-bin/matrix-dendrite-create-account.j2
@@ -1,7 +1,7 @@
 #jinja2: lstrip_blocks: "True"
 #!/bin/bash
 
-if [ $# -ne 2 ]; then
+if [ $# -ne 3 ]; then
 	echo "Usage: "$0" <username> <password> <admin access: 0 or 1>"
 	exit 1
 fi


### PR DESCRIPTION
This is probably a continuation of changes made in d7ed672f7.