### PR TITLE
Hi again, sorry about the last pull request.

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -390,6 +390,12 @@ See [How can I see the logs?](#how-can-i-see-the-logs).
 
 ### How can I see the logs?
 
+By default, we're configuring containers to use "none" as the logging driver, meaning that the output is simply discarded. By using 
+
+`matrix_synapse_log_driver=json-file`
+
+in your host vars, you can set it to something else (in this case, "json-file").
+
 We utilize [systemd/journald](https://www.freedesktop.org/software/systemd/man/systemd-journald.service.html#Description) for logging.
 
 To see logs for Synapse, run `journalctl -fu matrix-synapse.service`. You may wish to see the [manual page for journalctl](https://www.commandlinux.com/man-page/man1/journalctl.1.html).

--- a/roles/custom/matrix-synapse/templates/goofys/systemd/matrix-goofys.service.j2
+++ b/roles/custom/matrix-synapse/templates/goofys/systemd/matrix-goofys.service.j2
@@ -12,7 +12,11 @@ ExecStartPre=-{{ devture_systemd_docker_base_host_command_docker }} kill %n
 ExecStartPre=-{{ devture_systemd_docker_base_host_command_docker }} rm %n
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} run --rm --name %n \
+			{% if matrix_synapse_log_driver %}
+			--log-driver={{ matrix_synapse_log_driver }} \
+			{% else %}
 			--log-driver=none \
+			{% endif %}
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--mount type=bind,src=/etc/passwd,dst=/etc/passwd,ro \
 			--mount type=bind,src=/etc/group,dst=/etc/group,ro \

--- a/roles/custom/matrix-synapse/templates/synapse/ext/s3-storage-provider/env.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/ext/s3-storage-provider/env.j2
@@ -2,7 +2,11 @@ AWS_ACCESS_KEY_ID={{ matrix_synapse_ext_synapse_s3_storage_provider_config_acces
 AWS_SECRET_ACCESS_KEY={{ matrix_synapse_ext_synapse_s3_storage_provider_config_secret_access_key }}
 AWS_DEFAULT_REGION={{ matrix_synapse_ext_synapse_s3_storage_provider_config_region_name }}
 
+# only set the endpoint if it is set in the vars.
+{% if matrix_synapse_ext_synapse_s3_storage_provider_config_endpoint_url %}
 ENDPOINT={{ matrix_synapse_ext_synapse_s3_storage_provider_config_endpoint_url }}
+{% endif %}
+
 BUCKET={{ matrix_synapse_ext_synapse_s3_storage_provider_config_bucket }}
 STORAGE_CLASS={{ matrix_synapse_ext_synapse_s3_storage_provider_config_storage_class }}
 

--- a/roles/custom/matrix-synapse/templates/synapse/ext/s3-storage-provider/media_storage_provider.yaml.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/ext/s3-storage-provider/media_storage_provider.yaml.j2
@@ -5,7 +5,9 @@ store_synchronous: {{ matrix_synapse_ext_synapse_s3_storage_provider_store_synch
 config:
   bucket: {{ matrix_synapse_ext_synapse_s3_storage_provider_config_bucket | to_json }}
   region_name: {{ matrix_synapse_ext_synapse_s3_storage_provider_config_region_name | to_json }}
+  {% if matrix_synapse_ext_synapse_s3_storage_provider_config_endpoint_url %}
   endpoint_url: {{ matrix_synapse_ext_synapse_s3_storage_provider_config_endpoint_url | to_json }}
+  {% endif %}
   access_key_id: {{ matrix_synapse_ext_synapse_s3_storage_provider_config_access_key_id | to_json }}
   secret_access_key: {{ matrix_synapse_ext_synapse_s3_storage_provider_config_secret_access_key | to_json }}
 

--- a/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -2622,7 +2622,9 @@ user_directory:
     # Uncomment to return search results containing all known users, even if that
     # user does not share a room with the requester.
     #
-    #search_all_users: true
+    {% if matrix_synapse_config_search_all_users %}
+    search_all_users: {{ matrix_synapse_config_search_all_users  }}
+    {% endif %}
 
     # Defines whether to prefer local users in search query results.
     # If True, local users are more likely to appear above remote users

--- a/roles/custom/matrix-synapse/templates/synapse/systemd/matrix-synapse-worker.service.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/systemd/matrix-synapse-worker.service.j2
@@ -15,7 +15,11 @@ ExecStartPre=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_s
 ExecStartPre={{ matrix_host_command_sleep }} 5
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} run --rm --name {{ matrix_synapse_worker_container_name }} \
+			{% if matrix_synapse_log_driver %}
+			--log-driver={{ matrix_synapse_log_driver }} \
+			{% else %}
 			--log-driver=none \
+			{% endif %}
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
 			--read-only \


### PR DESCRIPTION
The last pull request was a little bit messy, so i decide to clean stuff and make it easier.
I added some more configuration options in the homeserver- and systemd unit templates. Default behaviour is unchanged, but:

matrix_synapse_log_driver - allows changing the log driver

matrix_synapse_config_search_all_users - allows changing the search behaviour in the homeserver.yaml

matrix_synapse_ext_synapse_s3_storage_provider_config_endpoint_url - changes the behaviour so that the endpoint url is optional (in case you're using vanillas S3)