### PR TITLE
Fixed issue to allow coturn to use host networking

### DIFF
--- a/roles/custom/matrix-coturn/tasks/setup_install.yml
+++ b/roles/custom/matrix-coturn/tasks/setup_install.yml
@@ -66,6 +66,7 @@
   community.docker.docker_network:
     name: "{{ matrix_coturn_docker_network }}"
     driver: bridge
+  when: "'host' not in matrix_coturn_docker_network"
 
 - name: Ensure matrix-coturn.service installed
   ansible.builtin.template:


### PR DESCRIPTION
Currently the playbook does not allow a user to use host networking with co-turn.

In the current playbook we cannot select host networking for co-turn as it tries to create the network named 'host' which for obvious reasons fails.

I've added a check to not create the network if a user selects the name 'host' as the co-turn network.

The reason for selecting host networking is that on large port ranges docker' userland proxy runs out of memory - see https://github.com/moby/moby/issues/11185.