### PR TITLE
Add ability to sync only direct Chats in TG-Bridge

### DIFF
--- a/docs/configuring-playbook-bridge-mautrix-telegram.md
+++ b/docs/configuring-playbook-bridge-mautrix-telegram.md
@@ -59,3 +59,8 @@ matrix_mautrix_telegram_configuration_extension_yaml: |
 
 More details about permissions in this example:
 https://github.com/mautrix/telegram/blob/master/mautrix_telegram/example-config.yaml#L410
+
+If you like to exclude all groups from syncing and use the Telgeram-Bridge only for direct chats, you can add the following additional playbook configuration:
+```yaml
+matrix_mautrix_telegram_filter_mode: whitelist
+```

--- a/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-telegram/defaults/main.yml
@@ -38,6 +38,9 @@ matrix_mautrix_telegram_api_id: ''
 matrix_mautrix_telegram_api_hash: ''
 matrix_mautrix_telegram_bot_token: disabled
 
+# Define the filter-mode
+matrix_mautrix_telegram_filter_mode: "blacklist"
+
 # Whether or not the public-facing endpoints should be enabled (web-based login)
 matrix_mautrix_telegram_appservice_public_enabled: true
 

--- a/roles/matrix-bridge-mautrix-telegram/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-telegram/templates/config.yaml.j2
@@ -273,7 +273,7 @@ bridge:
         # Filter mode to use. Either "blacklist" or "whitelist".
         # If the mode is "blacklist", the listed chats will never be bridged.
         # If the mode is "whitelist", only the listed chats can be bridged.
-        mode: blacklist
+        mode: "{{ matrix_mautrix_telegram_filter_mode }}"
         # The list of group/channel IDs to filter.
         list: []
 

--- a/roles/matrix-bridge-mautrix-telegram/templates/config.yaml.j2
+++ b/roles/matrix-bridge-mautrix-telegram/templates/config.yaml.j2
@@ -273,12 +273,12 @@ bridge:
         # Filter mode to use. Either "blacklist" or "whitelist".
         # If the mode is "blacklist", the listed chats will never be bridged.
         # If the mode is "whitelist", only the listed chats can be bridged.
-        mode: "{{ matrix_mautrix_telegram_filter_mode }}"
+        mode: {{ matrix_mautrix_telegram_filter_mode | to_json }}
         # The list of group/channel IDs to filter.
         list: []
 
     # The prefix for commands. Only required in non-management rooms.
-    command_prefix: "{{ matrix_mautrix_telegram_command_prefix }}"
+    command_prefix: {{ matrix_mautrix_telegram_command_prefix | to_json }}
 
     # Permissions for using the bridge.
     # Permitted values:
@@ -291,7 +291,7 @@ bridge:
     #        * - All Matrix users
     #   domain - All users on that homeserver
     #     mxid - Specific user
-    permissions: {{ matrix_mautrix_telegram_bridge_permissions|to_json }}
+    permissions: {{ matrix_mautrix_telegram_bridge_permissions | to_json }}
 
     # Options related to the message relay Telegram bot.
     relaybot:


### PR DESCRIPTION
Hi all,

as a bloody beginner I tried to add the ability to sync only direct-chats with the bridge, because for me TG-Groups and Channels are way to noisy ... 

I would love to have this reviewed regarding:
1. Is that the right way to extend the project?
2. Can somebody confirm the filter-mode works like this?

Regards & thanks for that really nice project!