### PR TITLE
Update Caddy examples and outdated Jitsi docker env variable/documentation link

### DIFF
--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -87,7 +87,7 @@ For more information refer to the [docker-jitsi-meet](https://github.com/jitsi/d
 
 By default the Jitsi Meet instance does not work with a client in LAN (Local Area Network), even if others are connected from WAN. There are no video and audio. In the case of WAN to WAN everything is ok.
 
-The reason is the Jitsi VideoBridge git to LAN client the IP address of the docker image instead of the host. The [documentation](https://github.com/jitsi/docker-jitsi-meet#running-behind-nat-or-on-a-lan-environment) of Jitsi in docker suggest to add `DOCKER_HOST_ADDRESS` in enviornment variable to make it work.
+The reason is the Jitsi VideoBridge git to LAN client the IP address of the docker image instead of the host. The [documentation](https://jitsi.github.io/handbook/docs/devops-guide/devops-guide-docker/#running-behind-nat-or-on-a-lan-environment) of Jitsi in docker suggest to add `JVB_ADVERTISE_IPS` in enviornment variable to make it work.
 
 Here is how to do it in the playbook.
 
@@ -95,7 +95,7 @@ Add these two lines to your `inventory/host_vars/matrix.DOMAIN/vars.yml` configu
 
 ```yaml
 matrix_jitsi_jvb_container_extra_arguments:
-  - '--env "DOCKER_HOST_ADDRESS=<Local IP adress of the host>"'
+  - '--env "JVB_ADVERTISE_IPS=<Local IP address of the host>"'
 ```
 
 ## (Optional) Fine tune Jitsi

--- a/docs/configuring-playbook-own-webserver.md
+++ b/docs/configuring-playbook-own-webserver.md
@@ -35,7 +35,7 @@ No matter which external webserver you decide to go with, you'll need to:
         ```
     - if using an external server on another host, add the `<service>_http_host_bind_port` or `<service>_http_bind_port` variables for the services that will be exposed by the external server on the other host. The actual name of the variable is listed in the `roles/<service>/defaults/vars.yml` file for each service. Most variables follow the `<service>_http_host_bind_port` format.
        
-      These variables will make Docker expose the ports to the local network instead of localhost only.
+      These variables will make Docker expose the ports on all network interfaces instead of localhost only.
       [Keep in mind that there are some security concerns if you simply proxy everything.](https://github.com/matrix-org/synapse/blob/master/docs/reverse_proxy.md#synapse-administration-endpoints)
 
       Here are the variables required for the default configuration (Synapse and Element)

--- a/docs/configuring-playbook-own-webserver.md
+++ b/docs/configuring-playbook-own-webserver.md
@@ -33,16 +33,16 @@ No matter which external webserver you decide to go with, you'll need to:
         ```yaml
         matrix_nginx_proxy_enabled: false
         ```
-    - if using an external server on another docker network or host, add the `<service>_http_host_bind_port` or `<service>_http_bind_port` variables for the services that will be exposed by the external server on the other docker network or host. The actual name of the variable is listed in the `roles/<service>/defaults/vars.yml` file for each service. Most variables follow the `<service>_http_host_bind_port` format.
+    - if using an external server on another host, add the `<service>_http_host_bind_port` or `<service>_http_bind_port` variables for the services that will be exposed by the external server on the other host. The actual name of the variable is listed in the `roles/<service>/defaults/vars.yml` file for each service. Most variables follow the `<service>_http_host_bind_port` format.
        
       These variables will make Docker expose the ports to the local network instead of localhost only.
       [Keep in mind that there are some security concerns if you simply proxy everything.](https://github.com/matrix-org/synapse/blob/master/docs/reverse_proxy.md#synapse-administration-endpoints)
 
       Here are the variables required for the default configuration (Synapse and Element)
        ```
-        matrix_synapse_container_client_api_host_bind_port: '8008'
-        matrix_synapse_container_federation_api_plain_host_bind_port: '8048'
-        matrix_client_element_container_http_host_bind_port: "8765"
+        matrix_synapse_container_client_api_host_bind_port: '0.0.0.0:8008'
+        matrix_synapse_container_federation_api_plain_host_bind_port: '0.0.0.0:8048'
+        matrix_client_element_container_http_host_bind_port: "0.0.0.0:8765"
        ```
 
 3) **If you'll manage SSL certificates by yourself**, edit your configuration file (`inventory/host_vars/matrix.<your-domain>/vars.yml`) to disable SSL certificate retrieval:

--- a/docs/configuring-playbook-own-webserver.md
+++ b/docs/configuring-playbook-own-webserver.md
@@ -27,11 +27,23 @@ No matter which external webserver you decide to go with, you'll need to:
 
 1) Make sure your web server user (something like `http`, `apache`, `www-data`, `nginx`) is part of the `matrix` group. You should run something like this: `usermod -a -G matrix nginx`. This allows your webserver user to access files owned by the `matrix` group. When using an external nginx webserver, this allows it to read configuration files from `/matrix/nginx-proxy/conf.d`. When using another server, it would make other files, such as `/matrix/static-files/.well-known`, accessible to it.
 
-2) Edit your configuration file (`inventory/host_vars/matrix.<your-domain>/vars.yml`) to disable the integrated nginx server:
+2) Edit your configuration file (`inventory/host_vars/matrix.<your-domain>/vars.yml`)
+   - to disable the integrated nginx server:
 
-```yaml
-matrix_nginx_proxy_enabled: false
-```
+        ```yaml
+        matrix_nginx_proxy_enabled: false
+        ```
+    - if using an external server on another docker network or host, add the `<service>_http_host_bind_port` or `<service>_http_bind_port` variables for the services that will be exposed by the external server on the other docker network or host. The actual name of the variable is listed in the `roles/<service>/defaults/vars.yml` file for each service. Most variables follow the `<service>_http_host_bind_port` format.
+       
+      These variables will make Docker expose the ports to the local network instead of localhost only.
+      [Keep in mind that there are some security concerns if you simply proxy everything.](https://github.com/matrix-org/synapse/blob/master/docs/reverse_proxy.md#synapse-administration-endpoints)
+
+      Here are the variables required for the default configuration (Synapse and Element)
+       ```
+        matrix_synapse_container_client_api_host_bind_port: '8008'
+        matrix_synapse_container_federation_api_plain_host_bind_port: '8048'
+        matrix_client_element_container_http_host_bind_port: "8765"
+       ```
 
 3) **If you'll manage SSL certificates by yourself**, edit your configuration file (`inventory/host_vars/matrix.<your-domain>/vars.yml`) to disable SSL certificate retrieval:
 
@@ -40,7 +52,6 @@ matrix_ssl_retrieval_method: none
 ```
 
 **Note**: During [installation](installing.md), unless you've disabled SSL certificate management (`matrix_ssl_retrieval_method: none`), the playbook would need 80 to be available, in order to retrieve SSL certificates. **Please manually stop your other webserver while installing**. You can start it back up afterwards.
-
 
 ### Using your own external nginx webserver
 
@@ -59,15 +70,6 @@ matrix_nginx_proxy_ssl_protocols: "TLSv1.2"
 ```
 
 If you are experiencing issues, try updating to a newer version of Nginx. As a data point in May 2021 a user reported that Nginx 1.14.2 was not working for them. They were getting errors about socket leaks. Updating to Nginx 1.19 fixed their issue.
-
-If you are not going to be running your webserver on the same docker network, or the same machine as matrix, these variables can be set to bind synapse to an exposed port. [Keep in mind that there are some security concerns if you simply proxy everything to it](https://github.com/matrix-org/synapse/blob/master/docs/reverse_proxy.md#synapse-administration-endpoints)
-```yaml
-# Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:8048" or "192.168.1.3:80"), or empty string to not expose.
-matrix_synapse_container_client_api_host_bind_port: ''
-matrix_synapse_container_federation_api_plain_host_bind_port: ''
-```
-
-
 
 ### Using your own external Apache webserver
 

--- a/examples/caddy2/Caddyfile
+++ b/examples/caddy2/Caddyfile
@@ -1,3 +1,15 @@
+(cors) {
+	@cors_preflight method OPTIONS
+
+	handle @cors_preflight {
+		header Access-Control-Allow-Origin "{args.0}"
+		header Access-Control-Allow-Methods "HEAD, GET, POST, PUT, PATCH, DELETE"
+		header Access-Control-Allow-Headers "Content-Type, Authorization"
+		header Access-Control-Max-Age "3600"
+	}
+}
+
+
 matrix.DOMAIN.tld {
 
   # creates letsencrypt certificate
@@ -81,6 +93,13 @@ matrix.DOMAIN.tld {
         header Access-Control-Allow-Origin *
         file_server
   }
+  
+  # If you have other well-knowns already handled by your base domain, you can replace the above block by this one, along with the replacement suggested in the base domain
+  #handle @wellknown {
+  #  # .well-known is handled by base domain
+  #  reverse_proxy https://DOMAIN.tld {
+  #  header_up Host {http.reverse_proxy.upstream.hostport}
+  #}
 
   handle {
         encode zstd gzip
@@ -114,6 +133,8 @@ element.DOMAIN.tld {
       # creates letsencrypt certificate
       # tls your@email.com
 
+      import cors https://*.DOMAIN.tld
+
       header {
                 # Enable HTTP Strict Transport Security (HSTS) to force clients to always connect via HTTPS
                 Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
@@ -123,6 +144,8 @@ element.DOMAIN.tld {
                 X-Content-Type-Options "nosniff"
                 # Disallow the site to be rendered within a frame (clickjacking protection)
                 X-Frame-Options "DENY"
+                # If using integrations that add frames to Element, such as Dimension and its integrations running on the same domain, it can be a good idea to limit sources allowed to be rendered
+                # Content-Security-Policy frame-src https://*.DOMAIN.tld
                 # X-Robots-Tag
                 X-Robots-Tag "noindex, noarchive, nofollow"
         }
@@ -144,6 +167,8 @@ element.DOMAIN.tld {
 #      # creates letsencrypt certificate
 #      # tls your@email.com
 #
+#      import cors https://*.DOMAIN.tld
+#
 #      header {
 #          # Enable HTTP Strict Transport Security (HSTS) to force clients to always connect via HTTPS
 #          Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
@@ -151,8 +176,8 @@ element.DOMAIN.tld {
 #          X-XSS-Protection "1; mode=block"
 #          # Prevent some browsers from MIME-sniffing a response away from the declared Content-Type
 #          X-Content-Type-Options "nosniff"
-#          # Disallow the site to be rendered within a frame (clickjacking protection)
-#          X-Frame-Options "DENY"
+#          # Only allow same base domain to render this website in a frame; Can be removed if the client (Element for example) is hosted on another domain (clickjacking protection)
+#          # Content-Security-Policy frame-ancestors https://*.DOMAIN.tld
 #          # X-Robots-Tag
 #          X-Robots-Tag "noindex, noarchive, nofollow"
 #    }
@@ -176,6 +201,8 @@ element.DOMAIN.tld {
 #  creates letsencrypt certificate
 #  tls your@email.com
 #
+#  import cors https://*.DOMAIN.tld
+#
 #  header {
 #        # Enable HTTP Strict Transport Security (HSTS) to force clients to always connect via HTTPS
 #        Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
@@ -185,9 +212,9 @@ element.DOMAIN.tld {
 #
 #        # Prevent some browsers from MIME-sniffing a response away from the declared Content-Type
 #        X-Content-Type-Options "nosniff"
-#
-#        # Disallow the site to be rendered within a frame (clickjacking protection)
-#        X-Frame-Options "SAMEORIGIN"
+
+#        # Only allow same base domain to render this website in a frame; Can be removed if the client (Element for example) is hosted on another domain
+#        # Content-Security-Policy frame-ancestors https://*.DOMAIN.tld
 #
 #        # Disable some features
 #        Feature-Policy "accelerometer 'none';ambient-light-sensor 'none'; autoplay 'none';camera 'none';encrypted-media 'none';focus-without-user-activation 'none'; geolocation 'none';gyroscope #'none';magnetometer 'none';microphone 'none';midi 'none';payment 'none';picture-in-picture 'none'; speaker 'none';sync-xhr 'none';usb 'none';vr 'none'"
@@ -225,6 +252,14 @@ element.DOMAIN.tld {
 #            header_up Host {http.reverse_proxy.upstream.hostport}
 #        }
 #    }
+#    # If you have other well-knowns already handled by your base domain, you can replace the above block by this one, along with the replacement suggested in the matrix subdomain
+#      # handle /.well-known/* {
+#	#	encode zstd gzip
+#	#	header Cache-Control max-age=14400
+#	#	header Content-Type application/json
+#	#	header Access-Control-Allow-Origin *
+#	#}
+#
 #    # Configration for the base domain goes here
 #   # handle {
 #   #    header -Server

--- a/examples/caddy2/Caddyfile
+++ b/examples/caddy2/Caddyfile
@@ -177,7 +177,7 @@ element.DOMAIN.tld {
 #          # Prevent some browsers from MIME-sniffing a response away from the declared Content-Type
 #          X-Content-Type-Options "nosniff"
 #          # Only allow same base domain to render this website in a frame; Can be removed if the client (Element for example) is hosted on another domain (clickjacking protection)
-#          # Content-Security-Policy frame-ancestors https://*.DOMAIN.tld
+#          Content-Security-Policy frame-ancestors https://*.DOMAIN.tld
 #          # X-Robots-Tag
 #          X-Robots-Tag "noindex, noarchive, nofollow"
 #    }
@@ -214,7 +214,7 @@ element.DOMAIN.tld {
 #        X-Content-Type-Options "nosniff"
 
 #        # Only allow same base domain to render this website in a frame; Can be removed if the client (Element for example) is hosted on another domain
-#        # Content-Security-Policy frame-ancestors https://*.DOMAIN.tld
+#        Content-Security-Policy frame-ancestors https://*.DOMAIN.tld
 #
 #        # Disable some features
 #        Feature-Policy "accelerometer 'none';ambient-light-sensor 'none'; autoplay 'none';camera 'none';encrypted-media 'none';focus-without-user-activation 'none'; geolocation 'none';gyroscope #'none';magnetometer 'none';microphone 'none';midi 'none';payment 'none';picture-in-picture 'none'; speaker 'none';sync-xhr 'none';usb 'none';vr 'none'"


### PR DESCRIPTION
I encountered a few issues when setting up my instance, some of them caused by lacking or outdated documentation.

1. Updated the `DOCKER_HOST_ADDRESS` for Jitsi to its new name (`JVB_ADVERTISE_IPS`)
2. Moved a part of the external webserver documentation that seemed to be specific to nginx because it was in the nginx section to the generic section since the configuration needed for all external webservers on another docker network or host. Also includes an example for a default setup (Synapse + Element)
3. Updated Caddyfile to :
    - Support CORS
    - Update some click-jacking protection directives to use a different approach that allows different subdomains to use the website as a frame, not just the exact same origin (ex : `element.example.com` trying to use `jitsi.example.com` in an iframe)
    - Add an example to handle `.well-knowns` in cases where the base domain already has `.well-knowns`