### PR TITLE
Set Traefik base path

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -3781,6 +3781,8 @@ matrix_user_verification_service_uvs_auth_token: "{{ '%s' | format(matrix_homese
 # See the comment there for more details about why we have both `devture_traefik_enabled` and `matrix_playbook_traefik_role_enabled`.
 devture_traefik_enabled: "{{ matrix_playbook_reverse_proxy_type == 'playbook-managed-traefik' }}"
 
+devture_traefik_base_path: "{{ matrix_base_data_path }}/traefik"
+
 devture_traefik_uid: "{{ matrix_user_uid }}"
 devture_traefik_gid: "{{ matrix_user_gid }}"
 


### PR DESCRIPTION
set Traefik's base path to be in the matrix base path tree. This is in alignment with all other roles' data paths