### PR TITLE
Update proxied nginx for maubot

### DIFF
--- a/roles/matrix-bot-maubot/tasks/init.yml
+++ b/roles/matrix-bot-maubot/tasks/init.yml
@@ -14,14 +14,13 @@
           {% if matrix_nginx_proxy_enabled | default(False) %}
             {# Use the embedded DNS resolver in Docker containers to discover the service #}
              resolver 127.0.0.11 valid=5s;
-             set $backend "matrix-bot-maubot:{{ matrix_bot_maubot_management_interface_port }}$request_uri";
-             proxy_pass http://$backend;
-             proxy_set_header Host $host;
+             set $backend "matrix-bot-maubot:{{ matrix_bot_maubot_management_interface_port }};
+             proxy_pass http://$backend$request_uri";
              proxy_set_header Upgrade $http_upgrade;
              proxy_set_header Connection "upgrade";
           {% else %}
             {# Generic configuration for use outside of our container setup #}
-            proxy_pass http://127.0.0.1:{{ matrix_bot_maubot_management_interface_port }}/$1;
+            proxy_pass http://127.0.0.1:{{ matrix_bot_maubot_management_interface_port }}$request_uri";
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
           {% endif %}

--- a/roles/matrix-bot-maubot/tasks/init.yml
+++ b/roles/matrix-bot-maubot/tasks/init.yml
@@ -14,8 +14,9 @@
           {% if matrix_nginx_proxy_enabled | default(False) %}
             {# Use the embedded DNS resolver in Docker containers to discover the service #}
              resolver 127.0.0.11 valid=5s;
-             set $backend "matrix-bot-maubot:{{ matrix_bot_maubot_management_interface_port }}/$1";
+             set $backend "matrix-bot-maubot:{{ matrix_bot_maubot_management_interface_port }}$request_uri";
              proxy_pass http://$backend;
+             proxy_set_header Host $host;
              proxy_set_header Upgrade $http_upgrade;
              proxy_set_header Connection "upgrade";
           {% else %}


### PR DESCRIPTION
I've got a situation where I'm using maubot with gitlab bot. 
My matrix server is setup behind a nginx configured as a proxy.
The bot is giving me error 400 : room not found on webhooks.
The proposed change is working fixes the problem in my situation. However I have not tested it on other configurations nor ran any test.