### PR TITLE
Add .gitattributes with checking out with lf line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
[The line 7 of .editorconfig](https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/0393bd63562bf958205614d7f7d467aa9a48cf32/.editorconfig#l7) specifies that all files use lf line endings. However if the repository is cloned on Windows and the user has `core.autocrlf = true`, they will end up with crlf line endings on everything with text editors configured to use lf line endings (although they may autodetect that).

`.gitattributes` of `* text=auto eol=lf` enables end of line normalization for checked in files that are detected as text and checks them out with lf line-endings regardless of the platform overriding `core.autocrlf`.

- https://www.git-scm.com/docs/gitattributes#_end_of_line_conversion

As an alternative to this pull request, the offending line in `.editorconfig` could be removed, but that would still include risk of getting wrong line-endings checked into the repository unless everyone ever contributing had `core.autocrlf = input` or always used `.editorconfig` capable text editors (which sadly isn't their universal state).