### PR TITLE
Change Synapse default room version from 9 to 10

### DIFF
--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -844,7 +844,7 @@ matrix_synapse_room_list_publication_rules:
     room_id: "*"
     action: allow
 
-matrix_synapse_default_room_version: "9"
+matrix_synapse_default_room_version: "10"
 
 # Controls the Synapse `spam_checker` setting.
 #


### PR DESCRIPTION
This PR bumps the default room version in accordance to [MSC3904](https://github.com/matrix-org/matrix-spec-proposals/pull/3904). This MSC is in FCP currently and is expected to pass.

All homeserver softwares that this playbook support support version 10. 

Dendrite and Conduit seem to have these hard coded or not in exposed config options that we currently use that is why this PR is Synapse only.