### PR TITLE
Add ability to disable password auth

### DIFF
--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -371,6 +371,11 @@ matrix_synapse_auto_join_rooms: []
 # automatically if they don't already exist.
 matrix_synapse_autocreate_auto_join_rooms: true
 
+# Controls whether password authentication is allowed
+# It may be useful when you've configured OAuth, SAML or CAS and want authentication
+# to happen only through them
+matrix_synapse_password_config_enabled: true
+
 # Controls password-peppering for Synapse. Not to be changed after initial setup.
 matrix_synapse_password_config_pepper: ""
 

--- a/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -2241,7 +2241,7 @@ sso:
 password_config:
    # Uncomment to disable password login
    #
-   #enabled: false
+   enabled: {{ matrix_synapse_password_config_enabled|to_json }}
 
    # Uncomment to disable authentication against the local password
    # database. This is ignored if `enabled` is false, and is only useful


### PR DESCRIPTION
When you've configured SSO, it may be useful to disable password authentication to only allow users to connect through it.

Note: I did commit through Github UI, it may be preferable to squash when merging