### PR TITLE
Do not restart postmoogle during installation

### DIFF
--- a/roles/matrix-bot-postmoogle/tasks/setup_install.yml
+++ b/roles/matrix-bot-postmoogle/tasks/setup_install.yml
@@ -91,9 +91,3 @@
   ansible.builtin.service:
     daemon_reload: true
   when: "matrix_bot_postmoogle_systemd_service_result.changed | bool"
-
-- name: Ensure matrix-bot-postmoogle.service restarted, if necessary
-  ansible.builtin.service:
-    name: "matrix-bot-postmoogle.service"
-    state: restarted
-  when: "matrix_bot_postmoogle_systemd_service_result.changed | bool"


### PR DESCRIPTION
Reason: during a fresh install, when there is no synapse yet, systemd unit fails to start, thus whole play fails