### PR TITLE
remove devture services in remove-all script

### DIFF
--- a/roles/custom/matrix-base/templates/bin/remove-all.j2
+++ b/roles/custom/matrix-base/templates/bin/remove-all.j2
@@ -21,6 +21,13 @@ else
 		rm -f {{ devture_systemd_docker_base_systemd_path }}/$s
 	done
 
+    echo "Stop and remove devture services"
+
+	for s in $(find {{ devture_systemd_docker_base_systemd_path }}/ -type f -name "devture-*" -printf "%f\n"); do
+		systemctl disable --now $s
+		rm -f {{ devture_systemd_docker_base_systemd_path }}/$s
+	done
+
 	systemctl daemon-reload
 
 	echo "Remove unused Docker images and resources"


### PR DESCRIPTION
Currently the `remove-all.j2` script (or `/matrix/bin/remove-all`) removes all matrix systemd services but leaves `devture-traefik.service`. If more devture services are added in the future they will also be left running.