### PR TITLE
Update signald version

### DIFF
--- a/roles/custom/matrix-bridge-mautrix-signal/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-signal/defaults/main.yml
@@ -10,7 +10,7 @@ matrix_mautrix_signal_docker_repo_version: "{{ 'master' if matrix_mautrix_signal
 matrix_mautrix_signal_docker_src_files_path: "{{ matrix_base_data_path }}/mautrix-signal/docker-src"
 
 matrix_mautrix_signal_version: v0.4.2
-matrix_mautrix_signal_daemon_version: 0.23.1
+matrix_mautrix_signal_daemon_version: 0.23.2
 # See: https://mau.dev/mautrix/signal/container_registry
 matrix_mautrix_signal_docker_image: "{{ matrix_mautrix_signal_docker_image_name_prefix }}mautrix/signal:{{ matrix_mautrix_signal_version }}"
 matrix_mautrix_signal_docker_image_name_prefix: "{{ 'localhost/' if matrix_mautrix_signal_container_image_self_build else 'dock.mau.dev/' }}"


### PR DESCRIPTION
0.23.1 no longer syncs groups properly, the solution is to use 0.23.2, which works as expected. Thanks to `@boris:tilt303.org` for helping me uncover this.