### PR TITLE
Prevent schildichat from being installed by default

### DIFF
--- a/roles/custom/matrix-client-schildichat/defaults/main.yml
+++ b/roles/custom/matrix-client-schildichat/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Project source code URL: https://github.com/SchildiChat/schildichat-desktop
 
-matrix_client_schildichat_enabled: true
+matrix_client_schildichat_enabled: false
 
 matrix_client_schildichat_container_image_self_build: false
 


### PR DESCRIPTION
Currently `matrix_client_schildichat_enabled` is set to true, installing Schildichat by default and causing the playbook to fail at SSL certificate retrieval if a DNS record for Schildichat has not been set (which I suspect is the case for majority of playbook users).

This PR sets that variable to false, requiring Schildichat to be manually enabled, as per the docs.