### PR TITLE
convert to list from generator

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -283,7 +283,7 @@ devture_systemd_service_manager_services_list_auto: |
     +
     ([{'name': 'matrix-nginx-proxy.service', 'priority': 3000, 'groups': ['matrix', 'nginx', 'reverse-proxies']}] if matrix_nginx_proxy_enabled else [])
     +
-    (matrix_ssl_renewal_systemd_units_list | selectattr('applicable') | selectattr('enableable'))
+    (matrix_ssl_renewal_systemd_units_list | selectattr('applicable') | selectattr('enableable') | list )
     +
     ([{'name': 'matrix-ntfy.service', 'priority': 800, 'groups': ['matrix', 'ntfy']}] if matrix_ntfy_enabled else [])
     +


### PR DESCRIPTION
selectattr() returns a generator object, an iterator. This leads to an exception later, lists can't concated to iterators, only to other lists. So '| list' converts the iterator to a list and the script runs happily.

Maybe it's only my system (CentOS 7, Python 2.7) wich struggels here, but the documentation of jinja list-filters say's also, the return of selectattr() is a iterator. Anyway, this simple fix converts this to a list and everything is fine.