### PR TITLE
Edit docs for signal-bridge, coturn, postmoogle

### DIFF
--- a/docs/configuring-dns.md
+++ b/docs/configuring-dns.md
@@ -43,7 +43,7 @@ If you are using Cloudflare DNS, make sure to disable the proxy and set all reco
 | [Postmoogle](configuring-playbook-bot-postmoogle.md)/[Email2Matrix](configuring-playbook-email2matrix.md) email bridges | MX    | `matrix`                       | 10       | 0      | -    | `matrix.<your-domain>`      |
 | [Postmoogle](configuring-playbook-bot-postmoogle.md) email bridge                                                       | TXT   | `matrix`                       | -        | -      | -    | `v=spf1 ip4:<your-ip> -all` |
 | [Postmoogle](configuring-playbook-bot-postmoogle.md) email bridge                                                       | TXT   | `_dmarc.matrix`                | -        | -      | -    | `v=DMARC1; p=quarantine;`   |
-| [Postmoogle](configuring-playbook-bot-postmoogle.md) email bridge                                                       | TXT   | `postmoogle._domainkey.matrix` | -        | -      | -    | get it from `!pm dkim`      |
+| [Postmoogle](configuring-playbook-bot-postmoogle.md) email bridge                                                       | TXT   | `postmoogle._domainkey.matrix` | -        | -      | -    | get it from [`!pm dkim`](https://github.com/spantaleev/matrix-docker-ansible-deploy/blame/master/docs/configuring-playbook-bot-postmoogle.md#L43)      |
 
 ## Subdomains setup
 

--- a/docs/configuring-playbook-bot-postmoogle.md
+++ b/docs/configuring-playbook-bot-postmoogle.md
@@ -40,7 +40,12 @@ matrix_bot_postmoogle_password: PASSWORD_FOR_THE_BOT
 You will need to add several DNS records
 See [Configuring DNS](configuring-dns.md).
 
-To be able to get the value for `!pm dkim` for your DNS settings you need to have admin-rights for the bridge:
+To be able to get the value for `!pm dkim` for your DNS settings you need to have admin-rights for the bridge.
+If you didn't set this generally for all bridges with:
+```yaml
+matrix_admin: "@username:{{ matrix_domain }}"
+```
+you need to set one for administering postmoogle with this item in your `vars.yml`:
 ```yaml
 matrix_bot_postmoogle_admins:
   - "@<username>:{{ matrix_domain }}"
@@ -68,6 +73,21 @@ matrix_bot_postmoogle_tls_cert: ""
 matrix_bot_postmoogle_tls_key: ""
 ```
 **Note:** `matrix_bot_postmoogle_ssl_path:` defaults to what you set for `matrix_ssl_config_dir_path:` As seen in [/group_vars/matrix_servers](https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/group_vars/matrix_servers#L1213) but it has to be set again to make postmoogle look for it outside the docker-container.
+
+## Open Ports
+If you run a firewall on your server and/or it sits behind a NAT-Router, remember to open/forward the ports `25` (for non-TLS) and `587` (TLS)
+as set [here](https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/roles/matrix-bot-postmoogle/defaults/main.yml#L121)
+
+It's possible to change those ports in `vars.yml` with:
+```yaml
+matrix_bot_postmoogle_smtp_host_bind_port: ""
+matrix_bot_postmoogle_submission_host_bind_port: ""
+```
+
+If you want to enforce TLS on both ports add this to `vars.yml`:
+```yaml
+matrix_bot_postmoogle_tls_required: true
+```
 
 ## Installing
 

--- a/docs/configuring-playbook-bot-postmoogle.md
+++ b/docs/configuring-playbook-bot-postmoogle.md
@@ -35,9 +35,39 @@ matrix_bot_postmoogle_enabled: true
 matrix_bot_postmoogle_password: PASSWORD_FOR_THE_BOT
 ```
 
-You will also need to add several DNS records so that postmoogle can send emails.
+## Use Postmoogle for sending mails
+
+You will need to add several DNS records
 See [Configuring DNS](configuring-dns.md).
 
+To be able to get the value for `!pm dkim` for your DNS settings you need to have admin-rights for the bridge:
+```yaml
+matrix_bot_postmoogle_admins:
+  - "@<username>:{{ matrix_domain }}"
+```
+
+If you want to use TLS (you should) and you use `matrix_ssl_retrieval_method: manually-managed`) you have to add to `vars.yml`:
+```yaml
+### SSL
+## on-host SSL dir
+matrix_bot_postmoogle_ssl_path: ""
+
+## in-container SSL paths
+# matrix_bot_postmoogle_tls_cert is the SSL certificate's certificate.
+# This is likely set via group_vars/matrix_servers, so you don't need to set it.
+# If you do need to set it manually, note that this is an in-container path.
+# To mount a certificates volumes into the container, use matrix_bot_postmoogle_ssl_path
+# Example value: /ssl/live/{{ matrix_bot_postmoogle_domain }}/fullchain.pem
+matrix_bot_postmoogle_tls_cert: ""
+
+# matrix_bot_postmoogle_tls_key is the SSL certificate's key.
+# This is likely set via group_vars/matrix_servers, so you don't need to set it.
+# If you do need to set it manually, note that this is an in-container path.
+# To mount a certificates volumes into the container, use matrix_bot_postmoogle_ssl_path
+# Example value: /ssl/live/{{ matrix_bot_postmoogle_domain }}/privkey.pem
+matrix_bot_postmoogle_tls_key: ""
+```
+**Note:** `matrix_bot_postmoogle_ssl_path:` defaults to what you set for `matrix_ssl_config_dir_path:` As seen in [/group_vars/matrix_servers](https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/group_vars/matrix_servers#L1213) but it has to be set again to make postmoogle look for it outside the docker-container.
 
 ## Installing
 

--- a/docs/configuring-playbook-bridge-mautrix-signal.md
+++ b/docs/configuring-playbook-bridge-mautrix-signal.md
@@ -93,7 +93,15 @@ As seen in the mentioned [upstream-documentation](https://docs.mau.fi/bridges/py
 - `allow: true` the bridge won't enable encryption on its own, but will work in encrypted rooms
 - `default: true` the bridge will automatically enable encryption in new portals.
 
-**Note**: [Upstream-documentation](https://docs.mau.fi/bridges/python/signal/index.html) mentions to make sure using postgres if enabling the bridge in encrypted rooms.
+**Note**: 
+* [Upstream-documentation](https://docs.mau.fi/bridges/python/signal/index.html) mentions to make sure using postgres if enabling the bridge in encrypted rooms.
+* Careful when setting `matrix_mautrix_signal_configuration_extension_yaml:`: If you already used this item before for setting permissions add the part: 
+```
+    encryption:
+	  allow: true
+      default: true
+```
+below the permission-part.
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mautrix-signal.md
+++ b/docs/configuring-playbook-bridge-mautrix-signal.md
@@ -98,3 +98,8 @@ As seen in the mentioned [upstream-documentation](https://docs.mau.fi/bridges/py
 ## Usage
 
 You then need to start a chat with `@signalbot:YOUR_DOMAIN` (where `YOUR_DOMAIN` is your base domain, not the `matrix.` domain).
+
+If you want to invite Signal-contacts to an existing Matrix-Room.
+- invite `@signalbot:<matrix-domain>` into the room (refer to [Enable End-to-End-Encryption](#Enable End-to-End-Encryption))
+- type `!signal create`, which will create the Signal-Group
+- invite the contacts you want

--- a/docs/configuring-playbook-bridge-mautrix-signal.md
+++ b/docs/configuring-playbook-bridge-mautrix-signal.md
@@ -79,6 +79,21 @@ When using this method, **each user** that wishes to enable Double Puppeting nee
 
 - make sure you don't log out the `Mautrix-Signal` device some time in the future, as that would break the Double Puppeting feature
 
+## Enable End-to-End-Encryption
+
+To enable the Bridge to work in encrypted rooms add this to your `vars.yml` file:
+``` yaml
+matrix_mautrix_signal_configuration_extension_yaml: |
+  bridge:
+    encryption:
+	  allow: true
+      default: true
+```
+As seen in the mentioned [upstream-documentation](https://docs.mau.fi/bridges/python/signal/index.html):
+- `allow: true` the bridge won't enable encryption on its own, but will work in encrypted rooms
+- `default: true` the bridge will automatically enable encryption in new portals.
+
+**Note**: [Upstream-documentation](https://docs.mau.fi/bridges/python/signal/index.html) mentions to make sure using postgres if enabling the bridge in encrypted rooms.
 
 ## Usage
 

--- a/docs/configuring-playbook-turn.md
+++ b/docs/configuring-playbook-turn.md
@@ -31,6 +31,7 @@ matrix_synapse_turn_uris:
 - turn:HOSTNAME_OR_IP?transport=udp
 - turn:HOSTNAME_OR_IP?transport=tcp
 ```
+**Note:** Add this item to your `vars.yml` file, even when you have the default Coturn-Server via the playbook if you have `matrix_ssl_retrieval_method: manually-managed` BUT still use Let's-Encrypt for your certificates. There is a known [upstream-bug](https://github.com/spantaleev/matrix-docker-ansible-deploy/pull/1145#issuecomment-874346433) in Elements and its forks (e.g. Schildichat) not beeing able to use a coturn-server with those certificates and the playbook only takes care of it with this [commit](https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/8b146f083ef3bf78c0bf0cc27658631d96ea30dd) when SSL-certificates are managed by the playbook `matrix_ssl_retrieval_method: "lets-encrypt"` (which is the default).
 
 If you have or want to enable [Jitsi](configuring-playbook-jitsi.md), you might want to enable the TURN server there too.
 If you do not do it, Jitsi will fall back to an upstream service.


### PR DESCRIPTION
- add how to enable signal-bridge to work with encryption. I think this would maybe work for other python-based mautrix-bridges? (just tested with mautrix-signal)

- add another usage scenario, how to add signal-contacts to matrix-rooms (for me was neither clear from this docs nor the upstream ones)

- add solution for problematic use-case scenario when setting up coturn with manually managed lets-encrypt certs

- add info to set postmoogle-admin, to get `!pm dkim` to work

- add infos to set up postmoogle with self-managed ssl