### PR TITLE
Removing warning that no longer applies

### DIFF
--- a/docs/configuring-playbook-synapse.md
+++ b/docs/configuring-playbook-synapse.md
@@ -42,8 +42,6 @@ devture_postgres_process_extra_arguments: [
 ]
 ```
 
-**NOTE**: Disabling `matrix-nginx-proxy` (`matrix_nginx_proxy_enabled: false`) (that is, [using your own other webserver](configuring-playbook-own-webserver.md) when running a Synapse worker setup is likely to cause various troubles (see [this issue](https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/2090)).
-
 In case any problems occur, make sure to have a look at the [list of synapse issues about workers](https://github.com/matrix-org/synapse/issues?q=workers+in%3Atitle) and your `journalctl --unit 'matrix-*'`.
 
 


### PR DESCRIPTION
Please review, I believe this note in the docs is no longer necessary. This was added in https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/05819056bc16b7e5ba2e75060bf1e9dcb003f999 but this PR is not a complete revert of that commit. There used to be another note, but I don't know if it should be re-added ? I let you check.

----


Similar to:
https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/362954aeab35398e3cd6cd5e735f3fade338b022

This warning was added because of:
https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/2090

The problem has since been fixed by:
https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/e9e84341a91fb0013469d74ee8c88c2edb5ad3a5

This current patch was provoked by:
https://github.com/spantaleev/matrix-docker-ansible-deploy/pull/2352