### PR TITLE
Advertise sliding-sync support when using conduit

### DIFF
--- a/docs/configuring-playbook-sliding-sync-proxy.md
+++ b/docs/configuring-playbook-sliding-sync-proxy.md
@@ -12,6 +12,7 @@ Element X Android requires manual compilation to get it working with a non-`matr
 
 **NOTE**: The Sliding Sync proxy **only works with the Traefik reverse-proxy**. If you have an old server installation (from the time `matrix-nginx-proxy` was our default reverse-proxy - `matrix_playbook_reverse_proxy_type: playbook-managed-nginx`), you won't be able to use Sliding Sync.
 
+**NOTE**: The sliding-sync proxy is **not required** when using the **Conduit homeserver**. Starting from version `0.6.0` Conduit has native support for some sliding sync features. If there are issues with the native implementation, you might have a better experience when enabling the sliding-sync proxy anyway.
 
 ## Decide on a domain and path
 

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -4018,6 +4018,8 @@ matrix_sliding_sync_environment_variable_syncv3_secret: "{{ '%s' | format(matrix
 matrix_sliding_sync_database_hostname: "{{ devture_postgres_connection_hostname if devture_postgres_enabled else '' }}"
 matrix_sliding_sync_database_password: "{{ '%s' | format(matrix_homeserver_generic_secret_key) | password_hash('sha512', 'ss.db', rounds=655555) | to_uuid }}"
 
+matrix_homeserver_sliding_sync_url: "{{ matrix_sliding_sync_base_url if matrix_sliding_sync_enabled else matrix_homeserver_sliding_sync_url }}"
+
 ######################################################################
 #
 # /matrix-sliding-sync
@@ -4107,6 +4109,8 @@ matrix_conduit_systemd_required_services_list: |
     (['docker.service'])
   }}
 
+# Starting from version `0.6.0` conduit natively supports some sync v3 (sliding-sync) features.
+matrix_homeserver_sliding_sync_url: "{{ matrix_homeserver_url if matrix_conduit_enabled and not matrix_sliding_sync_enabled else matrix_homeserver_sliding_sync_url }}"
 
 ######################################################################
 #

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -4018,7 +4018,8 @@ matrix_sliding_sync_environment_variable_syncv3_secret: "{{ '%s' | format(matrix
 matrix_sliding_sync_database_hostname: "{{ devture_postgres_connection_hostname if devture_postgres_enabled else '' }}"
 matrix_sliding_sync_database_password: "{{ '%s' | format(matrix_homeserver_generic_secret_key) | password_hash('sha512', 'ss.db', rounds=655555) | to_uuid }}"
 
-matrix_homeserver_sliding_sync_url: "{{ matrix_sliding_sync_base_url if matrix_sliding_sync_enabled else matrix_homeserver_sliding_sync_url }}"
+# Starting from version `0.6.0` conduit natively supports some sync v3 (sliding-sync) features.
+matrix_homeserver_sliding_sync_url: "{{ matrix_sliding_sync_base_url if matrix_sliding_sync_enabled else matrix_homeserver_url if matrix_conduit_enabled else '' }}"
 
 ######################################################################
 #
@@ -4108,9 +4109,6 @@ matrix_conduit_systemd_required_services_list: |
   {{
     (['docker.service'])
   }}
-
-# Starting from version `0.6.0` conduit natively supports some sync v3 (sliding-sync) features.
-matrix_homeserver_sliding_sync_url: "{{ matrix_homeserver_url if matrix_conduit_enabled and not matrix_sliding_sync_enabled else matrix_homeserver_sliding_sync_url }}"
 
 ######################################################################
 #

--- a/roles/custom/matrix-base/defaults/main.yml
+++ b/roles/custom/matrix-base/defaults/main.yml
@@ -150,6 +150,12 @@ matrix_homeserver_container_url: ""
 # This likely gets overriden elsewhere.
 matrix_homeserver_container_federation_url: ""
 
+# Specifies the public url of the Sync v3 (sliding-sync) API.
+# This will be used to set the `org.matrix.msc3575.proxy` property in `/.well-known/matrix/client`.
+# Once the API is stabilized, this will no longer be required.
+# See MSC3575: https://github.com/matrix-org/matrix-spec-proposals/blob/kegan/sync-v3/proposals/3575-sync.md
+matrix_homeserver_sliding_sync_url: ""
+
 matrix_identity_server_url: ~
 
 matrix_integration_manager_rest_url: ~

--- a/roles/custom/matrix-base/templates/static-files/well-known/matrix-client.j2
+++ b/roles/custom/matrix-base/templates/static-files/well-known/matrix-client.j2
@@ -30,6 +30,10 @@
 	"org.matrix.msc3575.proxy": {
 		"url": "{{ matrix_sliding_sync_base_url }}"
 	}
+ 	{% elif matrix_homeserver_implementation == 'conduit' %},
+	"org.matrix.msc3575.proxy": {
+		"url": "{{ matrix_homeserver_url }}"
+	}
 	{% endif %}
 	{% if matrix_client_element_location_sharing_enabled %},
 	"m.tile_server": {

--- a/roles/custom/matrix-base/templates/static-files/well-known/matrix-client.j2
+++ b/roles/custom/matrix-base/templates/static-files/well-known/matrix-client.j2
@@ -26,13 +26,9 @@
 		"preferredDomain": {{ matrix_client_element_jitsi_preferred_domain|to_json }}
 	}
 	{% endif %}
-	{% if matrix_sliding_sync_enabled %},
+	{% if matrix_homeserver_sliding_sync_url %},
 	"org.matrix.msc3575.proxy": {
-		"url": "{{ matrix_sliding_sync_base_url }}"
-	}
- 	{% elif matrix_homeserver_implementation == 'conduit' %},
-	"org.matrix.msc3575.proxy": {
-		"url": "{{ matrix_homeserver_url }}"
+		"url": "{{ matrix_homeserver_sliding_sync_url }}"
 	}
 	{% endif %}
 	{% if matrix_client_element_location_sharing_enabled %},


### PR DESCRIPTION
Starting from version `0.6.0` conduit natively supports some sync v3 (sliding-sync) features.

https://gitlab.com/famedly/conduit/-/releases/v0.6.0
https://gitlab.com/famedly/conduit/-/merge_requests/501