### PR TITLE
add 'not' to fail check for s3_storage_provider

### DIFF
--- a/roles/custom/matrix-synapse/tasks/ext/s3-storage-provider/validate_config.yml
+++ b/roles/custom/matrix-synapse/tasks/ext/s3-storage-provider/validate_config.yml
@@ -16,4 +16,4 @@
   ansible.builtin.fail:
     msg: >-
       `matrix_synapse_ext_synapse_s3_storage_provider_config_endpoint_url` needs to look like a URL (`http://` or `https://` prefix).
-  when: "matrix_synapse_ext_synapse_s3_storage_provider_config_endpoint_url.startswith('http')"
+  when: "not matrix_synapse_ext_synapse_s3_storage_provider_config_endpoint_url.startswith('http')"


### PR DESCRIPTION
add 'not' to fail check for  matrix_synapse_ext_synapse_s3_storage_provider_config_endpoint_url