### PR TITLE
add updated Caddyfile example

### DIFF
--- a/docs/configuring-playbook-own-webserver.md
+++ b/docs/configuring-playbook-own-webserver.md
@@ -160,7 +160,7 @@ devture_traefik_additional_entrypoints_auto:
     #     # trustedIPs: ['IP-ADDRESS-OF-YOUR-REVERSE-PROXY']
 ```
 
-For an example where the playbook's Traefik reverse-proxy is fronted by [Nginx](https://nginx.org/) running on the same server, see [Nginx reverse-proxy fronting the playbook's Traefik](../examples/nginx/README.md).
+For an example where the playbook's Traefik reverse-proxy is fronted by another reverse-proxy running on the same server, see [Nginx reverse-proxy fronting the playbook's Traefik](../examples/nginx/README.md) or [Caddy reverse-proxy fronting the playbook's Traefik](../examples/caddy2/README.md).
 
 
 ### Using no reverse-proxy on the Matrix side at all

--- a/examples/caddy2/Caddyfile
+++ b/examples/caddy2/Caddyfile
@@ -1,112 +1,10 @@
-(cors) {
-	@cors_preflight method OPTIONS
-
-	handle @cors_preflight {
-		header Access-Control-Allow-Origin "{args.0}"
-		header Access-Control-Allow-Methods "HEAD, GET, POST, PUT, PATCH, DELETE"
-		header Access-Control-Allow-Headers "Content-Type, Authorization"
-		header Access-Control-Max-Age "3600"
-	}
-}
-
-
-matrix.DOMAIN.tld {
-
-  # creates letsencrypt certificate
-  # tls your@email.com
-
-  @identity {
-        path /_matrix/identity/*
-  }
-
-  @noidentity {
-        not path /_matrix/identity/*
-  }
-
-  @search {
-        path /_matrix/client/r0/user_directory/search/*
-  }
-
-  @nosearch {
-        not path /_matrix/client/r0/user_directory/search/*
-  }
-
-  @static {
-        path /matrix/static-files/*
-  }
-
-  @nostatic {
-        not path /matrix/static-files/*
-  }
-
-  @wellknown {
-        path /.well-known/matrix/*
-  }
-
-  header {
-        # Enable HTTP Strict Transport Security (HSTS) to force clients to always connect via HTTPS
-        Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
-        # Enable cross-site filter (XSS) and tell browser to block detected attacks
-        X-XSS-Protection "1; mode=block"
-        # Prevent some browsers from MIME-sniffing a response away from the declared Content-Type
-        X-Content-Type-Options "nosniff"
-        # Disallow the site to be rendered within a frame (clickjacking protection)
-        X-Frame-Options "DENY"
-        # X-Robots-Tag
-        X-Robots-Tag "noindex, noarchive, nofollow"
-  }
-
-  # Cache
-  header @static {
-        # Cache
-    Cache-Control "public, max-age=31536000"
-    defer
-  }
-
-  # identity
-  handle @identity {
-        reverse_proxy localhost:8090  {
-               header_up X-Forwarded-Port {http.request.port}
-               header_up X-Forwarded-Proto {http.request.scheme}
-               header_up X-Forwarded-TlsProto {tls_protocol}
-               header_up X-Forwarded-TlsCipher {tls_cipher}
-               header_up X-Forwarded-HttpsProto {proto}
-        }
-  }
-
-  # search
-  handle @search {
-        reverse_proxy localhost:8090   {
-               header_up X-Forwarded-Port {http.request.port}
-               header_up X-Forwarded-Proto {http.request.scheme}
-               header_up X-Forwarded-TlsProto {tls_protocol}
-               header_up X-Forwarded-TlsCipher {tls_cipher}
-               header_up X-Forwarded-HttpsProto {proto}
-        }
-  }
-
-  handle @wellknown {
-        encode zstd gzip
-        root * /matrix/static-files
-	header Cache-Control max-age=14400
-        header Content-Type application/json
-        header Access-Control-Allow-Origin *
-        file_server
-  }
-  
-  # If you have other well-knowns already handled by your base domain, you can replace the above block by this one, along with the replacement suggested in the base domain
-  #handle @wellknown {
-  #  # .well-known is handled by base domain
-  #  reverse_proxy https://DOMAIN.tld {
-  #  header_up Host {http.reverse_proxy.upstream.hostport}
-  #}
+matrix.example.tld {
 
   handle {
         encode zstd gzip
 
-        reverse_proxy localhost:8008  {
+        reverse_proxy localhost:81  {
                header_up X-Forwarded-Port {http.request.port}
-               header_up X-Forwarded-Proto {http.request.scheme}
                header_up X-Forwarded-TlsProto {tls_protocol}
                header_up X-Forwarded-TlsCipher {tls_cipher}
                header_up X-Forwarded-HttpsProto {proto}
@@ -114,13 +12,12 @@ matrix.DOMAIN.tld {
   }
 }
 
-matrix.DOMAIN.tld:8448 {
+matrix.example.tld:8448 {
     handle {
         encode zstd gzip
 
-        reverse_proxy 127.0.0.1:8048 {
+        reverse_proxy 127.0.0.1:8449 {
                header_up X-Forwarded-Port {http.request.port}
-               header_up X-Forwarded-Proto {http.request.scheme}
                header_up X-Forwarded-TlsProto {tls_protocol}
                header_up X-Forwarded-TlsCipher {tls_cipher}
                header_up X-Forwarded-HttpsProto {proto}
@@ -128,142 +25,16 @@ matrix.DOMAIN.tld:8448 {
     }
 }
 
-element.DOMAIN.tld {
 
-      # creates letsencrypt certificate
-      # tls your@email.com
-
-      import cors https://*.DOMAIN.tld
-
-      header {
-                # Enable HTTP Strict Transport Security (HSTS) to force clients to always connect via HTTPS
-                Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
-                # Enable cross-site filter (XSS) and tell browser to block detected attacks
-                X-XSS-Protection "1; mode=block"
-                # Prevent some browsers from MIME-sniffing a response away from the declared Content-Type
-                X-Content-Type-Options "nosniff"
-                # Disallow the site to be rendered within a frame (clickjacking protection)
-                X-Frame-Options "DENY"
-                # If using integrations that add frames to Element, such as Dimension and its integrations running on the same domain, it can be a good idea to limit sources allowed to be rendered
-                # Content-Security-Policy frame-src https://*.DOMAIN.tld
-                # X-Robots-Tag
-                X-Robots-Tag "noindex, noarchive, nofollow"
-        }
-
-        handle {
-              encode zstd gzip
-
-              reverse_proxy localhost:8765 {
-                     header_up X-Forwarded-Port {http.request.port}
-                     header_up X-Forwarded-Proto {http.request.scheme}
-                     header_up X-Forwarded-TlsProto {tls_protocol}
-                     header_up X-Forwarded-TlsCipher {tls_cipher}
-                     header_up X-Forwarded-HttpsProto {proto}
-        }
-}
-
-#dimension.DOMAIN.tld {
-#
-#      # creates letsencrypt certificate
-#      # tls your@email.com
-#
-#      import cors https://*.DOMAIN.tld
-#
-#      header {
-#          # Enable HTTP Strict Transport Security (HSTS) to force clients to always connect via HTTPS
-#          Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
-#          # Enable cross-site filter (XSS) and tell browser to block detected attacks
-#          X-XSS-Protection "1; mode=block"
-#          # Prevent some browsers from MIME-sniffing a response away from the declared Content-Type
-#          X-Content-Type-Options "nosniff"
-#          # Only allow same base domain to render this website in a frame; Can be removed if the client (Element for example) is hosted on another domain (clickjacking protection)
-#          Content-Security-Policy frame-ancestors https://*.DOMAIN.tld
-#          # X-Robots-Tag
-#          X-Robots-Tag "noindex, noarchive, nofollow"
-#    }
-#
-#      handle {
-#          encode zstd gzip
-#
-#          reverse_proxy localhost:8184  {
-#                  header_up X-Forwarded-Port {http.request.port}
-#                  header_up X-Forwarded-Proto {http.request.scheme}
-#                  header_up X-Forwarded-TlsProto {tls_protocol}
-#                  header_up X-Forwarded-TlsCipher {tls_cipher}
-#                  header_up X-Forwarded-HttpsProto {proto}
-#          }
-#    }
-#}
-
-
-#jitsi.DOMAIN.tld {
-#
-#  creates letsencrypt certificate
-#  tls your@email.com
-#
-#  import cors https://*.DOMAIN.tld
-#
-#  header {
-#        # Enable HTTP Strict Transport Security (HSTS) to force clients to always connect via HTTPS
-#        Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
-#
-#        # Enable cross-site filter (XSS) and tell browser to block detected attacks
-#        X-XSS-Protection "1; mode=block"
-#
-#        # Prevent some browsers from MIME-sniffing a response away from the declared Content-Type
-#        X-Content-Type-Options "nosniff"
-
-#        # Only allow same base domain to render this website in a frame; Can be removed if the client (Element for example) is hosted on another domain
-#        Content-Security-Policy frame-ancestors https://*.DOMAIN.tld
-#
-#        # Disable some features
-#        Feature-Policy "accelerometer 'none';ambient-light-sensor 'none'; autoplay 'none';camera 'none';encrypted-media 'none';focus-without-user-activation 'none'; geolocation 'none';gyroscope #'none';magnetometer 'none';microphone 'none';midi 'none';payment 'none';picture-in-picture 'none'; speaker 'none';sync-xhr 'none';usb 'none';vr 'none'"
-#
-#        # Referer
-#        Referrer-Policy "no-referrer"
-#
-#        # X-Robots-Tag
-#        X-Robots-Tag "none"
-#
-#        # Remove Server header
-#        -Server
-#  }
-#
-#  handle {
-#        encode zstd gzip
-#
-#        reverse_proxy 127.0.0.1:13080 {
-#               header_up X-Forwarded-Port {http.request.port}
-#               header_up X-Forwarded-Proto {http.request.scheme}
-#               header_up X-Forwarded-TlsProto {tls_protocol}
-#               header_up X-Forwarded-TlsCipher {tls_cipher}
-#               header_up X-Forwarded-HttpsProto {proto}
-#        }
-#  }
-#}
-#DOMAIN.com {
+example.tld {
 # Uncomment this if you are following "(Option 3): Setting up reverse-proxying of the well-known files from the base domain's server to the Matrix server" of https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/docs/configuring-well-known.md#option-3-setting-up-reverse-proxying-of-the-well-known-files-from-the-base-domains-server-to-the-matrix-server
-#    @wellknown {
-#        path /.well-known/matrix/*
-#    }
-#
-#    handle @wellknown {
-#        reverse_proxy https://matrix.DOMAIN.com {
-#            header_up Host {http.reverse_proxy.upstream.hostport}
-#        }
-#    }
-#    # If you have other well-knowns already handled by your base domain, you can replace the above block by this one, along with the replacement suggested in the matrix subdomain
-#      # handle /.well-known/* {
-#	#	encode zstd gzip
-#	#	header Cache-Control max-age=14400
-#	#	header Content-Type application/json
-#	#	header Access-Control-Allow-Origin *
-#	#}
-#
-#    # Configration for the base domain goes here
-#   # handle {
-#   #    header -Server
-#   #     encode zstd gzip
-#   #    reverse_proxy localhost:4020
-#   # }
-#}
+    @wellknown {
+        path /.well-known/matrix/*
+    }
+
+    handle @wellknown {
+        reverse_proxy https://matrix.example.tld {
+            header_up Host {http.reverse_proxy.upstream.hostport}
+        }
+    }
+}

--- a/examples/caddy2/Caddyfile.deprecated
+++ b/examples/caddy2/Caddyfile.deprecated
@@ -1,0 +1,269 @@
+(cors) {
+	@cors_preflight method OPTIONS
+
+	handle @cors_preflight {
+		header Access-Control-Allow-Origin "{args.0}"
+		header Access-Control-Allow-Methods "HEAD, GET, POST, PUT, PATCH, DELETE"
+		header Access-Control-Allow-Headers "Content-Type, Authorization"
+		header Access-Control-Max-Age "3600"
+	}
+}
+
+
+matrix.DOMAIN.tld {
+
+  # creates letsencrypt certificate
+  # tls your@email.com
+
+  @identity {
+        path /_matrix/identity/*
+  }
+
+  @noidentity {
+        not path /_matrix/identity/*
+  }
+
+  @search {
+        path /_matrix/client/r0/user_directory/search/*
+  }
+
+  @nosearch {
+        not path /_matrix/client/r0/user_directory/search/*
+  }
+
+  @static {
+        path /matrix/static-files/*
+  }
+
+  @nostatic {
+        not path /matrix/static-files/*
+  }
+
+  @wellknown {
+        path /.well-known/matrix/*
+  }
+
+  header {
+        # Enable HTTP Strict Transport Security (HSTS) to force clients to always connect via HTTPS
+        Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+        # Enable cross-site filter (XSS) and tell browser to block detected attacks
+        X-XSS-Protection "1; mode=block"
+        # Prevent some browsers from MIME-sniffing a response away from the declared Content-Type
+        X-Content-Type-Options "nosniff"
+        # Disallow the site to be rendered within a frame (clickjacking protection)
+        X-Frame-Options "DENY"
+        # X-Robots-Tag
+        X-Robots-Tag "noindex, noarchive, nofollow"
+  }
+
+  # Cache
+  header @static {
+        # Cache
+    Cache-Control "public, max-age=31536000"
+    defer
+  }
+
+  # identity
+  handle @identity {
+        reverse_proxy localhost:8090  {
+               header_up X-Forwarded-Port {http.request.port}
+               header_up X-Forwarded-Proto {http.request.scheme}
+               header_up X-Forwarded-TlsProto {tls_protocol}
+               header_up X-Forwarded-TlsCipher {tls_cipher}
+               header_up X-Forwarded-HttpsProto {proto}
+        }
+  }
+
+  # search
+  handle @search {
+        reverse_proxy localhost:8090   {
+               header_up X-Forwarded-Port {http.request.port}
+               header_up X-Forwarded-Proto {http.request.scheme}
+               header_up X-Forwarded-TlsProto {tls_protocol}
+               header_up X-Forwarded-TlsCipher {tls_cipher}
+               header_up X-Forwarded-HttpsProto {proto}
+        }
+  }
+
+  handle @wellknown {
+        encode zstd gzip
+        root * /matrix/static-files
+	header Cache-Control max-age=14400
+        header Content-Type application/json
+        header Access-Control-Allow-Origin *
+        file_server
+  }
+  
+  # If you have other well-knowns already handled by your base domain, you can replace the above block by this one, along with the replacement suggested in the base domain
+  #handle @wellknown {
+  #  # .well-known is handled by base domain
+  #  reverse_proxy https://DOMAIN.tld {
+  #  header_up Host {http.reverse_proxy.upstream.hostport}
+  #}
+
+  handle {
+        encode zstd gzip
+
+        reverse_proxy localhost:8008  {
+               header_up X-Forwarded-Port {http.request.port}
+               header_up X-Forwarded-Proto {http.request.scheme}
+               header_up X-Forwarded-TlsProto {tls_protocol}
+               header_up X-Forwarded-TlsCipher {tls_cipher}
+               header_up X-Forwarded-HttpsProto {proto}
+        }
+  }
+}
+
+matrix.DOMAIN.tld:8448 {
+    handle {
+        encode zstd gzip
+
+        reverse_proxy 127.0.0.1:8048 {
+               header_up X-Forwarded-Port {http.request.port}
+               header_up X-Forwarded-Proto {http.request.scheme}
+               header_up X-Forwarded-TlsProto {tls_protocol}
+               header_up X-Forwarded-TlsCipher {tls_cipher}
+               header_up X-Forwarded-HttpsProto {proto}
+        }
+    }
+}
+
+element.DOMAIN.tld {
+
+      # creates letsencrypt certificate
+      # tls your@email.com
+
+      import cors https://*.DOMAIN.tld
+
+      header {
+                # Enable HTTP Strict Transport Security (HSTS) to force clients to always connect via HTTPS
+                Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+                # Enable cross-site filter (XSS) and tell browser to block detected attacks
+                X-XSS-Protection "1; mode=block"
+                # Prevent some browsers from MIME-sniffing a response away from the declared Content-Type
+                X-Content-Type-Options "nosniff"
+                # Disallow the site to be rendered within a frame (clickjacking protection)
+                X-Frame-Options "DENY"
+                # If using integrations that add frames to Element, such as Dimension and its integrations running on the same domain, it can be a good idea to limit sources allowed to be rendered
+                # Content-Security-Policy frame-src https://*.DOMAIN.tld
+                # X-Robots-Tag
+                X-Robots-Tag "noindex, noarchive, nofollow"
+        }
+
+        handle {
+              encode zstd gzip
+
+              reverse_proxy localhost:8765 {
+                     header_up X-Forwarded-Port {http.request.port}
+                     header_up X-Forwarded-Proto {http.request.scheme}
+                     header_up X-Forwarded-TlsProto {tls_protocol}
+                     header_up X-Forwarded-TlsCipher {tls_cipher}
+                     header_up X-Forwarded-HttpsProto {proto}
+        }
+}
+
+#dimension.DOMAIN.tld {
+#
+#      # creates letsencrypt certificate
+#      # tls your@email.com
+#
+#      import cors https://*.DOMAIN.tld
+#
+#      header {
+#          # Enable HTTP Strict Transport Security (HSTS) to force clients to always connect via HTTPS
+#          Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+#          # Enable cross-site filter (XSS) and tell browser to block detected attacks
+#          X-XSS-Protection "1; mode=block"
+#          # Prevent some browsers from MIME-sniffing a response away from the declared Content-Type
+#          X-Content-Type-Options "nosniff"
+#          # Only allow same base domain to render this website in a frame; Can be removed if the client (Element for example) is hosted on another domain (clickjacking protection)
+#          Content-Security-Policy frame-ancestors https://*.DOMAIN.tld
+#          # X-Robots-Tag
+#          X-Robots-Tag "noindex, noarchive, nofollow"
+#    }
+#
+#      handle {
+#          encode zstd gzip
+#
+#          reverse_proxy localhost:8184  {
+#                  header_up X-Forwarded-Port {http.request.port}
+#                  header_up X-Forwarded-Proto {http.request.scheme}
+#                  header_up X-Forwarded-TlsProto {tls_protocol}
+#                  header_up X-Forwarded-TlsCipher {tls_cipher}
+#                  header_up X-Forwarded-HttpsProto {proto}
+#          }
+#    }
+#}
+
+
+#jitsi.DOMAIN.tld {
+#
+#  creates letsencrypt certificate
+#  tls your@email.com
+#
+#  import cors https://*.DOMAIN.tld
+#
+#  header {
+#        # Enable HTTP Strict Transport Security (HSTS) to force clients to always connect via HTTPS
+#        Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+#
+#        # Enable cross-site filter (XSS) and tell browser to block detected attacks
+#        X-XSS-Protection "1; mode=block"
+#
+#        # Prevent some browsers from MIME-sniffing a response away from the declared Content-Type
+#        X-Content-Type-Options "nosniff"
+
+#        # Only allow same base domain to render this website in a frame; Can be removed if the client (Element for example) is hosted on another domain
+#        Content-Security-Policy frame-ancestors https://*.DOMAIN.tld
+#
+#        # Disable some features
+#        Feature-Policy "accelerometer 'none';ambient-light-sensor 'none'; autoplay 'none';camera 'none';encrypted-media 'none';focus-without-user-activation 'none'; geolocation 'none';gyroscope #'none';magnetometer 'none';microphone 'none';midi 'none';payment 'none';picture-in-picture 'none'; speaker 'none';sync-xhr 'none';usb 'none';vr 'none'"
+#
+#        # Referer
+#        Referrer-Policy "no-referrer"
+#
+#        # X-Robots-Tag
+#        X-Robots-Tag "none"
+#
+#        # Remove Server header
+#        -Server
+#  }
+#
+#  handle {
+#        encode zstd gzip
+#
+#        reverse_proxy 127.0.0.1:13080 {
+#               header_up X-Forwarded-Port {http.request.port}
+#               header_up X-Forwarded-Proto {http.request.scheme}
+#               header_up X-Forwarded-TlsProto {tls_protocol}
+#               header_up X-Forwarded-TlsCipher {tls_cipher}
+#               header_up X-Forwarded-HttpsProto {proto}
+#        }
+#  }
+#}
+#DOMAIN.com {
+# Uncomment this if you are following "(Option 3): Setting up reverse-proxying of the well-known files from the base domain's server to the Matrix server" of https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/docs/configuring-well-known.md#option-3-setting-up-reverse-proxying-of-the-well-known-files-from-the-base-domains-server-to-the-matrix-server
+#    @wellknown {
+#        path /.well-known/matrix/*
+#    }
+#
+#    handle @wellknown {
+#        reverse_proxy https://matrix.DOMAIN.com {
+#            header_up Host {http.reverse_proxy.upstream.hostport}
+#        }
+#    }
+#    # If you have other well-knowns already handled by your base domain, you can replace the above block by this one, along with the replacement suggested in the matrix subdomain
+#      # handle /.well-known/* {
+#	#	encode zstd gzip
+#	#	header Cache-Control max-age=14400
+#	#	header Content-Type application/json
+#	#	header Access-Control-Allow-Origin *
+#	#}
+#
+#    # Configration for the base domain goes here
+#   # handle {
+#   #    header -Server
+#   #     encode zstd gzip
+#   #    reverse_proxy localhost:4020
+#   # }
+#}

--- a/examples/caddy2/README.md
+++ b/examples/caddy2/README.md
@@ -1,12 +1,20 @@
-# Caddyfile
+# Caddy reverse-proxy fronting the playbook's integrated Traefik reverse-proxy
 
-This directory contains sample files that show you how to do reverse-proxying using Caddy2.
+This directory contains a sample config that shows you how to front the integrated [Traefik](https://traefik.io/) reverse-proxy webserver with your own [Caddy](https://caddyserver.com/) reverse-proxy.
 
-## Config
 
-| Variable           | Function |
-| ------------------ | -------- |
-| tls your@email.com | Specify an email address for your [ACME account](https://caddyserver.com/docs/caddyfile/directives/tls) (but if only one email is used for all sites, we recommend the email [global option](https://caddyserver.com/docs/caddyfile/options) instead) | 
-| tls                | To enable [tls](https://caddyserver.com/docs/caddyfile/directives/tls) support uncomment the lines for tls |
-| Dimension         | To enable Dimension support uncomment the lines for Dimension and set your data |
-| Jitsi              | To enable Jitsi support uncomment the lines for Jitsi and set your data |
+## Prerequisite configuration
+
+To get started, first follow the [front the integrated reverse-proxy webserver with another reverse-proxy](../../docs/configuring-playbook-own-webserver.md#fronting-the-integrated-reverse-proxy-webserver-with-another-reverse-proxy) instructions and update your playbook's configuration (`inventory/host_vars/matrix.<your-domain>/vars.yml`).
+
+
+## Using the Caddyfile
+
+You can either just use the [Caddyfile](Caddyfile) directly or append its content to your own Caddyfile.
+In both cases make sure to replace all the `example.tld` domains with your own domain.
+
+This example does  not include additional services like element, but you should be able copy the first block and replace the matrix subdomain with the additional services subdomain. I have not tested this though.
+
+# Caddyfile.deprecated
+
+This can be used as a [Caddy](https://caddyserver.com/) reverse-proxy without intermediary playbook managed reverse proxy. However, this setup is not supported by the playbook anymore. Instead [front the integrated reverse-proxy webserver with another reverse-proxy](../../docs/configuring-playbook-own-webserver.md#fronting-the-integrated-reverse-proxy-webserver-with-another-reverse-proxy) as described above.

--- a/examples/nginx/README.md
+++ b/examples/nginx/README.md
@@ -1,6 +1,6 @@
 # Nginx reverse-proxy fronting the playbook's integrated Traefik reverse-proxy
 
-This directory contains a sample config that shows you how use the [nginx](https://nginx.org/) webserver to front the integrated [Traefik](https://traefik.io/) reverse-proxy webserver with another reverse-proxy.
+This directory contains a sample config that shows you how to use the [nginx](https://nginx.org/) webserver to front the integrated [Traefik](https://traefik.io/) reverse-proxy webserver with another reverse-proxy.
 
 
 ## Prerequisite configuration


### PR DESCRIPTION
Because I was so scared by touching my reverse proxy setup without having an example to follow, I postponed upgrading my matrix server until now. Today I finally decided to do the upgrade and discovered that guessing the correct cofiguration was actually not that hard.

To save others from this hurdle, I decided to add my Caddyfile as an example. Because the old example Caddyfile could still be of use, I did not remove it, but renamed it to `Caddyfile.deprecated`. To make clear what is what, I finally updated the `README.md` heavily inspired by the one of the nginx example.