### PR TITLE
Fix client js and css download (load compiled version)

### DIFF
--- a/roles/custom/matrix-cactus-comments/defaults/main.yml
+++ b/roles/custom/matrix-cactus-comments/defaults/main.yml
@@ -31,7 +31,7 @@ matrix_cactus_comments_version: 0.9.0
 matrix_cactus_comments_docker_image: "{{ matrix_container_global_registry_prefix }}cactuscomments/cactus-appservice:{{ matrix_cactus_comments_version }}"
 matrix_cactus_comments_docker_image_force_pull: "{{ matrix_cactus_comments_docker_image.endswith(':latest') }}"
 
-# The released&compiled client ist uploaded to URL that changes per commit. Therefore it is necessary to check the
+# The released & compiled client is uploaded to a URL that changes per commit. Therefore it is necessary to check the
 # available versions and adjust the url manually.
 # For available versions, see: https://gitlab.com/cactus-comments/cactus-client/-/releases
 # Also see: `matrix_cactus_comments_client_local_dir`

--- a/roles/custom/matrix-cactus-comments/defaults/main.yml
+++ b/roles/custom/matrix-cactus-comments/defaults/main.yml
@@ -31,10 +31,12 @@ matrix_cactus_comments_version: 0.9.0
 matrix_cactus_comments_docker_image: "{{ matrix_container_global_registry_prefix }}cactuscomments/cactus-appservice:{{ matrix_cactus_comments_version }}"
 matrix_cactus_comments_docker_image_force_pull: "{{ matrix_cactus_comments_docker_image.endswith(':latest') }}"
 
-# matrix_cactus_comments_client_version specifies the version of the cactus-client release to use.
+# The released&compiled client ist uploaded to URL that changes per commit. Therefore it is necessary to check the
+# available versions and adjust the url manually.
 # For available versions, see: https://gitlab.com/cactus-comments/cactus-client/-/releases
 # Also see: `matrix_cactus_comments_client_local_dir`
-matrix_cactus_comments_client_version: "0.13.0"
+matrix_cactus_comments_webclient_js_url: "https://gateway.pinata.cloud/ipfs/QmSiWN27KZZ1XE32jKwifBnS3nWTUcFGNArKzur2nmDgoL/v0.13.0/cactus.js"
+matrix_cactus_comments_webclient_css_url: "https://gateway.pinata.cloud/ipfs/QmSiWN27KZZ1XE32jKwifBnS3nWTUcFGNArKzur2nmDgoL/v0.13.0/style.css"
 
 # matrix_cactus_comments_client_local_dir specifies a local directory (on the Ansible controller, not on the remote server) with cactus-client files to use.
 # This is an alternative to `matrix_cactus_comments_client_version`, to be used when you'd like to

--- a/roles/custom/matrix-cactus-comments/tasks/setup_install.yml
+++ b/roles/custom/matrix-cactus-comments/tasks/setup_install.yml
@@ -67,37 +67,16 @@
 
 - when: matrix_cactus_comments_client_local_dir | length == 0
   block:
-    - name: Download client binary to local folder
+    - name: Download web client js
       ansible.builtin.get_url:
-        url: "https://gitlab.com/cactus-comments/cactus-client/-/archive/v{{ matrix_cactus_comments_client_version }}/cactus-client-v{{ matrix_cactus_comments_client_version }}.tar.gz"
-        dest: "/tmp/cactus-comments-{{ matrix_cactus_comments_client_version }}.tar.gz"
-        mode: '0644'
-      register: _download_client
-      until: _download_client is succeeded
-      retries: 5
-      delay: 2
-      check_mode: false
-
-    - name: Unpack client
-      ansible.builtin.unarchive:
-        src: "/tmp/cactus-comments-{{ matrix_cactus_comments_client_version }}.tar.gz"
-        dest: "/tmp/"
-        remote_src: true
-        mode: 0600
-      check_mode: false
-
-    - name: Propagate client javascript file
-      ansible.builtin.copy:
-        src: "/tmp/cactus-client-v{{ matrix_cactus_comments_client_version }}/src/cactus.js"
-        remote_src: true
+        url: "{{ matrix_cactus_comments_webclient_js_url }}"
         dest: "{{ matrix_cactus_comments_client_path }}/cactus.js"
         mode: "{{ matrix_cactus_comments_client_file_permissions }}"
         owner: "{{ matrix_user_username }}"
         group: "{{ matrix_user_groupname }}"
-    - name: Propagate client style file
-      ansible.builtin.copy:
-        src: "/tmp/cactus-client-v{{ matrix_cactus_comments_client_version }}/src/style.css"
-        remote_src: true
+    - name: Download web client css
+      ansible.builtin.get_url:
+        url: "{{ matrix_cactus_comments_webclient_css_url }}"
         dest: "{{ matrix_cactus_comments_client_path }}/style.css"
         mode: "{{ matrix_cactus_comments_client_file_permissions }}"
         owner: "{{ matrix_user_username }}"


### PR DESCRIPTION
This is a long overdue fix that enables users to use the "real" client css and cs file. It is not as beautiful as for each updated the files must be updated individually, but that is something we can't change as cactus comments decides to distribute the client this way.

PS: Might take me a while to answer feedback on this PR