### PR TITLE
Update Prometheus to v2.42.0 from v2.41.0

### DIFF
--- a/roles/custom/matrix-prometheus/defaults/main.yml
+++ b/roles/custom/matrix-prometheus/defaults/main.yml
@@ -5,7 +5,7 @@
 
 matrix_prometheus_enabled: false
 
-matrix_prometheus_version: v2.41.0
+matrix_prometheus_version: v2.42.0
 matrix_prometheus_docker_image: "{{ matrix_container_global_registry_prefix }}prom/prometheus:{{ matrix_prometheus_version }}"
 matrix_prometheus_docker_image_force_pull: "{{ matrix_prometheus_docker_image.endswith(':latest') }}"
 


### PR DESCRIPTION
Docker images are released now so this change can now be pushed.