### PR TITLE
Use upstream Docker image for amd64 rather than self-build

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -2658,6 +2658,8 @@ matrix_client_element_jitsi_preferredDomain: "{{ matrix_server_fqn_jitsi if matr
 
 matrix_client_hydrogen_enabled: false
 
+matrix_client_hydrogen_container_image_self_build: "{{ matrix_architecture not in ['amd64'] }}"
+
 # Normally, matrix-nginx-proxy is enabled and nginx can reach Hydrogen over the container network.
 # If matrix-nginx-proxy is not enabled, or you otherwise have a need for it, you can expose
 # the HTTP port to the local host.

--- a/roles/custom/matrix-client-hydrogen/defaults/main.yml
+++ b/roles/custom/matrix-client-hydrogen/defaults/main.yml
@@ -3,14 +3,12 @@
 
 matrix_client_hydrogen_enabled: true
 
-# Self building is used by default because the `config.json` file is only read at build time.
-# The pre-built images also were not functional as of 2021-05-15.
-matrix_client_hydrogen_container_image_self_build: true
+matrix_client_hydrogen_container_image_self_build: false
 matrix_client_hydrogen_container_image_self_build_repo: "https://github.com/vector-im/hydrogen-web.git"
 
 matrix_client_hydrogen_version: v0.3.5
-matrix_client_hydrogen_docker_image: "{{ matrix_client_hydrogen_docker_image_name_prefix }}vectorim/hydrogen-web:{{ matrix_client_hydrogen_version }}"
-matrix_client_hydrogen_docker_image_name_prefix: "{{ 'localhost/' if matrix_client_hydrogen_container_image_self_build else matrix_container_global_registry_prefix }}"
+matrix_client_hydrogen_docker_image: "{{ matrix_client_hydrogen_docker_image_name_prefix }}vector-im/hydrogen-web:{{ matrix_client_hydrogen_version }}"
+matrix_client_hydrogen_docker_image_name_prefix: "{{ 'localhost/' if matrix_client_hydrogen_container_image_self_build else 'ghcr.io/' }}"
 matrix_client_hydrogen_docker_image_force_pull: "{{ matrix_client_hydrogen_docker_image.endswith(':latest') }}"
 
 matrix_client_hydrogen_data_path: "{{ matrix_base_data_path }}/client-hydrogen"

--- a/roles/custom/matrix-client-hydrogen/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-hydrogen/tasks/setup_install.yml
@@ -38,11 +38,10 @@
 - name: Ensure Hydrogen configuration installed
   ansible.builtin.copy:
     content: "{{ matrix_client_hydrogen_configuration | to_nice_json }}"
-    dest: "{{ matrix_client_hydrogen_docker_src_files_path }}/src/platform/web/assets/config.json"
+    dest: "{{ matrix_client_hydrogen_data_path }}/config.json"
     mode: 0644
     owner: "{{ matrix_user_username }}"
     group: "{{ matrix_user_groupname }}"
-  when: "matrix_client_hydrogen_container_image_self_build | bool"
 
 - name: Ensure Hydrogen additional config files installed
   ansible.builtin.template:
@@ -55,8 +54,6 @@
     - {src: "{{ role_path }}/templates/nginx.conf.j2", name: "nginx.conf"}
   when: "item.src is not none"
 
-# This step MUST come after the steps to install the configuration files because the config files
-# are currently only read at build time, not at run time like most other components in the playbook
 - name: Ensure Hydrogen Docker image is built
   community.docker.docker_image:
     name: "{{ matrix_client_hydrogen_docker_image }}"

--- a/roles/custom/matrix-client-hydrogen/templates/config.json.j2
+++ b/roles/custom/matrix-client-hydrogen/templates/config.json.j2
@@ -3,7 +3,7 @@
 	"defaultHomeServer": {{ matrix_client_hydrogen_default_hs_url | string | to_json }},
 	"bugReportEndpointUrl": {{ matrix_client_hydrogen_bugReportEndpointUrl | to_json }},
 	"themeManifests": [
-		"assets/theme-Element.json"
+		"assets/theme-element.json"
 	],
 	"defaultTheme": {
 		"light": "element-light",

--- a/roles/custom/matrix-client-hydrogen/templates/systemd/matrix-client-hydrogen.service.j2
+++ b/roles/custom/matrix-client-hydrogen/templates/systemd/matrix-client-hydrogen.service.j2
@@ -24,6 +24,7 @@ ExecStart={{ devture_systemd_docker_base_host_command_docker }} run --rm --name 
 			{% endif %}
 			--tmpfs=/tmp:rw,noexec,nosuid,size=10m \
 			--mount type=bind,src={{ matrix_client_hydrogen_data_path }}/nginx.conf,dst=/etc/nginx/nginx.conf,ro \
+			--mount type=bind,src={{ matrix_client_hydrogen_data_path }}/config.json,dst=/usr/share/nginx/html/config.json,ro \
 			{% for arg in matrix_client_hydrogen_container_extra_arguments %}
 			{{ arg }} \
 			{% endfor %}


### PR DESCRIPTION
I've just tested this, and confirmed that using the upstream Docker image for Hydrogen and bind-mounting in the config file works correctly. That is to say, it configures the Hydrogen client to use my own Matrix server etc.

I was a bit confused as to why I needed to change the case of the theme in the config file, but after doing so to make it match that of the file within the Docker image, it all seemed to behave itself.

Fixes #2294