### PR TITLE
Update mautrix-signal 0.4.0 -> 0.4.1

### DIFF
--- a/roles/matrix-bridge-mautrix-signal/defaults/main.yml
+++ b/roles/matrix-bridge-mautrix-signal/defaults/main.yml
@@ -9,7 +9,7 @@ matrix_mautrix_signal_docker_repo: "https://mau.dev/mautrix/signal.git"
 matrix_mautrix_signal_docker_repo_version: "{{ 'master' if matrix_mautrix_signal_version == 'latest' else matrix_mautrix_signal_version }}"
 matrix_mautrix_signal_docker_src_files_path: "{{ matrix_base_data_path }}/mautrix-signal/docker-src"
 
-matrix_mautrix_signal_version: v0.4.0
+matrix_mautrix_signal_version: v0.4.1
 matrix_mautrix_signal_daemon_version: 0.23.0
 # See: https://mau.dev/mautrix/signal/container_registry
 matrix_mautrix_signal_docker_image: "dock.mau.dev/mautrix/signal:{{ matrix_mautrix_signal_version }}"


### PR DESCRIPTION
ref: https://github.com/mautrix/signal/releases/tag/v0.4.1

Note that part:
> The docker image now has an option to bypass the startup script by setting the MAUTRIX_DIRECT_STARTUP environment variable. Additionally, it will refuse to run as a non-root user if that variable is not set (and print an error message suggesting to either set the variable or use a custom command).