### PR TITLE
Change signald version fom 0.22.2 to 0.23.0

### DIFF
--- a/roles/matrix-bridge-mautrix-signal/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-signal/defaults/main.yml
@@ -10,7 +10,7 @@ matrix_mautrix_signal_docker_repo_version: "{{ 'master' if matrix_mautrix_signal
 matrix_mautrix_signal_docker_src_files_path: "{{ matrix_base_data_path }}/mautrix-signal/docker-src"
 
 matrix_mautrix_signal_version: v0.4.0
-matrix_mautrix_signal_daemon_version: 0.22.2
+matrix_mautrix_signal_daemon_version: 0.23.0
 # See: https://mau.dev/mautrix/signal/container_registry
 matrix_mautrix_signal_docker_image: "dock.mau.dev/mautrix/signal:{{ matrix_mautrix_signal_version }}"
 matrix_mautrix_signal_docker_image_force_pull: "{{ matrix_mautrix_signal_docker_image.endswith(':latest') }}"


### PR DESCRIPTION
As mentioned in https://github.com/mautrix/signal/issues/314 signald version is not directly managed by mautrix-bridge-signal. But mautrix-signal 0.4.0 seems to work with signald 0.23.0.

First test seems good. Connection to Signal is working again.