### PR TITLE
Support EC2 instance metadata for S3 storage provider

### DIFF
--- a/docs/configuring-playbook-synapse-s3-storage-provider.md
+++ b/docs/configuring-playbook-synapse-s3-storage-provider.md
@@ -37,6 +37,10 @@ matrix_synapse_ext_synapse_s3_storage_provider_config_access_key_id: access-key-
 matrix_synapse_ext_synapse_s3_storage_provider_config_secret_access_key: secret-key-goes-here
 matrix_synapse_ext_synapse_s3_storage_provider_config_storage_class: STANDARD # or STANDARD_IA, etc.
 
+# If you're using an EC2 instance with an instance profile that grants it permissions to access S3, set the following variable to true
+# Defaulted to false, when this is enabled you do not need to provide the access_key_id or secret_access_key.
+matrix_synapse_ext_synapse_s3_storage_provider_config_ec2_instance_profile: true
+
 # For additional advanced settings, take a look at `roles/custom/matrix-synapse/defaults/main.yml`
 ```
 

--- a/docs/configuring-playbook-synapse-s3-storage-provider.md
+++ b/docs/configuring-playbook-synapse-s3-storage-provider.md
@@ -30,16 +30,22 @@ After [creating the S3 bucket and configuring it](configuring-playbook-s3.md#buc
 
 ```yaml
 matrix_synapse_ext_synapse_s3_storage_provider_enabled: true
+
 matrix_synapse_ext_synapse_s3_storage_provider_config_bucket: your-bucket-name
 matrix_synapse_ext_synapse_s3_storage_provider_config_region_name: some-region-name # e.g. eu-central-1
 matrix_synapse_ext_synapse_s3_storage_provider_config_endpoint_url: https://s3.REGION_NAME.amazonaws.com # adjust this
-matrix_synapse_ext_synapse_s3_storage_provider_config_access_key_id: access-key-goes-here
-matrix_synapse_ext_synapse_s3_storage_provider_config_secret_access_key: secret-key-goes-here
 matrix_synapse_ext_synapse_s3_storage_provider_config_storage_class: STANDARD # or STANDARD_IA, etc.
 
-# If you're using an EC2 instance with an instance profile that grants it permissions to access S3, set the following variable to true
-# Defaulted to false, when this is enabled you do not need to provide the access_key_id or secret_access_key.
-matrix_synapse_ext_synapse_s3_storage_provider_config_ec2_instance_profile: true
+# Authentication Method 1 - (access key id + secret)
+# This works on all providers (AWS and other compatible systems).
+# Uncomment the variables below to use it.
+# matrix_synapse_ext_synapse_s3_storage_provider_config_access_key_id: access-key-goes-here
+# matrix_synapse_ext_synapse_s3_storage_provider_config_secret_access_key: secret-key-goes-here
+
+# Authentication Method 2 - EC2 instance profile which grants permission to access S3
+# This only works on AWS when your server is hosted on an EC2 instance with the correct instance profile set.
+# Uncomment the variable below to use it.
+# matrix_synapse_ext_synapse_s3_storage_provider_config_ec2_instance_profile: true
 
 # For additional advanced settings, take a look at `roles/custom/matrix-synapse/defaults/main.yml`
 ```

--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -885,6 +885,8 @@ matrix_synapse_ext_synapse_s3_storage_provider_config_region_name: ''
 matrix_synapse_ext_synapse_s3_storage_provider_config_endpoint_url: ''
 matrix_synapse_ext_synapse_s3_storage_provider_config_access_key_id: ''
 matrix_synapse_ext_synapse_s3_storage_provider_config_secret_access_key: ''
+# Enable this to use EC2 instance profile metadata to grab IAM credentials instead of passing credentials directly.
+matrix_synapse_ext_synapse_s3_storage_provider_config_ec2_instance_profile: false
 matrix_synapse_ext_synapse_s3_storage_provider_config_sse_customer_enabled: false
 matrix_synapse_ext_synapse_s3_storage_provider_config_sse_customer_key: ''
 matrix_synapse_ext_synapse_s3_storage_provider_config_sse_customer_algo: 'AES256'

--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -885,7 +885,8 @@ matrix_synapse_ext_synapse_s3_storage_provider_config_region_name: ''
 matrix_synapse_ext_synapse_s3_storage_provider_config_endpoint_url: ''
 matrix_synapse_ext_synapse_s3_storage_provider_config_access_key_id: ''
 matrix_synapse_ext_synapse_s3_storage_provider_config_secret_access_key: ''
-# Enable this to use EC2 instance profile metadata to grab IAM credentials instead of passing credentials directly.
+# Enable this to use EC2 instance profile metadata to grab IAM credentials instead of passing credentials directly
+# via matrix_synapse_ext_synapse_s3_storage_provider_config_access_key_id and matrix_synapse_ext_synapse_s3_storage_provider_config_secret_access_key
 matrix_synapse_ext_synapse_s3_storage_provider_config_ec2_instance_profile: false
 matrix_synapse_ext_synapse_s3_storage_provider_config_sse_customer_enabled: false
 matrix_synapse_ext_synapse_s3_storage_provider_config_sse_customer_key: ''

--- a/roles/custom/matrix-synapse/tasks/ext/s3-storage-provider/validate_config.yml
+++ b/roles/custom/matrix-synapse/tasks/ext/s3-storage-provider/validate_config.yml
@@ -1,27 +1,22 @@
 ---
-- name: Set base required s3-storage-provider settings
-  set_fact:
-    base_s3_storage_provider_config:
-      - "matrix_synapse_ext_synapse_s3_storage_provider_config_bucket"
-      - "matrix_synapse_ext_synapse_s3_storage_provider_config_region_name"
-      - "matrix_synapse_ext_synapse_s3_storage_provider_config_endpoint_url"
-
-- name: Set optional required s3-storage-provider settings
-  set_fact:
-    optional_s3_storage_provider_config:
-      - "matrix_synapse_ext_synapse_s3_storage_provider_config_access_key_id"
-      - "matrix_synapse_ext_synapse_s3_storage_provider_config_secret_access_key"
-
-- name: Prepare a list of required s3-storage-provider settings
-  set_fact:
-    required_s3_settings: "{{ base_s3_storage_provider_config + (optional_s3_storage_provider_config if not matrix_synapse_ext_synapse_s3_storage_provider_config_ec2_instance_profile|default(false)|bool else []) }}"
-
 - name: Fail if required s3-storage-provider settings not defined
   ansible.builtin.fail:
     msg: >-
       You need to define a required configuration setting (`{{ item }}`) for using s3-storage-provider.
   when: "vars[item] == ''"
-  with_items: "{{ required_s3_settings }}"
+  with_items:
+    - "matrix_synapse_ext_synapse_s3_storage_provider_config_bucket"
+    - "matrix_synapse_ext_synapse_s3_storage_provider_config_region_name"
+    - "matrix_synapse_ext_synapse_s3_storage_provider_config_endpoint_url"
+
+- name: Fail if required s3-storage-provider auth settings not defined
+  ansible.builtin.fail:
+    msg: >-
+      You need to define a required configuration setting (`{{ item }}`) for using s3-storage-provider.
+  when: "not matrix_synapse_ext_synapse_s3_storage_provider_config_ec2_instance_profile|default(false)|bool and vars[item] == ''"
+  with_items:
+    - "matrix_synapse_ext_synapse_s3_storage_provider_config_access_key_id"
+    - "matrix_synapse_ext_synapse_s3_storage_provider_config_secret_access_key"
 
 - name: Fail if required matrix_synapse_ext_synapse_s3_storage_provider_config_endpoint_url looks invalid
   ansible.builtin.fail:

--- a/roles/custom/matrix-synapse/tasks/ext/s3-storage-provider/validate_config.yml
+++ b/roles/custom/matrix-synapse/tasks/ext/s3-storage-provider/validate_config.yml
@@ -8,8 +8,6 @@
   with_items:
     - "matrix_synapse_ext_synapse_s3_storage_provider_config_bucket"
     - "matrix_synapse_ext_synapse_s3_storage_provider_config_region_name"
-    - "matrix_synapse_ext_synapse_s3_storage_provider_config_access_key_id"
-    - "matrix_synapse_ext_synapse_s3_storage_provider_config_secret_access_key"
     - "matrix_synapse_ext_synapse_s3_storage_provider_config_endpoint_url"
 
 - name: Fail if required matrix_synapse_ext_synapse_s3_storage_provider_config_endpoint_url looks invalid

--- a/roles/custom/matrix-synapse/tasks/ext/s3-storage-provider/validate_config.yml
+++ b/roles/custom/matrix-synapse/tasks/ext/s3-storage-provider/validate_config.yml
@@ -9,11 +9,11 @@
     - "matrix_synapse_ext_synapse_s3_storage_provider_config_region_name"
     - "matrix_synapse_ext_synapse_s3_storage_provider_config_endpoint_url"
 
-- name: Fail if required s3-storage-provider auth settings not defined
+- name: Fail if required s3-storage-provider auth settings not defined when not using an EC2 profile
   ansible.builtin.fail:
     msg: >-
       You need to define a required configuration setting (`{{ item }}`) for using s3-storage-provider.
-  when: "not matrix_synapse_ext_synapse_s3_storage_provider_config_ec2_instance_profile|default(false)|bool and vars[item] == ''"
+  when: "not matrix_synapse_ext_synapse_s3_storage_provider_config_ec2_instance_profile | bool and vars[item] == ''"
   with_items:
     - "matrix_synapse_ext_synapse_s3_storage_provider_config_access_key_id"
     - "matrix_synapse_ext_synapse_s3_storage_provider_config_secret_access_key"

--- a/roles/custom/matrix-synapse/tasks/ext/s3-storage-provider/validate_config.yml
+++ b/roles/custom/matrix-synapse/tasks/ext/s3-storage-provider/validate_config.yml
@@ -1,14 +1,27 @@
 ---
+- name: Set base required s3-storage-provider settings
+  set_fact:
+    base_s3_storage_provider_config:
+      - "matrix_synapse_ext_synapse_s3_storage_provider_config_bucket"
+      - "matrix_synapse_ext_synapse_s3_storage_provider_config_region_name"
+      - "matrix_synapse_ext_synapse_s3_storage_provider_config_endpoint_url"
+
+- name: Set optional required s3-storage-provider settings
+  set_fact:
+    optional_s3_storage_provider_config:
+      - "matrix_synapse_ext_synapse_s3_storage_provider_config_access_key_id"
+      - "matrix_synapse_ext_synapse_s3_storage_provider_config_secret_access_key"
+
+- name: Prepare a list of required s3-storage-provider settings
+  set_fact:
+    required_s3_settings: "{{ base_s3_storage_provider_config + (optional_s3_storage_provider_config if not matrix_synapse_ext_synapse_s3_storage_provider_config_ec2_instance_profile|default(false)|bool else []) }}"
 
 - name: Fail if required s3-storage-provider settings not defined
   ansible.builtin.fail:
     msg: >-
       You need to define a required configuration setting (`{{ item }}`) for using s3-storage-provider.
   when: "vars[item] == ''"
-  with_items:
-    - "matrix_synapse_ext_synapse_s3_storage_provider_config_bucket"
-    - "matrix_synapse_ext_synapse_s3_storage_provider_config_region_name"
-    - "matrix_synapse_ext_synapse_s3_storage_provider_config_endpoint_url"
+  with_items: "{{ required_s3_settings }}"
 
 - name: Fail if required matrix_synapse_ext_synapse_s3_storage_provider_config_endpoint_url looks invalid
   ansible.builtin.fail:

--- a/roles/custom/matrix-synapse/templates/synapse/ext/s3-storage-provider/env.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/ext/s3-storage-provider/env.j2
@@ -1,3 +1,7 @@
+{% if not matrix_synapse_ext_synapse_s3_storage_provider_config_ec2_instance_profile|default(false)|bool %}
+AWS_ACCESS_KEY_ID={{ matrix_synapse_ext_synapse_s3_storage_provider_config_access_key_id }}
+AWS_SECRET_ACCESS_KEY={{ matrix_synapse_ext_synapse_s3_storage_provider_config_secret_access_key }}
+{% endif %}
 AWS_DEFAULT_REGION={{ matrix_synapse_ext_synapse_s3_storage_provider_config_region_name }}
 
 ENDPOINT={{ matrix_synapse_ext_synapse_s3_storage_provider_config_endpoint_url }}

--- a/roles/custom/matrix-synapse/templates/synapse/ext/s3-storage-provider/env.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/ext/s3-storage-provider/env.j2
@@ -1,4 +1,4 @@
-{% if not matrix_synapse_ext_synapse_s3_storage_provider_config_ec2_instance_profile|default(false)|bool %}
+{% if not matrix_synapse_ext_synapse_s3_storage_provider_config_ec2_instance_profile | bool %}
 AWS_ACCESS_KEY_ID={{ matrix_synapse_ext_synapse_s3_storage_provider_config_access_key_id }}
 AWS_SECRET_ACCESS_KEY={{ matrix_synapse_ext_synapse_s3_storage_provider_config_secret_access_key }}
 {% endif %}

--- a/roles/custom/matrix-synapse/templates/synapse/ext/s3-storage-provider/env.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/ext/s3-storage-provider/env.j2
@@ -1,5 +1,3 @@
-AWS_ACCESS_KEY_ID={{ matrix_synapse_ext_synapse_s3_storage_provider_config_access_key_id }}
-AWS_SECRET_ACCESS_KEY={{ matrix_synapse_ext_synapse_s3_storage_provider_config_secret_access_key }}
 AWS_DEFAULT_REGION={{ matrix_synapse_ext_synapse_s3_storage_provider_config_region_name }}
 
 ENDPOINT={{ matrix_synapse_ext_synapse_s3_storage_provider_config_endpoint_url }}

--- a/roles/custom/matrix-synapse/templates/synapse/ext/s3-storage-provider/media_storage_provider.yaml.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/ext/s3-storage-provider/media_storage_provider.yaml.j2
@@ -6,7 +6,7 @@ config:
   bucket: {{ matrix_synapse_ext_synapse_s3_storage_provider_config_bucket | to_json }}
   region_name: {{ matrix_synapse_ext_synapse_s3_storage_provider_config_region_name | to_json }}
   endpoint_url: {{ matrix_synapse_ext_synapse_s3_storage_provider_config_endpoint_url | to_json }}
-{% if not matrix_synapse_ext_synapse_s3_storage_provider_config_ec2_instance_profile|default(false)|bool %}
+{% if not matrix_synapse_ext_synapse_s3_storage_provider_config_ec2_instance_profile | bool %}
   access_key_id: {{ matrix_synapse_ext_synapse_s3_storage_provider_config_access_key_id | to_json }}
   secret_access_key: {{ matrix_synapse_ext_synapse_s3_storage_provider_config_secret_access_key | to_json }}
 {% endif %}

--- a/roles/custom/matrix-synapse/templates/synapse/ext/s3-storage-provider/media_storage_provider.yaml.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/ext/s3-storage-provider/media_storage_provider.yaml.j2
@@ -6,6 +6,10 @@ config:
   bucket: {{ matrix_synapse_ext_synapse_s3_storage_provider_config_bucket | to_json }}
   region_name: {{ matrix_synapse_ext_synapse_s3_storage_provider_config_region_name | to_json }}
   endpoint_url: {{ matrix_synapse_ext_synapse_s3_storage_provider_config_endpoint_url | to_json }}
+{% if not matrix_synapse_ext_synapse_s3_storage_provider_config_ec2_instance_profile|default(false)|bool %}
+  access_key_id: {{ matrix_synapse_ext_synapse_s3_storage_provider_config_access_key_id | to_json }}
+  secret_access_key: {{ matrix_synapse_ext_synapse_s3_storage_provider_config_secret_access_key | to_json }}
+{% endif %}
 
 {% if matrix_synapse_ext_synapse_s3_storage_provider_config_sse_customer_enabled %}
   sse_customer_key: {{ matrix_synapse_ext_synapse_s3_storage_provider_config_sse_customer_key | to_json }}

--- a/roles/custom/matrix-synapse/templates/synapse/ext/s3-storage-provider/media_storage_provider.yaml.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/ext/s3-storage-provider/media_storage_provider.yaml.j2
@@ -6,8 +6,6 @@ config:
   bucket: {{ matrix_synapse_ext_synapse_s3_storage_provider_config_bucket | to_json }}
   region_name: {{ matrix_synapse_ext_synapse_s3_storage_provider_config_region_name | to_json }}
   endpoint_url: {{ matrix_synapse_ext_synapse_s3_storage_provider_config_endpoint_url | to_json }}
-  access_key_id: {{ matrix_synapse_ext_synapse_s3_storage_provider_config_access_key_id | to_json }}
-  secret_access_key: {{ matrix_synapse_ext_synapse_s3_storage_provider_config_secret_access_key | to_json }}
 
 {% if matrix_synapse_ext_synapse_s3_storage_provider_config_sse_customer_enabled %}
   sse_customer_key: {{ matrix_synapse_ext_synapse_s3_storage_provider_config_sse_customer_key | to_json }}


### PR DESCRIPTION
I have an EC2 instance that I deployed my stack to. I wanted to use the S3 storage provider but I'm not too keen on creating IAM users (and especially access keys) when I don't have to [so I assigned an IAM role directly to my EC2 instance. ](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-metadata.html)

The playbook just needed a few tiny tweaks so that it can optionally stop expecting the `matrix_synapse_ext_synapse_s3_storage_provider_config_access_key_id` and `...secret_access_key` variables. 

By setting the variable `matrix_synapse_ext_synapse_s3_storage_provider_config_ec2_instance_profile` to `true` in your host vars, the access key id/secret will not be expected by the playbook and will not be provided to the server, allowing instance metadata to get picked up. The s3_storage_provider uses boto3 so it already picks up the instance metadata without a hitch, after these few tweaks Synapse started uploading images to S3 without a problem.

Thanks for the very cool and comprehensive playbook