### PR TITLE
add global bridges relay mode switch

### DIFF
--- a/docs/configuring-playbook-mautrix-bridges.md
+++ b/docs/configuring-playbook-mautrix-bridges.md
@@ -32,14 +32,18 @@ matrix_mautrix_SERVICENAME_configuration_extension_yaml: |
       '@YOUR_USERNAME:{{ matrix_domain }}': admin
 ```
 
+## encryption
+
 Encryption support is off by default. If you would like to enable encryption, add the following to your `vars.yml` file:
 
 **for all bridges with encryption support**:
+
 ```yaml
 matrix_bridges_encryption_enabled: true
 ```
 
 **Alternatively**, for a specific bridge:
+
 ```yaml
 matrix_mautrix_SERVICENAME_configuration_extension_yaml: |
   bridge:
@@ -48,6 +52,24 @@ matrix_mautrix_SERVICENAME_configuration_extension_yaml: |
       default: true
 ```
 
+## relay mode
+
+Relay mode is off by default. If you would like to enable relay mode, add the following to your `vars.yml` file:
+
+**for all bridges with relay mode support**:
+
+```yaml
+matrix_bridges_relay_enabled: true
+```
+
+**Alternatively**, for a specific bridge:
+
+```yaml
+matrix_mautrix_SERVICENAME_configuration_extension_yaml: |
+  bridge:
+    relay:
+      enabled: true
+```
 
 You can only have one `matrix_mautrix_SERVICENAME_configuration_extension_yaml` definition in `vars.yml` per bridge, so if you need multiple pieces of configuration there, just merge them like this:
 

--- a/roles/custom/matrix-base/defaults/main.yml
+++ b/roles/custom/matrix-base/defaults/main.yml
@@ -16,6 +16,9 @@ matrix_admin: ''
 # Global var to enable/disable encryption across all bridges with encryption support
 matrix_bridges_encryption_enabled: false
 
+# Global var to enable/disable relay mode across all bridges with relay mode support
+matrix_bridges_relay_enabled: false
+
 # matrix_homeserver_enabled controls whether to enable the homeserver systemd service, etc.
 #
 # Unless you're wrapping this playbook in another one

--- a/roles/custom/matrix-bridge-appservice-kakaotalk/defaults/main.yml
+++ b/roles/custom/matrix-bridge-appservice-kakaotalk/defaults/main.yml
@@ -110,6 +110,8 @@ matrix_appservice_kakaotalk_login_shared_secret: ''
 
 matrix_appservice_kakaotalk_bridge_login_shared_secret_map: "{{ {matrix_appservice_kakaotalk_homeserver_domain: matrix_appservice_kakaotalk_login_shared_secret} if matrix_appservice_kakaotalk_login_shared_secret else {} }}"
 
+matrix_appservice_kakaotalk_bridge_relay_enabled: "{{ matrix_bridges_relay_enabled }}"
+
 matrix_appservice_kakaotalk_bridge_permissions: |
   {{
     {matrix_appservice_kakaotalk_homeserver_domain: 'user'}

--- a/roles/custom/matrix-bridge-appservice-kakaotalk/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-appservice-kakaotalk/templates/config.yaml.j2
@@ -220,7 +220,7 @@ bridge:
     relay:
         # Whether relay mode should be allowed. If allowed, `!kt set-relay` can be used to turn any
         # authenticated user into a relaybot for that chat.
-        enabled: false
+        enabled: {{ matrix_appservice_kakaotalk_bridge_relay_enabled }}
         # The formats to use when sending messages to KakaoTalk via a relay user.
         #
         # Available variables:

--- a/roles/custom/matrix-bridge-mautrix-facebook/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-facebook/defaults/main.yml
@@ -103,6 +103,9 @@ matrix_mautrix_facebook_login_shared_secret: ''
 
 matrix_mautrix_facebook_bridge_login_shared_secret_map: "{{ {matrix_mautrix_facebook_homeserver_domain: matrix_mautrix_facebook_login_shared_secret} if matrix_mautrix_facebook_login_shared_secret else {} }}"
 
+# Enable bridge relay bot functionality
+matrix_mautrix_facebook_relay_enabled: "{{ matrix_bridges_relay_enabled }}"
+
 matrix_mautrix_facebook_appservice_bot_username: facebookbot
 
 matrix_mautrix_facebook_bridge_presence: true

--- a/roles/custom/matrix-bridge-mautrix-facebook/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mautrix-facebook/templates/config.yaml.j2
@@ -206,7 +206,7 @@ bridge:
     relay:
         # Whether relay mode should be allowed. If allowed, `!fb set-relay` can be used to turn any
         # authenticated user into a relaybot for that chat.
-        enabled: false
+        enabled: {{ matrix_mautrix_facebook_relay_enabled }}
         # The formats to use when sending messages to Messenger via a relay user.
         #
         # Available variables:

--- a/roles/custom/matrix-bridge-mautrix-instagram/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-instagram/defaults/main.yml
@@ -83,6 +83,9 @@ matrix_mautrix_instagram_login_shared_secret: ''
 
 matrix_mautrix_instagram_bridge_login_shared_secret_map: "{{ {matrix_mautrix_instagram_homeserver_domain: matrix_mautrix_instagram_login_shared_secret} if matrix_mautrix_instagram_login_shared_secret else {} }}"
 
+# Enable bridge relay bot functionality
+matrix_mautrix_instagram_relay_enabled: "{{ matrix_bridges_relay_enabled }}"
+
 matrix_mautrix_instagram_appservice_bot_username: instagrambot
 
 matrix_mautrix_instagram_bridge_presence: true

--- a/roles/custom/matrix-bridge-mautrix-instagram/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mautrix-instagram/templates/config.yaml.j2
@@ -196,6 +196,23 @@ bridge:
     # The shared secret to authorize users of the API.
     # Set to "generate" to generate and save a new token.
     shared_secret: generate
+  relay:
+    # Whether relay mode should be allowed. If allowed, `!ig set-relay` can be used to turn any
+    # authenticated user into a relaybot for that chat.
+    enabled: {{ matrix_mautrix_instagram_relay_enabled }}
+    # The formats to use when sending messages to Instagram via a relay user.
+    #
+    # Available variables:
+    #   $sender_displayname - The display name of the sender (e.g. Example User)
+    #   $sender_username    - The username (Matrix ID localpart) of the sender (e.g. exampleuser)
+    #   $sender_mxid        - The Matrix ID of the sender (e.g. @exampleuser:example.com)
+    #   $message            - The message content
+    #
+    # Note that Instagram doesn't support captions for images, so images won't include any indication of being relayed.
+    message_formats:
+      m.text: '$sender_displayname: $message'
+      m.notice: '$sender_displayname: $message'
+      m.emote: '* $sender_displayname $message'
 
 # Python logging configuration.
 #

--- a/roles/custom/matrix-bridge-mautrix-signal/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-signal/defaults/main.yml
@@ -104,7 +104,7 @@ matrix_mautrix_signal_appservice_database: "{{
 matrix_mautrix_signal_login_shared_secret: ''
 
 # Enable bridge relay bot functionality
-matrix_mautrix_signal_relaybot_enabled: false
+matrix_mautrix_signal_relaybot_enabled: "{{ matrix_bridges_relay_enabled }}"
 
 # Permissions for using the bridge.
 # Permitted values:

--- a/roles/custom/matrix-bridge-mautrix-whatsapp/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-whatsapp/defaults/main.yml
@@ -113,7 +113,7 @@ matrix_mautrix_whatsapp_bridge_permissions: |
   }}
 
 # Enable bridge relay functionality
-matrix_mautrix_whatsapp_bridge_relay_enabled: false
+matrix_mautrix_whatsapp_bridge_relay_enabled: "{{ matrix_bridges_relay_enabled }}"
 
 # Only allow admins on this home server to set themselves as a relay user
 matrix_mautrix_whatsapp_bridge_relay_admin_only: true


### PR DESCRIPTION
WhatsApp, Signal, Instagram, Facebook and KakaoTalk bridges support it, others may follow later.

Ref (mautrix): https://docs.mau.fi/bridges/general/relay-mode.html