### PR TITLE
Configure renovate to automatically open pull requests for docker image updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": [
+		"config:base"
+	],
+	"regexManagers": [
+		{
+			"fileMatch": [".*y[a]?ml$"],
+			"matchStrings": [
+				"# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[a-z-0-9]+?))?\\s+[A-Za-z0-9_]+?_version\\s*:\\s*[\"']?(?<currentValue>.+?)[\"']?\\s"
+			]
+		}
+	]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,7 @@
 	],
 	"regexManagers": [
 		{
-			"fileMatch": [".*y[a]?ml$"],
+			"fileMatch": ["defaults/main.yml$"],
 			"matchStrings": [
 				"# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[a-z-0-9]+?))?\\s+[A-Za-z0-9_]+?(?:_version|_tag)\\s*:\\s*[\"']?(?<currentValue>.+?)[\"']?\\s"
 			]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,7 @@
 		{
 			"fileMatch": [".*y[a]?ml$"],
 			"matchStrings": [
-				"# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[a-z-0-9]+?))?\\s+[A-Za-z0-9_]+?_version\\s*:\\s*[\"']?(?<currentValue>.+?)[\"']?\\s"
+				"# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[a-z-0-9]+?))?\\s+[A-Za-z0-9_]+?(?:_version|_tag)\\s*:\\s*[\"']?(?<currentValue>.+?)[\"']?\\s"
 			]
 		}
 	]

--- a/roles/custom/matrix-bot-buscarron/defaults/main.yml
+++ b/roles/custom/matrix-bot-buscarron/defaults/main.yml
@@ -5,6 +5,7 @@
 
 matrix_bot_buscarron_enabled: true
 
+# renovate: datasource=docker depName=registry.gitlab.com/etke.cc/buscarron
 matrix_bot_buscarron_version: v1.3.1
 
 # The hostname at which Buscarron is served.

--- a/roles/custom/matrix-bot-chatgpt/defaults/main.yml
+++ b/roles/custom/matrix-bot-chatgpt/defaults/main.yml
@@ -4,6 +4,7 @@
 
 matrix_bot_chatgpt_enabled: true
 
+# renovate: datasource=docker depName=ghcr.io/matrixgpt/matrix-chatgpt-bot
 matrix_bot_chatgpt_version: 3.1.2
 
 matrix_bot_chatgpt_container_image_self_build: false

--- a/roles/custom/matrix-bot-draupnir/defaults/main.yml
+++ b/roles/custom/matrix-bot-draupnir/defaults/main.yml
@@ -4,6 +4,7 @@
 
 matrix_bot_draupnir_enabled: true
 
+# renovate: datasource=docker depName=gnuxie/draupnir
 matrix_bot_draupnir_version: "v1.85.1"
 
 matrix_bot_draupnir_container_image_self_build: false

--- a/roles/custom/matrix-bot-go-neb/defaults/main.yml
+++ b/roles/custom/matrix-bot-go-neb/defaults/main.yml
@@ -5,6 +5,7 @@
 
 matrix_bot_go_neb_enabled: true
 
+# renovate: datasource=docker depName=matrixdotorg/go-neb
 matrix_bot_go_neb_version: latest
 
 matrix_bot_go_neb_scheme: https

--- a/roles/custom/matrix-bot-honoroit/defaults/main.yml
+++ b/roles/custom/matrix-bot-honoroit/defaults/main.yml
@@ -20,6 +20,7 @@ matrix_bot_honoroit_docker_repo: "https://gitlab.com/etke.cc/honoroit.git"
 matrix_bot_honoroit_docker_repo_version: "{{ matrix_bot_honoroit_version }}"
 matrix_bot_honoroit_docker_src_files_path: "{{ matrix_base_data_path }}/honoroit/docker-src"
 
+# renovate: datasource=docker depName=registry.gitlab.com/etke.cc/honoroit
 matrix_bot_honoroit_version: v0.9.19
 matrix_bot_honoroit_docker_image: "{{ matrix_bot_honoroit_docker_image_name_prefix }}etke.cc/honoroit:{{ matrix_bot_honoroit_version }}"
 matrix_bot_honoroit_docker_image_name_prefix: "{{ 'localhost/' if matrix_bot_honoroit_container_image_self_build else 'registry.gitlab.com/' }}"

--- a/roles/custom/matrix-bot-matrix-registration-bot/defaults/main.yml
+++ b/roles/custom/matrix-bot-matrix-registration-bot/defaults/main.yml
@@ -8,6 +8,7 @@ matrix_bot_matrix_registration_bot_docker_repo: "https://github.com/moan0s/matri
 matrix_bot_matrix_registration_bot_docker_repo_version: "{{ 'main' if matrix_bot_matrix_registration_bot_version == 'latest' else ('v' + matrix_bot_matrix_registration_bot_version) }}"
 matrix_bot_matrix_registration_bot_docker_src_files_path: "{{ matrix_bot_matrix_registration_bot_base_path }}/docker-src"
 
+# renovate: datasource=docker depName=moanos/matrix-registration-bot
 matrix_bot_matrix_registration_bot_version: 1.3.0
 matrix_bot_matrix_registration_bot_docker_iteration: 0
 matrix_bot_matrix_registration_bot_docker_tag: "{{ matrix_bot_matrix_registration_bot_version }}-{{ matrix_bot_matrix_registration_bot_docker_iteration}}"

--- a/roles/custom/matrix-bot-matrix-reminder-bot/defaults/main.yml
+++ b/roles/custom/matrix-bot-matrix-reminder-bot/defaults/main.yml
@@ -9,6 +9,7 @@ matrix_bot_matrix_reminder_bot_docker_repo: "https://github.com/anoadragon453/ma
 matrix_bot_matrix_reminder_bot_docker_repo_version: "{{ matrix_bot_matrix_reminder_bot_version }}"
 matrix_bot_matrix_reminder_bot_docker_src_files_path: "{{ matrix_base_data_path }}/matrix-reminder-bot/docker-src"
 
+# renovate: datasource=docker depName=anoa/matrix-reminder-bot
 matrix_bot_matrix_reminder_bot_version: release-v0.2.1
 matrix_bot_matrix_reminder_bot_docker_image: "{{ matrix_container_global_registry_prefix }}anoa/matrix-reminder-bot:{{ matrix_bot_matrix_reminder_bot_version }}"
 matrix_bot_matrix_reminder_bot_docker_image_force_pull: "{{ matrix_bot_matrix_reminder_bot_docker_image.endswith(':latest') }}"

--- a/roles/custom/matrix-bot-maubot/defaults/main.yml
+++ b/roles/custom/matrix-bot-maubot/defaults/main.yml
@@ -10,6 +10,7 @@ matrix_bot_maubot_docker_src_files_path: "{{ matrix_bot_maubot_base_path }}/dock
 matrix_bot_maubot_docker_repo_version: "{{ 'master' if matrix_bot_maubot_version == 'latest' else matrix_bot_maubot_version }}"
 
 
+# renovate: datasource=docker depName=dock.mau.dev/maubot/maubot
 matrix_bot_maubot_version: v0.4.2
 matrix_bot_maubot_docker_image: "{{ matrix_bot_maubot_docker_image_name_prefix }}maubot/maubot:{{ matrix_bot_maubot_version }}"
 matrix_bot_maubot_docker_image_name_prefix: "{{ 'localhost/' if matrix_bot_maubot_container_image_self_build else 'dock.mau.dev/' }}"

--- a/roles/custom/matrix-bot-mjolnir/defaults/main.yml
+++ b/roles/custom/matrix-bot-mjolnir/defaults/main.yml
@@ -4,6 +4,7 @@
 
 matrix_bot_mjolnir_enabled: true
 
+# renovate: datasource=docker depName=matrixdotorg/mjolnir
 matrix_bot_mjolnir_version: "v1.6.4"
 
 matrix_bot_mjolnir_container_image_self_build: false

--- a/roles/custom/matrix-bot-postmoogle/defaults/main.yml
+++ b/roles/custom/matrix-bot-postmoogle/defaults/main.yml
@@ -9,6 +9,7 @@ matrix_bot_postmoogle_docker_repo: "https://gitlab.com/etke.cc/postmoogle.git"
 matrix_bot_postmoogle_docker_repo_version: "{{ 'main' if matrix_bot_postmoogle_version == 'latest' else matrix_bot_postmoogle_version }}"
 matrix_bot_postmoogle_docker_src_files_path: "{{ matrix_base_data_path }}/postmoogle/docker-src"
 
+# renovate: datasource=docker depName=registry.gitlab.com/etke.cc/postmoogle
 matrix_bot_postmoogle_version: v0.9.16
 matrix_bot_postmoogle_docker_image: "{{ matrix_bot_postmoogle_docker_image_name_prefix }}etke.cc/postmoogle:{{ matrix_bot_postmoogle_version }}"
 matrix_bot_postmoogle_docker_image_name_prefix: "{{ 'localhost/' if matrix_bot_postmoogle_container_image_self_build else 'registry.gitlab.com/' }}"

--- a/roles/custom/matrix-bridge-appservice-discord/defaults/main.yml
+++ b/roles/custom/matrix-bridge-appservice-discord/defaults/main.yml
@@ -5,6 +5,7 @@
 matrix_appservice_discord_enabled: false
 matrix_appservice_discord_container_image_self_build: false
 
+# renovate: datasource=docker depName=ghcr.io/matrix-org/matrix-appservice-discord
 matrix_appservice_discord_version: v4.0.0
 matrix_appservice_discord_docker_image: "{{ matrix_appservice_discord_docker_image_name_prefix }}matrix-org/matrix-appservice-discord:{{ matrix_appservice_discord_version }}"
 matrix_appservice_discord_docker_image_name_prefix: "{{ 'localhost/' if matrix_appservice_discord_container_image_self_build else 'ghcr.io/' }}"

--- a/roles/custom/matrix-bridge-appservice-irc/defaults/main.yml
+++ b/roles/custom/matrix-bridge-appservice-irc/defaults/main.yml
@@ -11,6 +11,7 @@ matrix_appservice_irc_docker_src_files_path: "{{ matrix_base_data_path }}/appser
 
 # matrix_appservice_irc_version used to contain the full Docker image tag (e.g. `release-X.X.X`).
 # It's a bare version number now. We try to somewhat retain compatibility below.
+# renovate: datasource=docker depName=docker.io/matrixdotorg/matrix-appservice-irc
 matrix_appservice_irc_version: 1.0.1
 matrix_appservice_irc_docker_image: "{{ matrix_container_global_registry_prefix }}matrixdotorg/matrix-appservice-irc:{{ matrix_appservice_irc_docker_image_tag }}"
 matrix_appservice_irc_docker_image_tag: "{{ 'latest' if matrix_appservice_irc_version == 'latest' else ('release-' + matrix_appservice_irc_version) }}"

--- a/roles/custom/matrix-bridge-appservice-slack/defaults/main.yml
+++ b/roles/custom/matrix-bridge-appservice-slack/defaults/main.yml
@@ -11,6 +11,7 @@ matrix_appservice_slack_docker_src_files_path: "{{ matrix_base_data_path }}/apps
 
 # matrix_appservice_slack_version used to contain the full Docker image tag (e.g. `release-X.X.X`).
 # It's a bare version number now. We try to somewhat retain compatibility below.
+# renovate: datasource=docker depName=docker.io/matrixdotorg/matrix-appservice-slack
 matrix_appservice_slack_version: 2.1.2
 matrix_appservice_slack_docker_image: "{{ matrix_container_global_registry_prefix }}matrixdotorg/matrix-appservice-slack:{{ matrix_appservice_slack_docker_image_tag }}"
 matrix_appservice_slack_docker_image_tag: "{{ 'latest' if matrix_appservice_slack_version == 'latest' else ('release-' + matrix_appservice_slack_version) }}"

--- a/roles/custom/matrix-bridge-beeper-linkedin/defaults/main.yml
+++ b/roles/custom/matrix-bridge-beeper-linkedin/defaults/main.yml
@@ -4,6 +4,7 @@
 
 matrix_beeper_linkedin_enabled: true
 
+# renovate: datasource=docker depName=ghcr.io/beeper/linkedin
 matrix_beeper_linkedin_version: latest
 
 # See: https://github.com/beeper/linkedin/pkgs/container/linkedin

--- a/roles/custom/matrix-bridge-go-skype-bridge/defaults/main.yml
+++ b/roles/custom/matrix-bridge-go-skype-bridge/defaults/main.yml
@@ -8,6 +8,7 @@ matrix_go_skype_bridge_container_image_self_build: false
 matrix_go_skype_bridge_container_image_self_build_repo: "https://github.com/kelaresg/go-skype-bridge.git"
 matrix_go_skype_bridge_container_image_self_build_branch: "{{ 'master' if matrix_go_skype_bridge_version == 'latest' else matrix_go_skype_bridge_version }}"
 
+# renovate: datasource=docker depName=nodefyme/go-skype-bridge
 matrix_go_skype_bridge_version: latest
 matrix_go_skype_bridge_docker_image: "{{ matrix_go_skype_bridge_docker_image_name_prefix }}nodefyme/go-skype-bridge:{{ matrix_go_skype_bridge_version }}"
 matrix_go_skype_bridge_docker_image_name_prefix: "{{ 'localhost/' if matrix_go_skype_bridge_container_image_self_build else matrix_container_global_registry_prefix }}"

--- a/roles/custom/matrix-bridge-heisenbridge/defaults/main.yml
+++ b/roles/custom/matrix-bridge-heisenbridge/defaults/main.yml
@@ -4,6 +4,7 @@
 
 matrix_heisenbridge_enabled: true
 
+# renovate: datasource=docker depName=hif1/heisenbridge
 matrix_heisenbridge_version: 1.14.5
 matrix_heisenbridge_docker_image: "{{ matrix_container_global_registry_prefix }}hif1/heisenbridge:{{ matrix_heisenbridge_version }}"
 matrix_heisenbridge_docker_image_force_pull: "{{ matrix_heisenbridge_docker_image.endswith(':latest') }}"

--- a/roles/custom/matrix-bridge-hookshot/defaults/main.yml
+++ b/roles/custom/matrix-bridge-hookshot/defaults/main.yml
@@ -10,6 +10,7 @@ matrix_hookshot_container_image_self_build: false
 matrix_hookshot_container_image_self_build_repo: "https://github.com/matrix-org/matrix-hookshot.git"
 matrix_hookshot_container_image_self_build_branch: "{{ 'main' if matrix_hookshot_version == 'latest' else matrix_hookshot_version }}"
 
+# renovate: datasource=docker depName=halfshot/matrix-hookshot
 matrix_hookshot_version: 4.5.1
 
 matrix_hookshot_docker_image: "{{ matrix_hookshot_docker_image_name_prefix }}halfshot/matrix-hookshot:{{ matrix_hookshot_version }}"

--- a/roles/custom/matrix-bridge-mautrix-discord/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-discord/defaults/main.yml
@@ -8,6 +8,7 @@ matrix_mautrix_discord_container_image_self_build: false
 matrix_mautrix_discord_container_image_self_build_repo: "https://mau.dev/mautrix/discord.git"
 matrix_mautrix_discord_container_image_self_build_branch: "{{ 'main' if matrix_mautrix_discord_version == 'latest' else matrix_mautrix_discord_version }}"
 
+# renovate: datasource=docker depName=dock.mau.dev/mautrix/discord
 matrix_mautrix_discord_version: v0.6.2
 # See: https://mau.dev/mautrix/discord/container_registry
 matrix_mautrix_discord_docker_image: "{{ matrix_mautrix_discord_docker_image_name_prefix }}mautrix/discord:{{ matrix_mautrix_discord_version }}"

--- a/roles/custom/matrix-bridge-mautrix-facebook/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-facebook/defaults/main.yml
@@ -7,6 +7,7 @@ matrix_mautrix_facebook_enabled: true
 matrix_mautrix_facebook_container_image_self_build: false
 matrix_mautrix_facebook_container_image_self_build_repo: "https://mau.dev/mautrix/facebook.git"
 
+# renovate: datasource=docker depName=dock.mau.dev/mautrix/facebook
 matrix_mautrix_facebook_version: v0.5.1
 matrix_mautrix_facebook_docker_image: "{{ matrix_mautrix_facebook_docker_image_name_prefix }}mautrix/facebook:{{ matrix_mautrix_facebook_version }}"
 matrix_mautrix_facebook_docker_image_name_prefix: "{{ 'localhost/' if matrix_mautrix_facebook_container_image_self_build else 'dock.mau.dev/' }}"

--- a/roles/custom/matrix-bridge-mautrix-gmessages/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-gmessages/defaults/main.yml
@@ -8,6 +8,7 @@ matrix_mautrix_gmessages_container_image_self_build: false
 matrix_mautrix_gmessages_container_image_self_build_repo: "https://github.com/mautrix/gmessages.git"
 matrix_mautrix_gmessages_container_image_self_build_branch: "{{ 'main' if matrix_mautrix_gmessages_version == 'latest' else matrix_mautrix_gmessages_version }}"
 
+# renovate: datasource=docker depName=dock.mau.dev/mautrix/gmessages
 matrix_mautrix_gmessages_version: v0.2.0
 # See: https://mau.dev/mautrix/gmessages/container_registry
 matrix_mautrix_gmessages_docker_image: "{{ matrix_mautrix_gmessages_docker_image_name_prefix }}mautrix/gmessages:{{ matrix_mautrix_gmessages_version }}"

--- a/roles/custom/matrix-bridge-mautrix-googlechat/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-googlechat/defaults/main.yml
@@ -8,6 +8,7 @@ matrix_mautrix_googlechat_container_image_self_build: false
 matrix_mautrix_googlechat_container_image_self_build_repo: "https://github.com/mautrix/googlechat.git"
 matrix_mautrix_googlechat_container_image_self_build_repo_version: "{{ 'master' if matrix_mautrix_googlechat_version == 'latest' else matrix_mautrix_googlechat_version }}"
 
+# renovate: datasource=docker depName=dock.mau.dev/mautrix/googlechat
 matrix_mautrix_googlechat_version: v0.5.1
 # See: https://mau.dev/mautrix/googlechat/container_registry
 matrix_mautrix_googlechat_docker_image: "{{ matrix_mautrix_googlechat_docker_image_name_prefix }}mautrix/googlechat:{{ matrix_mautrix_googlechat_version }}"

--- a/roles/custom/matrix-bridge-mautrix-hangouts/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-hangouts/defaults/main.yml
@@ -8,6 +8,7 @@ matrix_mautrix_hangouts_container_image_self_build: false
 matrix_mautrix_hangouts_container_image_self_build_repo: "https://github.com/mautrix/hangouts.git"
 matrix_mautrix_hangouts_container_image_self_build_repo_version: "{{ 'master' if matrix_mautrix_hangouts_version == 'latest' else matrix_mautrix_googlechat_version }}"
 
+# renovate: datasource=docker depName=dock.mau.dev/mautrix/hangouts
 matrix_mautrix_hangouts_version: latest
 # See: https://mau.dev/mautrix/hangouts/container_registry
 matrix_mautrix_hangouts_docker_image: "{{ matrix_mautrix_hangouts_docker_image_name_prefix }}mautrix/hangouts:{{ matrix_mautrix_hangouts_version }}"

--- a/roles/custom/matrix-bridge-mautrix-instagram/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-instagram/defaults/main.yml
@@ -8,6 +8,7 @@ matrix_mautrix_instagram_container_image_self_build: false
 matrix_mautrix_instagram_container_image_self_build_repo: "https://github.com/mautrix/instagram.git"
 matrix_mautrix_instagram_container_image_self_build_repo_version: "{{ 'master' if matrix_mautrix_instagram_version == 'latest' else matrix_mautrix_instagram_version }}"
 
+# renovate: datasource=docker depName=dock.mau.dev/mautrix/instagram
 matrix_mautrix_instagram_version: v0.3.1
 # See: https://mau.dev/tulir/mautrix-instagram/container_registry
 matrix_mautrix_instagram_docker_image: "{{ matrix_mautrix_instagram_docker_image_name_prefix }}mautrix/instagram:{{ matrix_mautrix_instagram_version }}"

--- a/roles/custom/matrix-bridge-mautrix-signal/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-signal/defaults/main.yml
@@ -9,7 +9,9 @@ matrix_mautrix_signal_docker_repo: "https://mau.dev/mautrix/signal.git"
 matrix_mautrix_signal_docker_repo_version: "{{ 'master' if matrix_mautrix_signal_version == 'latest' else matrix_mautrix_signal_version }}"
 matrix_mautrix_signal_docker_src_files_path: "{{ matrix_base_data_path }}/mautrix-signal/docker-src"
 
+# renovate: datasource=docker depName=dock.mau.dev/mautrix/signal
 matrix_mautrix_signal_version: v0.4.3
+# renovate: datasource=docker depName=signald/signald
 matrix_mautrix_signal_daemon_version: 0.23.2
 # See: https://mau.dev/mautrix/signal/container_registry
 matrix_mautrix_signal_docker_image: "{{ matrix_mautrix_signal_docker_image_name_prefix }}mautrix/signal:{{ matrix_mautrix_signal_version }}"

--- a/roles/custom/matrix-bridge-mautrix-slack/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-slack/defaults/main.yml
@@ -8,6 +8,7 @@ matrix_mautrix_slack_container_image_self_build: false
 matrix_mautrix_slack_container_image_self_build_repo: "https://mau.dev/mautrix/slack.git"
 matrix_mautrix_slack_container_image_self_build_branch: "{{ 'main' if matrix_mautrix_slack_version == 'latest' else matrix_mautrix_slack_version }}"
 
+# renovate: datasource=docker depName=dock.mau.dev/mautrix/slack
 matrix_mautrix_slack_version: latest
 # See: https://mau.dev/mautrix/slack/container_registry
 matrix_mautrix_slack_docker_image: "{{ matrix_mautrix_slack_docker_image_name_prefix }}mautrix/slack:{{ matrix_mautrix_slack_version }}"

--- a/roles/custom/matrix-bridge-mautrix-telegram/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-telegram/defaults/main.yml
@@ -17,6 +17,7 @@ matrix_mautrix_telegram_docker_repo: "https://mau.dev/mautrix/telegram.git"
 matrix_mautrix_telegram_docker_repo_version: "{{ 'master' if matrix_mautrix_telegram_version == 'latest' else matrix_mautrix_telegram_version }}"
 matrix_mautrix_telegram_docker_src_files_path: "{{ matrix_base_data_path }}/mautrix-telegram/docker-src"
 
+# renovate: datasource=docker depName=dock.mau.dev/mautrix/telegram
 matrix_mautrix_telegram_version: v0.14.2
 # See: https://mau.dev/mautrix/telegram/container_registry
 matrix_mautrix_telegram_docker_image: "{{ matrix_mautrix_telegram_docker_image_name_prefix }}mautrix/telegram:{{ matrix_mautrix_telegram_version }}"

--- a/roles/custom/matrix-bridge-mautrix-twitter/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-twitter/defaults/main.yml
@@ -8,6 +8,7 @@ matrix_mautrix_twitter_container_image_self_build: false
 matrix_mautrix_twitter_container_image_self_build_repo: "https://github.com/mautrix/twitter.git"
 matrix_mautrix_twitter_container_image_self_build_repo_version: "{{ 'master' if matrix_mautrix_twitter_version == 'latest' else matrix_mautrix_twitter_version }}"
 
+# renovate: datasource=docker depName=dock.mau.dev/mautrix/twitter
 matrix_mautrix_twitter_version: v0.1.7
 # See: https://mau.dev/tulir/mautrix-twitter/container_registry
 matrix_mautrix_twitter_docker_image: "{{ matrix_mautrix_twitter_docker_image_name_prefix }}mautrix/twitter:{{ matrix_mautrix_twitter_version }}"

--- a/roles/custom/matrix-bridge-mautrix-whatsapp/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-whatsapp/defaults/main.yml
@@ -8,6 +8,7 @@ matrix_mautrix_whatsapp_container_image_self_build: false
 matrix_mautrix_whatsapp_container_image_self_build_repo: "https://mau.dev/mautrix/whatsapp.git"
 matrix_mautrix_whatsapp_container_image_self_build_branch: "{{ 'master' if matrix_mautrix_whatsapp_version == 'latest' else matrix_mautrix_whatsapp_version }}"
 
+# renovate: datasource=docker depName=dock.mau.dev/mautrix/whatsapp
 matrix_mautrix_whatsapp_version: v0.10.2
 # See: https://mau.dev/mautrix/whatsapp/container_registry
 matrix_mautrix_whatsapp_docker_image: "{{ matrix_mautrix_whatsapp_docker_image_name_prefix }}mautrix/whatsapp:{{ matrix_mautrix_whatsapp_version }}"

--- a/roles/custom/matrix-bridge-mautrix-wsproxy/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-wsproxy/defaults/main.yml
@@ -127,6 +127,7 @@ matrix_mautrix_imessage_registration_yaml: |
 matrix_mautrix_imessage_registration: "{{ matrix_mautrix_imessage_registration_yaml|from_yaml }}"
 
 # Syncproxy-related configuration fields
+# renovate: datasource=docker depName=dock.mau.dev/mautrix/syncproxy
 matrix_mautrix_wsproxy_syncproxy_version: latest
 # See: https://mau.dev/mautrix/wsproxy/container_registry
 matrix_mautrix_wsproxy_syncproxy_docker_image: "dock.mau.dev/mautrix/syncproxy:{{ matrix_mautrix_wsproxy_syncproxy_version }}"

--- a/roles/custom/matrix-bridge-mx-puppet-discord/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-discord/defaults/main.yml
@@ -14,6 +14,7 @@ matrix_mx_puppet_discord_container_image_self_build_dockerfile_path: "Dockerfile
 # Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:8432"), or empty string to not expose.
 matrix_mx_puppet_discord_container_http_host_bind_port: ''
 
+# renovate: datasource=docker depName=registry.gitlab.com/mx-puppet/discord/mx-puppet-discord
 matrix_mx_puppet_discord_version: v0.1.1
 matrix_mx_puppet_discord_docker_image: "{{ matrix_mx_puppet_discord_docker_image_name_prefix }}mx-puppet/discord/mx-puppet-discord:{{ matrix_mx_puppet_discord_version }}"
 matrix_mx_puppet_discord_docker_image_name_prefix: "{{ 'localhost/' if matrix_mx_puppet_discord_container_image_self_build else 'registry.gitlab.com/' }}"

--- a/roles/custom/matrix-bridge-mx-puppet-instagram/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-instagram/defaults/main.yml
@@ -8,6 +8,7 @@ matrix_mx_puppet_instagram_container_image_self_build: false
 matrix_mx_puppet_instagram_container_image_self_build_repo: "https://github.com/Sorunome/mx-puppet-instagram.git"
 matrix_mx_puppet_instagram_container_image_self_build_repo_version: "{{ 'master' if matrix_mx_puppet_instagram_version == 'latest' else matrix_mx_puppet_instagram_version }}"
 
+# renovate: datasource=docker depName=sorunome/mx-puppet-instagram
 matrix_mx_puppet_instagram_version: latest
 matrix_mx_puppet_instagram_docker_image: "{{ matrix_mx_puppet_instagram_docker_image_name_prefix }}sorunome/mx-puppet-instagram:{{ matrix_mx_puppet_instagram_version }}"
 matrix_mx_puppet_instagram_docker_image_name_prefix: "{{ 'localhost/' if matrix_mx_puppet_instagram_container_image_self_build else matrix_container_global_registry_prefix }}"

--- a/roles/custom/matrix-bridge-mx-puppet-slack/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-slack/defaults/main.yml
@@ -17,6 +17,7 @@ matrix_mx_puppet_slack_container_image_self_build_dockerfile_path: "Dockerfile"
 # Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:8432"), or empty string to not expose.
 matrix_mx_puppet_slack_container_http_host_bind_port: ''
 
+# renovate: datasource=docker depName=registry.gitlab.com/mx-puppet/slack/mx-puppet-slack
 matrix_mx_puppet_slack_version: v0.1.2
 matrix_mx_puppet_slack_docker_image: "{{ matrix_mx_puppet_slack_docker_image_name_prefix }}mx-puppet/slack/mx-puppet-slack:{{ matrix_mx_puppet_slack_version }}"
 matrix_mx_puppet_slack_docker_image_name_prefix: "{{ 'localhost/' if matrix_mx_puppet_slack_container_image_self_build else 'registry.gitlab.com/' }}"

--- a/roles/custom/matrix-bridge-mx-puppet-steam/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-steam/defaults/main.yml
@@ -13,6 +13,7 @@ matrix_mx_puppet_steam_container_image_self_build_repo_version: "{{ 'master' if 
 # Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:8432"), or empty string to not expose.
 matrix_mx_puppet_steam_container_http_host_bind_port: ''
 
+# renovate: datasource=docker depName=icewind1991/mx-puppet-steam
 matrix_mx_puppet_steam_version: latest
 matrix_mx_puppet_steam_docker_image: "{{ matrix_mx_puppet_steam_docker_image_name_prefix }}icewind1991/mx-puppet-steam:{{ matrix_mx_puppet_steam_version }}"
 matrix_mx_puppet_steam_docker_image_name_prefix: "{{ 'localhost/' if matrix_mx_puppet_steam_container_image_self_build else matrix_container_global_registry_prefix }}"

--- a/roles/custom/matrix-bridge-mx-puppet-twitter/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-twitter/defaults/main.yml
@@ -13,6 +13,7 @@ matrix_mx_puppet_twitter_container_image_self_build_repo: "https://github.com/So
 # Takes an "<ip>:<port>" or "<port>" value (e.g. "127.0.0.1:8432"), or empty string to not expose.
 matrix_mx_puppet_twitter_container_http_host_bind_port: ''
 
+# renovate: datasource=docker depName=sorunome/mx-puppet-twitter
 matrix_mx_puppet_twitter_version: latest
 matrix_mx_puppet_twitter_docker_image: "{{ matrix_mx_puppet_twitter_docker_image_name_prefix }}sorunome/mx-puppet-twitter:{{ matrix_mx_puppet_twitter_version }}"
 matrix_mx_puppet_twitter_docker_image_name_prefix: "{{ 'localhost/' if matrix_mx_puppet_twitter_container_image_self_build else matrix_container_global_registry_prefix }}"

--- a/roles/custom/matrix-bridge-sms/defaults/main.yml
+++ b/roles/custom/matrix-bridge-sms/defaults/main.yml
@@ -4,6 +4,7 @@
 
 matrix_sms_bridge_enabled: true
 
+# renovate: datasource=docker depName=folivonet/matrix-sms-bridge
 matrix_sms_bridge_version: 0.5.7
 matrix_sms_bridge_docker_image: "{{ matrix_container_global_registry_prefix }}folivonet/matrix-sms-bridge:{{ matrix_sms_bridge_version }}"
 

--- a/roles/custom/matrix-cactus-comments/defaults/main.yml
+++ b/roles/custom/matrix-cactus-comments/defaults/main.yml
@@ -27,6 +27,7 @@ matrix_cactus_comments_tmp_directory_size_mb: 1
 
 matrix_cactus_comments_container_port: 5000
 
+# renovate: datasource=docker depName=cactuscomments/cactus-appservice
 matrix_cactus_comments_version: 0.9.0
 matrix_cactus_comments_docker_image: "{{ matrix_container_global_registry_prefix }}cactuscomments/cactus-appservice:{{ matrix_cactus_comments_version }}"
 matrix_cactus_comments_docker_image_force_pull: "{{ matrix_cactus_comments_docker_image.endswith(':latest') }}"

--- a/roles/custom/matrix-client-cinny/defaults/main.yml
+++ b/roles/custom/matrix-client-cinny/defaults/main.yml
@@ -6,6 +6,7 @@ matrix_client_cinny_enabled: true
 matrix_client_cinny_container_image_self_build: false
 matrix_client_cinny_container_image_self_build_repo: "https://github.com/ajbura/cinny.git"
 
+# renovate: datasource=docker depName=ajbura/cinny
 matrix_client_cinny_version: v2.2.6
 matrix_client_cinny_docker_image: "{{ matrix_client_cinny_docker_image_name_prefix }}ajbura/cinny:{{ matrix_client_cinny_version }}"
 matrix_client_cinny_docker_image_name_prefix: "{{ 'localhost/' if matrix_client_cinny_container_image_self_build else matrix_container_global_registry_prefix }}"

--- a/roles/custom/matrix-client-element/defaults/main.yml
+++ b/roles/custom/matrix-client-element/defaults/main.yml
@@ -10,6 +10,7 @@ matrix_client_element_container_image_self_build_repo: "https://github.com/vecto
 # - https://github.com/vector-im/element-web/issues/19544
 matrix_client_element_container_image_self_build_low_memory_system_patch_enabled: "{{ ansible_memtotal_mb < 4096 }}"
 
+# renovate: datasource=docker depName=vectorim/element-web
 matrix_client_element_version: v1.11.45
 matrix_client_element_docker_image: "{{ matrix_client_element_docker_image_name_prefix }}vectorim/element-web:{{ matrix_client_element_version }}"
 matrix_client_element_docker_image_name_prefix: "{{ 'localhost/' if matrix_client_element_container_image_self_build else matrix_container_global_registry_prefix }}"

--- a/roles/custom/matrix-client-hydrogen/defaults/main.yml
+++ b/roles/custom/matrix-client-hydrogen/defaults/main.yml
@@ -6,6 +6,7 @@ matrix_client_hydrogen_enabled: true
 matrix_client_hydrogen_container_image_self_build: false
 matrix_client_hydrogen_container_image_self_build_repo: "https://github.com/vector-im/hydrogen-web.git"
 
+# renovate: datasource=docker depName=ghcr.io/vectorim/hydrogen-web
 matrix_client_hydrogen_version: v0.4.1
 matrix_client_hydrogen_docker_image: "{{ matrix_client_hydrogen_docker_image_name_prefix }}vector-im/hydrogen-web:{{ matrix_client_hydrogen_version }}"
 matrix_client_hydrogen_docker_image_name_prefix: "{{ 'localhost/' if matrix_client_hydrogen_container_image_self_build else 'ghcr.io/' }}"

--- a/roles/custom/matrix-client-hydrogen/defaults/main.yml
+++ b/roles/custom/matrix-client-hydrogen/defaults/main.yml
@@ -6,7 +6,7 @@ matrix_client_hydrogen_enabled: true
 matrix_client_hydrogen_container_image_self_build: false
 matrix_client_hydrogen_container_image_self_build_repo: "https://github.com/vector-im/hydrogen-web.git"
 
-# renovate: datasource=docker depName=ghcr.io/vectorim/hydrogen-web
+# renovate: datasource=docker depName=ghcr.io/vector-im/hydrogen-web
 matrix_client_hydrogen_version: v0.4.1
 matrix_client_hydrogen_docker_image: "{{ matrix_client_hydrogen_docker_image_name_prefix }}vector-im/hydrogen-web:{{ matrix_client_hydrogen_version }}"
 matrix_client_hydrogen_docker_image_name_prefix: "{{ 'localhost/' if matrix_client_hydrogen_container_image_self_build else 'ghcr.io/' }}"

--- a/roles/custom/matrix-client-schildichat/defaults/main.yml
+++ b/roles/custom/matrix-client-schildichat/defaults/main.yml
@@ -5,6 +5,7 @@ matrix_client_schildichat_enabled: true
 
 matrix_client_schildichat_container_image_self_build: false
 
+# renovate: datasource=docker depName=registry.gitlab.com/etke.cc/schildichat-web
 matrix_client_schildichat_version: v1.11.30-sc.2
 matrix_client_schildichat_docker_image: "{{ matrix_client_schildichat_docker_image_name_prefix }}etke.cc/schildichat-web:{{ matrix_client_schildichat_version }}"
 matrix_client_schildichat_docker_image_name_prefix: "{{ 'localhost/' if matrix_client_schildichat_container_image_self_build else 'registry.gitlab.com/' }}"

--- a/roles/custom/matrix-conduit/defaults/main.yml
+++ b/roles/custom/matrix-conduit/defaults/main.yml
@@ -6,6 +6,7 @@ matrix_conduit_enabled: true
 
 matrix_conduit_docker_image: "{{ matrix_conduit_docker_image_name_prefix }}matrixconduit/matrix-conduit:{{ matrix_conduit_docker_image_tag }}"
 matrix_conduit_docker_image_name_prefix: "docker.io/"
+# renovate: datasource=docker depName=matrixconduit/matrix-conduit
 matrix_conduit_docker_image_tag: "v0.6.0"
 matrix_conduit_docker_image_force_pull: "{{ matrix_conduit_docker_image.endswith(':latest') }}"
 

--- a/roles/custom/matrix-corporal/defaults/main.yml
+++ b/roles/custom/matrix-corporal/defaults/main.yml
@@ -23,6 +23,7 @@ matrix_corporal_container_extra_arguments: []
 # List of systemd services that matrix-corporal.service depends on
 matrix_corporal_systemd_required_services_list: ['docker.service']
 
+# renovate: datasource=docker depName=devture/matrix-corporal
 matrix_corporal_version: 2.5.2
 matrix_corporal_docker_image: "{{ matrix_corporal_docker_image_name_prefix }}devture/matrix-corporal:{{ matrix_corporal_docker_image_tag }}"
 matrix_corporal_docker_image_name_prefix: "{{ 'localhost/' if matrix_corporal_container_image_self_build else matrix_container_global_registry_prefix }}"

--- a/roles/custom/matrix-coturn/defaults/main.yml
+++ b/roles/custom/matrix-coturn/defaults/main.yml
@@ -8,6 +8,7 @@ matrix_coturn_container_image_self_build_repo: "https://github.com/coturn/coturn
 matrix_coturn_container_image_self_build_repo_version: "docker/{{ matrix_coturn_version }}"
 matrix_coturn_container_image_self_build_repo_dockerfile_path: "docker/coturn/alpine/Dockerfile"
 
+# renovate: datasource=docker depName=coturn/coturn
 matrix_coturn_version: 4.6.2-r5
 matrix_coturn_docker_image: "{{ matrix_coturn_docker_image_name_prefix }}coturn/coturn:{{ matrix_coturn_version }}-alpine"
 matrix_coturn_docker_image_name_prefix: "{{ 'localhost/' if matrix_coturn_container_image_self_build else matrix_container_global_registry_prefix }}"

--- a/roles/custom/matrix-dendrite/defaults/main.yml
+++ b/roles/custom/matrix-dendrite/defaults/main.yml
@@ -10,6 +10,7 @@ matrix_dendrite_container_image_self_build_repo: "https://github.com/matrix-org/
 matrix_dendrite_docker_image_path: "matrixdotorg/dendrite-monolith"
 matrix_dendrite_docker_image: "{{ matrix_dendrite_docker_image_name_prefix }}{{ matrix_dendrite_docker_image_path }}:{{ matrix_dendrite_docker_image_tag }}"
 matrix_dendrite_docker_image_name_prefix: "{{ 'localhost/' if matrix_dendrite_container_image_self_build else matrix_container_global_registry_prefix }}"
+# renovate: datasource=docker depName=matrixdotorg/dendrite-monolith
 matrix_dendrite_docker_image_tag: "v0.13.3"
 matrix_dendrite_docker_image_force_pull: "{{ matrix_dendrite_docker_image.endswith(':latest') }}"
 

--- a/roles/custom/matrix-dimension/defaults/main.yml
+++ b/roles/custom/matrix-dimension/defaults/main.yml
@@ -29,6 +29,7 @@ matrix_dimension_container_image_self_build_branch: master
 matrix_dimension_base_path: "{{ matrix_base_data_path }}/dimension"
 matrix_dimension_docker_src_files_path: "{{ matrix_base_data_path }}/docker-src/dimension"
 
+# renovate: datasource=docker depName=turt2live/matrix-dimension
 matrix_dimension_version: latest
 matrix_dimension_docker_image: "{{ matrix_dimension_docker_image_name_prefix }}turt2live/matrix-dimension:{{ matrix_dimension_version }}"
 matrix_dimension_docker_image_name_prefix: "{{ 'localhost/' if matrix_dimension_container_image_self_build else matrix_container_global_registry_prefix }}"

--- a/roles/custom/matrix-dynamic-dns/defaults/main.yml
+++ b/roles/custom/matrix-dynamic-dns/defaults/main.yml
@@ -7,6 +7,7 @@ matrix_dynamic_dns_enabled: true
 # The dynamic dns daemon interval
 matrix_dynamic_dns_daemon_interval: '300'
 
+# renovate: datasource=docker depName=linuxserver/ddclient
 matrix_dynamic_dns_version: v3.10.0-ls135
 
 # The docker container to use when in mode

--- a/roles/custom/matrix-email2matrix/defaults/main.yml
+++ b/roles/custom/matrix-email2matrix/defaults/main.yml
@@ -11,6 +11,7 @@ matrix_email2matrix_container_image_self_build: false
 matrix_email2matrix_container_image_self_build_repo: "https://github.com/devture/email2matrix.git"
 matrix_email2matrix_container_image_self_build_branch: "{{ matrix_email2matrix_version }}"
 
+# renovate: datasource=docker depName=devture/email2matrix
 matrix_email2matrix_version: 1.1.0
 matrix_email2matrix_docker_image_prefix: "{{ 'localhost/' if matrix_email2matrix_container_image_self_build else matrix_container_global_registry_prefix }}"
 matrix_email2matrix_docker_image: "{{ matrix_email2matrix_docker_image_prefix }}devture/email2matrix:{{ matrix_email2matrix_version }}"

--- a/roles/custom/matrix-ma1sd/defaults/main.yml
+++ b/roles/custom/matrix-ma1sd/defaults/main.yml
@@ -8,6 +8,7 @@ matrix_ma1sd_container_image_self_build: false
 matrix_ma1sd_container_image_self_build_repo: "https://github.com/ma1uta/ma1sd.git"
 matrix_ma1sd_container_image_self_build_branch: "{{ matrix_ma1sd_version }}"
 
+# renovate: datasource=docker depName=ma1uta/ma1sd
 matrix_ma1sd_version: "2.5.0"
 
 matrix_ma1sd_docker_image: "{{ matrix_ma1sd_docker_image_name_prefix }}ma1uta/ma1sd:{{ matrix_ma1sd_version }}"

--- a/roles/custom/matrix-mailer/defaults/main.yml
+++ b/roles/custom/matrix-mailer/defaults/main.yml
@@ -10,6 +10,7 @@ matrix_mailer_container_image_self_build_repository_url: "https://github.com/dev
 matrix_mailer_container_image_self_build_src_files_path: "{{ matrix_mailer_base_path }}/docker-src"
 matrix_mailer_container_image_self_build_version: "{{ matrix_mailer_docker_image.split(':')[1] }}"
 
+# renovate: datasource=docker depName=devture/exim-relay
 matrix_mailer_version: 4.96-r1-0
 matrix_mailer_docker_image: "{{ matrix_mailer_docker_image_name_prefix }}devture/exim-relay:{{ matrix_mailer_version }}"
 matrix_mailer_docker_image_name_prefix: "{{ 'localhost/' if matrix_mailer_container_image_self_build else matrix_container_global_registry_prefix }}"

--- a/roles/custom/matrix-media-repo/defaults/main.yml
+++ b/roles/custom/matrix-media-repo/defaults/main.yml
@@ -18,6 +18,7 @@ matrix_media_repo_container_image_self_build_repo: "https://github.com/turt2live
 matrix_media_repo_docker_image_path: "turt2live/matrix-media-repo"
 matrix_media_repo_docker_image: "{{ matrix_media_repo_docker_image_name_prefix }}{{ matrix_media_repo_docker_image_path }}:{{ matrix_media_repo_docker_image_tag }}"
 matrix_media_repo_docker_image_name_prefix: "{{ 'localhost/' if matrix_media_repo_container_image_self_build else matrix_container_global_registry_prefix }}"
+# renovate: datasource=docker depName=turt2live/matrix-media-repo
 matrix_media_repo_docker_image_tag: "v1.2.13"
 matrix_media_repo_docker_image_force_pull: "{{ matrix_media_repo_docker_image.endswith(':latest') }}"
 

--- a/roles/custom/matrix-nginx-proxy/defaults/main.yml
+++ b/roles/custom/matrix-nginx-proxy/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 # Project source code URL: https://github.com/nginx/nginx
 matrix_nginx_proxy_enabled: true
+# renovate: datasource=docker depName=nginx
 matrix_nginx_proxy_version: 1.25.2-alpine
 
 # We use an official nginx image, which we fix-up to run unprivileged.
@@ -307,6 +308,7 @@ matrix_nginx_proxy_proxy_matrix_metrics_basic_auth_path: "{{ matrix_nginx_proxy_
 # To avoid using this, use `matrix_nginx_proxy_proxy_matrix_metrics_basic_auth_raw_content` instead of supplying username/password.
 # Learn more in: `roles/custom/matrix-nginx-proxy/tasks/nginx-proxy/setup_metrics_auth.yml`.
 matrix_nginx_proxy_proxy_matrix_metrics_basic_auth_apache_container_image: "{{ matrix_container_global_registry_prefix }}httpd:{{ matrix_nginx_proxy_proxy_matrix_metrics_basic_auth_apache_container_image_tag }}"
+# renovate: datasource=docker depName=httpd
 matrix_nginx_proxy_proxy_matrix_metrics_basic_auth_apache_container_image_tag: "2.4.54-alpine3.16"
 matrix_nginx_proxy_proxy_matrix_metrics_basic_auth_apache_container_force_pull: "{{ matrix_nginx_proxy_proxy_matrix_metrics_basic_auth_apache_container_image_tag.endswith(':latest') }}"
 

--- a/roles/custom/matrix-prometheus-nginxlog-exporter/defaults/main.yml
+++ b/roles/custom/matrix-prometheus-nginxlog-exporter/defaults/main.yml
@@ -3,6 +3,7 @@
 # See: https://github.com/martin-helmich/prometheus-nginxlog-exporter/
 
 matrix_prometheus_nginxlog_exporter_enabled: true
+# renovate: datasource=docker depName=ghcr.io/martin-helmich/prometheus-nginxlog-exporter/exporter
 matrix_prometheus_nginxlog_exporter_version: v1.10.0
 
 matrix_prometheus_nginxlog_exporter_container_hostname: 'matrix-prometheus-nginxlog-exporter'

--- a/roles/custom/matrix-rageshake/defaults/main.yml
+++ b/roles/custom/matrix-rageshake/defaults/main.yml
@@ -16,6 +16,7 @@ matrix_rageshake_path_prefix: /
 
 # There are no stable container image tags yet.
 # See: https://github.com/matrix-org/rageshake/issues/69
+# renovate: datasource=docker depName=ghcr.io/matrix-org/rageshake
 matrix_rageshake_version: 1.9.0
 
 matrix_rageshake_base_path: "{{ matrix_base_data_path }}/rageshake"

--- a/roles/custom/matrix-registration/defaults/main.yml
+++ b/roles/custom/matrix-registration/defaults/main.yml
@@ -18,6 +18,7 @@ matrix_registration_config_path: "{{ matrix_registration_base_path }}/config"
 matrix_registration_data_path: "{{ matrix_registration_base_path }}/data"
 matrix_registration_docker_src_files_path: "{{ matrix_registration_base_path }}/docker-src"
 
+# renovate: datasource=docker depName=zeratax/matrix-registration
 matrix_registration_version: "v0.7.2"
 
 matrix_registration_docker_image: "{{ matrix_registration_docker_image_name_prefix }}zeratax/matrix-registration:{{ matrix_registration_version }}"

--- a/roles/custom/matrix-sliding-sync/defaults/main.yml
+++ b/roles/custom/matrix-sliding-sync/defaults/main.yml
@@ -5,6 +5,7 @@
 
 matrix_sliding_sync_enabled: true
 
+# renovate: datasource=docker depName=ghcr.io/matrix-org/sliding-sync
 matrix_sliding_sync_version: v0.99.10
 
 matrix_sliding_sync_scheme: https

--- a/roles/custom/matrix-sygnal/defaults/main.yml
+++ b/roles/custom/matrix-sygnal/defaults/main.yml
@@ -12,6 +12,7 @@ matrix_sygnal_hostname: ''
 # This value must either be `/` or not end with a slash (e.g. `/sygnal`).
 matrix_sygnal_path_prefix: /
 
+# renovate: datasource=docker depName=matrixdotorg/sygnal
 matrix_sygnal_version: v0.12.0
 
 matrix_sygnal_base_path: "{{ matrix_base_data_path }}/sygnal"

--- a/roles/custom/matrix-synapse-admin/defaults/main.yml
+++ b/roles/custom/matrix-synapse-admin/defaults/main.yml
@@ -14,6 +14,7 @@ matrix_synapse_admin_nginx_proxy_integration_enabled: false
 matrix_synapse_admin_container_image_self_build: false
 matrix_synapse_admin_container_image_self_build_repo: "https://github.com/Awesome-Technologies/synapse-admin.git"
 
+# renovate: datasource=docker depName=awesometechnologies/synapse-admin
 matrix_synapse_admin_version: 0.8.7
 matrix_synapse_admin_docker_image: "{{ matrix_synapse_admin_docker_image_name_prefix }}awesometechnologies/synapse-admin:{{ matrix_synapse_admin_version }}"
 matrix_synapse_admin_docker_image_name_prefix: "{{ 'localhost/' if matrix_synapse_admin_container_image_self_build else matrix_container_global_registry_prefix }}"

--- a/roles/custom/matrix-synapse-auto-compressor/defaults/main.yml
+++ b/roles/custom/matrix-synapse-auto-compressor/defaults/main.yml
@@ -5,6 +5,7 @@
 
 matrix_synapse_auto_compressor_enabled: true
 
+# renovate: datasource=docker depName=registry.gitlab.com/etke.cc/rust-synapse-compress-state
 matrix_synapse_auto_compressor_version: v0.1.3
 
 matrix_synapse_auto_compressor_base_path: "{{ matrix_base_data_path }}/synapse-auto-compressor"

--- a/roles/custom/matrix-synapse-reverse-proxy-companion/defaults/main.yml
+++ b/roles/custom/matrix-synapse-reverse-proxy-companion/defaults/main.yml
@@ -25,6 +25,7 @@
 
 matrix_synapse_reverse_proxy_companion_enabled: true
 
+# renovate: datasource=docker depName=nginx
 matrix_synapse_reverse_proxy_companion_version: 1.25.2-alpine
 
 matrix_synapse_reverse_proxy_companion_base_path: "{{ matrix_synapse_base_path }}/reverse-proxy-companion"

--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -4,6 +4,7 @@
 
 matrix_synapse_enabled: true
 
+# renovate: datasource=docker depName=matrixdotorg/synapse
 matrix_synapse_version: v1.93.0
 
 matrix_synapse_username: ''

--- a/roles/custom/matrix-user-verification-service/defaults/main.yml
+++ b/roles/custom/matrix-user-verification-service/defaults/main.yml
@@ -6,6 +6,7 @@ matrix_user_verification_service_ansible_name: "Matrix User Verification Service
 matrix_user_verification_service_enabled: true
 
 # Fix version tag
+# renovate: datasource=docker depName=matrixdotorg/matrix-user-verification-service
 matrix_user_verification_service_version: "v2.0.0"
 
 # Paths


### PR DESCRIPTION
This requires the [Renovate GitHub App](https://github.com/apps/renovate) to be enabled for the repository.
 If you prefer that Renovate creates a fork instead of creating branches in this repo, you can use [Forking Renovate](https://docs.renovatebot.com/getting-started/running/#forking-renovate-app) instead.

Once configured, Renovate will start opening pull requests like this: https://github.com/meenzen/matrix-docker-ansible-deploy/pull/3

### How does this work?

When using the default configuration, Renovate can't detect any dependencies in the ansible files:

```yml
matrix_conduit_docker_image_tag: "v0.6.0"
```

I have created a custom [Regex Manager](https://docs.renovatebot.com/modules/manager/regex/) that uses comments to be able to detect the dependencies. By annotating the version numbers with the required metadata, Renovate now understands them:

```yml
# renovate: datasource=docker depName=matrixconduit/matrix-conduit
matrix_conduit_docker_image_tag: "v0.6.0"
```

In the future this could be expanded to non-docker dependencies as well, I just haven't looked into it yet. Renovate supports [a bunch of other datasources](https://docs.renovatebot.com/modules/datasource/#supported-datasources).