### PR TITLE
add self-build for matrix_user_verification

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -4303,9 +4303,6 @@ matrix_user_creator_users_auto: |
 #
 ######################################################################
 
-## FIXME: Needs to be updated when there is a proper release by upstream.
-matrix_user_verification_service_docker_image: "{{ matrix_user_verification_service_docker_image_name_prefix }}matrixdotorg/matrix-user-verification-service@sha256:d2aabc984dd69d258c91900c36928972d7aaef19d776caa3cd6a0fbc0e307270"
-
 matrix_user_verification_service_enabled: false
 matrix_user_verification_service_systemd_required_services_list: |
   {{

--- a/roles/custom/matrix-user-verification-service/defaults/main.yml
+++ b/roles/custom/matrix-user-verification-service/defaults/main.yml
@@ -5,6 +5,10 @@ matrix_user_verification_service_ansible_name: "Matrix User Verification Service
 # Enable by default. This is overwritten in provided group vars.
 matrix_user_verification_service_enabled: true
 
+matrix_user_verification_service_container_image_self_build: "{{ matrix_architecture != 'amd64' }}"
+matrix_user_verification_service_container_image_self_build_repo: "https://github.com/matrix-org/matrix-user-verification-service"
+matrix_user_verification_service_container_image_self_build_branch: "{{ 'master' if matrix_registration_version == 'latest' else matrix_user_verification_service_version }}"
+
 # Fix version tag
 # renovate: datasource=docker depName=matrixdotorg/matrix-user-verification-service
 matrix_user_verification_service_version: "v3.0.0"
@@ -13,6 +17,7 @@ matrix_user_verification_service_version: "v3.0.0"
 matrix_user_verification_service_base_path: "{{ matrix_base_data_path }}/user-verification-service"
 matrix_user_verification_service_config_path: "{{ matrix_user_verification_service_base_path }}/config"
 matrix_user_verification_service_config_env_file: "{{ matrix_user_verification_service_config_path }}/.env"
+matrix_user_verification_service_docker_src_files_path: "{{ matrix_user_verification_service_base_path }}/docker-src"
 
 # Docker
 matrix_user_verification_service_docker_image_name_prefix: "{{ matrix_container_global_registry_prefix }}"

--- a/roles/custom/matrix-user-verification-service/tasks/setup_install.yml
+++ b/roles/custom/matrix-user-verification-service/tasks/setup_install.yml
@@ -9,6 +9,7 @@
     group: "{{ matrix_user_groupname }}"
   with_items:
     - {path: "{{ matrix_user_verification_service_config_path }}", when: true}
+    - {path: "{{ matrix_user_verification_service_docker_src_files_path }}", when: "{{ matrix_user_verification_service_container_image_self_build }}"}
   when: item.when | bool
 
 - name: Ensure Matrix User Verification Service image is pulled
@@ -21,6 +22,30 @@
   retries: "{{ devture_playbook_help_container_retries_count }}"
   delay: "{{ devture_playbook_help_container_retries_delay }}"
   until: result is not failed
+  when: "not matrix_user_verification_service_container_image_self_build | bool"
+
+- name: Ensure Matrix User Verification Service repository is present when self-building
+  ansible.builtin.git:
+    repo: "{{ matrix_user_verification_service_container_image_self_build_repo }}"
+    dest: "{{ matrix_user_verification_service_docker_src_files_path }}"
+    version: "{{ matrix_user_verification_service_container_image_self_build_branch }}"
+    force: "yes"
+  become: true
+  become_user: "{{ matrix_user_username }}"
+  register: matrix_user_verification_service_git_pull_results
+  when: "matrix_user_verification_service_container_image_self_build | bool"
+
+- name: Ensure Matrix User Verification Service image is built
+  community.docker.docker_image:
+    name: "{{ matrix_user_verification_service_docker_image }}"
+    source: build
+    force_source: "{{ matrix_user_verification_service_git_pull_results.changed if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
+    force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_user_verification_service_git_pull_results.changed }}"
+    build:
+      dockerfile: Dockerfile
+      path: "{{ matrix_user_verification_service_docker_src_files_path }}"
+      pull: true
+  when: "matrix_user_verification_service_container_image_self_build | bool"
 
 - name: Ensure Matrix User Verification Service env file installed
   ansible.builtin.template:

--- a/roles/custom/matrix-user-verification-service/templates/systemd/matrix-user-verification-service.service.j2
+++ b/roles/custom/matrix-user-verification-service/templates/systemd/matrix-user-verification-service.service.j2
@@ -24,6 +24,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
 			--read-only \
+			--tmpfs /.npm \
 			--network={{ matrix_user_verification_service_container_network }} \
 			{% if matrix_user_verification_service_container_http_host_bind_port %}
 			-p {{ matrix_user_verification_service_container_http_host_bind_port }}:3000 \


### PR DESCRIPTION
Currently v3.0.0 tested with no issues.
So remove matrix_user_verification_service_docker_image from groups_vars.

/.npm must be writable or an error will be reported.