### PR TITLE
Fix Dimension,Mjolnir and Drapunir crashing upon startup just to recover. 

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -187,9 +187,9 @@ devture_systemd_service_manager_services_list_auto: |
     +
     ([{'name': 'matrix-bot-maubot.service', 'priority': 2200, 'groups': ['matrix', 'bots', 'maubot']}] if matrix_bot_maubot_enabled else [])
     +
-    ([{'name': 'matrix-bot-mjolnir.service', 'priority': 2200, 'groups': ['matrix', 'bots', 'mjolnir']}] if matrix_bot_mjolnir_enabled else [])
+    ([{'name': 'matrix-bot-mjolnir.service', 'priority': 4000, 'groups': ['matrix', 'bots', 'mjolnir']}] if matrix_bot_mjolnir_enabled else [])
     +
-    ([{'name': 'matrix-bot-draupnir.service', 'priority': 2200, 'groups': ['matrix', 'bots', 'draupnir']}] if matrix_bot_draupnir_enabled else [])
+    ([{'name': 'matrix-bot-draupnir.service', 'priority': 4000, 'groups': ['matrix', 'bots', 'draupnir']}] if matrix_bot_draupnir_enabled else [])
     +
     ([{'name': 'matrix-bot-postmoogle.service', 'priority': 2200, 'groups': ['matrix', 'bots', 'postmoogle']}] if matrix_bot_postmoogle_enabled else [])
     +
@@ -267,7 +267,7 @@ devture_systemd_service_manager_services_list_auto: |
     +
     ([{'name': 'matrix-coturn-reload.timer', 'priority': 5000, 'groups': ['matrix', 'coturn']}] if (matrix_coturn_enabled and matrix_coturn_tls_enabled) else [])
     +
-    ([{'name': 'matrix-dimension.service', 'priority': 2500, 'groups': ['matrix', 'integration-managers', 'dimension']}] if matrix_dimension_enabled else [])
+    ([{'name': 'matrix-dimension.service', 'priority': 4000, 'groups': ['matrix', 'integration-managers', 'dimension']}] if matrix_dimension_enabled else [])
     +
     ([{'name': 'matrix-dynamic-dns.service', 'priority': 5000, 'groups': ['matrix', 'dynamic-dns']}] if matrix_dynamic_dns_enabled else [])
     +


### PR DESCRIPTION
Dimension,Mjolnir and Drapunir all crash if they lack HS connectivity upon startup. For mjolnir this was "fixed" with the introduction of a potentially very BAD flaw and therefore its recomended in some circles to stick to 1.6.1 or move to Drapunir that does not have the flaw. Dimension also has this behavior but unknown if its intentional like Mjolnir pre 1.6.2 or like Drapunir where its intentionally kept. All these services will recover smoothly after HS connectivity is established. By moving the priority to a higher value this should make it so we start these services later in the chain allowing the full proxy chain to start if using the intregrated proxy. If using an external proxy and only using the Helper if running Synapse this issue is mittigated but i think we should not only support these users. 

This PR is made using assumptions about how the start order works in the playbook taken from the Traffeik branch and just inline documentation. 