### PR TITLE
Create hooks for user search ability

### DIFF
--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -334,6 +334,11 @@ matrix_synapse_limit_profile_requests_to_users_who_share_rooms: false
 # Defaults to 'true'.
 matrix_synapse_include_profile_data_on_invite: true
 
+
+# User search behaviour
+matrix_synapse_search_all_users: false
+matrix_synapse_prefer_local_users: false
+
 # Controls whether people with access to the homeserver can register by themselves.
 matrix_synapse_enable_registration: false
 # Controls whether people with access to the homeserver can register by themselves without verification (email/msisdn/token)

--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -336,8 +336,8 @@ matrix_synapse_include_profile_data_on_invite: true
 
 
 # User search behaviour
-matrix_synapse_search_all_users: false
-matrix_synapse_prefer_local_users: false
+matrix_synapse_user_directory_search_all_users: false
+matrix_synapse_user_directory_prefer_local_users: false
 
 # Controls whether people with access to the homeserver can register by themselves.
 matrix_synapse_enable_registration: false

--- a/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -2630,7 +2630,7 @@ user_directory:
     # Uncomment to return search results containing all known users, even if that
     # user does not share a room with the requester.
     #
-    #search_all_users: true
+    search_all_users: {{ matrix_synapse_search_all_users|to_json }}
 
     # Defines whether to prefer local users in search query results.
     # If True, local users are more likely to appear above remote users
@@ -2639,7 +2639,7 @@ user_directory:
     # Uncomment to prefer local over remote users in user directory search
     # results.
     #
-    #prefer_local_users: true
+    prefer_local_users: {{ matrix_synapse_prefer_local_users|to_json }}
 
 
 # User Consent configuration

--- a/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -2630,7 +2630,7 @@ user_directory:
     # Uncomment to return search results containing all known users, even if that
     # user does not share a room with the requester.
     #
-    search_all_users: {{ matrix_synapse_search_all_users|to_json }}
+    search_all_users: {{ matrix_synapse_user_directory_search_all_users | to_json }}
 
     # Defines whether to prefer local users in search query results.
     # If True, local users are more likely to appear above remote users

--- a/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -2639,7 +2639,7 @@ user_directory:
     # Uncomment to prefer local over remote users in user directory search
     # results.
     #
-    prefer_local_users: {{ matrix_synapse_prefer_local_users|to_json }}
+    prefer_local_users: {{ matrix_synapse_user_directory_prefer_local_users | to_json }}
 
 
 # User Consent configuration


### PR DESCRIPTION
YAML hooks to have all users searchable and prefer local user search.

This is to mimic the behaviour of Teams and Slack.