### PR TITLE
Gmessage bridge: Remove file logging, and add existing log level variable to config

### DIFF
--- a/roles/custom/matrix-bridge-mautrix-gmessages/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mautrix-gmessages/templates/config.yaml.j2
@@ -286,13 +286,7 @@ bridge:
 
 # Logging config. See https://github.com/tulir/zeroconfig for details.
 logging:
-    min_level: debug
+    min_level: {{ matrix_mautrix_gmessages_logging_level }}
     writers:
-    - type: stdout
-      format: pretty-colored
-    - type: file
-      format: json
-      filename: ./logs/mautrix-gmessages.log
-      max_size: 100
-      max_backups: 10
-      compress: true
+        - type: stdout
+          format: pretty-colored


### PR DESCRIPTION
The current config defaults to not using the variable it's created for logging, as well as logging to a file as well as to the journal.

This updates it to use the existing variable, and removes the logging to file.

This will change everyone who's already installed it from 'debug' to 'warn' as the configuration file that did not use the variable was for 'debug' while the default for the variable is 'warn'