### PR TITLE
Allow configure default country code in element welcome page.

### DIFF
--- a/roles/custom/matrix-client-element/defaults/main.yml
+++ b/roles/custom/matrix-client-element/defaults/main.yml
@@ -191,6 +191,9 @@ matrix_client_element_self_check_validate_certificates: true
 # don't show the registration button on welcome page
 matrix_client_element_registration_enabled: false
 
+# Default country code on welcome page when login by phone number
+matrix_client_element_default_country_code: "GB"
+
 # Controls whether presence will be enabled
 matrix_client_element_enable_presence_by_hs_url: ~
 

--- a/roles/custom/matrix-client-element/templates/config.json.j2
+++ b/roles/custom/matrix-client-element/templates/config.json.j2
@@ -12,6 +12,7 @@
 		"custom_themes": {{ matrix_client_element_settingDefaults_custom_themes|to_json }}
 	},
 	"default_theme": {{ matrix_client_element_default_theme | string|to_json }},
+	"default_country_code": {{ matrix_client_element_default_country_code | string|to_json }},
 	"permalinkPrefix": {{ matrix_client_element_permalinkPrefix | string|to_json }},
 	"disable_custom_urls": {{ matrix_client_element_disable_custom_urls|to_json }},
 	"disable_guests": {{ matrix_client_element_disable_guests|to_json }},

--- a/roles/custom/matrix-client-element/templates/config.json.j2
+++ b/roles/custom/matrix-client-element/templates/config.json.j2
@@ -1,49 +1,49 @@
 {
 	"default_server_config": {
 		"m.homeserver": {
-			"base_url": {{ matrix_client_element_default_hs_url | string|to_json }},
-			"server_name": {{ matrix_client_element_default_server_name | string|to_json }}
+			"base_url": {{ matrix_client_element_default_hs_url | string | to_json }},
+			"server_name": {{ matrix_client_element_default_server_name | string | to_json }}
 		},
 		"m.identity_server": {
-			"base_url": {{ matrix_client_element_default_is_url | string|to_json }}
+			"base_url": {{ matrix_client_element_default_is_url | string | to_json }}
 		}
 	},
 	"settingDefaults": {
-		"custom_themes": {{ matrix_client_element_settingDefaults_custom_themes|to_json }}
+		"custom_themes": {{ matrix_client_element_settingDefaults_custom_themes | to_json }}
 	},
-	"default_theme": {{ matrix_client_element_default_theme | string|to_json }},
-	"default_country_code": {{ matrix_client_element_default_country_code | string|to_json }},
-	"permalinkPrefix": {{ matrix_client_element_permalinkPrefix | string|to_json }},
-	"disable_custom_urls": {{ matrix_client_element_disable_custom_urls|to_json }},
-	"disable_guests": {{ matrix_client_element_disable_guests|to_json }},
-	"brand": {{ matrix_client_element_brand|to_json }},
-	"integrations_ui_url": {{ matrix_client_element_integrations_ui_url | string|to_json }},
-	"integrations_rest_url": {{ matrix_client_element_integrations_rest_url | string|to_json }},
-	"integrations_widgets_urls": {{ matrix_client_element_integrations_widgets_urls|to_json }},
-	"integrations_jitsi_widget_url": {{ matrix_client_element_integrations_jitsi_widget_url | string|to_json }},
-	"bug_report_endpoint_url": {{ matrix_client_element_bug_report_endpoint_url|to_json }},
-	"showLabsSettings": {{ matrix_client_element_showLabsSettings|to_json }},
+	"default_theme": {{ matrix_client_element_default_theme | string | to_json }},
+	"default_country_code": {{ matrix_client_element_default_country_code | string | to_json }},
+	"permalinkPrefix": {{ matrix_client_element_permalinkPrefix | string | to_json }},
+	"disable_custom_urls": {{ matrix_client_element_disable_custom_urls | to_json }},
+	"disable_guests": {{ matrix_client_element_disable_guests | to_json }},
+	"brand": {{ matrix_client_element_brand | to_json }},
+	"integrations_ui_url": {{ matrix_client_element_integrations_ui_url | string | to_json }},
+	"integrations_rest_url": {{ matrix_client_element_integrations_rest_url | string | to_json }},
+	"integrations_widgets_urls": {{ matrix_client_element_integrations_widgets_urls | to_json }},
+	"integrations_jitsi_widget_url": {{ matrix_client_element_integrations_jitsi_widget_url | string | to_json }},
+	"bug_report_endpoint_url": {{ matrix_client_element_bug_report_endpoint_url | to_json }},
+	"showLabsSettings": {{ matrix_client_element_showLabsSettings | to_json }},
 	"roomDirectory": {
-		"servers": {{ matrix_client_element_roomdir_servers|to_json }}
+		"servers": {{ matrix_client_element_roomdir_servers | to_json }}
 	},
-	"welcomeUserId": {{ matrix_client_element_welcome_user_id|to_json }},
+	"welcomeUserId": {{ matrix_client_element_welcome_user_id | to_json }},
 	{% if matrix_client_element_enable_presence_by_hs_url is not none %}
-		"enable_presence_by_hs_url": {{ matrix_client_element_enable_presence_by_hs_url|to_json }},
+		"enable_presence_by_hs_url": {{ matrix_client_element_enable_presence_by_hs_url | to_json }},
 	{% endif %}
 	"embeddedPages": {
-		"homeUrl": {{ matrix_client_element_embedded_pages_home_url | string|to_json }}
+		"homeUrl": {{ matrix_client_element_embedded_pages_home_url | string | to_json }}
 	},
 	{% if matrix_client_element_jitsi_preferredDomain %}
 	"jitsi": {
-        "preferredDomain": {{ matrix_client_element_jitsi_preferredDomain|to_json }}
+        "preferredDomain": {{ matrix_client_element_jitsi_preferredDomain | to_json }}
     },
 	{% endif %}
 	{% if matrix_client_element_location_sharing_enabled %}
 	"map_style_url": "https://{{ matrix_server_fqn_element }}/map_style.json",
 	{% endif %}
 	"branding": {
-		"authFooterLinks": {{ matrix_client_element_branding_authFooterLinks|to_json }},
-		"authHeaderLogoUrl": {{ matrix_client_element_branding_authHeaderLogoUrl|to_json }},
-		"welcomeBackgroundUrl": {{ matrix_client_element_branding_welcomeBackgroundUrl|to_json }}
+		"authFooterLinks": {{ matrix_client_element_branding_authFooterLinks | to_json }},
+		"authHeaderLogoUrl": {{ matrix_client_element_branding_authHeaderLogoUrl | to_json }},
+		"welcomeBackgroundUrl": {{ matrix_client_element_branding_welcomeBackgroundUrl | to_json }}
 	}
 }


### PR DESCRIPTION
Element web client has ability to set default phone country code to use when login via phone number. By default it is 'GB' but can be changed by setting ['default_country_code'](https://github.com/vector-im/element-web/blob/a26be2665fc1ba55842a613a154cddab5bdb32e6/docs/config.md#default-settings) in 'config.json'. So I've added a new variable to configure it when needed.