### PR TITLE
Update matrix chatgpt bot  (v3.0.0 -> v3.1.0)

### DIFF
--- a/roles/custom/matrix-bot-chatgpt/defaults/main.yml
+++ b/roles/custom/matrix-bot-chatgpt/defaults/main.yml
@@ -4,7 +4,7 @@
 
 matrix_bot_chatgpt_enabled: true
 
-matrix_bot_chatgpt_version: 3.0.0
+matrix_bot_chatgpt_version: 3.1.0
 
 matrix_bot_chatgpt_container_image_self_build: false
 matrix_bot_chatgpt_container_image_self_build_repo: "https://github.com/matrixgpt/matrix-chatgpt-bot"


### PR DESCRIPTION
update matrix_bot_chatgpt_version to 3.1.0 adding support for gpt-4, reverse proxy and custom api url