### PR TITLE
Update Postmoogle 0.9.4 -> 0.9.5

### DIFF
--- a/roles/matrix-bot-postmoogle/defaults/main.yml
+++ b/roles/matrix-bot-postmoogle/defaults/main.yml
@@ -9,7 +9,7 @@ matrix_bot_postmoogle_docker_repo: "https://gitlab.com/etke.cc/postmoogle.git"
 matrix_bot_postmoogle_docker_repo_version: "{{ 'main' if matrix_bot_postmoogle_version == 'latest' else matrix_bot_postmoogle_version }}"
 matrix_bot_postmoogle_docker_src_files_path: "{{ matrix_base_data_path }}/postmoogle/docker-src"
 
-matrix_bot_postmoogle_version: v0.9.4
+matrix_bot_postmoogle_version: v0.9.5
 matrix_bot_postmoogle_docker_image: "{{ matrix_bot_postmoogle_docker_image_name_prefix }}postmoogle:{{ matrix_bot_postmoogle_version }}"
 matrix_bot_postmoogle_docker_image_name_prefix: "{{ 'localhost/' if matrix_bot_postmoogle_container_image_self_build else 'registry.gitlab.com/etke.cc/' }}"
 matrix_bot_postmoogle_docker_image_force_pull: "{{ matrix_bot_postmoogle_docker_image.endswith(':latest') }}"
@@ -109,6 +109,9 @@ matrix_bot_postmoogle_loglevel: 'INFO'
 matrix_bot_postmoogle_noencryption: false
 
 matrix_bot_postmoogle_domain: "{{ matrix_server_fqn_matrix }}"
+
+# Password (passphrase) to encrypt account data
+matrix_bot_postmoogle_data_secret: ""
 
 # in-container ports
 matrix_bot_postmoogle_port: '2525'

--- a/roles/matrix-bot-postmoogle/templates/env.j2
+++ b/roles/matrix-bot-postmoogle/templates/env.j2
@@ -15,5 +15,6 @@ POSTMOOGLE_TLS_PORT={{ matrix_bot_postmoogle_tls_port }}
 POSTMOOGLE_TLS_CERT={{ matrix_bot_postmoogle_tls_cert }}
 POSTMOOGLE_TLS_KEY={{ matrix_bot_postmoogle_tls_key }}
 POSTMOOGLE_TLS_REQUIRED={{ matrix_bot_postmoogle_tls_required }}
+POSTMOOGLE_DATA_SECRET={{ matrix_bot_postmoogle_data_secret }}
 
 {{ matrix_bot_postmoogle_environment_variables_extension }}


### PR DESCRIPTION
* fix `!pm send` parsing with one-word subject and body
* fix `CTE_8BIT_MISMATCH`
* add account data encryption (keys and values) support
* add catch-all mailbox support

**WARNING**: [CI job is in progress](https://gitlab.com/etke.cc/postmoogle/-/jobs/3138819456)