### PR TITLE
fix(traefik): Ignore federation endpoint if entrypoint with port already exists

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -4106,11 +4106,16 @@ devture_traefik_base_path: "{{ matrix_base_data_path }}/traefik"
 devture_traefik_uid: "{{ matrix_user_uid }}"
 devture_traefik_gid: "{{ matrix_user_gid }}"
 
-devture_traefik_additional_entrypoints_auto:
-  - name: matrix-federation
-    port: "{{ matrix_federation_public_port }}"
-    host_bind_port: "{{ matrix_federation_public_port }}"
-    config: {}
+devture_traefik_federation_entrypoint:
+  name: matrix-federation
+  port: "{{ matrix_federation_public_port }}"
+  host_bind_port: "{{ matrix_federation_public_port }}"
+  config: {}
+
+devture_traefik_additional_entrypoints_auto: |
+  {{
+    ([devture_traefik_federation_entrypoint] if (matrix_federation_public_port != devture_traefik_config_entrypoint_web_port) and (matrix_federation_public_port != devture_traefik_config_entrypoint_web_secure_port) else [])
+  }}
 
 devture_traefik_additional_domains_to_obtain_certificates_for: "{{ matrix_ssl_additional_domains_to_obtain_certificates_for }}"
 


### PR DESCRIPTION
## Current Behavior
Docker binds ports `devture_traefik_config_entrypoint_web_port` (80), `devture_traefik_config_entrypoint_web_secure_port` (443), and `matrix_federation_public_port` (8448) for Traefik,
If `matrix_federation_public_port` is set to 443, docker attempts to bind to 443 twice and consequently fails.

## Expected Behavior
`matrix_federation_public_port` is bound only if it is not set to `devture_traefik_config_entrypoint_web_port` and `devture_traefik_config_entrypoint_web_secure_port`.
This way, Traefik uses the existing entrypoint.