### PR TITLE
Fix ChatGPT container

### DIFF
--- a/roles/custom/matrix-bot-chatgpt/templates/systemd/matrix-bot-chatgpt.service.j2
+++ b/roles/custom/matrix-bot-chatgpt/templates/systemd/matrix-bot-chatgpt.service.j2
@@ -25,6 +25,7 @@ ExecStart={{ devture_systemd_docker_base_host_command_docker }} run --rm --name 
 			--network={{ matrix_docker_network }} \
 			--env-file={{ matrix_bot_chatgpt_config_path }}/env \
 			--mount type=bind,src={{ matrix_bot_chatgpt_data_path }},dst=/data \
+			--env HOME=/data/home \
 			{% for arg in matrix_bot_chatgpt_container_extra_arguments %}
 			{{ arg }} \
 			{% endfor %}


### PR DESCRIPTION
This container needs a writable $HOME, and will fail at startup if there isn't one.

Provide one by pointing HOME to a path under the mounted /data directory.