### PR TITLE
Update Draupnir from v1.80.0 to v1.80.1

### DIFF
--- a/roles/custom/matrix-bot-draupnir/defaults/main.yml
+++ b/roles/custom/matrix-bot-draupnir/defaults/main.yml
@@ -4,7 +4,7 @@
 
 matrix_bot_draupnir_enabled: true
 
-matrix_bot_draupnir_version: "v1.80.0"
+matrix_bot_draupnir_version: "v1.80.1"
 
 matrix_bot_draupnir_container_image_self_build: false
 matrix_bot_draupnir_container_image_self_build_repo: "https://github.com/Gnuxie/Draupnir.git"

--- a/roles/custom/matrix-bot-draupnir/templates/production.yaml.j2
+++ b/roles/custom/matrix-bot-draupnir/templates/production.yaml.j2
@@ -1,79 +1,79 @@
-# Endpoint URL that draupnir uses to interact with the matrix homeserver (client-server API),
+# Endpoint URL that Draupnir uses to interact with the matrix homeserver (client-server API),
 # set this to the pantalaimon URL if you're using that.
 homeserverUrl: "{{ matrix_homeserver_url }}"
 
-# Endpoint URL that draupnir could use to fetch events related to reports (client-server API and /_synapse/),
+# Endpoint URL that Draupnir could use to fetch events related to reports (client-server API and /_synapse/),
 # only set this to the public-internet homeserver client API URL, do NOT set this to the pantalaimon URL.
 rawHomeserverUrl: "{{ matrix_homeserver_url }}"
 
-# Matrix Access Token to use, draupnir will only use this if pantalaimon.use is false.
+# Matrix Access Token to use, Draupnir will only use this if pantalaimon.use is false.
 accessToken: "{{ matrix_bot_draupnir_access_token }}"
 
 # Options related to Pantalaimon (https://github.com/matrix-org/pantalaimon)
 #pantalaimon:
-#  # Whether or not draupnir will use pantalaimon to access the matrix homeserver,
+#  # Whether or not Draupnir will use pantalaimon to access the matrix homeserver,
 #  # set to `true` if you're using pantalaimon.
 #  #
 #  # Be sure to point homeserverUrl to the pantalaimon instance.
 #  #
-#  # draupnir will log in using the given username and password once,
+#  # Draupnir will log in using the given username and password once,
 #  # then store the resulting access token in a file under dataPath.
 #  use: false
 #
 #  # The username to login with.
 #  username: draupnir
 #
-#  # The password draupnir will login with.
+#  # The password Draupnir will login with.
 #  #
 #  # After successfully logging in once, this will be ignored, so this value can be blanked after first startup.
 #  password: your_password
 
-# The path draupnir will store its state/data in, leave default ("/data/storage") when using containers.
+# The path Draupnir will store its state/data in, leave default ("/data/storage") when using containers.
 dataPath: "/data"
 
-# If true (the default), draupnir will only accept invites from users present in managementRoom.
+# If true (the default), Draupnir will only accept invites from users present in managementRoom.
 autojoinOnlyIfManager: true
 
 # If `autojoinOnlyIfManager` is false, only the members in this space can invite
 # the bot to new rooms.
-#acceptInvitesFromSpace: "!example:example.org"
+acceptInvitesFromSpace: "!example:example.org"
 
-# Whether draupnir should report ignored invites to the management room (if autojoinOnlyIfManager is true).
+# Whether Draupnir should report ignored invites to the management room (if autojoinOnlyIfManager is true).
 recordIgnoredInvites: false
 
-# The room ID (or room alias) of the management room, anyone in this room can issue commands to draupnir.
+# The room ID (or room alias) of the management room, anyone in this room can issue commands to Draupnir.
 #
-# draupnir has no more granular access controls other than this, be sure you trust everyone in this room - secure it!
+# Draupnir has no more granular access controls other than this, be sure you trust everyone in this room - secure it!
 #
 # This should be a room alias or room ID - not a matrix.to URL.
 #
-# Note: By default, draupnir is fairly verbose - expect a lot of messages in this room.
+# Note: By default, Draupnir is fairly verbose - expect a lot of messages in this room.
 # (see verboseLogging to adjust this a bit.)
-managementRoom: "{{ matrix_bot_draupnir_management_room }}"
+managementRoom: "#moderators:example.org"
 
-# Whether draupnir should log a lot more messages in the room,
-# mainly involves "all-OK" messages, and debugging messages for when draupnir checks bans in a room.
-verboseLogging: false
+# Whether Draupnir should log a lot more messages in the room,
+# mainly involves "all-OK" messages, and debugging messages for when Draupnir checks bans in a room.
+verboseLogging: true
 
 # The log level of terminal (or container) output,
 # can be one of DEBUG, INFO, WARN and ERROR, in increasing order of importance and severity.
 #
-# This should be at INFO or DEBUG in order to get support for draupnir problems.
+# This should be at INFO or DEBUG in order to get support for Draupnir problems.
 logLevel: "INFO"
 
-# Whether or not draupnir should synchronize policy lists immediately after startup.
+# Whether or not Draupnir should synchronize policy lists immediately after startup.
 # Equivalent to running '!draupnir sync'.
 syncOnStartup: true
 
-# Whether or not draupnir should check moderation permissions in all protected rooms on startup.
+# Whether or not Draupnir should check moderation permissions in all protected rooms on startup.
 # Equivalent to running `!draupnir verify`.
 verifyPermissionsOnStartup: true
 
-# Whether or not draupnir should actually apply bans and policy lists,
+# Whether or not Draupnir should actually apply bans and policy lists,
 # turn on to trial some untrusted configuration or lists.
 noop: false
 
-# Whether draupnir should check member lists quicker (by using a different endpoint),
+# Whether Draupnir should check member lists quicker (by using a different endpoint),
 # keep in mind that enabling this will miss invited (but not joined) users.
 #
 # Turn on if your bot is in (very) large rooms, or in large amounts of rooms.
@@ -94,7 +94,7 @@ automaticallyRedactForReasons:
   - "spam"
   - "advertising"
 
-# A list of rooms to protect. draupnir will add this to the list it knows from its account data.
+# A list of rooms to protect. Draupnir will add this to the list it knows from its account data.
 #
 # It won't, however, add it to the account data.
 # Manually add the room via '!draupnir rooms add' to have it stay protected regardless if this config value changes.
@@ -116,21 +116,21 @@ automaticallyRedactForReasons:
 # Explicitly add these rooms as a protected room list if you want them protected.
 protectAllJoinedRooms: false
 
-# Increase this delay to have Mjölnir wait longer between two consecutive backgrounded
+# Increase this delay to have Draupnir wait longer between two consecutive backgrounded
 # operations. The total duration of operations will be longer, but the homeserver won't
-# be affected as much. Conversely, decrease this delay to have Mjölnir chain operations
+# be affected as much. Conversely, decrease this delay to have Draupnir chain operations
 # faster. The total duration of operations will generally be shorter, but the performance
 # of the homeserver may be more impacted.
 backgroundDelayMS: 500
 
-# Server administration commands, these commands will only work if draupnir is
+# Server administration commands, these commands will only work if Draupnir is
 # a global server administrator, and the bot's server is a Synapse instance.
-#admin:
-#  # Whether or not draupnir can temporarily take control of any eligible account from the local homeserver who's in the room
-#  # (with enough permissions) to "make" a user an admin.
-#  #
-#  # This only works if a local user with enough admin permissions is present in the room.
-#  enableMakeRoomAdminCommand: false
+admin:
+  # Whether or not Draupnir can temporarily take control of any eligible account from the local homeserver who's in the room
+  # (with enough permissions) to "make" a user an admin.
+  #
+  # This only works if a local user with enough admin permissions is present in the room.
+  enableMakeRoomAdminCommand: true
 
 # Misc options for command handling and commands
 commands:
@@ -138,19 +138,27 @@ commands:
   #
   # If `true`, will allow commands like `!ban`, `!help`, etc.
   #
-  # Note: draupnir can also be pinged by display name instead of having to use
+  # Note: Draupnir can also be pinged by display name instead of having to use
   # the !draupnir prefix. For example, "my_moderator_bot: ban @spammer:example.org"
   # will address only my_moderator_bot.
   allowNoPrefix: false
 
-  # Any additional bot prefixes that draupnir will listen to. i.e. adding `mod` will allow `!mod help`.
+  # Any additional bot prefixes that Draupnir will listen to. i.e. adding `mod` will allow `!mod help`.
   additionalPrefixes:
-    - "draupnir_bot"
+    - "draupnir-bot"
     - "draupnir"
 
   # Whether or not commands with a wildcard (*) will require an additional `--force` argument
   # in the command to be able to be submitted.
   confirmWildcardBan: true
+
+  # The default reasons to be prompted with if the reason is missing from a ban command.
+  ban:
+    defaultReasons: 
+      - "spam"
+      - "brigading"
+      - "harassment"
+      - "disagreement"
 
 # Configuration specific to certain toggle-able protections
 #protections:


### PR DESCRIPTION
Updates the config to include options from upstream for easier changes. Also by upgrading we finally get the new ban constructor working. It was broken last release and fixed due to me submitting logs from the error. This release does share the same flaw as its predecessor tho of having incorrect version string. This release calls it self `v1.80.0-5-g64e721d` and last release called it self `v1.80.0-beta.0-23-g5e2a175`