### PR TITLE
Changes to allow a user to set the max participants on a jitsi conference

### DIFF
--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -127,6 +127,16 @@ Read how it works [here](https://github.com/jitsi/jitsi-videobridge/blob/master/
 
 You may want to **limit the maximum video resolution**, to save up resources on both server and clients.
 
+## (Optional) Specify a Max number of participants on a Jitsi conference
+
+The playbook allows a user to set a max number of participants allowed to join a Jitsi conference. By default there is no limit.
+
+In order to set the max number of participants add the following variable to your `inventory/host_vars/matrix.DOMAIN/vars.yml` configuration:
+
+```
+jitsi_max_participants: <INTEGER OF MAX PARTICPANTS>
+```
+
 ## (Optional) Additional JVBs
 
 By default, a single JVB ([Jitsi VideoBridge](https://github.com/jitsi/jitsi-videobridge)) is deployed on the same host as the Matrix server. To allow more video-conferences to happen at the same time, you may need to provision additional JVB services on other hosts.

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -134,7 +134,7 @@ The playbook allows a user to set a max number of participants allowed to join a
 In order to set the max number of participants add the following variable to your `inventory/host_vars/matrix.DOMAIN/vars.yml` configuration:
 
 ```
-jitsi_max_participants: <INTEGER OF MAX PARTICPANTS>
+matrix_prosody_jitsi_max_participants: <INTEGER OF MAX PARTICPANTS>
 ```
 
 ## (Optional) Additional JVBs

--- a/roles/custom/matrix-jitsi/defaults/main.yml
+++ b/roles/custom/matrix-jitsi/defaults/main.yml
@@ -281,4 +281,4 @@ matrix_jitsi_jvb_container_colibri_ws_host_bind_port: ''
 # Default max participants to the empty string
 #
 # The setting requires an integer to be set for usage and allows a user to specify the max number of particpants on a conference.
-jitsi_max_participants: ''
+matrix_prosody_jitsi_max_participants: ''

--- a/roles/custom/matrix-jitsi/defaults/main.yml
+++ b/roles/custom/matrix-jitsi/defaults/main.yml
@@ -277,3 +277,8 @@ matrix_jitsi_jvb_container_rtp_tcp_host_bind_port: "{{ matrix_jitsi_jvb_rtp_tcp_
 #
 # Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:12090"), or empty string to not expose.
 matrix_jitsi_jvb_container_colibri_ws_host_bind_port: ''
+
+# Default max participants to the empty string
+#
+# The setting requires an integer to be set for usage and allows a user to specify the max number of particpants on a conference.
+jitsi_max_participants: ''

--- a/roles/custom/matrix-jitsi/templates/prosody/env.j2
+++ b/roles/custom/matrix-jitsi/templates/prosody/env.j2
@@ -58,3 +58,6 @@ XMPP_MUC_MODULES=
 XMPP_INTERNAL_MUC_MODULES=
 XMPP_RECORDER_DOMAIN={{ matrix_jitsi_recorder_domain }}
 XMPP_CROSS_DOMAIN=true
+{% if jitsi_max_participants is number %}
+MAX_PARTICIPANTS={{ jitsi_max_participants }}
+{% endif %}

--- a/roles/custom/matrix-jitsi/templates/prosody/env.j2
+++ b/roles/custom/matrix-jitsi/templates/prosody/env.j2
@@ -58,6 +58,6 @@ XMPP_MUC_MODULES=
 XMPP_INTERNAL_MUC_MODULES=
 XMPP_RECORDER_DOMAIN={{ matrix_jitsi_recorder_domain }}
 XMPP_CROSS_DOMAIN=true
-{% if jitsi_max_participants is number %}
-MAX_PARTICIPANTS={{ jitsi_max_participants }}
+{% if matrix_prosody_jitsi_max_participants is number %}
+MAX_PARTICIPANTS={{ matrix_prosody_jitsi_max_participants }}
 {% endif %}


### PR DESCRIPTION
Hi Spantaleev,

I have added an option to set the max participants on a jitsi conference. The changes simply add another variable to the prosody env file based upon a user setting a specific INT variable in the playbook host-vars configuration file 