### PR TITLE
Added matrix_nginx_proxy_https_enabled to the own-nginx documentation

### DIFF
--- a/docs/configuring-playbook-own-webserver.md
+++ b/docs/configuring-playbook-own-webserver.md
@@ -185,6 +185,9 @@ If you'll be using `nginx` running on the same machine (not in a container), you
 ```yaml
 matrix_playbook_reverse_proxy_type: other-nginx-non-container
 
+# If you want https configured in /matrix/nginx-proxy/conf.d/
+matrix_nginx_proxy_https_enabled: true
+
 # If you will manage SSL certificates yourself, uncomment the line below
 # matrix_ssl_retrieval_method: none
 


### PR DESCRIPTION
Without `matrix_nginx_proxy_https_enabled: true` the playbook won't generate the https related parts of `/matrix/nginx-proxy/conf.d/matrix-domain.conf`. So the Matrix Server would not be accessible over https://matirx.{base-domain}.