### PR TITLE
Bump ChatGPT version and add new config settings

### DIFF
--- a/roles/custom/matrix-bot-chatgpt/defaults/main.yml
+++ b/roles/custom/matrix-bot-chatgpt/defaults/main.yml
@@ -9,7 +9,7 @@ matrix_bot_chatgpt_docker_repo: "https://github.com/matrixgpt/matrix-chatgpt-bot
 matrix_bot_chatgpt_docker_repo_version: "{{ 'latest' if matrix_bot_chatgpt_version == 'latest' else matrix_bot_chatgpt_version }}"
 matrix_bot_chatgpt_docker_src_files_path: "{{ matrix_base_data_path }}/chatgpt/docker-src"
 
-matrix_bot_chatgpt_version: 2.2.1
+matrix_bot_chatgpt_version: 3.0.0
 matrix_bot_chatgpt_docker_image: "{{ matrix_bot_chatgpt_docker_image_name_prefix }}matrixgpt/matrix-chatgpt-bot:{{ matrix_bot_chatgpt_version }}"
 matrix_bot_chatgpt_docker_image_name_prefix: "{{ 'localhost/' if matrix_bot_chatgpt_container_image_self_build else 'ghcr.io/' }}"
 matrix_bot_chatgpt_docker_image_force_pull: "{{ matrix_bot_chatgpt_docker_image.endswith(':latest') }}"
@@ -29,6 +29,7 @@ matrix_bot_chatgpt_systemd_wanted_services_list: []
 
 # ChatGPT Settings
 matrix_bot_chatgpt_openai_api_key: ''
+matrix_bot_chatgpt_api_model: 'gpt-3.5-turbo'
 matrix_bot_chatgpt_context: 'thread'  # CHATGPT_CONTEXT="thread"
 
 matrix_bot_chatgpt_keyv_backend: 'file'

--- a/roles/custom/matrix-bot-chatgpt/templates/env.j2
+++ b/roles/custom/matrix-bot-chatgpt/templates/env.j2
@@ -3,6 +3,7 @@ MATRIX_ACCESS_TOKEN={{ matrix_bot_chatgpt_matrix_access_token }}
 
 OPENAI_API_KEY={{ matrix_bot_chatgpt_openai_api_key }}
 CHATGPT_CONTEXT={{ matrix_bot_chatgpt_context }}
+CHATGPT_API_MODEL={{ matrix_bot_chatgpt_api_model }}
 
 KEYV_BACKEND={{ matrix_bot_chatgpt_keyv_backend }}
 KEYV_URL={{ matrix_bot_chatgpt_keyv_url }}


### PR DESCRIPTION
OpenAI changed the model a month ago and broke the bot. This bump fixes it and adds the default model.