### PR TITLE
docs/configuring-playbook: Add link to etherpad configuration

### DIFF
--- a/docs/configuring-playbook.md
+++ b/docs/configuring-playbook.md
@@ -34,6 +34,8 @@ When you're done with all the configuration you'd like to do, continue with [Ins
 
 - [Setting up the Jitsi video-conferencing platform](configuring-playbook-jitsi.md) (optional)
 
+- [Setting up Etherpad](configuring-playbook-etherpad.md) (optional)
+
 - [Setting up Dynamic DNS](configuring-playbook-dynamic-dns.md) (optional)
 
 - [Enabling metrics and graphs (Prometheus, Grafana) for your Matrix server](configuring-playbook-prometheus-grafana.md) (optional)


### PR DESCRIPTION
Had to search a few minutes for the Etherpad configuration documentation. This PR should make it easier to find.