### PR TITLE
Update README.md: add mash-playbook, remove archived playbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,14 +197,8 @@ When updating the playbook, refer to [the changelog](CHANGELOG.md) to catch up w
 
 ## Related
 
-You may also be interested in these other Ansible playbooks:
+You may also be interested in another Ansible playbook for adding non-matrix related services:
 
-- [gitea-docker-ansible-deploy](https://github.com/spantaleev/gitea-docker-ansible-deploy) - for deploying a [Gitea](https://gitea.io/) git version-control server
+- [mash-playbook](https://github.com/mother-of-all-self-hosting/mash-playbook) - for deploying a large number of self-hosted software. [List of supported services](https://github.com/mother-of-all-self-hosting/mash-playbook/blob/main/docs/supported-services.md)
 
-- [nextcloud-docker-ansible-deploy](https://github.com/spantaleev/nextcloud-docker-ansible-deploy) - for deploying a [Nextcloud](https://nextcloud.com/) server
-
-- [peertube-docker-ansible-deploy](https://github.com/spantaleev/peertube-docker-ansible-deploy) - for deploying a [PeerTube](https://joinpeertube.org/) video-platform server
-
-- [vaultwarden-docker-ansible-deploy](https://github.com/spantaleev/vaultwarden-docker-ansible-deploy) - for deploying a [Vaultwarden](https://github.com/dani-garcia/vaultwarden) password manager server (unofficial [Bitwarden](https://bitwarden.com/) compatible server)
-
-They're all making use of Traefik as their reverse-proxy, so it should be easy to host all these services on the same server. Follow the `docs/configuring-playbook-interoperability.md` documentation in each playbook.
+It makes use of Traefik as its reverse-proxy, so it should be easy to host all these services on the same server. See `docs/interoperability.md` contained there for further details.

--- a/README.md
+++ b/README.md
@@ -197,8 +197,6 @@ When updating the playbook, refer to [the changelog](CHANGELOG.md) to catch up w
 
 ## Related
 
-You may also be interested in another Ansible playbook for adding non-matrix related services:
+You may also be interested in [mash-playbook](https://github.com/mother-of-all-self-hosting/mash-playbook) - another Ansible playbook for self-hosting non-Matrix services (see its [List of supported services](https://github.com/mother-of-all-self-hosting/mash-playbook/blob/main/docs/supported-services.md)).
 
-- [mash-playbook](https://github.com/mother-of-all-self-hosting/mash-playbook) - for deploying a large number of self-hosted software. [List of supported services](https://github.com/mother-of-all-self-hosting/mash-playbook/blob/main/docs/supported-services.md)
-
-It makes use of Traefik as its reverse-proxy, so it should be easy to host all these services on the same server. See `docs/interoperability.md` contained there for further details.
+mash-playbook also makes use of [Traefik](./docs/configuring-playbook-traefik.md) as its reverse-proxy, so with minor [interoperability adjustments](https://github.com/mother-of-all-self-hosting/mash-playbook/blob/main/docs/interoperability.md), you can make matrix-docker-ansible-deploy and mash-playbook co-exist and host Matrix and non-Matrix services on the same server.


### PR DESCRIPTION
Notced the old playbooks were finally archived. Figured it would be a good time to remove them and replace with the successor in the README.md