### PR TITLE
stop gradle pacman error on ubuntu

### DIFF
--- a/roles/custom/matrix-ma1sd/tasks/setup_install.yml
+++ b/roles/custom/matrix-ma1sd/tasks/setup_install.yml
@@ -74,13 +74,8 @@
         msg: "Installing gradle on RedHat ({{ ansible_distribution }}) is currently not supported, so self-building ma1sd cannot happen at this time"
       when: ansible_os_family == 'RedHat'
 
-    - name: Ensure gradle is installed for self-building (Archlinux)
-      community.general.pacman:
-        name:
-          - gradle
-        state: present
-        update_cache: true
-      when: ansible_distribution == 'Archlinux'
+    - ansible.builtin.include_tasks: "{{ role_path }}/tasks/util/ensure_gradle_installed_archlinux.yml"
+      when: "ansible_distribution == 'Archlinux'"
 
     - name: Ensure ma1sd repository is present on self-build
       ansible.builtin.git:

--- a/roles/custom/matrix-ma1sd/tasks/util/ensure_gradle_installed_archlinux.yml
+++ b/roles/custom/matrix-ma1sd/tasks/util/ensure_gradle_installed_archlinux.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Ensure gradle installed (Archlinux)
+  community.general.pacman:
+    name: gradle
+    state: present


### PR DESCRIPTION
On Ubuntu 18.04.6, when I run: `ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start --ask-pass`

I get this error:
````
SSH password:
ERROR! couldn't resolve module/action 'community.general.pacman'. This often indicates a misspelling, missing collection, or incorrect module path.

The error appears to be in '/home/redacted/spant_matrix-docker-ansible-deploy/roles/custom/matrix-ma1sd/tasks/setup_install.yml': line 77, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


    - name: Ensure gradle is installed for self-building (Archlinux)
      ^ here
````

This commit hopefully fixes that.

I'm not sure about the `update_cache: true` part.