### PR TITLE
feat: allow renovate to update ansible dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,5 +10,15 @@
 				"# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[a-z-0-9]+?))?\\s+[A-Za-z0-9_]+?(?:_version|_tag)\\s*:\\s*[\"']?(?<currentValue>.+?)[\"']?\\s"
 			]
 		}
+	],
+	"packageRules": [
+		{
+			"matchSourceUrlPrefixes": [
+				"https://github.com/devture/com.devture.ansible.role",
+				"https://gitlab.com/etke.cc/roles",
+				"https://github.com/mother-of-all-self-hosting"
+			],
+			"ignoreUnstable": false
+		}
 	]
 }


### PR DESCRIPTION
Because the versioning scheme used for the external ansible roles contains hyphens, renovate treats them as unstable. This behavior is correct when strictly adhering to semver, but in case of the ansible roles it is undesirable as it blocks the automated updates.

By disabling the `ignoreUnstable` setting, renovate will be able to automatically update them as well.

Example renovate pr: https://github.com/meenzen/matrix-docker-ansible-deploy/pull/18