### PR TITLE
Enable hookshot feeds by default

### DIFF
--- a/roles/matrix-bridge-hookshot/defaults/main.yml
+++ b/roles/matrix-bridge-hookshot/defaults/main.yml
@@ -128,7 +128,7 @@ matrix_hookshot_generic_allow_js_transformation_functions: false
 matrix_hookshot_generic_user_id_prefix: '_webhooks_'
 
 
-matrix_hookshot_feeds_enabled: false
+matrix_hookshot_feeds_enabled: true
 # polling interval in seconds
 matrix_hookshot_feeds_interval: 600
 


### PR DESCRIPTION
as per documentation: "Services that need no further configuration are enabled by default" and feeds service doesn't require it