### PR TITLE
Fix violation of privacy

### DIFF
--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -318,7 +318,7 @@ matrix_synapse_allow_public_rooms_without_auth: false
 # However, disabling federation completely (see `matrix_synapse_federation_enabled`) is a better way to make your server private,
 # instead of relying on security-by-obscurity -- federating with others, having your public rooms joinable by anyone,
 # but hiding them and thinking you've secured them.
-matrix_synapse_allow_public_rooms_over_federation: true
+matrix_synapse_allow_public_rooms_over_federation: false
 
 # Whether to require authentication to retrieve profile data (avatars,
 # display names) of other users through the client API. Defaults to


### PR DESCRIPTION
This is not only not really obvious to newcomers imho but also is a horrible default. It not only violates the privacy but also can easily leak information to the public.

Also it seems like a bad idea to change defaults as a middleman for a repo that itself wants to be used as a generalized server deployment tool.