### PR TITLE
Allow the mautrix whatsapp relaybot to be enabled with a variable

### DIFF
--- a/docs/configuring-playbook-bridge-mautrix-whatsapp.md
+++ b/docs/configuring-playbook-bridge-mautrix-whatsapp.md
@@ -11,6 +11,19 @@ matrix_mautrix_whatsapp_enabled: true
 ``` 
 Whatsapp multidevice beta is required, now it is enough if Whatsapp is connected to the Internet every 2 weeks.
 
+The relay bot functionality is off by default. If you would like to enable the relay bot, add the following to your `vars.yml` file:
+```yaml
+matrix_mautrix_whatsapp_relaybot_enabled: true
+```
+
+By default, only admins are allowed to set themselves as relay users. To allow anyone on your homeserver to set themselves as relay users add this to your `vars.yml` file:
+```yaml
+matrix_mautrix_whatsapp_relaybot_admin_only: false
+```
+
+If you want to activate the relay bot in a room, use `!whatsapp set-relay`.
+Use `!whatsapp unset-relay` to deactivate.
+
 ## Enable backfilling history
 This requires a server with MSC2716 support, which is currently an experimental feature in synapse.
 Note that as of Synapse 1.46, there are still some bugs with the implementation, especially if using event persistence workers.

--- a/docs/configuring-playbook-bridge-mautrix-whatsapp.md
+++ b/docs/configuring-playbook-bridge-mautrix-whatsapp.md
@@ -13,12 +13,12 @@ Whatsapp multidevice beta is required, now it is enough if Whatsapp is connected
 
 The relay bot functionality is off by default. If you would like to enable the relay bot, add the following to your `vars.yml` file:
 ```yaml
-matrix_mautrix_whatsapp_relaybot_enabled: true
+matrix_mautrix_whatsapp_bridge_relay_enabled: true
 ```
 
 By default, only admins are allowed to set themselves as relay users. To allow anyone on your homeserver to set themselves as relay users add this to your `vars.yml` file:
 ```yaml
-matrix_mautrix_whatsapp_relaybot_admin_only: false
+matrix_mautrix_whatsapp_bridge_relay_admin_only: false
 ```
 
 If you want to activate the relay bot in a room, use `!whatsapp set-relay`.

--- a/roles/custom/matrix-bridge-mautrix-whatsapp/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-whatsapp/defaults/main.yml
@@ -102,6 +102,12 @@ matrix_mautrix_whatsapp_bridge_permissions: |
     | combine({matrix_admin: 'admin'} if matrix_admin else {})
   }}
 
+# Enable bridge relay functionality
+matrix_mautrix_whatsapp_bridge_relay_enabled: false
+
+# Only allow admins on this home server to set themselves as a relay user
+matrix_mautrix_whatsapp_bridge_relay_admin_only: true
+
 # Default mautrix-whatsapp configuration template which covers the generic use case.
 # You can customize it by controlling the various variables inside it.
 #

--- a/roles/custom/matrix-bridge-mautrix-whatsapp/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mautrix-whatsapp/templates/config.yaml.j2
@@ -396,9 +396,9 @@ bridge:
     relay:
         # Whether relay mode should be allowed. If allowed, `!wa set-relay` can be used to turn any
         # authenticated user into a relaybot for that chat.
-        enabled: {{ matrix_mautrix_whatsapp_relaybot_enabled | default(false) }}
+        enabled: {{ matrix_mautrix_whatsapp_bridge_relay_enabled | default(false) }}
         # Should only admins be allowed to set themselves as relay users?
-        admin_only: {{ matrix_mautrix_whatsapp_relaybot_admin_only | default(true) }}
+        admin_only: {{ matrix_mautrix_whatsapp_bridge_relay_admin_only | default(true) }}
         # The formats to use when sending messages to WhatsApp via the relaybot.
         message_formats:
             m.text: "<b>{{ '{{ .Sender.Displayname }}' }}</b>: {{ '{{ .Message }}' }}"

--- a/roles/custom/matrix-bridge-mautrix-whatsapp/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mautrix-whatsapp/templates/config.yaml.j2
@@ -396,9 +396,9 @@ bridge:
     relay:
         # Whether relay mode should be allowed. If allowed, `!wa set-relay` can be used to turn any
         # authenticated user into a relaybot for that chat.
-        enabled: {{ matrix_mautrix_whatsapp_relaybot_enabled }}
+        enabled: {{ matrix_mautrix_whatsapp_relaybot_enabled | default(false) }}
         # Should only admins be allowed to set themselves as relay users?
-        admin_only: {{ matrix_mautrix_whatsapp_relaybot_admin_only }}
+        admin_only: {{ matrix_mautrix_whatsapp_relaybot_admin_only | default(true) }}
         # The formats to use when sending messages to WhatsApp via the relaybot.
         message_formats:
             m.text: "<b>{{ '{{ .Sender.Displayname }}' }}</b>: {{ '{{ .Message }}' }}"

--- a/roles/custom/matrix-bridge-mautrix-whatsapp/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mautrix-whatsapp/templates/config.yaml.j2
@@ -396,9 +396,9 @@ bridge:
     relay:
         # Whether relay mode should be allowed. If allowed, `!wa set-relay` can be used to turn any
         # authenticated user into a relaybot for that chat.
-        enabled: {{ matrix_mautrix_whatsapp_bridge_relay_enabled | default(false) }}
+        enabled: {{ matrix_mautrix_whatsapp_bridge_relay_enabled | to_json }}
         # Should only admins be allowed to set themselves as relay users?
-        admin_only: {{ matrix_mautrix_whatsapp_bridge_relay_admin_only | default(true) }}
+        admin_only: {{ matrix_mautrix_whatsapp_bridge_relay_admin_only | to_json }}
         # The formats to use when sending messages to WhatsApp via the relaybot.
         message_formats:
             m.text: "<b>{{ '{{ .Sender.Displayname }}' }}</b>: {{ '{{ .Message }}' }}"

--- a/roles/custom/matrix-bridge-mautrix-whatsapp/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mautrix-whatsapp/templates/config.yaml.j2
@@ -396,9 +396,9 @@ bridge:
     relay:
         # Whether relay mode should be allowed. If allowed, `!wa set-relay` can be used to turn any
         # authenticated user into a relaybot for that chat.
-        enabled: false
+        enabled: {{ matrix_mautrix_whatsapp_relaybot_enabled }}
         # Should only admins be allowed to set themselves as relay users?
-        admin_only: true
+        admin_only: {{ matrix_mautrix_whatsapp_relaybot_admin_only }}
         # The formats to use when sending messages to WhatsApp via the relaybot.
         message_formats:
             m.text: "<b>{{ '{{ .Sender.Displayname }}' }}</b>: {{ '{{ .Message }}' }}"


### PR DESCRIPTION
This allows a user to enable the relaybot by setting a variable in `vars.yml` in the same way that the mautrix signal relaybot is configured.