### PR TITLE
etherpad: add abiword and soffice config options, update log level

### DIFF
--- a/roles/custom/matrix-etherpad/defaults/main.yml
+++ b/roles/custom/matrix-etherpad/defaults/main.yml
@@ -58,6 +58,8 @@ matrix_etherpad_database_connection_string: 'postgres://{{ matrix_etherpad_datab
 
 # Variables configuring the etherpad
 matrix_etherpad_title: 'Etherpad'
+matrix_etherpad_abiword: null
+matrix_etherpad_soffice: null
 matrix_etherpad_default_pad_text: |
   Welcome to Etherpad!
 

--- a/roles/custom/matrix-etherpad/templates/settings.json.j2
+++ b/roles/custom/matrix-etherpad/templates/settings.json.j2
@@ -20,8 +20,8 @@
   "editOnly": false,
   "minify": true,
   "maxAge": 21600,
-  "abiword": null,
-  "soffice": null,
+  "abiword": {{ matrix_etherpad_abiword|to_json }},
+  "soffice": {{ matrix_etherpad_soffice|to_json }},
   "tidyHtml": null,
   "allowUnknownFileEnds": true,
   "requireAuthentication": false,
@@ -103,7 +103,7 @@
     "pageUp": true,
     "pageDown": true
   },
-  "loglevel": "INFO",
+  "loglevel": "WARN",
   "logconfig" :
     { "appenders": [
         { "type": "console",


### PR DESCRIPTION
They're used to integrate AbiWord or LibreOffice to import/export Microsoft Office docs.