### PR TITLE
Fix installing 'aux'-role on NTFS

### DIFF
--- a/playbooks/matrix.yml
+++ b/playbooks/matrix.yml
@@ -114,7 +114,7 @@
     - custom/matrix-nginx-proxy
     - custom/matrix-coturn
 
-    - role: galaxy/aux
+    - role: galaxy/auxiliary
 
     - role: galaxy/com.devture.ansible.role.postgres_backup
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -2,7 +2,7 @@
 
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-aux.git
   version: v1.0.0-1
-  name: aux
+  name: auxiliary
 - src: git+https://gitlab.com/etke.cc/roles/backup_borg.git
   version: v1.2.4-1.7.14-0
 - src: git+https://github.com/devture/com.devture.ansible.role.container_socket_proxy.git


### PR DESCRIPTION
As discussed in #2738 - this PR fixes installing the "ansible-role-aux" role on NTFS.

Tested using `just roles` and `just setup-all`.