### PR TITLE
Update beeper-linkedin 0.5.4 -> latest (security fix)

### DIFF
--- a/roles/custom/matrix-bridge-beeper-linkedin/defaults/main.yml
+++ b/roles/custom/matrix-bridge-beeper-linkedin/defaults/main.yml
@@ -4,7 +4,7 @@
 
 matrix_beeper_linkedin_enabled: true
 
-matrix_beeper_linkedin_version: v0.5.4
+matrix_beeper_linkedin_version: latest
 
 # See: https://github.com/beeper/linkedin/pkgs/container/linkedin
 matrix_beeper_linkedin_docker_image: "{{ matrix_beeper_linkedin_docker_image_name_prefix }}beeper/linkedin:{{ matrix_beeper_linkedin_docker_image_tag }}"


### PR DESCRIPTION
no pinned releases from 2022, security fix available with latest only