### PR TITLE
added matrix_ma1sd_container_additional_networks

### DIFF
--- a/roles/custom/matrix-ma1sd/defaults/main.yml
+++ b/roles/custom/matrix-ma1sd/defaults/main.yml
@@ -35,6 +35,13 @@ matrix_ma1sd_systemd_required_services_list: ['docker.service']
 # List of systemd services that matrix-ma1sd.service wants
 matrix_ma1sd_systemd_wanted_services_list: []
 
+# A list of additional container networks that matrix-ma1sd would be connected to.
+# The playbook does not create these networks, so make sure they already exist.
+#
+# Use this to expose matrix-ma1sd to another docker network, that matrix-ma1sd might have to reach for authentication (e.g. an ldap instance)
+#
+matrix_ma1sd_container_additional_networks: []
+
 # Your identity server is private by default.
 # To ensure maximum discovery, you can make your identity server
 # also forward lookups to the central matrix.org Identity server

--- a/roles/custom/matrix-ma1sd/templates/systemd/matrix-ma1sd.service.j2
+++ b/roles/custom/matrix-ma1sd/templates/systemd/matrix-ma1sd.service.j2
@@ -38,6 +38,10 @@ ExecStart={{ devture_systemd_docker_base_host_command_docker }} run --rm --name 
 			{% endfor %}
 			{{ matrix_ma1sd_docker_image }}
 
+{% for network in matrix_ma1sd_container_additional_networks %}
+ExecStartPost={{ devture_systemd_docker_base_host_command_sh }} -c 'attempt=0; while [ $attempt -le 29 ]; do attempt=$(( $attempt + 1 )); if [ "`docker inspect -f {{ '{{.State.Running}}' }} matrix-ma1sd 2> /dev/null`" = "true" ]; then break; fi; sleep 1; done; {{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-ma1sd'
+{% endfor %}
+
 ExecStop=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} kill matrix-ma1sd 2>/dev/null || true'
 ExecStop=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} rm matrix-ma1sd 2>/dev/null || true'
 Restart=always


### PR DESCRIPTION
 similar to matrix_nginx_proxy_container_additional_networks, this allows the matrix-ma1sd container to also join specified dockernetworks, e.g. to communicate with a dockerized openldap on the same server
