### PR TITLE
Update Draupnir from 1.84.0 to 1.85.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -405,7 +405,7 @@ Additional details are available in the [Authenticate using Matrix OpenID (Auth-
 
 ## Draupnir moderation tool (bot) support
 
-Thanks to [FSG-Cat](https://github.com/FSG-Cat), the playbook can now install and configure the [Draupnir](https://github.com/Gnuxie/Draupnir) moderation tool (bot). Draupnir is a fork of [Mjolnir](docs/configuring-playbook-bot-mjolnir.md) (which the playbook has supported for a long time) maintained by Mjolnir's former lead developer.
+Thanks to [FSG-Cat](https://github.com/FSG-Cat), the playbook can now install and configure the [Draupnir](https://github.com/the-draupnir-project/Draupnir) moderation tool (bot). Draupnir is a fork of [Mjolnir](docs/configuring-playbook-bot-mjolnir.md) (which the playbook has supported for a long time) maintained by Mjolnir's former lead developer.
 
 Additional details are available in [Setting up Draupnir](docs/configuring-playbook-bot-draupnir.md).
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Bots provide various additional functionality to your installation.
 | [Postmoogle](https://gitlab.com/etke.cc/postmoogle) | x | Email to matrix bot | [Link](docs/configuring-playbook-bot-postmoogle.md) |
 | [Go-NEB](https://github.com/matrix-org/go-neb) | x | A multi functional bot written in Go | [Link](docs/configuring-playbook-bot-go-neb.md) |
 | [Mjolnir](https://github.com/matrix-org/mjolnir) | x | A moderation tool for Matrix | [Link](docs/configuring-playbook-bot-mjolnir.md) |
-| [Draupnir](https://github.com/Gnuxie/Draupnir) | x | A moderation tool for Matrix (Fork of Mjolnir) | [Link](docs/configuring-playbook-bot-draupnir.md) |
+| [Draupnir](https://github.com/the-draupnir-project/Draupnir) | x | A moderation tool for Matrix (Fork of Mjolnir) | [Link](docs/configuring-playbook-bot-draupnir.md) |
 | [Buscarron](https://gitlab.com/etke.cc/buscarron) | x | Web forms (HTTP POST) to matrix | [Link](docs/configuring-playbook-bot-buscarron.md) |
 | [matrix-chatgpt-bot](https://github.com/matrixgpt/matrix-chatgpt-bot) | x | ChatGPT from matrix | [Link](docs/configuring-playbook-bot-chatgpt.md) |
 

--- a/docs/configuring-playbook-bot-draupnir.md
+++ b/docs/configuring-playbook-bot-draupnir.md
@@ -1,8 +1,8 @@
 # Setting up draupnir (optional)
 
-The playbook can install and configure the [draupnir](https://github.com/Gnuxie/Draupnir) moderation bot for you.
+The playbook can install and configure the [draupnir](https://github.com/the-draupnir-project/Draupnir) moderation bot for you.
 
-See the project's [documentation](https://github.com/Gnuxie/Draupnir) to learn what it does and why it might be useful to you.
+See the project's [documentation](https://github.com/the-draupnir-project/Draupnir) to learn what it does and why it might be useful to you.
 
 If your migrating from Mjolnir skip to step 5b.
 
@@ -77,7 +77,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 
 ## Usage
 
-You can refer to the upstream [documentation](https://github.com/Gnuxie/Draupnir) for additional ways to use and configure draupnir. Check out their [quickstart guide](https://github.com/matrix-org/draupnir/blob/main/docs/moderators.md#quick-usage) for some basic commands you can give to the bot.
+You can refer to the upstream [documentation](https://github.com/the-draupnir-project/Draupnir) for additional ways to use and configure draupnir. Check out their [quickstart guide](https://github.com/matrix-org/draupnir/blob/main/docs/moderators.md#quick-usage) for some basic commands you can give to the bot.
 
 You can configure additional options by adding the `matrix_bot_draupnir_configuration_extension_yaml` variable to your `inventory/host_vars/matrix.DOMAIN/vars.yml` file.
 

--- a/roles/custom/matrix-bot-draupnir/defaults/main.yml
+++ b/roles/custom/matrix-bot-draupnir/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # A moderation tool for Matrix
-# Project source code URL: https://github.com/Gnuxie/Draupnir
+# Project source code URL: https://github.com/the-draupnir-project/Draupnir
 
 matrix_bot_draupnir_enabled: true
 

--- a/roles/custom/matrix-bot-draupnir/defaults/main.yml
+++ b/roles/custom/matrix-bot-draupnir/defaults/main.yml
@@ -4,7 +4,7 @@
 
 matrix_bot_draupnir_enabled: true
 
-matrix_bot_draupnir_version: "v1.84.0"
+matrix_bot_draupnir_version: "v1.85.0"
 
 matrix_bot_draupnir_container_image_self_build: false
 matrix_bot_draupnir_container_image_self_build_repo: "https://github.com/the-draupnir-project/Draupnir.git"
@@ -35,6 +35,16 @@ matrix_bot_draupnir_access_token: ""
 # This should be a room alias or room ID - not a matrix.to URL.
 # Note: draupnir is fairly verbose - expect a lot of messages from it.
 matrix_bot_draupnir_management_room: ""
+
+# Disable Server ACL is used if you want to not give the bot the right to apply Server ACLs in rooms without complaints from the bot.
+# This setting is described the following way in the Configuration. 
+#
+# Whether or not Draupnir should apply `m.room.server_acl` events.
+# DO NOT change this to `true` unless you are very confident that you know what you are doing.
+#
+# Please follow the advice of upstream and only change this value if you know what your doing.
+# Its Exposed here because its common enough to be valid to expose.
+matrix_bot_draupnir_disable_server_acl: "false" 
 
 # Default configuration template which covers the generic use case.
 # You can customize it by controlling the various variables inside it.

--- a/roles/custom/matrix-bot-draupnir/defaults/main.yml
+++ b/roles/custom/matrix-bot-draupnir/defaults/main.yml
@@ -37,14 +37,14 @@ matrix_bot_draupnir_access_token: ""
 matrix_bot_draupnir_management_room: ""
 
 # Disable Server ACL is used if you want to not give the bot the right to apply Server ACLs in rooms without complaints from the bot.
-# This setting is described the following way in the Configuration. 
+# This setting is described the following way in the Configuration.
 #
 # Whether or not Draupnir should apply `m.room.server_acl` events.
 # DO NOT change this to `true` unless you are very confident that you know what you are doing.
 #
 # Please follow the advice of upstream and only change this value if you know what your doing.
 # Its Exposed here because its common enough to be valid to expose.
-matrix_bot_draupnir_disable_server_acl: "false" 
+matrix_bot_draupnir_disable_server_acl: "false"
 
 # Default configuration template which covers the generic use case.
 # You can customize it by controlling the various variables inside it.

--- a/roles/custom/matrix-bot-draupnir/defaults/main.yml
+++ b/roles/custom/matrix-bot-draupnir/defaults/main.yml
@@ -7,7 +7,7 @@ matrix_bot_draupnir_enabled: true
 matrix_bot_draupnir_version: "v1.84.0"
 
 matrix_bot_draupnir_container_image_self_build: false
-matrix_bot_draupnir_container_image_self_build_repo: "https://github.com/Gnuxie/Draupnir.git"
+matrix_bot_draupnir_container_image_self_build_repo: "https://github.com/the-draupnir-project/Draupnir.git"
 
 matrix_bot_draupnir_docker_image: "{{ matrix_bot_draupnir_docker_image_name_prefix }}gnuxie/draupnir:{{ matrix_bot_draupnir_version }}"
 matrix_bot_draupnir_docker_image_name_prefix: "{{ 'localhost/' if matrix_bot_draupnir_container_image_self_build else matrix_container_global_registry_prefix }}"

--- a/roles/custom/matrix-bot-draupnir/templates/production.yaml.j2
+++ b/roles/custom/matrix-bot-draupnir/templates/production.yaml.j2
@@ -51,9 +51,11 @@ recordIgnoredInvites: false
 # (see verboseLogging to adjust this a bit.)
 managementRoom: "{{ matrix_bot_draupnir_management_room }}"
 
+# Deprecated and will be removed in a future version.
+# Running with verboseLogging is unsupported.
 # Whether Draupnir should log a lot more messages in the room,
-# mainly involves "all-OK" messages, and debugging messages for when Draupnir checks bans in a room.
-verboseLogging: false
+# mainly involves "all-OK" messages, and debugging messages for when draupnir checks bans in a room.
+#verboseLogging: false
 
 # The log level of terminal (or container) output,
 # can be one of DEBUG, INFO, WARN and ERROR, in increasing order of importance and severity.
@@ -72,6 +74,10 @@ verifyPermissionsOnStartup: true
 # Whether or not Draupnir should actually apply bans and policy lists,
 # turn on to trial some untrusted configuration or lists.
 noop: false
+
+# Whether or not Draupnir should apply `m.room.server_acl` events.
+# DO NOT change this to `true` unless you are very confident that you know what you are doing.
+disableServerACL: "{{ matrix_bot_draupnir_disable_server_acl }}"
 
 # Whether Draupnir should check member lists quicker (by using a different endpoint),
 # keep in mind that enabling this will miss invited (but not joined) users.


### PR DESCRIPTION
This PR updates Draupnir from 1.84.0 to 1.85.0. 

Adds new config flag to the config and adds a new easy to access option for the newly introduced ACL control. 

The ability to not make the bot scream because you denied it ACL powers is common enough as a desire it seems to make it sensible to add for easy access. Its like one of like 3 attributes in the config that users might want to change the others being Control room, Homeserver (that we do for the user) and ACL sending disabled. 

The setting starts disabled as upstream recomends but you can enable it if you want to. 

This PR also changes the upstream Git repository as Draupnir changed git Repository as its now under a newly created github organisation instead of under Gnuxie/Draupnir