### PR TITLE
Make Conduit's rocksdb_max_open_files parameter configurable

### DIFF
--- a/roles/matrix-conduit/defaults/main.yml
+++ b/roles/matrix-conduit/defaults/main.yml
@@ -36,6 +36,11 @@ matrix_conduit_template_conduit_config: "{{ role_path }}/templates/conduit/condu
 # Max size for uploads, in bytes
 matrix_conduit_max_request_size: 20_000_000
 
+# Maximum number of open files for Conduit's embedded RocksDB database
+# See https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide#tuning-other-options
+# If not specified, Conduit defaults to a relatively low value of 20
+matrix_conduit_rocksdb_max_open_files: 64
+
 # Enables registration. If set to false, no users can register on this server.
 matrix_conduit_allow_registration: false
 

--- a/roles/matrix-conduit/templates/conduit/conduit.toml.j2
+++ b/roles/matrix-conduit/templates/conduit/conduit.toml.j2
@@ -34,6 +34,9 @@ port = {{ matrix_conduit_port_number }}
 # Max size for uploads
 max_request_size = {{ matrix_conduit_max_request_size }}
 
+# Max number of open files for the RocksDB database
+rocksdb_max_open_files = {{ matrix_conduit_rocksdb_max_open_files }}
+
 # Enables registration. If set to false, no users can register on this server.
 allow_registration = {{ matrix_conduit_allow_registration | to_json }}
 


### PR DESCRIPTION
This PR exposes the Conduit configuration variable `rocksdb_max_open_files` to the playbook and sets it to a slightly higher default value.

The parameter exists to prevent RocksDB from opening too many files and exceeding the system's maximum number of open files.

By default, Conduit sets the parameter to 20 if no value is given in the config file.  Here I'm setting it to 64 instead, so that we avoid creating a bottleneck on larger systems.  Some RocksDB documentation suggests allowing for at least one open file per CPU.