### PR TITLE
Exempt Matrix server from ntfy rate limit

### DIFF
--- a/roles/custom/matrix-ntfy/defaults/main.yml
+++ b/roles/custom/matrix-ntfy/defaults/main.yml
@@ -15,11 +15,13 @@ matrix_ntfy_docker_image_force_pull: "{{ matrix_ntfy_docker_image.endswith(':lat
 matrix_ntfy_base_url: "https://{{ matrix_server_fqn_ntfy }}"
 
 # Rate limits
-matrix_ntfy_limit_burst_rate: 60 # default
-matrix_ntfy_limit_replenish_rate: "5s" # default
-matrix_ntfy_limit_rate_exempt: "{{matrix_server_fqn_matrix}},localhost" # exempt our matrix server from rate limits, this may not work when the homeserver's outgoing IP is different from the incoming IP, but most small deployments should be fine.
-matrix_ntfy_limit_global_topic: 15000 # default
-matrix_ntfy_limit_visitor_subscriptions: 30 # default
+
+matrix_ntfy_global_topic_limit: 15000 # default
+matrix_ntfy_visitor_subscription_limit: 30 # default
+matrix_ntfy_visitor_request_limit_burst: 60 # default
+matrix_ntfy_visitor_request_limit_replenish: "5s" # default
+matrix_ntfy_visitor_request_limit_exempt_hosts: "{{matrix_server_fqn_matrix}},localhost" # exempt our matrix server from rate limits, this may not work when the homeserver's outgoing IP is different from the incoming IP, but most small deployments should be fine.
+
 
 # Controls whether the container exposes its HTTP port (tcp/80 in the container).
 #

--- a/roles/custom/matrix-ntfy/defaults/main.yml
+++ b/roles/custom/matrix-ntfy/defaults/main.yml
@@ -20,7 +20,6 @@ matrix_ntfy_global_topic_limit: 15000 # default
 matrix_ntfy_visitor_subscription_limit: 30 # default
 matrix_ntfy_visitor_request_limit_burst: 60 # default
 matrix_ntfy_visitor_request_limit_replenish: "5s" # default
-matrix_ntfy_visitor_request_limit_exempt_hosts: "{{matrix_server_fqn_matrix}},localhost" # exempt our matrix server from rate limits, this may not work when the homeserver's outgoing IP is different from the incoming IP, but most small deployments should be fine.
 
 
 # Controls whether the container exposes its HTTP port (tcp/80 in the container).

--- a/roles/custom/matrix-ntfy/defaults/main.yml
+++ b/roles/custom/matrix-ntfy/defaults/main.yml
@@ -14,6 +14,13 @@ matrix_ntfy_docker_image_force_pull: "{{ matrix_ntfy_docker_image.endswith(':lat
 # Public facing base URL of the ntfy service
 matrix_ntfy_base_url: "https://{{ matrix_server_fqn_ntfy }}"
 
+# Rate limits
+matrix_ntfy_limit_burst_rate: 60 # default
+matrix_ntfy_limit_replenish_rate: "5s" # default
+matrix_ntfy_limit_rate_exempt: "{{matrix_server_fqn_matrix}},localhost" # exempt our matrix server from rate limits, this may not work when the homeserver's outgoing IP is different from the incoming IP, but most small deployments should be fine.
+matrix_ntfy_limit_global_topic: 15000 # default
+matrix_ntfy_limit_visitor_subscriptions: 30 # default
+
 # Controls whether the container exposes its HTTP port (tcp/80 in the container).
 #
 # Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:2586"), or empty string to not expose.

--- a/roles/custom/matrix-ntfy/defaults/main.yml
+++ b/roles/custom/matrix-ntfy/defaults/main.yml
@@ -16,10 +16,10 @@ matrix_ntfy_base_url: "https://{{ matrix_server_fqn_ntfy }}"
 
 # Rate limits
 
-matrix_ntfy_global_topic_limit: 15000 # default
-matrix_ntfy_visitor_subscription_limit: 30 # default
-matrix_ntfy_visitor_request_limit_burst: 60 # default
-matrix_ntfy_visitor_request_limit_replenish: "5s" # default
+matrix_ntfy_global_topic_limit: 15000  # default
+matrix_ntfy_visitor_subscription_limit: 30  # default
+matrix_ntfy_visitor_request_limit_burst: 60  # default
+matrix_ntfy_visitor_request_limit_replenish: "5s"  # default
 
 
 # Controls whether the container exposes its HTTP port (tcp/80 in the container).

--- a/roles/custom/matrix-ntfy/templates/ntfy/server.yml.j2
+++ b/roles/custom/matrix-ntfy/templates/ntfy/server.yml.j2
@@ -8,5 +8,4 @@ global-topic-limit: {{ matrix_ntfy_global_topic_limit | to_json }}
 visitor-subscription-limit: {{ matrix_ntfy_visitor_subscription_limit | to_json }}
 
 visitor-request-limit-burst: {{ matrix_ntfy_visitor_request_limit_burst | to_json }}
-visitor-request-limit-replenish: "{{ matrix_ntfy_visitor_request_limit_replenish | to_json }}"
-visitor-request-limit-exempt-hosts: "{{ matrix_ntfy_visitor_request_limit_exempt_hosts | to_json }}"
+visitor-request-limit-replenish: "{{ matrix_ntfy_visitor_request_limit_replenish }}"

--- a/roles/custom/matrix-ntfy/templates/ntfy/server.yml.j2
+++ b/roles/custom/matrix-ntfy/templates/ntfy/server.yml.j2
@@ -4,9 +4,9 @@ cache_file: /data/cache.db
 listen-http: :8080
 
 # Rate Limits
-global-topic-limit: {{ matrix_ntfy_limit_global_topic }}
-visitor-subscription-limit: {{ matrix_ntfy_limit_visitor_subscriptions }}
+global-topic-limit: {{ matrix_ntfy_global_topic_limit | to_json }}
+visitor-subscription-limit: {{ matrix_ntfy_visitor_subscription_limit | to_json }}
 
-visitor-request-limit-burst: {{ matrix_ntfy_limit_burst_rate }}
-visitor-request-limit-replenish: "{{ matrix_ntfy_limit_replenish_rate }}"
-visitor-request-limit-exempt-hosts: "{{ matrix_ntfy_limit_rate_exempt }}"
+visitor-request-limit-burst: {{ matrix_ntfy_visitor_request_limit_burst | to_json }}
+visitor-request-limit-replenish: "{{ matrix_ntfy_visitor_request_limit_replenish | to_json }}"
+visitor-request-limit-exempt-hosts: "{{ matrix_ntfy_visitor_request_limit_exempt_hosts | to_json }}"

--- a/roles/custom/matrix-ntfy/templates/ntfy/server.yml.j2
+++ b/roles/custom/matrix-ntfy/templates/ntfy/server.yml.j2
@@ -2,3 +2,11 @@ base_url: {{ matrix_ntfy_base_url }}
 behind_proxy: true
 cache_file: /data/cache.db
 listen-http: :8080
+
+# Rate Limits
+global-topic-limit: {{ matrix_ntfy_limit_global_topic }}
+visitor-subscription-limit: {{ matrix_ntfy_limit_visitor_subscriptions }}
+
+visitor-request-limit-burst: {{ matrix_ntfy_limit_burst_rate }}
+visitor-request-limit-replenish: "{{ matrix_ntfy_limit_replenish_rate }}"
+visitor-request-limit-exempt-hosts: "{{ matrix_ntfy_limit_rate_exempt }}"

--- a/roles/custom/matrix-ntfy/templates/systemd/matrix-ntfy.service.j2
+++ b/roles/custom/matrix-ntfy/templates/systemd/matrix-ntfy.service.j2
@@ -11,11 +11,12 @@ Environment="HOME={{ devture_systemd_docker_base_systemd_unit_home_path }}"
 ExecStartPre=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} kill matrix-ntfy 2>/dev/null || true'
 ExecStartPre=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} rm matrix-ntfy 2>/dev/null || true'
 
-ExecStart={{ devture_systemd_docker_base_host_command_docker }} run --rm --name matrix-ntfy \
+ExecStart={{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} run --rm --name matrix-ntfy \
 			--log-driver=none \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
 			--read-only \
+                        --env NTFY_VISITOR_REQUEST_LIMIT_EXEMPT_HOSTS={{matrix_server_fqn_matrix}},localhost,$(docker network inspect {{matrix_docker_network}} -f "{{"{{"}} (index .IPAM.Config 0).Subnet {{"}}"}}") \
 			{% for arg in matrix_ntfy_container_extra_arguments %}
 			{{ arg }} \
 			{% endfor %}
@@ -26,7 +27,7 @@ ExecStart={{ devture_systemd_docker_base_host_command_docker }} run --rm --name 
 			--mount type=bind,src={{ matrix_ntfy_config_dir_path }},dst=/etc/ntfy,ro \
 			--mount type=bind,src={{ matrix_ntfy_data_path }},dst=/data \
 			{{ matrix_ntfy_docker_image }} \
-			serve
+			serve'
 
 ExecStop=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} kill matrix-ntfy 2>/dev/null || true'
 ExecStop=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} rm matrix-ntfy 2>/dev/null || true'

--- a/roles/custom/matrix-ntfy/templates/systemd/matrix-ntfy.service.j2
+++ b/roles/custom/matrix-ntfy/templates/systemd/matrix-ntfy.service.j2
@@ -16,7 +16,7 @@ ExecStart={{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_syste
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
 			--read-only \
-                        --env NTFY_VISITOR_REQUEST_LIMIT_EXEMPT_HOSTS={{matrix_server_fqn_matrix}},localhost,$(docker network inspect {{matrix_docker_network}} -f "{{"{{"}} (index .IPAM.Config 0).Subnet {{"}}"}}") \
+			--env NTFY_VISITOR_REQUEST_LIMIT_EXEMPT_HOSTS={{matrix_server_fqn_matrix}},localhost,$(docker network inspect {{matrix_docker_network}} -f "{{"{{"}} (index .IPAM.Config 0).Subnet {{"}}"}}") \
 			{% for arg in matrix_ntfy_container_extra_arguments %}
 			{{ arg }} \
 			{% endfor %}

--- a/roles/custom/matrix-ntfy/templates/systemd/matrix-ntfy.service.j2
+++ b/roles/custom/matrix-ntfy/templates/systemd/matrix-ntfy.service.j2
@@ -16,7 +16,7 @@ ExecStart={{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_syste
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
 			--read-only \
-			--env NTFY_VISITOR_REQUEST_LIMIT_EXEMPT_HOSTS={{matrix_server_fqn_matrix}},localhost,$(docker network inspect {{matrix_docker_network}} -f "{{"{{"}} (index .IPAM.Config 0).Subnet {{"}}"}}") \
+			--env NTFY_VISITOR_REQUEST_LIMIT_EXEMPT_HOSTS={{matrix_server_fqn_matrix}},localhost,$(docker network inspect {{matrix_docker_network}} -f "{% raw %}{{ (index .IPAM.Config 0).Subnet }}{% endraw %}") \
 			{% for arg in matrix_ntfy_container_extra_arguments %}
 			{{ arg }} \
 			{% endfor %}


### PR DESCRIPTION
Add the Matrix server to ntfy's exemption list. Also allow all ntfy rate limits to be configured through Ansible variables.

Reasoning: we (UnifiedPush) have seen some support requests for people not receiving notifications due to rate limits. At some point, someone using this playbook for a large-ish ntfy deployment will also run into that. Adding this as a precaution should mitigate that.

I will test this on my server soon, and then make this ready for review.