### PR TITLE
Update Draupnir from 1.80.1 to 1.82.0

### DIFF
--- a/roles/custom/matrix-bot-draupnir/defaults/main.yml
+++ b/roles/custom/matrix-bot-draupnir/defaults/main.yml
@@ -4,7 +4,7 @@
 
 matrix_bot_draupnir_enabled: true
 
-matrix_bot_draupnir_version: "v1.80.1"
+matrix_bot_draupnir_version: "v1.82.0"
 
 matrix_bot_draupnir_container_image_self_build: false
 matrix_bot_draupnir_container_image_self_build_repo: "https://github.com/Gnuxie/Draupnir.git"


### PR DESCRIPTION
Forgot to upstream my local Draupnir version bumps. Tested to be working as its currently in production for feline.support