### PR TITLE
Only delete playbook scripts from /usr/local/bin

### DIFF
--- a/roles/custom/matrix_playbook_migration/tasks/cleanup_usr_local_bin.yml
+++ b/roles/custom/matrix_playbook_migration/tasks/cleanup_usr_local_bin.yml
@@ -3,8 +3,20 @@
 - name: Find leftover matrix scripts in /usr/local/bin
   ansible.builtin.find:
     path: "/usr/local/bin"
-    patterns: "^matrix-.*"
-    use_regex: true
+    patterns:
+      - matrix-change-user-admin-status
+      - matrix-dendrite-create-account
+      - matrix-make-user-admin
+      - matrix-postgres-cli
+      - matrix-postgres-cli-non-interactive
+      - matrix-postgres-update-user-password-hash
+      - matrix-remove-all
+      - matrix-ssl-certificates-renew
+      - matrix-ssl-lets-encrypt-certificates-renew
+      - matrix-synapse-register-user
+      - matrix-synapse-s3-storage-provider-migrate
+      - matrix-synapse-s3-storage-provider-shell
+      - matrix-synapse-worker-write-pid
   register: matrix_usr_local_bin_files_result
 
 - name: Ensure /usr/local/bin does not contain matrix scripts


### PR DESCRIPTION
I had a script to run ansible in a docker container (similar to [this](https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/docs/ansible.md#running-ansible-in-a-container-on-the-matrix-server-itself)) that I put at the path `/usr/local/bin/matrix-install` to match the pattern of the other matrix maintenance scripts. It got deleted during my last update by [this new task](https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/3d1ea3e79ea9a89c05d022ef6a75f2a9dc897a9b).

I probably should have thought through the name/location for my script a bit more, but this change will ensure the playbook only deletes scripts from the shared directory `/usr/local/bin` that it originally created.