### PR TITLE
add database for Dendrite's relay API - fixes #2571

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -2742,6 +2742,10 @@ devture_postgres_managed_databases_auto: |
       'username': matrix_dendrite_database_user,
       'password': matrix_dendrite_database_password,
     },{
+      'name': matrix_dendrite_relay_api_database,
+      'username': matrix_dendrite_relay_api_user,
+      'password': matrix_dendrite_relay_api_password,
+    },{
       'name': matrix_dendrite_push_server_database,
       'username': matrix_dendrite_database_user,
       'password': matrix_dendrite_database_password,

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -2743,8 +2743,8 @@ devture_postgres_managed_databases_auto: |
       'password': matrix_dendrite_database_password,
     },{
       'name': matrix_dendrite_relay_api_database,
-      'username': matrix_dendrite_relay_api_user,
-      'password': matrix_dendrite_relay_api_password,
+      'username': matrix_dendrite_database_user,
+      'password': matrix_dendrite_database_password,
     },{
       'name': matrix_dendrite_push_server_database,
       'username': matrix_dendrite_database_user,

--- a/roles/custom/matrix-dendrite/defaults/main.yml
+++ b/roles/custom/matrix-dendrite/defaults/main.yml
@@ -157,6 +157,7 @@ matrix_dendrite_room_database: "dendrite_room"
 matrix_dendrite_sync_api_database: "dendrite_syncapi"
 matrix_dendrite_user_api_database: "dendrite_userapi"
 matrix_dendrite_push_server_database: "dendrite_pushserver"
+matrix_dendrite_relay_api_database: "dendrite_relayapi"
 matrix_dendrite_mscs_database: "dendrite_mscs"
 
 matrix_dendrite_client_api_turn_uris: []

--- a/roles/custom/matrix-dendrite/tasks/validate_config.yml
+++ b/roles/custom/matrix-dendrite/tasks/validate_config.yml
@@ -33,4 +33,5 @@
     - {'old': 'matrix_dendrite_userapi_auto_join_rooms', 'new': 'matrix_dendrite_user_api_auto_join_rooms'}
     - {'old': 'matrix_dendrite_federationapi_database', 'new': 'matrix_dendrite_federation_api_database'}
     - {'old': 'matrix_dendrite_pushserver_database', 'new': 'matrix_dendrite_push_server_database'}
+    - {'old': 'matrix_dendrite_relayapi_database', 'new': 'matrix_dendrite_relay_api_database'}
     - {'old': 'matrix_dendrite_keyserver_database', 'new': 'matrix_dendrite_key_server_database'}

--- a/roles/custom/matrix-dendrite/templates/dendrite/dendrite.yaml.j2
+++ b/roles/custom/matrix-dendrite/templates/dendrite/dendrite.yaml.j2
@@ -399,6 +399,12 @@ push_server:
     max_idle_conns: 2
     conn_max_lifetime: -1
 
+#
+#
+relay_api:
+  database:
+    connection_string: {{ matrix_dendrite_database_str }}/{{ matrix_dendrite_relay_api_database }}?sslmode=disable
+
 # Configuration for Opentracing.
 # See https://github.com/matrix-org/dendrite/tree/master/docs/tracing for information on
 # how this works and how to set it up.


### PR DESCRIPTION
Dendrite added a new API, `relay_api`, which requires a new database.
fixes: #2571
related: #2567 