### PR TITLE
update way to login to discord

### DIFF
--- a/docs/configuring-playbook-bridge-mautrix-discord.md
+++ b/docs/configuring-playbook-bridge-mautrix-discord.md
@@ -12,7 +12,7 @@ See the project's [documentation](https://docs.mau.fi/bridges/go/discord/index.h
 
 ## Prerequisites
 
-For using this bridge, you would **need to authenticate by scanning a QR code with the Discord app on your phone**.
+For using this bridge, you would need to authenticate by **scanning a QR code** with the Discord app on your phone **or** by using **discord account token**.
 
 You can delete the Discord app after the authentication process.
 
@@ -70,7 +70,7 @@ When using this method, **each user** that wishes to enable Double Puppeting nee
 ## Usage
 
 1. Start a chat with `@discordbot:YOUR_DOMAIN` (where `YOUR_DOMAIN` is your base domain, not the `matrix.` domain).
-2. Send a `login` command
+2. If you would like to login to Discord using a token, send `login-token` command, otherwise, send `login-qr` command.
 3. You'll see a QR code which you need to scan with the Discord app on your phone. You can scan it with the camera app too, which will open Discord, which will then instruct you to scan it a 2nd time in the Discord app.
 4. After confirming (in the Discord app) that you'd like to allow this login, the bot should respond with "Succcessfully authenticated as ..."
 5. Now that you're logged in, you can send a `help` command to the bot again, to see additional commands you have access to


### PR DESCRIPTION
You can now login/bridge using a discord token.
The `login` command still works but its [aliased to `login-qr`](https://github.com/mautrix/discord/blob/6be531685f308f081675034904d89c9e920be996/commands.go#L94).