### PR TITLE
update postmoogle 0.9.13 -> 0.9.14

### DIFF
--- a/roles/custom/matrix-bot-postmoogle/defaults/main.yml
+++ b/roles/custom/matrix-bot-postmoogle/defaults/main.yml
@@ -9,7 +9,7 @@ matrix_bot_postmoogle_docker_repo: "https://gitlab.com/etke.cc/postmoogle.git"
 matrix_bot_postmoogle_docker_repo_version: "{{ 'main' if matrix_bot_postmoogle_version == 'latest' else matrix_bot_postmoogle_version }}"
 matrix_bot_postmoogle_docker_src_files_path: "{{ matrix_base_data_path }}/postmoogle/docker-src"
 
-matrix_bot_postmoogle_version: v0.9.13
+matrix_bot_postmoogle_version: v0.9.14
 matrix_bot_postmoogle_docker_image: "{{ matrix_bot_postmoogle_docker_image_name_prefix }}etke.cc/postmoogle:{{ matrix_bot_postmoogle_version }}"
 matrix_bot_postmoogle_docker_image_name_prefix: "{{ 'localhost/' if matrix_bot_postmoogle_container_image_self_build else 'registry.gitlab.com/' }}"
 matrix_bot_postmoogle_docker_image_force_pull: "{{ matrix_bot_postmoogle_docker_image.endswith(':latest') }}"


### PR DESCRIPTION
* make banlist consistent
* proper multi-error message
* ignore "." MX hosts
* try recipient domain directly, even when MX records found, but failed

**Warning**: [CI pipeline is in progress](https://gitlab.com/etke.cc/postmoogle/-/pipelines/777596940)