### PR TITLE
Revert #2698 forget_rooms_on_leave to upstream value

### DIFF
--- a/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -143,7 +143,7 @@ default_room_version: {{ matrix_synapse_default_room_version|to_json }}
 
 # Set to true to automatically forget rooms for users when they leave them, either
 # normally or via a kick or ban. Defaults to false.
-forget_rooms_on_leave: true
+forget_rooms_on_leave: false
 
 # The GC threshold parameters to pass to `gc.set_threshold`, if defined
 #


### PR DESCRIPTION
Reverts forget_rooms_on_leave to upstream as this is too dangerous to change in a breaking way like this is doing. Especially doing it together with a Call to Action to update your Synapses causing this change to enter all playbook users playbooks who update.

Its safe to keep the version bump part of #2698 but not safe to keep this change that this commit is undoing by setting the value to false. This means our config now includes the value like a upstream config would but we keep it at false just like upstream does.

This value is recomended to be made easily accessible and a Changelog note about this should be noted so that users know this setting exists if they want to use it as we should have a note explaining this event happened either way. 