### PR TITLE
Update apache example for support discovery

### DIFF
--- a/examples/apache/matrix-synapse.conf
+++ b/examples/apache/matrix-synapse.conf
@@ -37,6 +37,7 @@
 	# Keep some URIs free for different proxy/location
 	ProxyPassMatch ^/.well-known/matrix/client !
 	ProxyPassMatch ^/.well-known/matrix/server !
+	ProxyPassMatch ^/.well-known/matrix/support !
 	ProxyPassMatch ^/_matrix/identity !
 	ProxyPassMatch ^/_matrix/client/r0/user_directory/search !
 
@@ -46,11 +47,11 @@
 	ProxyPassReverse /_matrix http://127.0.0.1:8008/_matrix
 	ProxyPass /_synapse/client http://127.0.0.1:8008/_synapse/client retry=0 nocanon
 	ProxyPassReverse /_synapse/client http://127.0.0.1:8008/_synapse/client
-	
+
 	# Proxy Admin API (necessary for Synapse-Admin)
 	# ProxyPass /_synapse/admin http://127.0.0.1:8008/_synapse/admin retry=0 nocanon
 	# ProxyPassReverse /_synapse/admin http://127.0.0.1:8008/_synapse/admin
-	
+
 	# Proxy Synapse-Admin
 	# ProxyPass /synapse-admin http://127.0.0.1:8766 retry=0 nocanon
 	# ProxyPassReverse /synapse-admin http://127.0.0.1:8766
@@ -64,6 +65,7 @@
 		Header always set Content-Type "application/json"
 		Header always set Access-Control-Allow-Origin "*"
 	</Location>
+
 	# Map /.well-known/matrix/server for server discovery
 	Alias /.well-known/matrix/server /matrix/static-files/.well-known/matrix/server
 	<Files "/matrix/static-files/.well-known/matrix/server">
@@ -72,6 +74,16 @@
 	<Location "/.well-known/matrix/server">
 		Header always set Content-Type "application/json"
 	</Location>
+
+	# Map /.well-known/matrix/support for support discovery
+	Alias /.well-known/matrix/support /matrix/static-files/.well-known/matrix/support
+	<Files "/matrix/static-files/.well-known/matrix/support">
+		Require all granted
+	</Files>
+	<Location "/.well-known/matrix/support">
+		Header always set Content-Type "application/json"
+	</Location>
+
 	<Directory /matrix/static-files/.well-known/matrix/>
 		AllowOverride All
 		# Apache 2.4:


### PR DESCRIPTION
This PR extends MSC1929 integration with an example for the Apache config to run your own webserver.