### PR TITLE
add mode var for synapse ext ldap auth

### DIFF
--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -725,6 +725,7 @@ matrix_synapse_ext_password_provider_shared_secret_config_yaml: |
 matrix_synapse_ext_password_provider_ldap_enabled: false
 matrix_synapse_ext_password_provider_ldap_uri: "ldap://ldap.mydomain.tld:389"
 matrix_synapse_ext_password_provider_ldap_start_tls: true
+matrix_synapse_ext_password_provider_ldap_mode: "search"
 matrix_synapse_ext_password_provider_ldap_base: ""
 matrix_synapse_ext_password_provider_ldap_attributes_uid: "uid"
 matrix_synapse_ext_password_provider_ldap_attributes_mail: "mail"

--- a/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -2511,6 +2511,7 @@ password_providers:
   - module: "ldap_auth_provider.LdapAuthProvider"
     config:
       enabled: true
+      mode: {{ matrix_synapse_ext_password_provider_ldap_mode | string | to_json }}
       uri: {{ matrix_synapse_ext_password_provider_ldap_uri | string|to_json }}
       start_tls: {{ matrix_synapse_ext_password_provider_ldap_start_tls|to_json }}
       base: {{ matrix_synapse_ext_password_provider_ldap_base | string|to_json }}


### PR DESCRIPTION
note about default value - "search" is desired default, because the only purpose to integrate synapse with LDAP is to use it as identity provider for SSO