### PR TITLE
Fix formating error in Draupnir docs

### DIFF
--- a/docs/configuring-playbook-bot-draupnir.md
+++ b/docs/configuring-playbook-bot-draupnir.md
@@ -81,7 +81,7 @@ matrix_bot_draupnir_management_room: "ROOM_ID_FROM_STEP_4_GOES_HERE"
 
 ## 5b. Migrating from Mjolnir (Only required if migrating.)
 
-Replace your matrix_bot_mjolnir config with matrix_bot_draupnir config. Also disable mjolnir if you're doing migration.
+Replace your `matrix_bot_mjolnir` config with `matrix_bot_draupnir` config. Also disable mjolnir if you're doing migration.
 That is all you need to do due to that Draupnir can complete migration on its own.
 
 ## 6. Installing


### PR DESCRIPTION
A small formating error managed to sneak its way past our review in the Draupnir docs. So this PR fixes it. 