### PR TITLE
Update configuring-playbook-synapse.md

### DIFF
--- a/docs/configuring-playbook-synapse.md
+++ b/docs/configuring-playbook-synapse.md
@@ -117,3 +117,10 @@ matrix_synapse_container_image_customizations_templates_git_repository_ssh_priva
 
 As mentioned in Synapse's Templates documentation, Synapse will fall back to its own templates if a template is not found in that directory.
 Due to this, it's recommended to only store and maintain template files in your repository if you need to make custom changes. Other files (which you don't need to change), should not be duplicated, so that you don't need to worry about getting out-of-sync with the original Synapse templates.
+
+
+## Monitoring Synapse Metrics with Prometheus and Grafana
+
+This playbook allows you to enable Synapse metrics, which can provide insight into the performance and activity of Synapse.
+
+To enable Synapse metrics see [`configuring-playbook-prometheus-grafana.md`](./configuring-playbook-prometheus-grafana.md)


### PR DESCRIPTION
This change adds a section that lets the reader know that it is possible to enable synapse metrics and references the relevant documentation.

It aims to be short and concise, leaving the specifics to the referenced documentation, while still giving the reader a good idea of what it is and what it is for.