### PR TITLE
Fix recaptcha vars ansible-vault compatibility

### DIFF
--- a/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -1223,12 +1223,12 @@ oembed:
 # This homeserver's ReCAPTCHA public key. Must be specified if
 # enable_registration_captcha is enabled.
 #
-recaptcha_public_key: {{ matrix_synapse_recaptcha_public_key|to_json }}
+recaptcha_public_key: {{ matrix_synapse_recaptcha_public_key|string|to_json }}
 
 # This homeserver's ReCAPTCHA private key. Must be specified if
 # enable_registration_captcha is enabled.
 #
-recaptcha_private_key: {{ matrix_synapse_recaptcha_private_key|to_json }}
+recaptcha_private_key: {{ matrix_synapse_recaptcha_private_key|string|to_json }}
 
 # Uncomment to enable ReCaptcha checks when registering, preventing signup
 # unless a captcha is answered. Requires a valid ReCaptcha


### PR DESCRIPTION
Without conversion to string vault encrypted variables doesn't decrypt
Same conversion is used for database password https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2#L864