### PR TITLE
bugfix: set the matrix public_baseurl

### DIFF
--- a/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -63,7 +63,7 @@ pid_file: /homeserver.pid
 #
 # Defaults to 'https://<server_name>/'.
 #
-public_baseurl: https://{{ matrix_server_fqn_matrix }}/
+public_baseurl: {{ matrix_homeserver_url }}
 
 # Uncomment the following to tell other servers to send federation traffic on
 # port 443.


### PR DESCRIPTION
Instead of computing this from the `matrix_server_fqn_matrix` this
should use the pre-computed (or overridden!) `matrix_homeserver_url` so
that it is possible to set the homeserver port, if that isn't `443`