### PR TITLE
fix(goofys): fix synapse systemd unit file to correctly require goofys

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -2364,7 +2364,7 @@ matrix_synapse_systemd_required_services_list: |
     +
     (['matrix-postgres.service'] if matrix_postgres_enabled else [])
     +
-    (['matrix-goofys'] if matrix_s3_media_store_enabled else [])
+    (['matrix-goofys.service'] if matrix_s3_media_store_enabled else [])
   }}
 
 matrix_synapse_systemd_wanted_services_list: |
@@ -2650,7 +2650,7 @@ matrix_dendrite_systemd_required_services_list: |
     +
     (['matrix-postgres.service'] if matrix_postgres_enabled else [])
     +
-    (['matrix-goofys'] if matrix_s3_media_store_enabled else [])
+    (['matrix-goofys.service'] if matrix_s3_media_store_enabled else [])
   }}
 
 matrix_dendrite_systemd_wanted_services_list: |


### PR DESCRIPTION
On Debian 10 (buster) at least, while the Synapse systemd service unit was referring to Goofys as `matrix-goofys` without a `.service` suffix, systemd was ignoring the goofys dependency, starting Synapse before Goofys. All other dependant units which work are using the ".service" suffix.

This generally leads to the mount path goofys using having been populated by Synapse before Goofys starts, causing it to fail due to the mount target not being empty.

The fix seems to be to ensure that the Synapse service unit refers to Goofys as `matrix-goofys.service`.

This change causes the following two lines in `/etc/systemd/system/matrix-synapse.service`:

    Requires=matrix-goofys
    After=matrix-goofys

To be modified to:

    Requires=matrix-goofys.service
    After=matrix-goofys.service

---

I believe this may fix both #1107 and #1740.