### PR TITLE
draft encryption support for hookshot

### DIFF
--- a/docs/configuring-playbook-bridge-hookshot.md
+++ b/docs/configuring-playbook-bridge-hookshot.md
@@ -23,6 +23,11 @@ Other configuration options are available via the `matrix_hookshot_configuration
 
 Finally, run the playbook (see [installing](installing.md)).
 
+### End-to-bridge endcryption
+
+1. Enable by setting `: true`
+
+If the crypto store has become corrupted, reset it by running `ansible-playbook -i inventory/hosts setup.yml -K --tags=reset-hookshot-encryption`.
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-hookshot.md
+++ b/docs/configuring-playbook-bridge-hookshot.md
@@ -25,7 +25,7 @@ Finally, run the playbook (see [installing](installing.md)).
 
 ### End-to-bridge endcryption
 
-1. Enable by setting `: true`
+1. Enable by setting `matrix_hookshot_experimental_encryption_enabled: true`
 
 If the crypto store has become corrupted, reset it by running `ansible-playbook -i inventory/hosts setup.yml -K --tags=reset-hookshot-encryption`.
 

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -3358,7 +3358,7 @@ ntfy_visitor_request_limit_exempt_hosts_hostnames_auto: |
 #
 ######################################################################
 
-redis_enabled: "{{ matrix_synapse_workers_enabled }}"
+redis_enabled: "{{ matrix_synapse_workers_enabled or matrix_hookshot_experimental_encryption_enabled }}"
 
 redis_identifier: matrix-redis
 

--- a/roles/custom/matrix-bridge-hookshot/defaults/main.yml
+++ b/roles/custom/matrix-bridge-hookshot/defaults/main.yml
@@ -30,6 +30,10 @@ matrix_hookshot_public_endpoint: /hookshot
 matrix_hookshot_appservice_port: 9993
 matrix_hookshot_appservice_endpoint: "{{ matrix_hookshot_public_endpoint }}/_matrix/app"
 
+# Controls whether the experimental end-to-bridge encryption support is enabled.
+# This requires that support is also enabled in the homeserver, see the hookshot docs.
+matrix_hookshot_experimental_encryption_enabled: false
+
 # Controls whether metrics are enabled in the bridge configuration.
 # Enabling them is usually enough for a local (in-container) Prometheus to consume them.
 # If metrics need to be consumed by another (external) Prometheus server, consider exposing them via `matrix_hookshot_metrics_proxying_enabled`.

--- a/roles/custom/matrix-bridge-hookshot/tasks/main.yml
+++ b/roles/custom/matrix-bridge-hookshot/tasks/main.yml
@@ -10,6 +10,12 @@
       ansible.builtin.include_tasks: "{{ role_path }}/tasks/inject_into_nginx_proxy.yml"
 
 - tags:
+    - reset-hookshot-encryption
+  block:
+    - when: matrix_hookshot_enabled | bool
+      ansible.builtin.include_tasks: "{{ role_path }}/tasks/reset_encryption.yml"
+
+- tags:
     - setup-all
     - setup-hookshot
     - install-all

--- a/roles/custom/matrix-bridge-hookshot/tasks/reset_encryptioon.yml
+++ b/roles/custom/matrix-bridge-hookshot/tasks/reset_encryptioon.yml
@@ -1,0 +1,12 @@
+---
+- name: Resetting Hookshot's crypto store
+  ansible.builtin.command:
+    cmd: |
+      {{ devture_systemd_docker_base_host_command_docker }} run
+      --rm
+      --name={{ matrix_hookshot_container_url }}-reset-crypto
+      --user={{ matrix_user_uid }}:{{ matrix_user_gid }}
+      --cap-drop=ALL
+      -v {{ matrix_hookshot_base_path }}/config.yml:/config.yml
+      {{ matrix_hookshot_docker_image }} yarn start:resetcrypto
+  changed_when: false

--- a/roles/custom/matrix-bridge-hookshot/templates/config.yml.j2
+++ b/roles/custom/matrix-bridge-hookshot/templates/config.yml.j2
@@ -107,6 +107,14 @@ metrics:
   # (Optional) Prometheus metrics support
   #
   enabled: {{ matrix_hookshot_metrics_enabled | to_json }}
+{% if matrix_hookshot_experimental_encryption_enabled %}
+queue:
+  monolithic: true
+  port: 6379
+  host: matrix-redis
+experimentalEncryption:
+  storagePath: /data/encryption
+{% endif %}
 logging:
   # (Optional) Logging settings. You can have a severity debug,info,warn,error
   #

--- a/roles/custom/matrix-bridge-hookshot/templates/registration.yml.j2
+++ b/roles/custom/matrix-bridge-hookshot/templates/registration.yml.j2
@@ -28,3 +28,9 @@ namespaces:
 sender_localpart: hookshot
 url: "http://{{ matrix_hookshot_container_url }}:{{ matrix_hookshot_appservice_port }}" # This should match the bridge.port in your config file
 rate_limited: false
+
+{% if matrix_hookshot_experimental_encryption_enabled %}
+de.sorunome.msc2409.push_ephemeral: true
+push_ephemeral: true
+org.matrix.msc3202: true
+{% endif %}

--- a/roles/custom/matrix-bridge-hookshot/templates/systemd/matrix-hookshot.service.j2
+++ b/roles/custom/matrix-bridge-hookshot/templates/systemd/matrix-hookshot.service.j2
@@ -16,7 +16,7 @@ Environment="HOME={{ devture_systemd_docker_base_systemd_unit_home_path }}"
 ExecStartPre=-{{ devture_systemd_docker_base_host_command_docker }} kill {{ matrix_hookshot_container_url }}
 ExecStartPre=-{{ devture_systemd_docker_base_host_command_docker }} rm {{ matrix_hookshot_container_url }}
 
-ExecStart={{ devture_systemd_docker_base_host_command_docker }} run --rm --name {{ matrix_hookshot_container_url }} \
+ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create --rm --name {{ matrix_hookshot_container_url }} \
           --log-driver=none \
           --user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
           --cap-drop=ALL \
@@ -29,6 +29,12 @@ ExecStart={{ devture_systemd_docker_base_host_command_docker }} run --rm --name 
           {{ arg }} \
           {% endfor %}
           {{ matrix_hookshot_docker_image }}
+
+{% if matrix_hookshot_experimental_encryption_enabled %}
+ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect matrix-redis {{ matrix_hookshot_container_url }}
+{% endif %}
+
+ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach {{ matrix_hookshot_container_url }}
 
 ExecStop=-{{ devture_systemd_docker_base_host_command_docker }} kill {{ matrix_hookshot_container_url }}
 ExecStop=-{{ devture_systemd_docker_base_host_command_docker }} rm {{ matrix_hookshot_container_url }}


### PR DESCRIPTION
per the comment in main.yml, this requires some experimental synapse features to also be enabled, which the role does not do yet at the time of writing (94abf2d5bde63919c6b5597f3142eea5fed73815).
i manage that by setting (iirc) in my host vars:
```
matrix_synapse_configuration_extension_yaml: |
  experimental_features:
    msc2409_to_device_messages_enabled: true
    msc3202_device_masquerading: true
    msc3202_transaction_extensions: true
```

other than that, i tried this out at some point which worked for a while but eventually broke in a way that hookshot's messages were not decryptable anymore. i couldn't figure out what broke it and had no time to try it again, so i never contributed this patch. i think the feature is not quite stable yet, unless i made a mistake somewhere, which is for you to review. i am sharing it now out of interest from members in the hookshot room.

this PR is a draft for the above 2 reasons. feel free to take it as the base for something production ready.