### PR TITLE
Fix mautrix-gmessages branch

### DIFF
--- a/roles/custom/matrix-bridge-mautrix-gmessages/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-gmessages/defaults/main.yml
@@ -6,7 +6,7 @@ matrix_mautrix_gmessages_enabled: true
 
 matrix_mautrix_gmessages_container_image_self_build: false
 matrix_mautrix_gmessages_container_image_self_build_repo: "https://github.com/mautrix/gmessages.git"
-matrix_mautrix_gmessages_container_image_self_build_branch: "{{ 'master' if matrix_mautrix_gmessages_version == 'latest' else matrix_mautrix_gmessages_version }}"
+matrix_mautrix_gmessages_container_image_self_build_branch: "{{ 'main' if matrix_mautrix_gmessages_version == 'latest' else matrix_mautrix_gmessages_version }}"
 
 matrix_mautrix_gmessages_version: v0.1.0
 # See: https://mau.dev/mautrix/gmessages/container_registry


### PR DESCRIPTION
The default branch of [mautrix-gmessages](https://github.com/mautrix/gmessages) is `main` not `master`. 