### PR TITLE
fix prometheus postgres exporter role name

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -47,6 +47,7 @@
 - src: git+https://gitlab.com/etke.cc/roles/prometheus_node_exporter.git
   version: v1.5.0-7
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-prometheus-postgres-exporter.git
+  name: prometheus_postgres_exporter
   version: v0.12.0-0
 - src: git+https://gitlab.com/etke.cc/roles/redis.git
   version: v7.0.10-0


### PR DESCRIPTION
otherwise role cannot be included with old name (setup.yml)