### PR TITLE
Update docs for older appservice bridges to enable legacy authorization

### DIFF
--- a/docs/configuring-playbook-bridge-appservice-discord.md
+++ b/docs/configuring-playbook-bridge-appservice-discord.md
@@ -1,7 +1,7 @@
 # Setting up Appservice Discord (optional)
 
-**Note**: bridging to [Discord](https://discordapp.com/) can also happen via the [mx-puppet-discord](configuring-playbook-bridge-mx-puppet-discord.md) and [mautrix-discord](configuring-playbook-bridge-mautrix-discord.md) bridges supported by the playbook.   
-- For using as a Bot we are recommend the Appservice Discord bridge (the one being discussed here), because it supports plumbing.  
+**Note**: bridging to [Discord](https://discordapp.com/) can also happen via the [mx-puppet-discord](configuring-playbook-bridge-mx-puppet-discord.md) and [mautrix-discord](configuring-playbook-bridge-mautrix-discord.md) bridges supported by the playbook.
+- For using as a Bot we are recommend the Appservice Discord bridge (the one being discussed here), because it supports plumbing.
 - For personal use we recommend the [mautrix-discord](configuring-playbook-bridge-mautrix-discord.md) bridge, because it is the most fully-featured and stable of the 3 Discord bridges supported by the playbook.
 
 The playbook can install and configure [matrix-appservice-discord](https://github.com/Half-Shot/matrix-appservice-discord) for you.
@@ -23,8 +23,13 @@ matrix_appservice_discord_enabled: true
 matrix_appservice_discord_client_id: "YOUR DISCORD APP CLIENT ID"
 matrix_appservice_discord_bot_token: "YOUR DISCORD APP BOT TOKEN"
 ```
+5. As of Synapse 1.90.0, you will need to add the following to ```matrix_synapse_configuration_extension_yaml``` to enable the [backwards compatibility](https://matrix-org.github.io/synapse/latest/upgrade#upgrading-to-v1900) that this bridge needs:
+```yaml
+use_appservice_legacy_authorization: true
+```
+*Note*: This deprecated method is considered insecure.
 
-5. If you've already installed Matrix services using the playbook before, you'll need to re-run it (`--tags=setup-all,start`). If not, proceed with [configuring other playbook services](configuring-playbook.md) and then with [Installing](installing.md). Get back to this guide once ready.
+6. If you've already installed Matrix services using the playbook before, you'll need to re-run it (`--tags=setup-all,start`). If not, proceed with [configuring other playbook services](configuring-playbook.md) and then with [Installing](installing.md). Get back to this guide once ready.
 
 Other configuration options are available via the `matrix_appservice_discord_configuration_extension_yaml` variable.
 

--- a/docs/configuring-playbook-bridge-appservice-discord.md
+++ b/docs/configuring-playbook-bridge-appservice-discord.md
@@ -27,6 +27,8 @@ matrix_appservice_discord_bot_token: "YOUR DISCORD APP BOT TOKEN"
 ```yaml
 matrix_synapse_configuration_extension_yaml: |
   use_appservice_legacy_authorization: true
+```
+*Note*: This deprecated method is considered insecure.
 
 6. If you've already installed Matrix services using the playbook before, you'll need to re-run it (`--tags=setup-all,start`). If not, proceed with [configuring other playbook services](configuring-playbook.md) and then with [Installing](installing.md). Get back to this guide once ready.
 

--- a/docs/configuring-playbook-bridge-appservice-discord.md
+++ b/docs/configuring-playbook-bridge-appservice-discord.md
@@ -23,11 +23,10 @@ matrix_appservice_discord_enabled: true
 matrix_appservice_discord_client_id: "YOUR DISCORD APP CLIENT ID"
 matrix_appservice_discord_bot_token: "YOUR DISCORD APP BOT TOKEN"
 ```
-5. As of Synapse 1.90.0, you will need to add the following to ```matrix_synapse_configuration_extension_yaml``` to enable the [backwards compatibility](https://matrix-org.github.io/synapse/latest/upgrade#upgrading-to-v1900) that this bridge needs:
+5. As of Synapse 1.90.0, you will need to add the following to `matrix_synapse_configuration_extension_yaml` to enable the [backwards compatibility](https://matrix-org.github.io/synapse/latest/upgrade#upgrading-to-v1900) that this bridge needs:
 ```yaml
-use_appservice_legacy_authorization: true
-```
-*Note*: This deprecated method is considered insecure.
+matrix_synapse_configuration_extension_yaml: |
+  use_appservice_legacy_authorization: true
 
 6. If you've already installed Matrix services using the playbook before, you'll need to re-run it (`--tags=setup-all,start`). If not, proceed with [configuring other playbook services](configuring-playbook.md) and then with [Installing](installing.md). Get back to this guide once ready.
 

--- a/docs/configuring-playbook-bridge-appservice-webhooks.md
+++ b/docs/configuring-playbook-bridge-appservice-webhooks.md
@@ -26,22 +26,28 @@ you can adjust this in `inventory/host_vars/matrix.<domain-name>/vars.yml` as we
 matrix_appservice_webhooks_log_level: '<log_level>'
 ```
 
-3. If you've already installed Matrix services using the playbook before, you'll need to re-run it (`--tags=setup-all,start`). If not, proceed with [configuring other playbook services](configuring-playbook.md) and then with [Installing](installing.md). Get back to this guide once ready.
+3. As of Synapse 1.90.0, you will need to add the following to ```matrix_synapse_configuration_extension_yaml``` to enable the [backwards compatibility](https://matrix-org.github.io/synapse/latest/upgrade#upgrading-to-v1900) that this bridge needs:
+```yaml
+use_appservice_legacy_authorization: true
+```
+*Note*: This deprecated method is considered insecure.
 
-4. If you're using the [Dimension Integration Manager](configuring-playbook-dimension.md), you can configure the Webhooks bridge by opening the Dimension integration manager -> Settings -> Bridges and selecting edit action for "Webhook Bridge". Press "Add self-hosted Bridge" button and populate "Provisioning URL"  & "Shared Secret" values from `/matrix/appservice-webhooks/config/config.yaml` file's homeserver URL value and provisioning secret value, respectively. 
+4. If you've already installed Matrix services using the playbook before, you'll need to re-run it (`--tags=setup-all,start`). If not, proceed with [configuring other playbook services](configuring-playbook.md) and then with [Installing](installing.md). Get back to this guide once ready.
 
-5. Invite the bridge bot user to your room:
+5. If you're using the [Dimension Integration Manager](configuring-playbook-dimension.md), you can configure the Webhooks bridge by opening the Dimension integration manager -> Settings -> Bridges and selecting edit action for "Webhook Bridge". Press "Add self-hosted Bridge" button and populate "Provisioning URL"  & "Shared Secret" values from `/matrix/appservice-webhooks/config/config.yaml` file's homeserver URL value and provisioning secret value, respectively.
+
+6. Invite the bridge bot user to your room:
 
     - either with `/invite @_webhook:<domain.name>` (*Note*: Make sure you have administration permissions in your room)
 
     - or simply add the bridge bot to a private channel (personal channels imply you being an administrator)
 
-6. Send a message to the bridge bot in order to receive a private message including the webhook link.
+7. Send a message to the bridge bot in order to receive a private message including the webhook link.
 ```
 !webhook
 ```
 
-7. The JSON body for posting messages will have to look like this:
+8. The JSON body for posting messages will have to look like this:
 ```json
 {
     "text": "Hello world!",

--- a/docs/configuring-playbook-bridge-appservice-webhooks.md
+++ b/docs/configuring-playbook-bridge-appservice-webhooks.md
@@ -30,6 +30,8 @@ matrix_appservice_webhooks_log_level: '<log_level>'
 ```yaml
 matrix_synapse_configuration_extension_yaml: |
   use_appservice_legacy_authorization: true
+```
+*Note*: This deprecated method is considered insecure.
 
 4. If you've already installed Matrix services using the playbook before, you'll need to re-run it (`--tags=setup-all,start`). If not, proceed with [configuring other playbook services](configuring-playbook.md) and then with [Installing](installing.md). Get back to this guide once ready.
 

--- a/docs/configuring-playbook-bridge-appservice-webhooks.md
+++ b/docs/configuring-playbook-bridge-appservice-webhooks.md
@@ -26,11 +26,10 @@ you can adjust this in `inventory/host_vars/matrix.<domain-name>/vars.yml` as we
 matrix_appservice_webhooks_log_level: '<log_level>'
 ```
 
-3. As of Synapse 1.90.0, you will need to add the following to ```matrix_synapse_configuration_extension_yaml``` to enable the [backwards compatibility](https://matrix-org.github.io/synapse/latest/upgrade#upgrading-to-v1900) that this bridge needs:
+3. As of Synapse 1.90.0, you will need to add the following to `matrix_synapse_configuration_extension_yaml` to enable the [backwards compatibility](https://matrix-org.github.io/synapse/latest/upgrade#upgrading-to-v1900) that this bridge needs:
 ```yaml
-use_appservice_legacy_authorization: true
-```
-*Note*: This deprecated method is considered insecure.
+matrix_synapse_configuration_extension_yaml: |
+  use_appservice_legacy_authorization: true
 
 4. If you've already installed Matrix services using the playbook before, you'll need to re-run it (`--tags=setup-all,start`). If not, proceed with [configuring other playbook services](configuring-playbook.md) and then with [Installing](installing.md). Get back to this guide once ready.
 


### PR DESCRIPTION
Add an extra step in the documentation. As of Synapse 1.90.0 backwards compatibility for appservice authorization needs to be explicitly turned on for these bridges to work. Fixes the issue I had in #2840. 