### PR TITLE
Upgrade Drapunir from 1.8.0 Beta to 1.8.0 release.

### DIFF
--- a/roles/custom/matrix-bot-draupnir/defaults/main.yml
+++ b/roles/custom/matrix-bot-draupnir/defaults/main.yml
@@ -4,7 +4,7 @@
 
 matrix_bot_draupnir_enabled: true
 
-matrix_bot_draupnir_version: "v1.80.0-beta.0"
+matrix_bot_draupnir_version: "v1.80.0"
 
 matrix_bot_draupnir_container_image_self_build: false
 matrix_bot_draupnir_container_image_self_build_repo: "https://github.com/Gnuxie/Draupnir.git"


### PR DESCRIPTION
https://github.com/Gnuxie/Draupnir/releases/tag/v1.80.0

Docker Image built and ready to go. Since Mjolnir did not build for ARM Draupnir does not either so we dont have to wait for ARM images. 