### PR TITLE
Always use resolver variable in nginx conf.d files

### DIFF
--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-base-domain.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-base-domain.conf.j2
@@ -45,7 +45,7 @@ server {
 		location /.well-known/acme-challenge {
 			{% if matrix_nginx_proxy_enabled %}
 				{# Use the embedded DNS resolver in Docker containers to discover the service #}
-				resolver 127.0.0.11 valid=5s;
+				resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 				set $backend "matrix-certbot:8080";
 				proxy_pass http://$backend;
 			{% else %}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-bot-buscarron.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-bot-buscarron.conf.j2
@@ -24,7 +24,7 @@
 	location / {
 		{% if matrix_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}
-			resolver 127.0.0.11 valid=5s;
+			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 			set $backend "matrix-bot-buscarron:8080";
 			proxy_pass http://$backend;
 		{% else %}
@@ -51,7 +51,7 @@ server {
 		location /.well-known/acme-challenge {
 			{% if matrix_nginx_proxy_enabled %}
 				{# Use the embedded DNS resolver in Docker containers to discover the service #}
-				resolver 127.0.0.11 valid=5s;
+				resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 				set $backend "matrix-certbot:8080";
 				proxy_pass http://$backend;
 			{% else %}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-bot-go-neb.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-bot-go-neb.conf.j2
@@ -18,7 +18,7 @@
 	location / {
 		{% if matrix_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}
-			resolver 127.0.0.11 valid=5s;
+			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 			set $backend "matrix-bot-go-neb:4050";
 			proxy_pass http://$backend;
 		{% else %}
@@ -44,7 +44,7 @@ server {
 		location /.well-known/acme-challenge {
 			{% if matrix_nginx_proxy_enabled %}
 				{# Use the embedded DNS resolver in Docker containers to discover the service #}
-				resolver 127.0.0.11 valid=5s;
+				resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 				set $backend "matrix-certbot:8080";
 				proxy_pass http://$backend;
 			{% else %}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-client-cinny.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-client-cinny.conf.j2
@@ -24,7 +24,7 @@
 	location / {
 		{% if matrix_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}
-			resolver 127.0.0.11 valid=5s;
+			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 			set $backend "matrix-client-cinny:8080";
 			proxy_pass http://$backend;
 		{% else %}
@@ -51,7 +51,7 @@ server {
 		location /.well-known/acme-challenge {
 			{% if matrix_nginx_proxy_enabled %}
 				{# Use the embedded DNS resolver in Docker containers to discover the service #}
-				resolver 127.0.0.11 valid=5s;
+				resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 				set $backend "matrix-certbot:8080";
 				proxy_pass http://$backend;
 			{% else %}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-client-element.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-client-element.conf.j2
@@ -26,7 +26,7 @@
 	location / {
 		{% if matrix_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}
-			resolver 127.0.0.11 valid=5s;
+			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 			set $backend "matrix-client-element:8080";
 			proxy_pass http://$backend;
 		{% else %}
@@ -53,7 +53,7 @@ server {
 		location /.well-known/acme-challenge {
 			{% if matrix_nginx_proxy_enabled %}
 				{# Use the embedded DNS resolver in Docker containers to discover the service #}
-				resolver 127.0.0.11 valid=5s;
+				resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 				set $backend "matrix-certbot:8080";
 				proxy_pass http://$backend;
 			{% else %}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-client-hydrogen.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-client-hydrogen.conf.j2
@@ -24,7 +24,7 @@
 	location / {
 		{% if matrix_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}
-			resolver 127.0.0.11 valid=5s;
+			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 			set $backend "matrix-client-hydrogen:8080";
 			proxy_pass http://$backend;
 		{% else %}
@@ -51,7 +51,7 @@ server {
 		location /.well-known/acme-challenge {
 			{% if matrix_nginx_proxy_enabled %}
 				{# Use the embedded DNS resolver in Docker containers to discover the service #}
-				resolver 127.0.0.11 valid=5s;
+				resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 				set $backend "matrix-certbot:8080";
 				proxy_pass http://$backend;
 			{% else %}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-conduit.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-conduit.conf.j2
@@ -28,7 +28,7 @@ server {
 	location / {
 		{% if matrix_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}
-			resolver 127.0.0.11 valid=5s;
+			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 			set $backend "{{ matrix_nginx_proxy_proxy_conduit_client_api_addr_with_container }}";
 			proxy_pass http://$backend;
 		{% else %}
@@ -59,7 +59,7 @@ server {
 	location / {
 		{% if matrix_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}
-			resolver 127.0.0.11 valid=5s;
+			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 			set $backend "{{ matrix_nginx_proxy_proxy_conduit_federation_api_addr_with_container }}";
 			proxy_pass http://$backend;
 		{% else %}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-dendrite.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-dendrite.conf.j2
@@ -28,7 +28,7 @@ server {
 	location / {
 		{% if matrix_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}
-			resolver 127.0.0.11 valid=5s;
+			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 			set $backend "{{ matrix_nginx_proxy_proxy_dendrite_client_api_addr_with_container }}";
 			proxy_pass http://$backend;
 		{% else %}
@@ -59,7 +59,7 @@ server {
 	location / {
 		{% if matrix_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}
-			resolver 127.0.0.11 valid=5s;
+			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 			set $backend "{{ matrix_nginx_proxy_proxy_dendrite_federation_api_addr_with_container }}";
 			proxy_pass http://$backend;
 		{% else %}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-dimension.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-dimension.conf.j2
@@ -21,7 +21,7 @@
 	location / {
 		{% if matrix_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}
-			resolver 127.0.0.11 valid=5s;
+			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 			set $backend "matrix-dimension:8184";
 			proxy_pass http://$backend;
 		{% else %}
@@ -47,7 +47,7 @@ server {
 		location /.well-known/acme-challenge {
 			{% if matrix_nginx_proxy_enabled %}
 				{# Use the embedded DNS resolver in Docker containers to discover the service #}
-				resolver 127.0.0.11 valid=5s;
+				resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 				set $backend "matrix-certbot:8080";
 				proxy_pass http://$backend;
 			{% else %}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
@@ -62,7 +62,7 @@
 	location ^~ /_matrix/corporal {
 		{% if matrix_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}
-			resolver 127.0.0.11 valid=5s;
+			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 			set $backend "{{ matrix_nginx_proxy_proxy_matrix_corporal_api_addr_with_container }}";
 			proxy_pass http://$backend;
 		{% else %}
@@ -80,7 +80,7 @@
 	location ^~ /_matrix/identity {
 		{% if matrix_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}
-			resolver 127.0.0.11 valid=5s;
+			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 			set $backend "{{ matrix_nginx_proxy_proxy_matrix_identity_api_addr_with_container }}";
 			proxy_pass http://$backend;
 		{% else %}
@@ -98,7 +98,7 @@
 	location ^~ /_matrix/client/r0/user_directory/search {
 		{% if matrix_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}
-			resolver 127.0.0.11 valid=5s;
+			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 			set $backend "{{ matrix_nginx_proxy_proxy_matrix_user_directory_search_addr_with_container }}";
 			proxy_pass http://$backend;
 		{% else %}
@@ -115,7 +115,7 @@
 	location ~ ^/_matrix/client/r0/register/(email|msisdn)/requestToken$ {
 		{% if matrix_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}
-			resolver 127.0.0.11 valid=5s;
+			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 			set $backend "{{ matrix_nginx_proxy_proxy_matrix_3pid_registration_addr_with_container }}";
 			proxy_pass http://$backend;
 		{% else %}
@@ -140,7 +140,7 @@
 	location ~* ^({{ matrix_nginx_proxy_proxy_matrix_client_api_forwarded_location_prefix_regexes|join('|') }}) {
 		{% if matrix_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}
-			resolver 127.0.0.11 valid=5s;
+			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 			set $backend "{{ matrix_nginx_proxy_proxy_matrix_client_api_addr_with_container }}";
 			proxy_pass http://$backend;
 		{% else %}
@@ -185,7 +185,7 @@ server {
 		location /.well-known/acme-challenge {
 			{% if matrix_nginx_proxy_enabled %}
 				{# Use the embedded DNS resolver in Docker containers to discover the service #}
-				resolver 127.0.0.11 valid=5s;
+				resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 				set $backend "matrix-certbot:8080";
 				proxy_pass http://$backend;
 			{% else %}
@@ -288,7 +288,7 @@ server {
 	location / {
 		{% if matrix_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}
-			resolver 127.0.0.11 valid=5s;
+			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 			set $backend "{{ matrix_nginx_proxy_proxy_matrix_federation_api_addr_with_container }}";
 			proxy_pass http://$backend;
 		{% else %}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-grafana.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-grafana.conf.j2
@@ -28,7 +28,7 @@
 	location / {
 		{% if matrix_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}
-			resolver 127.0.0.11 valid=5s;
+			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 			set $backend "matrix-grafana:3000";
 			proxy_pass http://$backend;
 		{% else %}
@@ -55,7 +55,7 @@ server {
 		location /.well-known/acme-challenge {
 			{% if matrix_nginx_proxy_enabled %}
 				{# Use the embedded DNS resolver in Docker containers to discover the service #}
-				resolver 127.0.0.11 valid=5s;
+				resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 				set $backend "matrix-certbot:8080";
 				proxy_pass http://$backend;
 			{% else %}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-jitsi.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-jitsi.conf.j2
@@ -21,7 +21,7 @@
 	location / {
 		{% if matrix_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}
-			resolver 127.0.0.11 valid=5s;
+			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 			set $backend "matrix-jitsi-web:80";
 			proxy_pass http://$backend;
 		{% else %}
@@ -36,7 +36,7 @@
 	# colibri (JVB) websockets
 	location ~ ^/colibri-ws/([a-zA-Z0-9-\.]+)/(.*) {
 		{% if matrix_nginx_proxy_enabled %}
-			resolver 127.0.0.11 valid=5s;
+			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 			set $backend "matrix-jitsi-jvb:9090";
 			proxy_pass http://$backend;
 		{% else %}
@@ -57,7 +57,7 @@
 	# XMPP websocket
 	location = /xmpp-websocket {
 		{% if matrix_nginx_proxy_enabled %}
-			resolver 127.0.0.11 valid=5s;
+			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 			set $backend {{ matrix_jitsi_xmpp_bosh_url_base }};
 			proxy_pass $backend/xmpp-websocket;
 		{% else %}
@@ -89,7 +89,7 @@ server {
 		location /.well-known/acme-challenge {
 			{% if matrix_nginx_proxy_enabled %}
 				{# Use the embedded DNS resolver in Docker containers to discover the service #}
-				resolver 127.0.0.11 valid=5s;
+				resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 				set $backend "matrix-certbot:8080";
 				proxy_pass http://$backend;
 			{% else %}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-ntfy.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-ntfy.conf.j2
@@ -20,7 +20,7 @@
 	location / {
 		{% if matrix_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}
-			resolver 127.0.0.11 valid=5s;
+			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 			set $backend "matrix-ntfy:8080";
 			proxy_pass http://$backend;
 		{% else %}
@@ -49,7 +49,7 @@ server {
 		location /.well-known/acme-challenge {
 			{% if matrix_nginx_proxy_enabled %}
 				{# Use the embedded DNS resolver in Docker containers to discover the service #}
-				resolver 127.0.0.11 valid=5s;
+				resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 				set $backend "matrix-certbot:8080";
 				proxy_pass http://$backend;
 			{% else %}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-riot-web.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-riot-web.conf.j2
@@ -36,7 +36,7 @@ server {
 		location /.well-known/acme-challenge {
 			{% if matrix_nginx_proxy_enabled %}
 				{# Use the embedded DNS resolver in Docker containers to discover the service #}
-				resolver 127.0.0.11 valid=5s;
+				resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 				set $backend "matrix-certbot:8080";
 				proxy_pass http://$backend;
 			{% else %}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-sygnal.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-sygnal.conf.j2
@@ -19,7 +19,7 @@
 	location / {
 		{% if matrix_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}
-			resolver 127.0.0.11 valid=5s;
+			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 			set $backend "matrix-sygnal:6000";
 			proxy_pass http://$backend;
 		{% else %}
@@ -46,7 +46,7 @@ server {
 		location /.well-known/acme-challenge {
 			{% if matrix_nginx_proxy_enabled %}
 				{# Use the embedded DNS resolver in Docker containers to discover the service #}
-				resolver 127.0.0.11 valid=5s;
+				resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 				set $backend "matrix-certbot:8080";
 				proxy_pass http://$backend;
 			{% else %}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-synapse.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-synapse.conf.j2
@@ -150,7 +150,7 @@ server {
 	location / {
 		{% if matrix_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}
-			resolver 127.0.0.11 valid=5s;
+			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 			set $backend "{{ matrix_nginx_proxy_proxy_synapse_client_api_addr_with_container }}";
 			proxy_pass http://$backend;
 		{% else %}
@@ -211,7 +211,7 @@ server {
 	location / {
 		{% if matrix_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}
-			resolver 127.0.0.11 valid=5s;
+			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 			set $backend "{{ matrix_nginx_proxy_proxy_synapse_federation_api_addr_with_container }}";
 			proxy_pass http://$backend;
 		{% else %}


### PR DESCRIPTION
For some tests with this playbook I currently do, I need to add the _**matrix_nginx_proxy_http_level_resolver**_ variable within all nginx configurations.

The variable already exists, is defined [here](https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/roles/matrix-nginx-proxy/defaults/main.yml#L506), but is not used in any files..

During a first test, it runs without any difference for result, because default value is same then current value and the empty "else" definition is not used, because all usages are also surrounded by **matrix_nginx_proxy_enabled** check.