### PR TITLE
dendrite: update tag to v0.10.6

### DIFF
--- a/roles/matrix-dendrite/defaults/main.yml
+++ b/roles/matrix-dendrite/defaults/main.yml
@@ -6,7 +6,7 @@ matrix_dendrite_enabled: true
 
 matrix_dendrite_docker_image: "{{ matrix_dendrite_docker_image_name_prefix }}matrixdotorg/dendrite-monolith:{{ matrix_dendrite_docker_image_tag }}"
 matrix_dendrite_docker_image_name_prefix: "docker.io/"
-matrix_dendrite_docker_image_tag: "v0.10.5"
+matrix_dendrite_docker_image_tag: "v0.10.6"
 matrix_dendrite_docker_image_force_pull: "{{ matrix_dendrite_docker_image.endswith(':latest') }}"
 
 matrix_dendrite_base_path: "{{ matrix_base_data_path }}/dendrite"


### PR DESCRIPTION
- update tag to latest dendrite release (https://github.com/matrix-org/dendrite/releases/tag/v0.10.6)