### PR TITLE
Fix documentation when fronting traefik with another reverse proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ At some point in the **near** future (days, or even weeks at most), we hope to c
 
 ### How do I keep using my own other reverse-proxy?
 
-We recommend that you follow the guide for [Fronting the integraed reverse-proxy webserver with another reverse-proxy](docs/configuring-playbook-own-webserver.md#fronting-the-integrated-reverse-proxy-webserver-with-another-reverse-proxy).
+We recommend that you follow the guide for [Fronting the integrated reverse-proxy webserver with another reverse-proxy](docs/configuring-playbook-own-webserver.md#fronting-the-integrated-reverse-proxy-webserver-with-another-reverse-proxy).
 
 
 # 2023-02-25

--- a/docs/configuring-playbook-own-webserver.md
+++ b/docs/configuring-playbook-own-webserver.md
@@ -138,8 +138,8 @@ devture_traefik_container_web_host_bind_port: '127.0.0.1:81'
 
 devture_traefik_additional_entrypoints_auto:
   - name: matrix-federation
-    port: "{{ matrix_federation_public_port }}"
-    host_bind_port: "127.0.0.1:{{ matrix_federation_public_port }}"
+    port: 8449
+    host_bind_port: '127.0.0.1:8449'
     config: {}
 ```
 


### PR DESCRIPTION
The old docs would lead to a port collision because both the traefik container as well as the fronting reverse proxy would try to bind to port 8448.

The old documentation for the nginx proxy used port 8449 as the local bind port so I added that one to the traefik documentation as well.