### PR TITLE
add matrix_hookshot_generic_enable_http_get option

### DIFF
--- a/roles/custom/matrix-bridge-hookshot/defaults/main.yml
+++ b/roles/custom/matrix-bridge-hookshot/defaults/main.yml
@@ -124,6 +124,7 @@ matrix_hookshot_generic_endpoint: "{{ matrix_hookshot_webhook_endpoint }}"
 # urlprefix gets updated with protocol & port in group_vars/matrix_servers
 matrix_hookshot_generic_urlprefix: "{{ matrix_hookshot_urlprefix }}{{ matrix_hookshot_generic_endpoint }}"
 matrix_hookshot_generic_allow_js_transformation_functions: false
+matrix_hookshot_generic_enable_http_get: false
 # If you're also using matrix-appservice-webhooks, take care that these prefixes don't overlap
 matrix_hookshot_generic_user_id_prefix: '_webhooks_'
 

--- a/roles/custom/matrix-bridge-hookshot/templates/config.yml.j2
+++ b/roles/custom/matrix-bridge-hookshot/templates/config.yml.j2
@@ -76,6 +76,7 @@ generic:
   enabled: {{ matrix_hookshot_generic_enabled }}
   urlPrefix: {{ matrix_hookshot_generic_urlprefix }}
   allowJsTransformationFunctions: {{ matrix_hookshot_generic_allow_js_transformation_functions }}
+  enableHttpGet: {{ matrix_hookshot_generic_enable_http_get }}
   userIdPrefix: {{ matrix_hookshot_generic_user_id_prefix|to_json }}
 {% endif %}
 {% if matrix_hookshot_feeds_enabled %}


### PR DESCRIPTION
Allowing use of get request on the webhook config so specific hardware can trigger a hook.
https://matrix-org.github.io/matrix-hookshot/latest/setup/webhooks.html#configuration