### PR TITLE
Use pre-build arm64 version of Hydrogen image

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -2658,7 +2658,7 @@ matrix_client_element_jitsi_preferredDomain: "{{ matrix_server_fqn_jitsi if matr
 
 matrix_client_hydrogen_enabled: false
 
-matrix_client_hydrogen_container_image_self_build: "{{ matrix_architecture not in ['amd64'] }}"
+matrix_client_hydrogen_container_image_self_build: "{{ matrix_architecture not in ['arm64', 'amd64'] }}"
 
 # Normally, matrix-nginx-proxy is enabled and nginx can reach Hydrogen over the container network.
 # If matrix-nginx-proxy is not enabled, or you otherwise have a need for it, you can expose


### PR DESCRIPTION
This PR is pending vector-im/hydrogen-web#948, but assuming that gets merged, this one will be good to go; I've already tested that the resulting arm64 image works on my arm64 system.