### PR TITLE
Upgrade Signald

### DIFF
--- a/roles/custom/matrix-bridge-mautrix-signal/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-signal/defaults/main.yml
@@ -10,7 +10,7 @@ matrix_mautrix_signal_docker_repo_version: "{{ 'master' if matrix_mautrix_signal
 matrix_mautrix_signal_docker_src_files_path: "{{ matrix_base_data_path }}/mautrix-signal/docker-src"
 
 matrix_mautrix_signal_version: v0.4.2
-matrix_mautrix_signal_daemon_version: 0.23.0
+matrix_mautrix_signal_daemon_version: 0.23.1
 # See: https://mau.dev/mautrix/signal/container_registry
 matrix_mautrix_signal_docker_image: "dock.mau.dev/mautrix/signal:{{ matrix_mautrix_signal_version }}"
 matrix_mautrix_signal_docker_image_force_pull: "{{ matrix_mautrix_signal_docker_image.endswith(':latest') }}"


### PR DESCRIPTION
When trying to use the !pm <phone number> command, I always got some weird error. This was caused by signald and is discussed in the following issue: https://gitlab.com/signald/signald/-/issues/345
The issue was fixed in version 0.23.1, so I would like to upgrade to it. I know that the latest mautrix-signal release recommends version 0.23.0, but its developer told me in his matrix channel that the bridge does not really care about the version. I have not tested if anything breaks through this upgrade, but I can confirm that the issue is indeed solved.