### PR TITLE
Update Element logo location

### DIFF
--- a/roles/custom/matrix-client-element/defaults/main.yml
+++ b/roles/custom/matrix-client-element/defaults/main.yml
@@ -159,7 +159,7 @@ matrix_client_element_welcome_user_id: ~
 matrix_client_element_brand: "Element"
 
 # URL to Logo on welcome page
-matrix_client_element_welcome_logo: "welcome/images/logo.svg"
+matrix_client_element_welcome_logo: "themes/element/img/logos/element-logo.svg"
 
 # URL of link on welcome image
 matrix_client_element_welcome_logo_link: "https://element.io"


### PR DESCRIPTION
Element's logo's location was moved a few versions ago and currently points to a non-existent path.