### PR TITLE
	modified:   roles/custom/matrix-bridge-mautrix-instagram/templates/c…

### DIFF
--- a/roles/custom/matrix-bridge-mautrix-instagram/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mautrix-instagram/templates/config.yaml.j2
@@ -143,15 +143,15 @@ bridge:
   # application service.
   encryption:
     # Allow encryption, work in group chat rooms with e2ee enabled
-    allow: {{ matrix_mautrix_discord_bridge_encryption_allow|to_json }}
+    allow: {{ matrix_mautrix_instagram_bridge_encryption_allow|to_json }}
     # Default to encryption, force-enable encryption in all portals the bridge creates
     # This will cause the bridge bot to be in private chats for the encryption to work properly.
-    default: {{ matrix_mautrix_discord_bridge_encryption_default|to_json }}
+    default: {{ matrix_mautrix_instagram_bridge_encryption_default|to_json }}
     # Options for automatic key sharing.
     key_sharing:
       # Enable key sharing? If enabled, key requests for rooms where users are in will be fulfilled.
       # You must use a client that supports requesting keys from other users to use this feature.
-      allow: {{ matrix_mautrix_discord_bridge_encryption_key_sharing_allow|to_json }}
+      allow: {{ matrix_mautrix_instagram_bridge_encryption_key_sharing_allow|to_json }}
       # Require the requesting device to have a valid cross-signing signature?
       # This doesn't require that the bridge has verified the device, only that the user has verified it.
       # Not yet implemented.


### PR DESCRIPTION
…onfig.yaml.j2

Noticed the config.yaml.j2 was referencing discord for the encryption settings. Updated for instagram.