### PR TITLE
Remove mention of Android Element X being less feature complete than the iOS version

### DIFF
--- a/docs/configuring-playbook-sliding-sync-proxy.md
+++ b/docs/configuring-playbook-sliding-sync-proxy.md
@@ -8,8 +8,6 @@ See the project's [documentation](https://github.com/matrix-org/sliding-sync) to
 
 Element X iOS is [available on TestFlight](https://testflight.apple.com/join/uZbeZCOi).
 
-Element X Android is less feature-complete than the iOS version.
-
 **NOTE**: The Sliding Sync proxy **only works with the Traefik reverse-proxy**. If you have an old server installation (from the time `matrix-nginx-proxy` was our default reverse-proxy - `matrix_playbook_reverse_proxy_type: playbook-managed-nginx`), you won't be able to use Sliding Sync.
 
 **NOTE**: The sliding-sync proxy is **not required** when using the **Conduit homeserver**. Starting from version `0.6.0` Conduit has native support for some sliding sync features. If there are issues with the native implementation, you might have a better experience when enabling the sliding-sync proxy anyway.

--- a/docs/configuring-playbook-sliding-sync-proxy.md
+++ b/docs/configuring-playbook-sliding-sync-proxy.md
@@ -8,6 +8,8 @@ See the project's [documentation](https://github.com/matrix-org/sliding-sync) to
 
 Element X iOS is [available on TestFlight](https://testflight.apple.com/join/uZbeZCOi).
 
+Element X Android is [available on the Github Releases page](https://github.com/vector-im/element-x-android/releases).
+
 **NOTE**: The Sliding Sync proxy **only works with the Traefik reverse-proxy**. If you have an old server installation (from the time `matrix-nginx-proxy` was our default reverse-proxy - `matrix_playbook_reverse_proxy_type: playbook-managed-nginx`), you won't be able to use Sliding Sync.
 
 **NOTE**: The sliding-sync proxy is **not required** when using the **Conduit homeserver**. Starting from version `0.6.0` Conduit has native support for some sliding sync features. If there are issues with the native implementation, you might have a better experience when enabling the sliding-sync proxy anyway.


### PR DESCRIPTION
Quoting upstream:

> Element X Android and Element X iOS apps are in a similar state.
> 
> https://github.com/vector-im/element-x-android/issues/911