### PR TITLE
Update matrix-domain.conf.j2 - trying to fix issue #2954

### DIFF
--- a/roles/custom/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
+++ b/roles/custom/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
@@ -119,7 +119,7 @@
 	# Redirect other endpoints registered by the media-repo to its container
 	# /_matrix/client/r0/logout
 	# /_matrix/client/r0/logout/all
-	location ^~ /_matrix/client/(r0|v1|v3|unstable)/(logout|logout/all) {
+	location ~ /_matrix/client/(r0|v1|v3|unstable)/(logout|logout/all) {
 		{% if matrix_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}
 			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
@@ -142,7 +142,7 @@
 	# Redirect other endpoints registered by the media-repo to its container
 	# /_matrix/client/r0/admin/purge_media_cache
 	# /_matrix/client/r0/admin/quarantine_media/{roomId:[^/]+}
-	location ^~ /_matrix/client/(r0|v1|v3|unstable)/admin/(purge_media_cache|quarantine_media/.*) {
+	location ~ /_matrix/client/(r0|v1|v3|unstable)/admin/(purge_media_cache|quarantine_media/.*) {
 		{% if matrix_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}
 			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
@@ -195,6 +195,9 @@
 		    {% endif %}
 			proxy_pass http://$backend;
 		{% else %}
+            {% if matrix_nginx_proxy_proxy_matrix_user_directory_search_v3_to_r0_redirect_enabled %}
+		    rewrite ^(.*?)/v3/(.*?)$  $1/r0/$2 break;
+		    {% endif %}
 			{# Generic configuration for use outside of our container setup #}
 			proxy_pass http://{{ matrix_nginx_proxy_proxy_matrix_user_directory_search_addr_sans_container }};
 		{% endif %}
@@ -215,6 +218,9 @@
 	        {% endif %}
 			proxy_pass http://$backend;
 		{% else %}
+            {% if matrix_nginx_proxy_proxy_matrix_user_directory_search_v3_to_r0_redirect_enabled %}
+		    rewrite ^(.*?)/v3/(.*?)$  $1/r0/$2 break;
+		    {% endif %}
 			{# Generic configuration for use outside of our container setup #}
 			proxy_pass http://{{ matrix_nginx_proxy_proxy_matrix_3pid_registration_addr_sans_container }};
 		{% endif %}

--- a/roles/custom/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
+++ b/roles/custom/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
@@ -185,15 +185,14 @@
 	{% endif %}
 
 	{% if matrix_nginx_proxy_proxy_matrix_user_directory_search_enabled %}
-	location ^~ /_matrix/client/(r0|v3)/user_directory/search {
-		{% if matrix_nginx_proxy_proxy_matrix_user_directory_search_v3_to_r0_redirect_enabled %}
-		rewrite ^(.*?)/v3/(.*?)$  $1/r0/$2 break;
-		{% endif %}
-
+	location ~ /_matrix/client/(r0|v3)/user_directory/search {
 		{% if matrix_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}
 			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
-			set $backend "{{ matrix_nginx_proxy_proxy_matrix_user_directory_search_addr_with_container }}";
+            set $backend "{{ matrix_nginx_proxy_proxy_matrix_user_directory_search_addr_with_container }}";
+            {% if matrix_nginx_proxy_proxy_matrix_user_directory_search_v3_to_r0_redirect_enabled %}
+		    rewrite ^(.*?)/v3/(.*?)$  $1/r0/$2 break;
+		    {% endif %}
 			proxy_pass http://$backend;
 		{% else %}
 			{# Generic configuration for use outside of our container setup #}

--- a/roles/custom/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
+++ b/roles/custom/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
@@ -206,14 +206,13 @@
 
 	{% if matrix_nginx_proxy_proxy_matrix_3pid_registration_enabled %}
 	location ~ ^/_matrix/client/(r0|v3)/register/(email|msisdn)/requestToken$ {
-		{% if matrix_nginx_proxy_proxy_matrix_3pid_registration_v3_to_r0_redirect_enabled %}
-		rewrite ^(.*?)/v3/(.*?)$  $1/r0/$2 break;
-		{% endif %}
-
 		{% if matrix_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}
 			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 			set $backend "{{ matrix_nginx_proxy_proxy_matrix_3pid_registration_addr_with_container }}";
+   		    {% if matrix_nginx_proxy_proxy_matrix_3pid_registration_v3_to_r0_redirect_enabled %}
+            rewrite ^(.*?)/v3/(.*?)$  $1/r0/$2 break;
+	        {% endif %}
 			proxy_pass http://$backend;
 		{% else %}
 			{# Generic configuration for use outside of our container setup #}

--- a/roles/custom/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
+++ b/roles/custom/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
@@ -189,15 +189,15 @@
 		{% if matrix_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}
 			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
-            set $backend "{{ matrix_nginx_proxy_proxy_matrix_user_directory_search_addr_with_container }}";
-            {% if matrix_nginx_proxy_proxy_matrix_user_directory_search_v3_to_r0_redirect_enabled %}
-		    rewrite ^(.*?)/v3/(.*?)$  $1/r0/$2 break;
-		    {% endif %}
+			set $backend "{{ matrix_nginx_proxy_proxy_matrix_user_directory_search_addr_with_container }}";
+			{% if matrix_nginx_proxy_proxy_matrix_user_directory_search_v3_to_r0_redirect_enabled %}
+			rewrite ^(.*?)/v3/(.*?)$  $1/r0/$2 break;
+			{% endif %}
 			proxy_pass http://$backend;
 		{% else %}
-            {% if matrix_nginx_proxy_proxy_matrix_user_directory_search_v3_to_r0_redirect_enabled %}
-		    rewrite ^(.*?)/v3/(.*?)$  $1/r0/$2 break;
-		    {% endif %}
+			{% if matrix_nginx_proxy_proxy_matrix_user_directory_search_v3_to_r0_redirect_enabled %}
+			rewrite ^(.*?)/v3/(.*?)$  $1/r0/$2 break;
+			{% endif %}
 			{# Generic configuration for use outside of our container setup #}
 			proxy_pass http://{{ matrix_nginx_proxy_proxy_matrix_user_directory_search_addr_sans_container }};
 		{% endif %}
@@ -213,14 +213,14 @@
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}
 			resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
 			set $backend "{{ matrix_nginx_proxy_proxy_matrix_3pid_registration_addr_with_container }}";
-   		    {% if matrix_nginx_proxy_proxy_matrix_3pid_registration_v3_to_r0_redirect_enabled %}
-            rewrite ^(.*?)/v3/(.*?)$  $1/r0/$2 break;
-	        {% endif %}
+			{% if matrix_nginx_proxy_proxy_matrix_3pid_registration_v3_to_r0_redirect_enabled %}
+			rewrite ^(.*?)/v3/(.*?)$  $1/r0/$2 break;
+			{% endif %}
 			proxy_pass http://$backend;
 		{% else %}
-   		    {% if matrix_nginx_proxy_proxy_matrix_3pid_registration_v3_to_r0_redirect_enabled %}
-            rewrite ^(.*?)/v3/(.*?)$  $1/r0/$2 break;
-	        {% endif %}
+			{% if matrix_nginx_proxy_proxy_matrix_3pid_registration_v3_to_r0_redirect_enabled %}
+			rewrite ^(.*?)/v3/(.*?)$  $1/r0/$2 break;
+			{% endif %}
 			{# Generic configuration for use outside of our container setup #}
 			proxy_pass http://{{ matrix_nginx_proxy_proxy_matrix_3pid_registration_addr_sans_container }};
 		{% endif %}

--- a/roles/custom/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
+++ b/roles/custom/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
@@ -218,9 +218,9 @@
 	        {% endif %}
 			proxy_pass http://$backend;
 		{% else %}
-            {% if matrix_nginx_proxy_proxy_matrix_user_directory_search_v3_to_r0_redirect_enabled %}
-		    rewrite ^(.*?)/v3/(.*?)$  $1/r0/$2 break;
-		    {% endif %}
+   		    {% if matrix_nginx_proxy_proxy_matrix_3pid_registration_v3_to_r0_redirect_enabled %}
+            rewrite ^(.*?)/v3/(.*?)$  $1/r0/$2 break;
+	        {% endif %}
 			{# Generic configuration for use outside of our container setup #}
 			proxy_pass http://{{ matrix_nginx_proxy_proxy_matrix_3pid_registration_addr_sans_container }};
 		{% endif %}


### PR DESCRIPTION
exchanged `^~` with `~` as a pattern matching in the location part. I am very sure, that it only works using `~`. I am not quite sure though, if this is the right way to do it, because `~` is probably more expensive than `^~`

the rewrite has to be behind the definition of the $backend. Otherwise nginx will fail to work. This is probably because "break" goes directly to the proxy_pass which uses $backend.