### PR TITLE
Create and set default for chatgpt prompt

### DIFF
--- a/roles/custom/matrix-bot-chatgpt/defaults/main.yml
+++ b/roles/custom/matrix-bot-chatgpt/defaults/main.yml
@@ -88,3 +88,5 @@ matrix_bot_chatgpt_matrix_rich_text: true  # MATRIX_RICH_TEXT=true
 # matrix_bot_chatgpt_environment_variables_extension: |
 #   chatgpt_TEXT_DONE=Done
 matrix_bot_chatgpt_environment_variables_extension: ''
+
+matrix_bot_chatgpt_matrix_bot_prompt_prefix: 'Instructions:\nYou are ChatGPT, a large language model trained by OpenAI.'

--- a/roles/custom/matrix-bot-chatgpt/templates/env.j2
+++ b/roles/custom/matrix-bot-chatgpt/templates/env.j2
@@ -25,6 +25,8 @@ MATRIX_ENCRYPTION={{ matrix_bot_chatgpt_matrix_encryption|lower }}
 MATRIX_THREADS={{ matrix_bot_chatgpt_matrix_threads|lower }}
 MATRIX_RICH_TEXT={{ matrix_bot_chatgpt_matrix_rich_text|lower }}
 
+CHATGPT_PROMPT_PREFIX={{ matrix_bot_chatgpt_matrix_bot_prompt_prefix }}
+
 DATA_PATH=/data/
 
 {{ matrix_bot_chatgpt_environment_variables_extension }}


### PR DESCRIPTION
This creates a variable and sets it to the default given in the example env from the bot's github page.

This will be handy so the bot can be more easily configured to reply to things in different ways.