### PR TITLE
mautrix-slack: add team name in channel name template

### DIFF
--- a/roles/custom/matrix-bridge-mautrix-slack/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mautrix-slack/templates/config.yaml.j2
@@ -79,7 +79,7 @@ bridge:
     # TODO: document variables
     displayname_template: "{{ '{{.RealName}} (S)' }}"
     bot_displayname_template: "{{ '{{.Name}} (bot)' }}"
-    channel_name_template: "{{ '#{{.Name}}' }}"
+    channel_name_template: "{{ '#{{.Name}} ({{.TeamName}})' }}"
 
     portal_message_buffer: 128
 


### PR DESCRIPTION
Supported since PR mautrix/slack/pull/13 