### PR TITLE
Update etherpad 1.8.18 -> 1.9.0

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -30,7 +30,7 @@
 - src: git+https://github.com/devture/com.devture.ansible.role.traefik_certs_dumper.git
   version: v2.8.1-0
 - src: git+https://gitlab.com/etke.cc/roles/etherpad.git
-  version: v1.8.18-2
+  version: v1.9.0-0
 - src: git+https://github.com/geerlingguy/ansible-role-docker
   version: 6.1.0
   name: geerlingguy.docker


### PR DESCRIPTION
**Warning**: no 1.9.0 tag yet - https://hub.docker.com/r/etherpad/etherpad/tags?page=1&name=1.9.0