### PR TITLE
Explain the option of manually defining your public IP in the documentation for Coturn

### DIFF
--- a/docs/configuring-playbook-turn.md
+++ b/docs/configuring-playbook-turn.md
@@ -15,6 +15,13 @@ matrix_coturn_enabled: false
 
 In that case, Synapse would not point to any Coturn servers and audio/video call functionality may fail.
 
+## Manually defining your public IP
+In the `hosts` file we explicitly ask for your server's external IP address when defining `ansible_host`, because the same value is used for configuring Coturn.
+If you'd rather use a local IP for `ansible_host`, make sure to set up `matrix_coturn_turn_external_ip_address` replacing `YOUR_PUBLIC_IP` with the pubic IP used by the server.
+
+```yaml
+matrix_coturn_turn_external_ip_address: "YOUR_PUBLIC_IP"
+```
 
 ## Using your own external Coturn server
 

--- a/docs/configuring-playbook-turn.md
+++ b/docs/configuring-playbook-turn.md
@@ -47,3 +47,6 @@ jitsi_web_stun_servers:
 - stun:HOSTNAME_OR_IP:PORT
 ```
 You can put multiple host/port combinations if you like.
+
+## Further variables and configuration options
+To see all the available configuration options, check roles/custom/matrix-coturn/defaults/main.yml 


### PR DESCRIPTION
I was very surprised by the fact that a rather important configuration option for Coturn was "hidden" in the Hosts file, but not mentioned here. 

Therefore my suggestion is to explicitly mention it here, as I believe that is that natural for people to look.