### PR TITLE
rcreate throws error (error parsing arguments: option rcreate)

### DIFF
--- a/roles/custom/matrix-backup-borg/templates/systemd/matrix-backup-borg.service.j2
+++ b/roles/custom/matrix-backup-borg/templates/systemd/matrix-backup-borg.service.j2
@@ -31,7 +31,7 @@ ExecStartPre=-{{ devture_systemd_docker_base_host_command_docker }} run --rm --n
 			{{ arg }} \
 			{% endfor %}
 			{{ matrix_backup_borg_docker_image }} \
-			sh -c "borgmatic rcreate --encryption {{ matrix_backup_borg_encryption }}"
+			sh -c "borgmatic init --encryption {{ matrix_backup_borg_encryption }}"
 
 # The `CAP_DAC_OVERRIDE` capability is required, so that `root` in the container
 # can read the `/etc/borgmatic.d/config.yaml` (`{{ matrix_backup_borg_config_path }}/config.yaml`) file,


### PR DESCRIPTION
according to manual we have the option rcreate: 

> rcreate (init, -I)  Create a new, empty Borg repository

But this one throws an error (due to wrong borg / not latest borg version? - https://torsion.org/borgmatic/docs/how-to/set-up-backups/#repository-creation)

`init` should do the same thing...

error:

```
Dec 30 01:02:55 v2202102141459143382 systemd[1]: Starting Matrix Borg Backup...
Dec 30 01:02:57 v2202102141459143382 matrix-backup-borg[3664550]: usage: borgmatic [-h] [-c [CONFIG_PATHS ...]] [--excludes EXCLUDES_FILENAME]
Dec 30 01:02:57 v2202102141459143382 matrix-backup-borg[3664550]:                  [-n] [-nc] [-v {-1,0,1,2}] [--syslog-verbosity {-1,0,1,2}]
Dec 30 01:02:57 v2202102141459143382 matrix-backup-borg[3664550]:                  [--log-file-verbosity {-1,0,1,2}]
Dec 30 01:02:57 v2202102141459143382 matrix-backup-borg[3664550]:                  [--monitoring-verbosity {-1,0,1,2}] [--log-file LOG_FILE]
Dec 30 01:02:57 v2202102141459143382 matrix-backup-borg[3664550]:                  [--override SECTION.OPTION=VALUE [SECTION.OPTION=VALUE ...]]
Dec 30 01:02:57 v2202102141459143382 matrix-backup-borg[3664550]:                  [--version]
Dec 30 01:02:57 v2202102141459143382 matrix-backup-borg[3664550]:                  ...
Dec 30 01:02:57 v2202102141459143382 matrix-backup-borg[3664550]: borgmatic: error: argument : invalid choice: 'rcreate' (choose from 'init', '--init', '-I', 'prune', '--prune', '-p', 'compact', 'create', '--create', '-C', 'check', '--check', '-k', 'extract', '--extract', '-x', 'export-tar', '--export-tar', 'mount', '--mount', '-m', 'umount', '--umount', '-u', 'restore', '--restore', '-r', 'list', '--list', '-l', 'info', '--info', '-i', 'borg')
borgmatic: error: argument : invalid choice: 'rcreate' (choose from 'init', '--init', '-I', 'prune', '--prun>
Dec 30 01:02:57 v2202102141459143382 matrix-backup-borg[3664550]: Error parsing arguments: /usr/bin/borgmatic rcreate --encryption repokey-blake2
```