### PR TITLE
Remove mention of the need for manual compilation of Element X for custom homeserver

### DIFF
--- a/docs/configuring-playbook-sliding-sync-proxy.md
+++ b/docs/configuring-playbook-sliding-sync-proxy.md
@@ -8,7 +8,7 @@ See the project's [documentation](https://github.com/matrix-org/sliding-sync) to
 
 Element X iOS is [available on TestFlight](https://testflight.apple.com/join/uZbeZCOi).
 
-Element X Android requires manual compilation to get it working with a non-`matrix.org` homeseserver. It's also less feature-complete than the iOS version.
+Element X Android is less feature-complete than the iOS version.
 
 **NOTE**: The Sliding Sync proxy **only works with the Traefik reverse-proxy**. If you have an old server installation (from the time `matrix-nginx-proxy` was our default reverse-proxy - `matrix_playbook_reverse_proxy_type: playbook-managed-nginx`), you won't be able to use Sliding Sync.
 


### PR DESCRIPTION
It's no longer necessary, as the Element X app now lets you configure the homeserver through the gui at first run