### PR TITLE
Adds a self build option for dendrite

### DIFF
--- a/roles/custom/matrix-dendrite/defaults/main.yml
+++ b/roles/custom/matrix-dendrite/defaults/main.yml
@@ -4,8 +4,12 @@
 
 matrix_dendrite_enabled: true
 
-matrix_dendrite_docker_image: "{{ matrix_dendrite_docker_image_name_prefix }}matrixdotorg/dendrite-monolith:{{ matrix_dendrite_docker_image_tag }}"
-matrix_dendrite_docker_image_name_prefix: "docker.io/"
+matrix_dendrite_container_image_self_build: false
+matrix_dendrite_container_image_self_build_repo: "https://github.com/matrix-org/dendrite.git"
+
+matrix_dendrite_docker_image_path: "matrixdotorg/dendrite-monolith"
+matrix_dendrite_docker_image: "{{ matrix_dendrite_docker_image_name_prefix }}{{ matrix_dendrite_docker_image_path }}:{{ matrix_dendrite_docker_image_tag }}"
+matrix_dendrite_docker_image_name_prefix: "{{ 'localhost/' if matrix_dendrite_container_image_self_build else matrix_container_global_registry_prefix }}"
 matrix_dendrite_docker_image_tag: "v0.12.0"
 matrix_dendrite_docker_image_force_pull: "{{ matrix_dendrite_docker_image.endswith(':latest') }}"
 
@@ -16,6 +20,8 @@ matrix_dendrite_media_store_path: "{{ matrix_dendrite_storage_path }}/media-stor
 matrix_dendrite_nats_storage_path: "{{ matrix_dendrite_base_path }}/nats"
 matrix_dendrite_bin_path: "{{ matrix_dendrite_base_path }}/bin"
 matrix_dendrite_ext_path: "{{ matrix_dendrite_base_path }}/ext"
+
+matrix_dendrite_docker_src_files_path: "{{ matrix_dendrite_base_path }}/docker-src"
 
 # By default, we make Dendrite only serve HTTP (not HTTPS).
 # HTTPS is usually served at the reverse-proxy side (usually via `matrix-nginx-proxy`).
@@ -85,14 +91,14 @@ matrix_dendrite_systemd_wanted_services_list: []
 # matrix_dendrite_template_dendrite_config: "{{ playbook_dir }}/inventory/host_vars/<host>/dendrite.yaml.j2"
 matrix_dendrite_template_dendrite_config: "{{ role_path }}/templates/dendrite/dendrite.yaml.j2"
 
-matrix_dendrite_client_api_registration_shared_secret: ''
+matrix_dendrite_client_api_registration_shared_secret: ""
 matrix_dendrite_allow_guest_access: false
 
 matrix_dendrite_max_file_size_bytes: 10485760
 
 # Controls which HTTP header (e.g. 'X-Forwarded-For', 'X-Real-IP') to inspect to find the real remote IP address of the client.
 # This is likely required if Dendrite is running behind a reverse proxy server.
-matrix_dendrite_sync_api_real_ip_header: 'X-Forwarded-For'
+matrix_dendrite_sync_api_real_ip_header: "X-Forwarded-For"
 
 # The tmpfs at /tmp needs to be large enough to handle multiple concurrent file uploads.
 matrix_dendrite_tmp_directory_size_mb: 500
@@ -147,7 +153,7 @@ matrix_dendrite_metrics_password: "metrics"
 
 # Postgres database information
 matrix_dendrite_database_str: "postgresql://{{ matrix_dendrite_database_user }}:{{ matrix_dendrite_database_password }}@{{ matrix_dendrite_database_hostname }}"
-matrix_dendrite_database_hostname: ''
+matrix_dendrite_database_hostname: ""
 matrix_dendrite_database_user: "dendrite"
 matrix_dendrite_database_password: "itsasecret"
 matrix_dendrite_federation_api_database: "dendrite_federationapi"

--- a/roles/custom/matrix-dendrite/tasks/setup_install.yml
+++ b/roles/custom/matrix-dendrite/tasks/setup_install.yml
@@ -1,17 +1,21 @@
 ---
-
 - name: Ensure Dendrite paths exist
   ansible.builtin.file:
-    path: "{{ item }}"
+    path: "{{ item.path }}"
     state: directory
     mode: 0750
     owner: "{{ matrix_user_username }}"
     group: "{{ matrix_user_groupname }}"
   with_items:
-    - "{{ matrix_dendrite_config_dir_path }}"
-    - "{{ matrix_dendrite_bin_path }}"
-    - "{{ matrix_dendrite_ext_path }}"
-    - "{{ matrix_dendrite_nats_storage_path }}"
+    - { path: "{{ matrix_dendrite_config_dir_path }}", when: true }
+    - { path: "{{ matrix_dendrite_bin_path }}", when: true }
+    - { path: "{{ matrix_dendrite_ext_path }}", when: true }
+    - { path: "{{ matrix_dendrite_nats_storage_path }}", when: true }
+    - {
+        path: "{{ matrix_dendrite_docker_src_files_path }}",
+        when: "{{ matrix_dendrite_container_image_self_build }}",
+      }
+  when: "item.when | bool"
 
 # This will throw a Permission Denied error if already mounted using fuse
 - name: Check Dendrite media store path
@@ -37,10 +41,22 @@
     source: "{{ 'pull' if ansible_version.major > 2 or ansible_version.minor > 7 else omit }}"
     force_source: "{{ matrix_dendrite_docker_image_force_pull if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
     force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_dendrite_docker_image_force_pull }}"
+  when: "not matrix_dendrite_container_image_self_build | bool"
   register: result
   retries: "{{ devture_playbook_help_container_retries_count }}"
   delay: "{{ devture_playbook_help_container_retries_delay }}"
   until: result is not failed
+
+- name: Ensure Dendrite repository is present on self-build
+  ansible.builtin.git:
+    repo: "{{ matrix_dendrite_container_image_self_build_repo }}"
+    dest: "{{ matrix_dendrite_docker_src_files_path }}"
+    version: "{{ matrix_dendrite_docker_image.split(':')[1] }}"
+    force: "yes"
+  become: true
+  become_user: "{{ matrix_user_username }}"
+  register: matrix_dendrite_git_pull_results
+  when: "matrix_dendrite_container_image_self_build | bool"
 
 # We do this so that the signing key would get generated.
 # We don't use the `docker_container` module, because using it with `cap_drop` requires
@@ -71,6 +87,11 @@
     mode: 0644
     owner: "{{ matrix_user_username }}"
     group: "{{ matrix_user_groupname }}"
+
+- name: Ensure Dendrite Docker image is built
+  ansible.builtin.command:
+    cmd: "{{ devture_systemd_docker_base_host_command_docker }} build -t {{ matrix_dendrite_docker_image }} {{ matrix_dendrite_docker_src_files_path }}"
+  when: "matrix_dendrite_container_image_self_build | bool"
 
 - name: Ensure Dendrite container network is created
   community.general.docker_network:

--- a/roles/custom/matrix-dendrite/tasks/setup_install.yml
+++ b/roles/custom/matrix-dendrite/tasks/setup_install.yml
@@ -47,17 +47,6 @@
   delay: "{{ devture_playbook_help_container_retries_delay }}"
   until: result is not failed
 
-- name: Ensure Dendrite repository is present on self-build
-  ansible.builtin.git:
-    repo: "{{ matrix_dendrite_container_image_self_build_repo }}"
-    dest: "{{ matrix_dendrite_docker_src_files_path }}"
-    version: "{{ matrix_dendrite_docker_image.split(':')[1] }}"
-    force: "yes"
-  become: true
-  become_user: "{{ matrix_user_username }}"
-  register: matrix_dendrite_git_pull_results
-  when: "matrix_dendrite_container_image_self_build | bool"
-
 # We do this so that the signing key would get generated.
 # We don't use the `docker_container` module, because using it with `cap_drop` requires
 # a very recent version, which is not available for a lot of people yet.
@@ -88,10 +77,32 @@
     owner: "{{ matrix_user_username }}"
     group: "{{ matrix_user_groupname }}"
 
-- name: Ensure Dendrite Docker image is built
-  ansible.builtin.command:
-    cmd: "{{ devture_systemd_docker_base_host_command_docker }} build -t {{ matrix_dendrite_docker_image }} {{ matrix_dendrite_docker_src_files_path }}"
-  when: "matrix_dendrite_container_image_self_build | bool"
+- when: "matrix_dendrite_container_image_self_build | bool"
+  block:
+    - name: Ensure Dendrite repository is present on self-build
+      ansible.builtin.git:
+        repo: "{{ matrix_dendrite_container_image_self_build_repo }}"
+        dest: "{{ matrix_dendrite_docker_src_files_path }}"
+        version: "{{ matrix_dendrite_docker_image.split(':')[1] }}"
+        force: "yes"
+      become: true
+      become_user: "{{ matrix_user_username }}"
+      register: matrix_dendrite_git_pull_results
+
+    - name: Check if Dendrite Docker image exists
+      ansible.builtin.command: "{{ devture_systemd_docker_base_host_command_docker }} images --quiet --filter 'reference={{ matrix_dendrite_docker_image }}'"
+      register: matrix_dendrite_docker_image_check_result
+      changed_when: false
+
+    # Invoking the `docker build` command here, instead of calling the `docker_image` Ansible module,
+    # because the latter does not support BuildKit.
+    # See: https://github.com/ansible-collections/community.general/issues/514
+    - name: Ensure Dendrite Docker image is built
+      ansible.builtin.command:
+        cmd: "{{ devture_systemd_docker_base_host_command_docker }} build -t {{ matrix_dendrite_docker_image }} {{ matrix_dendrite_docker_src_files_path }}"
+      environment:
+        DOCKER_BUILDKIT: 1
+      when: "matrix_dendrite_git_pull_results.changed | bool or matrix_dendrite_docker_image_check_result.stdout == ''"
 
 - name: Ensure Dendrite container network is created
   community.general.docker_network:


### PR DESCRIPTION
Recently I needed to add an option to self-build dendrite in order to [apply a bug patch](https://github.com/matrix-org/dendrite/issues/2902#issuecomment-1489937931) that's not yet in any official release.

The actual build itself is done with a `ansible.builtin.command` rather than a `community.docker.docker_image`, because [the dendrite Docker image uses the BUILDPLATFORM variable](https://github.com/matrix-org/dendrite/blob/aa1bda4c58d20e7d14267f9c87fab8efd7ae36ad/Dockerfile#L6), which is a [BuildKit/buildx feature](https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/), and according to the [`community.docker.docker_image` documentation](https://docs.ansible.com/ansible/latest/collections/community/docker/docker_image_module.html):

> Building images is done using Docker daemon’s API. It is not possible to use BuildKit / buildx this way.

Therefore we work around that by avoiding using Docker daemon's api and just using the docker cli via `ansible.builtin.command`.