### PR TITLE
Update Draupnir to 1.83.0 from 1.82.0

### DIFF
--- a/roles/custom/matrix-bot-draupnir/defaults/main.yml
+++ b/roles/custom/matrix-bot-draupnir/defaults/main.yml
@@ -4,7 +4,7 @@
 
 matrix_bot_draupnir_enabled: true
 
-matrix_bot_draupnir_version: "v1.82.0"
+matrix_bot_draupnir_version: "v1.83.0"
 
 matrix_bot_draupnir_container_image_self_build: false
 matrix_bot_draupnir_container_image_self_build_repo: "https://github.com/Gnuxie/Draupnir.git"


### PR DESCRIPTION
This release primarily fixes a UX issue and it also deprechiates anything before Node 18 due to the fact that Node 16 EOL was moved to match OpenSSL 1.1.1

Tested to work as its the running version on feline.support