### PR TITLE
fix: only add element related entries to client well-known if element is enabled

### DIFF
--- a/roles/custom/matrix-base/defaults/main.yml
+++ b/roles/custom/matrix-base/defaults/main.yml
@@ -170,7 +170,7 @@ matrix_well_known_matrix_client_io_element_e2ee_secure_backup_setup_methods: []
 # `matrix_well_known_matrix_client_io_element_e2ee_secure_backup_required`
 # `matrix_well_known_matrix_client_io_element_e2ee_secure_backup_setup_methods`
 matrix_well_known_matrix_client_io_element_e2ee_entries_enabled: "{{ not matrix_well_known_matrix_client_io_element_e2ee_default or matrix_well_known_matrix_client_io_element_e2ee_secure_backup_required or matrix_well_known_matrix_client_io_element_e2ee_secure_backup_setup_methods | length > 0 }}"
-ta
+
 # Default `/.well-known/matrix/client` configuration - it covers the generic use case.
 # You can customize it by controlling the various variables inside the template file that it references.
 #

--- a/roles/custom/matrix-base/defaults/main.yml
+++ b/roles/custom/matrix-base/defaults/main.yml
@@ -151,18 +151,26 @@ matrix_client_element_jitsi_preferredDomain: ''  # noqa var-naming
 # Controls whether Element should use End-to-End Encryption by default.
 # Setting this to false will update `/.well-known/matrix/client` and tell Element clients to avoid E2EE.
 # See: https://github.com/vector-im/element-web/blob/develop/docs/e2ee.md
-matrix_client_element_e2ee_default: true
+matrix_well_known_matrix_client_io_element_e2ee_default: true
 
 # Controls whether Element should require a secure backup set up before Element can be used.
 # Setting this to true will update `/.well-known/matrix/client` and tell Element require a secure backup.
 # See: https://github.com/vector-im/element-web/blob/develop/docs/e2ee.md
-matrix_client_element_e2ee_secure_backup_required: false
+matrix_well_known_matrix_client_io_element_e2ee_secure_backup_required: false
 
 # Controls which backup methods from ["key", "passphrase"] should be used, both is the default.
 # Setting this to other then empty will update `/.well-known/matrix/client` and tell Element which method to use
 # See: https://github.com/vector-im/element-web/blob/develop/docs/e2ee.md
-matrix_client_element_e2ee_secure_backup_setup_methods: []
+matrix_well_known_matrix_client_io_element_e2ee_secure_backup_setup_methods: []
 
+# Controls whether element related entries should be added to the client well-known. Override this to false to hide
+# element related well-known entries.
+# By default if any of the following change from their default this is set to true:
+# `matrix_well_known_matrix_client_io_element_e2ee_default`
+# `matrix_well_known_matrix_client_io_element_e2ee_secure_backup_required`
+# `matrix_well_known_matrix_client_io_element_e2ee_secure_backup_setup_methods`
+matrix_well_known_matrix_client_io_element_e2ee_entries_enabled: "{{ not matrix_well_known_matrix_client_io_element_e2ee_default or matrix_well_known_matrix_client_io_element_e2ee_secure_backup_required or matrix_well_known_matrix_client_io_element_e2ee_secure_backup_setup_methods | length > 0 }}"
+ta
 # Default `/.well-known/matrix/client` configuration - it covers the generic use case.
 # You can customize it by controlling the various variables inside the template file that it references.
 #

--- a/roles/custom/matrix-base/tasks/validate_config.yml
+++ b/roles/custom/matrix-base/tasks/validate_config.yml
@@ -18,6 +18,9 @@
     - {'old': 'hostname_riot', 'new': 'matrix_server_fqn_element'}
     - {'old': 'matrix_server_fqn_riot', 'new': 'matrix_server_fqn_element'}
     - {'old': 'matrix_local_bin_path', 'new': '<there is no global bin path anymore - each role has its own>'}
+    - {'old': 'matrix_client_element_e2ee_default', 'new': 'matrix_well_known_matrix_client_io_element_e2ee_default'}
+    - {'old': 'matrix_client_element_e2ee_secure_backup_required', 'new': 'matrix_well_known_matrix_client_io_element_e2ee_secure_backup_required'}
+    - {'old': 'matrix_client_element_e2ee_secure_backup_setup_methods', 'new': 'matrix_well_known_matrix_client_io_element_e2ee_secure_backup_setup_methods'}
 
 # We have a dedicated check for this variable, because we'd like to have a custom (friendlier) message.
 - name: Fail if matrix_homeserver_generic_secret_key is undefined

--- a/roles/custom/matrix-base/templates/static-files/well-known/matrix-client.j2
+++ b/roles/custom/matrix-base/templates/static-files/well-known/matrix-client.j2
@@ -31,13 +31,14 @@
         "map_style_url": "https://{{ matrix_server_fqn_element }}/map_style.json"
     }
 	{% endif %}
-	,
+	{% if matrix_well_known_matrix_client_io_element_e2ee_entries_enabled %},
 	"io.element.e2ee": {
-		"default": {{ matrix_client_element_e2ee_default|to_json }},
-		"secure_backup_required": {{ matrix_client_element_e2ee_secure_backup_required|to_json }},
-		"secure_backup_setup_methods": {{ matrix_client_element_e2ee_secure_backup_setup_methods|to_json }}
+		"default": {{ matrix_well_known_matrix_client_io_element_e2ee_default|to_json }},
+		"secure_backup_required": {{ matrix_well_known_matrix_client_io_element_e2ee_secure_backup_required|to_json }},
+		"secure_backup_setup_methods": {{ matrix_well_known_matrix_client_io_element_e2ee_secure_backup_setup_methods|to_json }}
 	},
+	{% if matrix_well_known_matrix_client_io_element_e2ee_entries_enabled %},
 	"im.vector.riot.e2ee": {
-		"default": {{ matrix_client_element_e2ee_default|to_json }}
+		"default": {{ matrix_well_known_matrix_client_io_element_e2ee_default|to_json }}
 	}
 }


### PR DESCRIPTION
As the title says, only add element related entries to client well-known if element is enabled.