### PR TITLE
Define missing matrix_bot_go_neb_identifier variable

### DIFF
--- a/roles/custom/matrix-bot-go-neb/defaults/main.yml
+++ b/roles/custom/matrix-bot-go-neb/defaults/main.yml
@@ -5,6 +5,8 @@
 
 matrix_bot_go_neb_enabled: true
 
+matrix_bot_go_neb_identifier: 'go-neb-bot'
+
 matrix_bot_go_neb_version: latest
 
 matrix_bot_go_neb_scheme: https


### PR DESCRIPTION
The playbook complained about a missing `matrix_bot_go_neb_identifier` variable when switching to `playbook-managed-traefik`. I hope this single line is the intended way to define it (in analogy to corresponding variables of other roles, though there usually seems to be another one in `group_vars/matrix_servers`). At least the setup works again now.