### PR TITLE
Added back variables which control which parts of the roles are run

### DIFF
--- a/roles/custom/matrix-bridge-hookshot/defaults/main.yml
+++ b/roles/custom/matrix-bridge-hookshot/defaults/main.yml
@@ -2,6 +2,9 @@
 
 # A bridge between Matrix and multiple project management services, such as GitHub, GitLab and JIRA.
 # Project source code URL: https://github.com/matrix-org/matrix-hookshot
+#
+run_reset_encryption: true
+run_setup: true
 
 matrix_hookshot_enabled: true
 

--- a/roles/custom/matrix-bridge-hookshot/tasks/main.yml
+++ b/roles/custom/matrix-bridge-hookshot/tasks/main.yml
@@ -3,7 +3,7 @@
 - tags:
     - reset-hookshot-encryption
   block:
-    - when: matrix_hookshot_enabled | bool
+    - when: matrix_hookshot_enabled | bool and run_reset_encryption | bool
       ansible.builtin.include_tasks: "{{ role_path }}/tasks/reset_encryption.yml"
 
 - tags:
@@ -14,10 +14,10 @@
     - install-hookshot
     - install-bridge-hookshot
   block:
-    - when: matrix_hookshot_enabled | bool
+    - when: matrix_hookshot_enabled | bool and run_setup | bool
       ansible.builtin.include_tasks: "{{ role_path }}/tasks/validate_config.yml"
 
-    - when: matrix_hookshot_enabled | bool
+    - when: matrix_hookshot_enabled | bool and run_setup | bool
       ansible.builtin.include_tasks: "{{ role_path }}/tasks/setup_install.yml"
 
 - tags:
@@ -25,5 +25,5 @@
     - setup-hookshot
     - setup-bridge-hookshot
   block:
-    - when: not matrix_hookshot_enabled | bool
+    - when: not matrix_hookshot_enabled | bool and run_setup | bool
       ansible.builtin.include_tasks: "{{ role_path }}/tasks/setup_uninstall.yml"

--- a/roles/custom/matrix-client-element/defaults/main.yml
+++ b/roles/custom/matrix-client-element/defaults/main.yml
@@ -3,6 +3,9 @@
 
 matrix_client_element_enabled: true
 
+run_setup: true
+run_self_check: true
+
 matrix_client_element_container_image_self_build: false
 matrix_client_element_container_image_self_build_repo: "https://github.com/element-hq/element-web.git"
 # Controls whether to patch webpack.config.js when self-building, so that building can pass on low-memory systems (< 4 GB RAM):

--- a/roles/custom/matrix-client-element/tasks/main.yml
+++ b/roles/custom/matrix-client-element/tasks/main.yml
@@ -12,18 +12,18 @@
     - when: matrix_client_element_enabled | bool
       ansible.builtin.include_tasks: "{{ role_path }}/tasks/prepare_themes.yml"
 
-    - when: matrix_client_element_enabled | bool
+    - when: matrix_client_element_enabled | bool and run_setup | bool
       ansible.builtin.include_tasks: "{{ role_path }}/tasks/setup_install.yml"
 
 - tags:
     - setup-all
     - setup-client-element
   block:
-    - when: not matrix_client_element_enabled | bool
+    - when: not matrix_client_element_enabled | bool and run_setup | bool
       ansible.builtin.include_tasks: "{{ role_path }}/tasks/setup_uninstall.yml"
 
 - tags:
     - self-check
   block:
-    - when: matrix_client_element_enabled | bool
+    - when: matrix_client_element_enabled | bool and run_self_check | bool
       ansible.builtin.include_tasks: "{{ role_path }}/tasks/self_check.yml"

--- a/roles/custom/matrix-static-files/defaults/main.yml
+++ b/roles/custom/matrix-static-files/defaults/main.yml
@@ -3,6 +3,7 @@
 # matrix-static-files is a role which generates and serves `/.well-known/matrix` files for the purposes of Matrix Delegation.
 # It also exposes some variables which allow this role to be used for serving additional files.
 
+run_self_check: true
 matrix_static_files_enabled: true
 
 matrix_static_files_identifier: matrix-static-files

--- a/roles/custom/matrix-static-files/tasks/main.yml
+++ b/roles/custom/matrix-static-files/tasks/main.yml
@@ -23,4 +23,5 @@
     - self-check
     - self-check-matrix-static-files
   block:
-    - ansible.builtin.include_tasks: "{{ role_path }}/tasks/self_check_well_known.yml"
+    - when: run_self_check | bool
+      ansible.builtin.include_tasks: "{{ role_path }}/tasks/self_check_well_known.yml"

--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -21,6 +21,16 @@ matrix_synapse_version: v1.100.0
 matrix_synapse_username: ''
 matrix_synapse_uid: ''
 matrix_synapse_gid: ''
+# Variables to control which part of the role is run
+# By default they are all true and filtering is done with tags
+# these variables are for use from other playbooks etc
+run_setup: true
+run_self_check: true
+run_synapse_register_user: true
+run_synapse_update_user_password: true
+run_synapse_import_media_store: true
+run_synapse_rust_synapse_compress_state: true
+run_synapse_import_sqlite_db: true
 
 matrix_synapse_container_image_self_build: false
 matrix_synapse_container_image_self_build_repo: "https://github.com/{{ matrix_synapse_github_org_and_repo }}.git"

--- a/roles/custom/matrix-synapse/tasks/main.yml
+++ b/roles/custom/matrix-synapse/tasks/main.yml
@@ -29,7 +29,7 @@
     - when: matrix_synapse_enabled | bool
       ansible.builtin.include_tasks: "{{ role_path }}/tasks/validate_config.yml"
 
-    - when: matrix_synapse_enabled | bool
+    - when: matrix_synapse_enabled | bool and run_setup | bool
       ansible.builtin.include_tasks: "{{ role_path }}/tasks/setup_install.yml"
 
 - tags:
@@ -37,43 +37,44 @@
     - setup-synapse
   block:
     # This always runs because it handles uninstallation for sub-components too.
-    - ansible.builtin.include_tasks: "{{ role_path }}/tasks/setup_uninstall.yml"
+    - when: not matrix_synapse_enabled | bool and run_setup | bool
+      ansible.builtin.include_tasks: "{{ role_path }}/tasks/setup_uninstall.yml"
 
 - tags:
     - import-synapse-media-store
   block:
-    - when: matrix_synapse_enabled | bool
+    - when: matrix_synapse_enabled | bool and run_synapse_import_media_store | bool
       ansible.builtin.include_tasks: "{{ role_path }}/tasks/import_media_store.yml"
 
 - tags:
     - import-synapse-sqlite-db
   block:
-    - when: matrix_synapse_enabled | bool
+    - when: matrix_synapse_enabled | bool and run_synapse_import_sqlite_db
       ansible.builtin.include_tasks: "{{ role_path }}/tasks/import_synapse_sqlite_db.yml"
 
 - tags:
     - register-user
   block:
-    - when: matrix_synapse_enabled | bool
+    - when: matrix_synapse_enabled | bool and run_synapse_register_user | bool
       ansible.builtin.include_tasks: "{{ role_path }}/tasks/register_user.yml"
 
 - tags:
     - update-user-password
   block:
-    - when: matrix_synapse_enabled | bool
+    - when: matrix_synapse_enabled | bool and run_synapse_update_user_password | bool
       ansible.builtin.include_tasks: "{{ role_path }}/tasks/update_user_password.yml"
 
 - tags:
     - rust-synapse-compress-state
   block:
-    - when: matrix_synapse_enabled | bool
+    - when: matrix_synapse_enabled | bool and run_synapse_rust_synapse_compress_state | bool
       ansible.builtin.include_tasks: "{{ role_path }}/tasks/rust-synapse-compress-state/main.yml"
 
 - tags:
     - self-check
   block:
-    - when: matrix_synapse_enabled | bool
+    - when: matrix_synapse_enabled | bool and run_self_check | bool
       ansible.builtin.include_tasks: "{{ role_path }}/tasks/self_check_client_api.yml"
 
-    - when: matrix_synapse_enabled | bool
+    - when: matrix_synapse_enabled | bool and run_self_check | bool
       ansible.builtin.include_tasks: "{{ role_path }}/tasks/self_check_federation_api.yml"


### PR DESCRIPTION
These were the ones I ran into issues with, but I guess there are others I should add if this approach is acceptable.

---

We have discussed this a little on matrix, but it's easy for things to get lost in the busy room, so I will lay out what I am trying to achieve here to motivate this and then maybe we can figure out the best way forward.

My setup is that I don't use the `playbooks/matrix.yml` playbook, I include the roles into my own custom playbook. The playbook I run does all the setup and any restarting needed, meaning I never need to (or need to for any other ansible roles I use) set any tags to get my infrastructure in the state described by the inventory. 

I basically run `ansible-playbook site.yml -l matrix` and multiple playbooks are invoked, in order, which setup my matrix host and associated services (such as database roles on another host) to the state I expect them to be in.

The issue I see with having roles like the ones in this playbook, which *require* you to set tags for them to work, is that there is no way to set tags inside a playbook when invoking a role (at least using `role:` and `include_role` seems to have other issues relating to inventory [1]). So, unless I am missing something, there would be no way for me to avoid requiring setting tags on my invocation of `ansible-playbook`.

In my experience with using ansible for my homelab, it feels alien to be to have to use tags to make a role work (i.e. running all the tasks without tag filtering is illogical) and also alien to be to have to use tags to filter out related-but-optional functionality of a role (e.g. rust-state-compress). When I put a `role:` directive in my playbook I expect it to setup a thing based on the state of the inventory.

I am really grateful for this project, and all it makes super easy, and I appreciate that the way I use these roles isn't the expected way, but with the change of removing these `run_` variables, it's now become very difficult to impossible to include these roles in another playbook without also accepting that you need to use the CLI tags interface documented for the main `setup.yml` playbook in this repo, which is what I am trying to avoid having to do.

[1] It appears that using `include_role` doesn't mix the variables of all the roles together in the same way as `role:` so you end up with a load of missing variables making it effectively useless.