### PR TITLE
Update synapse-s3-storage-provider

### DIFF
--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -907,7 +907,7 @@ matrix_synapse_ext_encryption_config_yaml: |
 # Installing it requires building a customized Docker image for Synapse (see `matrix_synapse_container_image_customizations_enabled`).
 # Enabling this will enable customizations and inject the appropriate Dockerfile clauses for installing synapse-s3-storage-provider.
 matrix_synapse_ext_synapse_s3_storage_provider_enabled: false
-matrix_synapse_ext_synapse_s3_storage_provider_version: 1.2.1
+matrix_synapse_ext_synapse_s3_storage_provider_version: 1.3.0
 # Controls whether media from this (local) server is stored in s3-storage-provider
 matrix_synapse_ext_synapse_s3_storage_provider_store_local: true
 # Controls whether media from remote servers is stored in s3-storage-provider


### PR DESCRIPTION
looks like newer version is required for synapse 1.96.1

ref: https://matrix.to/#/!QQpfJfZvqxbCfeDgCj:matrix.org/$2K4TnSNKydSUPb1rcplUpuzIeIxt2vaQUnMM87L28Os?via=matrix.org&via=envs.net&via=element.io