### PR TITLE
update postmoogle 0.9.8 -> 0.9.9

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -1255,8 +1255,8 @@ matrix_bot_buscarron_container_image_self_build: "{{ matrix_architecture not in 
 # We don't enable bots by default.
 matrix_bot_postmoogle_enabled: false
 matrix_bot_postmoogle_ssl_path: "{{ matrix_ssl_config_dir_path }}"
-matrix_bot_postmoogle_tls_cert: "/ssl/live/{{ matrix_bot_postmoogle_domain }}/fullchain.pem"
-matrix_bot_postmoogle_tls_key: "/ssl/live/{{ matrix_bot_postmoogle_domain }}/privkey.pem"
+matrix_bot_postmoogle_tls_cert: "{% for domain in matrix_bot_postmoogle_domains %}/ssl/live/{{ domain }}/fullchain.pem {% endfor %}"
+matrix_bot_postmoogle_tls_key: "{% for domain in matrix_bot_postmoogle_domains %}/ssl/live/{{ domain }}/privkey.pem {% endfor %}"
 
 matrix_bot_postmoogle_systemd_required_services_list: |
   {{

--- a/roles/custom/matrix-bot-postmoogle/defaults/main.yml
+++ b/roles/custom/matrix-bot-postmoogle/defaults/main.yml
@@ -9,7 +9,7 @@ matrix_bot_postmoogle_docker_repo: "https://gitlab.com/etke.cc/postmoogle.git"
 matrix_bot_postmoogle_docker_repo_version: "{{ 'main' if matrix_bot_postmoogle_version == 'latest' else matrix_bot_postmoogle_version }}"
 matrix_bot_postmoogle_docker_src_files_path: "{{ matrix_base_data_path }}/postmoogle/docker-src"
 
-matrix_bot_postmoogle_version: v0.9.8
+matrix_bot_postmoogle_version: v0.9.9
 matrix_bot_postmoogle_docker_image: "{{ matrix_bot_postmoogle_docker_image_name_prefix }}postmoogle:{{ matrix_bot_postmoogle_version }}"
 matrix_bot_postmoogle_docker_image_name_prefix: "{{ 'localhost/' if matrix_bot_postmoogle_container_image_self_build else 'registry.gitlab.com/etke.cc/' }}"
 matrix_bot_postmoogle_docker_image_force_pull: "{{ matrix_bot_postmoogle_docker_image.endswith(':latest') }}"
@@ -108,7 +108,11 @@ matrix_bot_postmoogle_loglevel: 'INFO'
 # Disable encryption
 matrix_bot_postmoogle_noencryption: false
 
+# deprecated, use matrix_bot_postmoogle_domains
 matrix_bot_postmoogle_domain: "{{ matrix_server_fqn_matrix }}"
+
+matrix_bot_postmoogle_domains:
+  - "{{ matrix_bot_postmoogle_domain }}" # backward compatibility
 
 # Password (passphrase) to encrypt account data
 matrix_bot_postmoogle_data_secret: ""
@@ -126,15 +130,15 @@ matrix_bot_postmoogle_submission_host_bind_port: '587'
 matrix_bot_postmoogle_ssl_path: ""
 
 ## in-container SSL paths
-# matrix_bot_postmoogle_tls_cert is the SSL certificate's certificate.
-# This is likely set via group_vars/matrix_servers, so you don't need to set it.
+# matrix_bot_postmoogle_tls_cert is the SSL certificates' certificates.
+# This var is likely set via group_vars/matrix_servers, so you don't need to set certs manually.
 # If you do need to set it manually, note that this is an in-container path.
 # To mount a certificates volumes into the container, use matrix_bot_postmoogle_ssl_path
 # Example value: /ssl/live/{{ matrix_bot_postmoogle_domain }}/fullchain.pem
 matrix_bot_postmoogle_tls_cert: ""
 
-# matrix_bot_postmoogle_tls_key is the SSL certificate's key.
-# This is likely set via group_vars/matrix_servers, so you don't need to set it.
+# matrix_bot_postmoogle_tls_key is the SSL certificates' keys.
+# This var is likely set via group_vars/matrix_servers, so you don't need to set keys manually.
 # If you do need to set it manually, note that this is an in-container path.
 # To mount a certificates volumes into the container, use matrix_bot_postmoogle_ssl_path
 # Example value: /ssl/live/{{ matrix_bot_postmoogle_domain }}/privkey.pem

--- a/roles/custom/matrix-bot-postmoogle/templates/env.j2
+++ b/roles/custom/matrix-bot-postmoogle/templates/env.j2
@@ -1,7 +1,7 @@
 POSTMOOGLE_LOGIN={{ matrix_bot_postmoogle_login }}
 POSTMOOGLE_PASSWORD={{ matrix_bot_postmoogle_password }}
 POSTMOOGLE_HOMESERVER={{ matrix_bot_postmoogle_homeserver }}
-POSTMOOGLE_DOMAIN={{ matrix_bot_postmoogle_domain }}
+POSTMOOGLE_DOMAINS={{ matrix_bot_postmoogle_domains | join(' ') }}
 POSTMOOGLE_PORT={{ matrix_bot_postmoogle_port }}
 POSTMOOGLE_DB_DSN={{ matrix_bot_postmoogle_database_connection_string }}
 POSTMOOGLE_DB_DIALECT={{ matrix_bot_postmoogle_database_dialect }}


### PR DESCRIPTION
* automatic ban list (can be enabled by postmoogle admin)
* automatic greylisting (can be configured by postmoogle admin)
* internal email queue to re-send failed emails (with 45x errors) automatically
* bridging email threads ⇿ matrix threads/reply-tos (for new emails)
* reply to an email in a matrix room (in a matrix thread or with reply-to) to automatically send an email reply into the email thread
* multi-domain mode with the ability to select a domain for sending emails per room/per mailbox (all other domains will act as aliases)
* `!pm send` and thread replies send multipart emails by default (both HTML from formatted markdown and plaintext in the same email)
* speed up incoming emails by omitting MX and SMTP checks when they are not explicitly enabled
* updated deps

docker tag is ready