### PR TITLE
matrix_ to devture_

### DIFF
--- a/docs/configuring-playbook-synapse.md
+++ b/docs/configuring-playbook-synapse.md
@@ -37,7 +37,7 @@ If you'd like more customization power, you can start with one of the presets an
 If you increase worker counts too much, you may need to increase the maximum number of Postgres connections too (example):
 
 ```yaml
-matrix_postgres_process_extra_arguments: [
+devture_postgres_process_extra_arguments: [
   "-c 'max_connections=200'"
 ]
 ```


### PR DESCRIPTION
I'm not sure, but this should be changed to devture_postgres_... !? 
https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/CHANGELOG.md#2022-11-28

```yaml
matrix_postgres_process_extra_arguments: [
  "-c 'max_connections=200'"
]
```