### PR TITLE
Fix error introduced in #2141

### DIFF
--- a/roles/matrix-bot-mjolnir/templates/production.yaml.j2
+++ b/roles/matrix-bot-mjolnir/templates/production.yaml.j2
@@ -239,8 +239,8 @@ health:
 # Whether or not to actively poll synapse for abuse reports, to be used
 # instead of intercepting client calls to synapse's abuse endpoint, when that
 # isn't possible/practical.
-pollReports: true
+pollReports: false
 
 # Whether or not new reports, received either by webapi or polling,
 # should be printed to our managementRoom.
-displayReports: true
+displayReports: false


### PR DESCRIPTION
#2141 introduced a change to the config that makes mjolnir poll for reports. This change is reverted in this PR as Mjolnir is not happy to try to poll for Reports but get denied due to lack of being a homeserver admin that is required. 

If your mjolnir is homeserver admin the changes where safe but i am not going to expect all mjolnirs to be homeserver admins. There are other config flags that require it being HS admin that are not default enabled in #2141 for that very reason. 