### PR TITLE
synapse: match upstream rate limit defaults

### DIFF
--- a/roles/matrix-synapse/defaults/main.yml
+++ b/roles/matrix-synapse/defaults/main.yml
@@ -148,22 +148,22 @@ matrix_synapse_rc_admin_redaction:
 matrix_synapse_rc_joins:
   local:
     per_second: 0.1
-    burst_count: 3
+    burst_count: 10
   remote:
     per_second: 0.01
-    burst_count: 3
+    burst_count: 10
 
 
 matrix_synapse_rc_invites:
   per_room:
-    per_second: 0.5
-    burst_count: 5
+    per_second: 0.3
+    burst_count: 10
   per_user:
-    per_second: 0.004
-    burst_count: 3
-  per_issuer:
-    per_second: 0.5
+    per_second: 0.003
     burst_count: 5
+  per_issuer:
+    per_second: 0.3
+    burst_count: 10
 
 
 matrix_synapse_rc_federation:


### PR DESCRIPTION
Updates rate limit variables to match default values as "documented" in [ratelimiting.py](https://github.com/matrix-org/synapse/blob/ac1a31740b6d0dfda4d57a25762aaddfde981caf/synapse/config/ratelimiting.py).