### PR TITLE
[#3043] vector im now element hq

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Web clients for matrix that you can host on your own domains.
 | Name | Default? | Description | Documentation |
 | ---- | -------- | ----------- | ------------- |
 | [Element](https://app.element.io/) | ✓ | Web UI, which is configured to connect to your own Synapse server by default | [Link](docs/configuring-playbook-client-element.md) |
-| [Hydrogen](https://github.com/vector-im/hydrogen-web) | x | Lightweight matrix client with legacy and mobile browser support | [Link](docs/configuring-playbook-client-hydrogen.md) |
+| [Hydrogen](https://github.com/element-hq/hydrogen-web) | x | Lightweight matrix client with legacy and mobile browser support | [Link](docs/configuring-playbook-client-hydrogen.md) |
 | [Cinny](https://github.com/ajbura/cinny) |  x | Simple, elegant and secure web client | [Link](docs/configuring-playbook-client-cinny.md) |
 | [SchildiChat](https://schildi.chat/) | x | Based on Element, with a more traditional instant messaging experience | [Link](docs/configuring-playbook-client-schildichat.md) |
 

--- a/docs/configuring-dns.md
+++ b/docs/configuring-dns.md
@@ -56,7 +56,7 @@ When setting up a SRV record, if you are asked for a service and protocol instea
 
 As the table above illustrates, you need to create 2 subdomains (`matrix.<your-domain>` and `element.<your-domain>`) and point both of them to your new server's IP address (DNS `A` record or `CNAME` record is fine).
 
-The `element.<your-domain>` subdomain may be necessary, because this playbook installs the [Element](https://github.com/vector-im/element-web) web client for you.
+The `element.<your-domain>` subdomain may be necessary, because this playbook installs the [Element](https://github.com/element-hq/element-web) web client for you.
 If you'd rather instruct the playbook not to install Element (`matrix_client_element_enabled: false` when [Configuring the playbook](configuring-playbook.md) later), feel free to skip the `element.<your-domain>` DNS record.
 
 The `dimension.<your-domain>` subdomain may be necessary, because this playbook could install the [Dimension integrations manager](http://dimension.t2bot.io/) for you. Dimension installation is disabled by default, because it's only possible to install it after the other Matrix services are working (see [Setting up Dimension](configuring-playbook-dimension.md) later). If you do not wish to set up Dimension, feel free to skip the `dimension.<your-domain>` DNS record.
@@ -73,7 +73,7 @@ The `ntfy.<your-domain>` subdomain may be necessary, because this playbook could
 
 The `etherpad.<your-domain>` subdomain may be necessary, because this playbook could install the [Etherpad](https://etherpad.org/) a highly customizable open source online editor providing collaborative editing in really real-time. The installation of etherpad is disabled by default, it is not a core required component. To learn how to install it, see our [configuring etherpad guide](configuring-playbook-etherpad.md). If you do not wish to set up etherpad, feel free to skip the `etherpad.<your-domain>` DNS record.
 
-The `hydrogen.<your-domain>` subdomain may be necessary, because this playbook could install the [Hydrogen](https://github.com/vector-im/hydrogen-web) web client. The installation of Hydrogen is disabled by default, it is not a core required component. To learn how to install it, see our [configuring Hydrogen guide](configuring-playbook-client-hydrogen.md). If you do not wish to set up Hydrogen, feel free to skip the `hydrogen.<your-domain>` DNS record.
+The `hydrogen.<your-domain>` subdomain may be necessary, because this playbook could install the [Hydrogen](https://github.com/element-hq/hydrogen-web) web client. The installation of Hydrogen is disabled by default, it is not a core required component. To learn how to install it, see our [configuring Hydrogen guide](configuring-playbook-client-hydrogen.md). If you do not wish to set up Hydrogen, feel free to skip the `hydrogen.<your-domain>` DNS record.
 
 The `cinny.<your-domain>` subdomain may be necessary, because this playbook could install the [Cinny](https://github.com/ajbura/cinny) web client. The installation of cinny is disabled by default, it is not a core required component. To learn how to install it, see our [configuring cinny guide](configuring-playbook-client-cinny.md). If you do not wish to set up cinny, feel free to skip the `cinny.<your-domain>` DNS record.
 

--- a/docs/configuring-playbook-client-element.md
+++ b/docs/configuring-playbook-client-element.md
@@ -1,6 +1,6 @@
 # Configuring Element (optional)
 
-By default, this playbook installs the [Element](https://github.com/vector-im/element-web) Matrix client web application.
+By default, this playbook installs the [Element](https://github.com/element-hq/element-web) Matrix client web application.
 If that's okay, you can skip this document.
 
 

--- a/docs/configuring-playbook-client-hydrogen.md
+++ b/docs/configuring-playbook-client-hydrogen.md
@@ -1,6 +1,6 @@
 # Configuring Hydrogen (optional)
 
-This playbook can install the [Hydrogen](https://github.com/vector-im/hydrogen-web) Matrix web client for you.
+This playbook can install the [Hydrogen](https://github.com/element-hq/hydrogen-web) Matrix web client for you.
 Hydrogen is a lightweight web client that supports mobile and legacy web browsers.
 Hydrogen can be installed alongside or instead of Element.
 

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -286,7 +286,7 @@ You can use the self-hosted Jitsi server in multiple ways:
 
 - **directly (without any Matrix integration)**. Just go to `https://jitsi.DOMAIN`
 
-**Note**: Element apps on mobile devices currently [don't support joining meetings on a self-hosted Jitsi server](https://github.com/vector-im/riot-web/blob/601816862f7d84ac47547891bd53effa73d32957/docs/jitsi.md#mobile-app-support).
+**Note**: Element apps on mobile devices currently [don't support joining meetings on a self-hosted Jitsi server](https://github.com/element-hq/riot-web/blob/601816862f7d84ac47547891bd53effa73d32957/docs/jitsi.md#mobile-app-support).
 
 
 ## Troubleshooting

--- a/docs/configuring-playbook-riot-web.md
+++ b/docs/configuring-playbook-riot-web.md
@@ -1,6 +1,6 @@
 # Configuring Riot-web (optional)
 
-By default, this playbook **used to install** the [Riot-web](https://github.com/vector-im/riot-web) Matrix client web application.
+By default, this playbook **used to install** the [Riot-web](https://github.com/element-hq/riot-web) Matrix client web application.
 
 Riot has since been [renamed to Element](https://element.io/blog/welcome-to-element/).
 

--- a/docs/configuring-playbook-sliding-sync-proxy.md
+++ b/docs/configuring-playbook-sliding-sync-proxy.md
@@ -2,13 +2,13 @@
 
 The playbook can install and configure [sliding-sync](https://github.com/matrix-org/sliding-sync) proxy for you.
 
-Sliding Sync is an implementation of [MSC3575](https://github.com/matrix-org/matrix-spec-proposals/blob/kegan/sync-v3/proposals/3575-sync.md) and a prerequisite for running the new (**still beta**) Element X clients ([Element X iOS](https://github.com/vector-im/element-x-ios) and [Element X Android](https://github.com/vector-im/element-x-android)).
+Sliding Sync is an implementation of [MSC3575](https://github.com/matrix-org/matrix-spec-proposals/blob/kegan/sync-v3/proposals/3575-sync.md) and a prerequisite for running the new (**still beta**) Element X clients ([Element X iOS](https://github.com/element-hq/element-x-ios) and [Element X Android](https://github.com/element-hq/element-x-android)).
 
 See the project's [documentation](https://github.com/matrix-org/sliding-sync) to learn more.
 
 Element X iOS is [available on TestFlight](https://testflight.apple.com/join/uZbeZCOi).
 
-Element X Android is [available on the Github Releases page](https://github.com/vector-im/element-x-android/releases).
+Element X Android is [available on the Github Releases page](https://github.com/element-hq/element-x-android/releases).
 
 **NOTE**: The Sliding Sync proxy **only works with the Traefik reverse-proxy**. If you have an old server installation (from the time `matrix-nginx-proxy` was our default reverse-proxy - `matrix_playbook_reverse_proxy_type: playbook-managed-nginx`), you won't be able to use Sliding Sync.
 

--- a/roles/custom/matrix-base/defaults/main.yml
+++ b/roles/custom/matrix-base/defaults/main.yml
@@ -169,22 +169,22 @@ matrix_integration_manager_ui_url: ~
 
 # The domain name where a Jitsi server is self-hosted.
 # If set, `/.well-known/matrix/client` will suggest Element clients to use that Jitsi server.
-# See: https://github.com/vector-im/element-web/blob/develop/docs/jitsi.md#configuring-element-to-use-your-self-hosted-jitsi-server
+# See: https://github.com/element-hq/element-web/blob/develop/docs/jitsi.md#configuring-element-to-use-your-self-hosted-jitsi-server
 matrix_client_element_jitsi_preferred_domain: ''  # noqa var-naming
 
 # Controls whether Element should use End-to-End Encryption by default.
 # Setting this to false will update `/.well-known/matrix/client` and tell Element clients to avoid E2EE.
-# See: https://github.com/vector-im/element-web/blob/develop/docs/e2ee.md
+# See: https://github.com/element-hq/element-web/blob/develop/docs/e2ee.md
 matrix_well_known_matrix_client_io_element_e2ee_default: true
 
 # Controls whether Element should require a secure backup set up before Element can be used.
 # Setting this to true will update `/.well-known/matrix/client` and tell Element require a secure backup.
-# See: https://github.com/vector-im/element-web/blob/develop/docs/e2ee.md
+# See: https://github.com/element-hq/element-web/blob/develop/docs/e2ee.md
 matrix_well_known_matrix_client_io_element_e2ee_secure_backup_required: false
 
 # Controls which backup methods from ["key", "passphrase"] should be used, both is the default.
 # Setting this to other then empty will update `/.well-known/matrix/client` and tell Element which method to use
-# See: https://github.com/vector-im/element-web/blob/develop/docs/e2ee.md
+# See: https://github.com/element-hq/element-web/blob/develop/docs/e2ee.md
 matrix_well_known_matrix_client_io_element_e2ee_secure_backup_setup_methods: []
 
 # Controls whether element related entries should be added to the client well-known. Override this to false to hide

--- a/roles/custom/matrix-client-element/defaults/main.yml
+++ b/roles/custom/matrix-client-element/defaults/main.yml
@@ -1,13 +1,13 @@
 ---
-# Project source code URL: https://github.com/vector-im/element-web
+# Project source code URL: https://github.com/element-hq/element-web
 
 matrix_client_element_enabled: true
 
 matrix_client_element_container_image_self_build: false
-matrix_client_element_container_image_self_build_repo: "https://github.com/vector-im/element-web.git"
+matrix_client_element_container_image_self_build_repo: "https://github.com/element-hq/element-web.git"
 # Controls whether to patch webpack.config.js when self-building, so that building can pass on low-memory systems (< 4 GB RAM):
 # - https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/1357
-# - https://github.com/vector-im/element-web/issues/19544
+# - https://github.com/element-hq/element-web/issues/19544
 matrix_client_element_container_image_self_build_low_memory_system_patch_enabled: "{{ ansible_memtotal_mb < 4096 }}"
 
 # renovate: datasource=docker depName=vectorim/element-web

--- a/roles/custom/matrix-client-element/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-element/tasks/setup_install.yml
@@ -37,7 +37,7 @@
 
 # See:
 # - https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/1357
-# - https://github.com/vector-im/element-web/issues/19544
+# - https://github.com/element-hq/element-web/issues/19544
 - name: Patch webpack.config.js to support building on low-memory (<4G RAM) devices
   ansible.builtin.lineinfile:
     path: "{{ matrix_client_element_docker_src_files_path }}/webpack.config.js"

--- a/roles/custom/matrix-client-element/templates/welcome.html.j2
+++ b/roles/custom/matrix-client-element/templates/welcome.html.j2
@@ -189,7 +189,7 @@ we don't have an account and should hide them. No account == no guest account ei
 {% if matrix_client_element_disable_guests != true %}
         <!-- The comments below are meant to be used by Ansible as a quick way
              to strip out the marked content when desired.
-             See https://github.com/vector-im/riot-web/issues/8622.
+             See https://github.com/element-hq/riot-web/issues/8622.
              TODO: Convert to config option if possible. -->
         <!-- BEGIN Ansible: Remove these lines when guest access is disabled -->
         <div class="mx_ButtonRow mx_WelcomePage_guestFunctions">

--- a/roles/custom/matrix-client-hydrogen/defaults/main.yml
+++ b/roles/custom/matrix-client-hydrogen/defaults/main.yml
@@ -1,14 +1,14 @@
 ---
-# Project source code URL: https://github.com/vector-im/hydrogen-web
+# Project source code URL: https://github.com/element-hq/hydrogen-web
 
 matrix_client_hydrogen_enabled: true
 
 matrix_client_hydrogen_container_image_self_build: false
-matrix_client_hydrogen_container_image_self_build_repo: "https://github.com/vector-im/hydrogen-web.git"
+matrix_client_hydrogen_container_image_self_build_repo: "https://github.com/element-hq/hydrogen-web.git"
 
-# renovate: datasource=docker depName=ghcr.io/vector-im/hydrogen-web
+# renovate: datasource=docker depName=ghcr.io/element-hq/hydrogen-web
 matrix_client_hydrogen_version: v0.4.1
-matrix_client_hydrogen_docker_image: "{{ matrix_client_hydrogen_docker_image_name_prefix }}vector-im/hydrogen-web:{{ matrix_client_hydrogen_version }}"
+matrix_client_hydrogen_docker_image: "{{ matrix_client_hydrogen_docker_image_name_prefix }}element-hq/hydrogen-web:{{ matrix_client_hydrogen_version }}"
 matrix_client_hydrogen_docker_image_name_prefix: "{{ 'localhost/' if matrix_client_hydrogen_container_image_self_build else 'ghcr.io/' }}"
 matrix_client_hydrogen_docker_image_force_pull: "{{ matrix_client_hydrogen_docker_image.endswith(':latest') }}"
 

--- a/roles/custom/matrix-client-schildichat/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-schildichat/tasks/setup_install.yml
@@ -37,7 +37,7 @@
 
 # See:
 # - https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/1357
-# - https://github.com/vector-im/schildichat-web/issues/19544
+# - https://github.com/vector-im/schildichat-web/issues/19544 -- # Update (2023-12-15): 404
 - name: Patch webpack.config.js to support building on low-memory (<4G RAM) devices
   ansible.builtin.lineinfile:
     path: "{{ matrix_client_schildichat_docker_src_files_path }}/webpack.config.js"

--- a/roles/custom/matrix-client-schildichat/templates/welcome.html.j2
+++ b/roles/custom/matrix-client-schildichat/templates/welcome.html.j2
@@ -189,7 +189,7 @@ we don't have an account and should hide them. No account == no guest account ei
 {% if matrix_client_schildichat_disable_guests != true %}
         <!-- The comments below are meant to be used by Ansible as a quick way
              to strip out the marked content when desired.
-             See https://github.com/vector-im/riot-web/issues/8622.
+             See https://github.com/element-hq/riot-web/issues/8622.
              TODO: Convert to config option if possible. -->
         <!-- BEGIN Ansible: Remove these lines when guest access is disabled -->
         <div class="mx_ButtonRow mx_WelcomePage_guestFunctions">


### PR DESCRIPTION
As mentioned in issue https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/3043 some components (e.g. hydrogen) were not accessible anymore due to the recent renaming of Vector-im.

Here are some updates of the links to prevent future breakdowns and fix hydrogen.

*Might not be complete as I can't test all components at once.*