### PR TITLE
Add support for backup LDAP servers

### DIFF
--- a/docs/configuring-playbook-ldap-auth.md
+++ b/docs/configuring-playbook-ldap-auth.md
@@ -8,7 +8,9 @@ If you decide that you'd like to let this playbook install it for you, you need 
 
 ```yaml
 matrix_synapse_ext_password_provider_ldap_enabled: true
-matrix_synapse_ext_password_provider_ldap_uri: "ldap://ldap.mydomain.tld:389"
+matrix_synapse_ext_password_provider_ldap_uri: 
+  - "ldap://ldap-01.mydomain.tld:389"
+  - "ldap://ldap-02.mydomain.tld:389"
 matrix_synapse_ext_password_provider_ldap_start_tls: true
 matrix_synapse_ext_password_provider_ldap_base: "ou=users,dc=example,dc=com"
 matrix_synapse_ext_password_provider_ldap_attributes_uid: "uid"

--- a/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -2515,10 +2515,7 @@ password_providers:
     config:
       enabled: true
       mode: {{ matrix_synapse_ext_password_provider_ldap_mode | string | to_json }}
-      uri:
-      {% for key in matrix_synapse_ext_password_provider_ldap_uri %}
-          - {{ key | string | to_json }}
-      {% endfor %}
+      uri: {{ matrix_synapse_ext_password_provider_ldap_uri | to_json }}
       start_tls: {{ matrix_synapse_ext_password_provider_ldap_start_tls|to_json }}
       base: {{ matrix_synapse_ext_password_provider_ldap_base | string|to_json }}
       active_directory: {{ matrix_synapse_ext_password_provider_ldap_active_directory|to_json }}

--- a/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -2515,7 +2515,10 @@ password_providers:
     config:
       enabled: true
       mode: {{ matrix_synapse_ext_password_provider_ldap_mode | string | to_json }}
-      uri: {{ matrix_synapse_ext_password_provider_ldap_uri | string|to_json }}
+      uri:
+      {% for key in matrix_synapse_ext_password_provider_ldap_uri %}
+          - {{ key | string | to_json }}
+      {% endfor %}
       start_tls: {{ matrix_synapse_ext_password_provider_ldap_start_tls|to_json }}
       base: {{ matrix_synapse_ext_password_provider_ldap_base | string|to_json }}
       active_directory: {{ matrix_synapse_ext_password_provider_ldap_active_directory|to_json }}


### PR DESCRIPTION
This commit enables [matrix-synapse-ldap3](https://github.com/matrix-org/matrix-synapse-ldap3) to support N-number of backup servers, according to their documentation "[the]  first available server is used"

