### PR TITLE
Fixed filter for Synapse stream_writer HS config

### DIFF
--- a/roles/matrix-synapse/tasks/synapse/workers/init.yml
+++ b/roles/matrix-synapse/tasks/synapse/workers/init.yml
@@ -37,7 +37,7 @@
 
 - name: Populate matrix_synapse_stream_writers from enabled stream writer workers list
   ansible.builtin.set_fact:
-    matrix_synapse_stream_writers: "{{ matrix_synapse_stream_writers | combine({item.ansible_facts.worker.stream_writer_stream: [item.ansible_facts.worker.name]}) }}"
+    matrix_synapse_stream_writers: "{{ matrix_synapse_stream_writers | combine({item.ansible_facts.worker.stream_writer_stream: [item.ansible_facts.worker.name]}, list_merge='append') }}"
   with_items: "{{ matrix_synapse_workers_list_results_stream_writer_workers.results }}"
 
 - name: Build federation sender workers


### PR DESCRIPTION
The [combine filter](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#combining-hashes-dictionaries) used for adding the Synapse `stream_writers` field in `homeserver.yaml` does not add multiple event stream writers if `matrix_synapse_workers_stream_writer_events_stream_workers_count > 1`. This results in only one event stream writer process being utilized by Synapse even if multiple event stream writers are defined.

According to the [Synapse documentation](https://matrix-org.github.io/synapse/latest/workers.html#the-events-stream), multiple event stream writers can be defined, so changing the `combine` default filter parameter from `replace` to `append` now populates `events` field with multiple writers if defined.

Synapse performance metrics on my homeserver now indicate that all event stream writer processes are now being utilized with this change.

Edit: For additional clarity, here is the homserver.yaml change when `matrix_synapse_workers_stream_writer_events_stream_workers_count = 4`

Before
```
stream_writers:
  ...
  events:
  - matrix-synapse-worker-stream-writer-3-events
```

After
```
stream_writers:
  ...
  events:
  - matrix-synapse-worker-stream-writer-0-events
  - matrix-synapse-worker-stream-writer-1-events
  - matrix-synapse-worker-stream-writer-2-events
  - matrix-synapse-worker-stream-writer-3-events
```