### PR TITLE
prometheus: don't just default to synapse

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -2310,8 +2310,7 @@ matrix_synapse_tls_private_key_path: ~
 
 matrix_synapse_federation_port_openid_resource_required: "{{ not matrix_synapse_federation_enabled and (matrix_dimension_enabled or matrix_ma1sd_enabled) }}"
 
-# If someone instals Prometheus via the playbook, they most likely wish to monitor Synapse.
-matrix_synapse_metrics_enabled: "{{ matrix_prometheus_enabled }}"
+matrix_synapse_metrics_enabled: "{{ matrix_synapse_enabled and matrix_prometheus_enabled }}"
 
 matrix_synapse_email_enabled: "{{ matrix_mailer_enabled }}"
 matrix_synapse_email_smtp_host: "matrix-mailer"
@@ -2635,6 +2634,8 @@ matrix_dendrite_systemd_wanted_services_list: |
 
 matrix_dendrite_container_runtime_injected_arguments: "{{ matrix_homeserver_container_runtime_injected_arguments }}"
 matrix_dendrite_app_service_runtime_injected_config_files: "{{ matrix_homeserver_app_service_runtime_injected_config_files }}"
+
+matrix_dendrite_metrics_enabled: "{{ matrix_dendrite_enabled and matrix_prometheus_enabled }}"
 
 ######################################################################
 #


### PR DESCRIPTION
I don't think dendrite is completely hookedup to export data just yet but at least now the playbook shouldn't just listen to synapse by default.