### PR TITLE
change stream writer worker metrics range start

### DIFF
--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -494,7 +494,7 @@ matrix_synapse_stream_writers: {}
 # It should be noted that not all of the background worker types will need to expose HTTP services, etc.
 matrix_synapse_workers_stream_writer_workers_http_port_range_start: 20011
 matrix_synapse_workers_stream_writer_workers_replication_port_range_start: 25011
-matrix_synapse_workers_stream_writer_workers_metrics_range_start: 19111
+matrix_synapse_workers_stream_writer_workers_metrics_range_start: 19211
 
 # matrix_synapse_workers_pusher_workers_count controls the number of pusher workers (workers who push out notifications) to spawn.
 # See https://matrix-org.github.io/synapse/latest/workers.html#synapseapppusher


### PR DESCRIPTION
`one-of-each` setting for workers,  recently broke with error messages from `matrix-synapse-worker-stream-writer-0-events.service` with  `port 19111 already in use` . 
Changing `matrix_synapse_workers_stream_writer_workers_metrics_range_start` from  `19111` to `19211` seem to fixed for me the issue 