### PR TITLE
Fix for hookshot validation failure

### DIFF
--- a/roles/custom/matrix-bridge-hookshot/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-hookshot/tasks/setup_install.yml
@@ -81,7 +81,7 @@
       --user={{ matrix_user_uid }}:{{ matrix_user_gid }}
       --cap-drop=ALL
       -v {{ matrix_hookshot_base_path }}/config.yml:/config.yml
-      {{ matrix_hookshot_docker_image }} node Config/Config.js /config.yml
+      {{ matrix_hookshot_docker_image }} node config/Config.js /config.yml
   register: hookshot_config_validation_result
   changed_when: false
 


### PR DESCRIPTION
For Issue #2718 

This is a fix for matrix-hookshot v4.1.0. PR #2714 

This will cause errors for people using <v4.1.0. 
