### PR TITLE
Update Draupnir from 1.83.0 to 1.84.0

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -2000,7 +2000,7 @@ matrix_bot_mjolnir_systemd_required_services_list: |
 # We don't enable bots by default.
 matrix_bot_draupnir_enabled: false
 
-matrix_bot_draupnir_container_image_self_build: "{{ matrix_architecture != 'amd64' }}"
+matrix_bot_draupnir_container_image_self_build: "{{ matrix_architecture not in ['amd64', 'arm64'] }}"
 
 matrix_bot_draupnir_systemd_required_services_list: |
   {{

--- a/roles/custom/matrix-bot-draupnir/defaults/main.yml
+++ b/roles/custom/matrix-bot-draupnir/defaults/main.yml
@@ -4,7 +4,7 @@
 
 matrix_bot_draupnir_enabled: true
 
-matrix_bot_draupnir_version: "v1.83.0"
+matrix_bot_draupnir_version: "v1.84.0"
 
 matrix_bot_draupnir_container_image_self_build: false
 matrix_bot_draupnir_container_image_self_build_repo: "https://github.com/Gnuxie/Draupnir.git"


### PR DESCRIPTION
In addition to bugfixes from a version bump this version is also the first version to support Arm as prebuilt containers. This was as far as i am aware contributed due to that arm based container deployment is used by Draupnir Contributors.

So huraa one less docker image that you have to self build if on Arm.