### PR TITLE
Update mautrix-googlechat 0.4.0 -> 0.5.0

### DIFF
--- a/roles/custom/matrix-bridge-mautrix-googlechat/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-googlechat/defaults/main.yml
@@ -8,7 +8,7 @@ matrix_mautrix_googlechat_container_image_self_build: false
 matrix_mautrix_googlechat_container_image_self_build_repo: "https://github.com/mautrix/googlechat.git"
 matrix_mautrix_googlechat_container_image_self_build_repo_version: "{{ 'master' if matrix_mautrix_googlechat_version == 'latest' else matrix_mautrix_googlechat_version }}"
 
-matrix_mautrix_googlechat_version: v0.4.0
+matrix_mautrix_googlechat_version: v0.5.0
 # See: https://mau.dev/mautrix/googlechat/container_registry
 matrix_mautrix_googlechat_docker_image: "{{ matrix_mautrix_googlechat_docker_image_name_prefix }}mautrix/googlechat:{{ matrix_mautrix_googlechat_version }}"
 matrix_mautrix_googlechat_docker_image_name_prefix: "{{ 'localhost/' if matrix_mautrix_googlechat_container_image_self_build else 'dock.mau.dev/' }}"


### PR DESCRIPTION
From the changelog:

> Switched to web app API to make authentication work again. This will require all users to relogin.