### PR TITLE
add auto join option to dendrite config

### DIFF
--- a/docs/configuring-playbook-dendrite.md
+++ b/docs/configuring-playbook-dendrite.md
@@ -8,7 +8,7 @@ By default, this playbook configures the [Dendrite](https://github.com/matrix-or
 
 - **homeserver implementations other than Dendrite may not be fully functional**. The playbook may also not assist you in an optimal way (like it does with Dendrite). Make yourself familiar with the downsides before proceeding
 
-The playbook provided settings for Dendrite are defined in [`roles/custom/matrix-dendrite/defaults/main.yml`](../roles/custom/matrix-dendrite/defaults/main.yml) and they ultimately end up in the generated `/matrix/dendrite/config/homeserver.yaml` file (on the server). This file is generated from the [`roles/custom/matrix-dendrite/templates/dendrite/homeserver.yaml.j2`](../roles/custom/matrix-dendrite/templates/dendrite/homeserver.yaml.j2) template.
+The playbook provided settings for Dendrite are defined in [`roles/custom/matrix-dendrite/defaults/main.yml`](../roles/custom/matrix-dendrite/defaults/main.yml) and they ultimately end up in the generated `/matrix/dendrite/config/homeserver.yaml` file (on the server). This file is generated from the [`roles/custom/matrix-dendrite/templates/dendrite/dendrite.yaml.j2`](../roles/custom/matrix-dendrite/templates/dendrite/dendrite.yaml.j2) template.
 
 **If there's an existing variable** which controls a setting you wish to change, you can simply define that variable in your configuration file (`inventory/host_vars/matrix.<your-domain>/vars.yml`) and [re-run the playbook](installing.md) to apply the changes.
 
@@ -16,7 +16,7 @@ Alternatively, **if there is no pre-defined variable** for a Dendrite setting yo
 
 - you can either **request a variable to be created** (or you can submit such a contribution yourself). Keep in mind that it's **probably not a good idea** to create variables for each one of Dendrite's various settings that rarely get used.
 
-- or, you can **extend and override the default configuration** ([`homeserver.yaml.j2`](../roles/custom/matrix-dendrite/templates/dendrite/homeserver.yaml.j2)) by making use of the `matrix_dendrite_configuration_extension_yaml` variable. You can find information about this in [`roles/custom/matrix-dendrite/defaults/main.yml`](../roles/custom/matrix-dendrite/defaults/main.yml).
+- or, you can **extend and override the default configuration** ([`dendrite.yaml.j2`](../roles/custom/matrix-dendrite/templates/dendrite/dendrite.yaml.j2)) by making use of the `matrix_dendrite_configuration_extension_yaml` variable. You can find information about this in [`roles/custom/matrix-dendrite/defaults/main.yml`](../roles/custom/matrix-dendrite/defaults/main.yml).
 
 - or, if extending the configuration is still not powerful enough for your needs, you can **override the configuration completely** using `matrix_dendrite_configuration` (or `matrix_dendrite_configuration_yaml`). You can find information about this in [`roles/custom/matrix-dendrite/defaults/main.yml`](../roles/custom/matrix-dendrite/defaults/main.yml).
 

--- a/docs/configuring-playbook-dendrite.md
+++ b/docs/configuring-playbook-dendrite.md
@@ -27,6 +27,6 @@ Alternatively, **if there is no pre-defined variable** for a Dendrite setting yo
 To use Dendrite, you **generally** need the following additional `vars.yml` configuration:
 
 ```yaml
-matrix_homeserver_implementation: Dendrite
+matrix_homeserver_implementation: dendrite
 ```
 

--- a/docs/configuring-playbook-dendrite.md
+++ b/docs/configuring-playbook-dendrite.md
@@ -1,0 +1,32 @@
+# Configuring Dendrite (optional)
+
+By default, this playbook configures the [Dendrite](https://github.com/matrix-org/dendrite) Matrix server, but you can also use [Dendrite](https://dendrite.rs).
+
+**NOTES**:
+
+- **You can't switch an existing Matrix server's implementation** (e.g. Dendrite -> Dendrite). Proceed below only if you're OK with losing data or you're dealing with a server on a new domain name, which hasn't participated in the Matrix federation yet.
+
+- **homeserver implementations other than Dendrite may not be fully functional**. The playbook may also not assist you in an optimal way (like it does with Dendrite). Make yourself familiar with the downsides before proceeding
+
+The playbook provided settings for Dendrite are defined in [`roles/custom/matrix-dendrite/defaults/main.yml`](../roles/custom/matrix-dendrite/defaults/main.yml) and they ultimately end up in the generated `/matrix/dendrite/config/homeserver.yaml` file (on the server). This file is generated from the [`roles/custom/matrix-dendrite/templates/dendrite/homeserver.yaml.j2`](../roles/custom/matrix-dendrite/templates/dendrite/homeserver.yaml.j2) template.
+
+**If there's an existing variable** which controls a setting you wish to change, you can simply define that variable in your configuration file (`inventory/host_vars/matrix.<your-domain>/vars.yml`) and [re-run the playbook](installing.md) to apply the changes.
+
+Alternatively, **if there is no pre-defined variable** for a Dendrite setting you wish to change:
+
+- you can either **request a variable to be created** (or you can submit such a contribution yourself). Keep in mind that it's **probably not a good idea** to create variables for each one of Dendrite's various settings that rarely get used.
+
+- or, you can **extend and override the default configuration** ([`homeserver.yaml.j2`](../roles/custom/matrix-dendrite/templates/dendrite/homeserver.yaml.j2)) by making use of the `matrix_dendrite_configuration_extension_yaml` variable. You can find information about this in [`roles/custom/matrix-dendrite/defaults/main.yml`](../roles/custom/matrix-dendrite/defaults/main.yml).
+
+- or, if extending the configuration is still not powerful enough for your needs, you can **override the configuration completely** using `matrix_dendrite_configuration` (or `matrix_dendrite_configuration_yaml`). You can find information about this in [`roles/custom/matrix-dendrite/defaults/main.yml`](../roles/custom/matrix-dendrite/defaults/main.yml).
+
+
+
+## Installation
+
+To use Dendrite, you **generally** need the following additional `vars.yml` configuration:
+
+```yaml
+matrix_homeserver_implementation: Dendrite
+```
+

--- a/docs/configuring-playbook-dendrite.md
+++ b/docs/configuring-playbook-dendrite.md
@@ -1,6 +1,6 @@
 # Configuring Dendrite (optional)
 
-By default, this playbook configures the [Dendrite](https://github.com/matrix-org/dendrite) Matrix server, but you can also use [Dendrite](https://dendrite.rs).
+By default, this playbook configures the [Synapse](https://github.com/matrix-org/synapse) Matrix server, but you can also use [Dendrite](https://github.com/matrix-org/dendrite).
 
 **NOTES**:
 

--- a/docs/configuring-playbook-dendrite.md
+++ b/docs/configuring-playbook-dendrite.md
@@ -6,7 +6,7 @@ By default, this playbook configures the [Synapse](https://github.com/matrix-org
 
 - **You can't switch an existing Matrix server's implementation** (e.g. Synapse -> Dendrite). Proceed below only if you're OK with losing data or you're dealing with a server on a new domain name, which hasn't participated in the Matrix federation yet.
 
-- **homeserver implementations other than Dendrite may not be fully functional**. The playbook may also not assist you in an optimal way (like it does with Dendrite). Make yourself familiar with the downsides before proceeding
+- **homeserver implementations other than Synapse may not be fully functional**. The playbook may also not assist you in an optimal way (like it does with Synapse). Make yourself familiar with the downsides before proceeding
 
 The playbook provided settings for Dendrite are defined in [`roles/custom/matrix-dendrite/defaults/main.yml`](../roles/custom/matrix-dendrite/defaults/main.yml) and they ultimately end up in the generated `/matrix/dendrite/config/homeserver.yaml` file (on the server). This file is generated from the [`roles/custom/matrix-dendrite/templates/dendrite/dendrite.yaml.j2`](../roles/custom/matrix-dendrite/templates/dendrite/dendrite.yaml.j2) template.
 

--- a/docs/configuring-playbook-dendrite.md
+++ b/docs/configuring-playbook-dendrite.md
@@ -8,7 +8,7 @@ By default, this playbook configures the [Synapse](https://github.com/matrix-org
 
 - **homeserver implementations other than Synapse may not be fully functional**. The playbook may also not assist you in an optimal way (like it does with Synapse). Make yourself familiar with the downsides before proceeding
 
-The playbook provided settings for Dendrite are defined in [`roles/custom/matrix-dendrite/defaults/main.yml`](../roles/custom/matrix-dendrite/defaults/main.yml) and they ultimately end up in the generated `/matrix/dendrite/config/homeserver.yaml` file (on the server). This file is generated from the [`roles/custom/matrix-dendrite/templates/dendrite/dendrite.yaml.j2`](../roles/custom/matrix-dendrite/templates/dendrite/dendrite.yaml.j2) template.
+The playbook provided settings for Dendrite are defined in [`roles/custom/matrix-dendrite/defaults/main.yml`](../roles/custom/matrix-dendrite/defaults/main.yml) and they ultimately end up in the generated `/matrix/dendrite/config/dendrite.yaml` file (on the server). This file is generated from the [`roles/custom/matrix-dendrite/templates/dendrite/dendrite.yaml.j2`](../roles/custom/matrix-dendrite/templates/dendrite/dendrite.yaml.j2) template.
 
 **If there's an existing variable** which controls a setting you wish to change, you can simply define that variable in your configuration file (`inventory/host_vars/matrix.<your-domain>/vars.yml`) and [re-run the playbook](installing.md) to apply the changes.
 

--- a/docs/configuring-playbook-dendrite.md
+++ b/docs/configuring-playbook-dendrite.md
@@ -4,7 +4,7 @@ By default, this playbook configures the [Synapse](https://github.com/matrix-org
 
 **NOTES**:
 
-- **You can't switch an existing Matrix server's implementation** (e.g. Dendrite -> Dendrite). Proceed below only if you're OK with losing data or you're dealing with a server on a new domain name, which hasn't participated in the Matrix federation yet.
+- **You can't switch an existing Matrix server's implementation** (e.g. Synapse -> Dendrite). Proceed below only if you're OK with losing data or you're dealing with a server on a new domain name, which hasn't participated in the Matrix federation yet.
 
 - **homeserver implementations other than Dendrite may not be fully functional**. The playbook may also not assist you in an optimal way (like it does with Dendrite). Make yourself familiar with the downsides before proceeding
 

--- a/docs/configuring-playbook.md
+++ b/docs/configuring-playbook.md
@@ -47,6 +47,8 @@ When you're done with all the configuration you'd like to do, continue with [Ins
 
   - [Configuring Conduit](configuring-playbook-conduit.md), if you've switched to the [Conduit](https://conduit.rs) homeserver implementation (optional)
 
+  - [Configuring Dendrite](configuring-playbook-dendrite.md), if you've switched to the [Dendrite](https://matrix-org.github.io/dendrite) homeserver implementation (optional)
+
 - [Configuring Element](configuring-playbook-client-element.md) (optional)
 
 - [Storing Matrix media files on Amazon S3](configuring-playbook-s3.md) (optional)

--- a/roles/custom/matrix-dendrite/defaults/main.yml
+++ b/roles/custom/matrix-dendrite/defaults/main.yml
@@ -194,3 +194,5 @@ matrix_dendrite_configuration_extension: "{{ matrix_dendrite_configuration_exten
 # Holds the final Dendrite configuration (a combination of the default and its extension).
 # You most likely don't need to touch this variable. Instead, see `matrix_dendrite_configuration_yaml`.
 matrix_dendrite_configuration: "{{ matrix_dendrite_configuration_yaml | from_yaml | combine(matrix_dendrite_configuration_extension, recursive=True) }}"
+
+auto_join_rooms: []

--- a/roles/custom/matrix-dendrite/defaults/main.yml
+++ b/roles/custom/matrix-dendrite/defaults/main.yml
@@ -195,4 +195,4 @@ matrix_dendrite_configuration_extension: "{{ matrix_dendrite_configuration_exten
 # You most likely don't need to touch this variable. Instead, see `matrix_dendrite_configuration_yaml`.
 matrix_dendrite_configuration: "{{ matrix_dendrite_configuration_yaml | from_yaml | combine(matrix_dendrite_configuration_extension, recursive=True) }}"
 
-auto_join_rooms: []
+matrix_dendrite_userapi_auto_join_rooms: []

--- a/roles/custom/matrix-dendrite/templates/dendrite/dendrite.yaml.j2
+++ b/roles/custom/matrix-dendrite/templates/dendrite/dendrite.yaml.j2
@@ -414,3 +414,16 @@ tracing:
 # Logging configuration, in addition to the standard logging that is sent to
 # stdout by Dendrite.
 logging: []
+
+# Users who register on this homeserver will automatically be joined to the rooms listed under "auto_join_rooms" option.
+# By default, any room aliases included in this list will be created as a publicly joinable room
+# when the first user registers for the homeserver. If the room already exists,
+# make certain it is a publicly joinable room, i.e. the join rule of the room must be set to 'public'.
+# As Spaces are just rooms under the hood, Space aliases may also be used.
+#auto_join_rooms:
+#  - "#main:matrix.org"
+
+{% if matrix_dendrite_auto_join_rooms|length > 0 %}
+auto_join_rooms:
+{{ matrix_dendrite_auto_join_rooms|to_nice_yaml(indent=2, width=999999) }}
+{% endif %}

--- a/roles/custom/matrix-dendrite/templates/dendrite/dendrite.yaml.j2
+++ b/roles/custom/matrix-dendrite/templates/dendrite/dendrite.yaml.j2
@@ -382,6 +382,7 @@ user_api:
   # is considered to be valid in milliseconds.
   # The default lifetime is 3600000ms (60 minutes).
   # openid_token_lifetime_ms: 3600000
+  auto_join_rooms: {{ matrix_dendrite_userapi_auto_join_rooms | to_json }}
 
 # Not in dendrite-config.yaml, but is in build/docker/config/dendrite.yaml
 # Configuration for the Push Server API.
@@ -415,15 +416,3 @@ tracing:
 # stdout by Dendrite.
 logging: []
 
-# Users who register on this homeserver will automatically be joined to the rooms listed under "auto_join_rooms" option.
-# By default, any room aliases included in this list will be created as a publicly joinable room
-# when the first user registers for the homeserver. If the room already exists,
-# make certain it is a publicly joinable room, i.e. the join rule of the room must be set to 'public'.
-# As Spaces are just rooms under the hood, Space aliases may also be used.
-#auto_join_rooms:
-#  - "#main:matrix.org"
-
-{% if matrix_dendrite_auto_join_rooms|length > 0 %}
-auto_join_rooms:
-{{ matrix_dendrite_auto_join_rooms|to_nice_yaml(indent=2, width=999999) }}
-{% endif %}


### PR DESCRIPTION
Dendrite 0.10.5 added the variable `auto_join_rooms` to its configuration.
I added `matrix_dendrite_auto_join_rooms` option but I'm certain this needs to be added in a couple different places.
I'm new to jinji btw :)