### PR TITLE
MMR reverse proxy updates

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -2693,8 +2693,6 @@ matrix_ma1sd_database_password: "{{ '%s' | format(matrix_homeserver_generic_secr
 #
 ######################################################################
 
-matrix_media_repo_identifier: matrix-media-repo
-
 matrix_media_repo_enabled: false
 matrix_media_repo_container_network: "{{ matrix_nginx_proxy_container_network if matrix_playbook_reverse_proxy_type == 'playbook-managed-nginx' else matrix_media_repo_identifier }}"
 

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -2693,10 +2693,21 @@ matrix_ma1sd_database_password: "{{ '%s' | format(matrix_homeserver_generic_secr
 #
 ######################################################################
 
-matrix_media_repo_enabled: false
-matrix_media_repo_container_network: "{{ matrix_docker_network }}"
+matrix_media_repo_identifier: matrix-media-repo
 
-matrix_media_repo_container_labels_traefik_enabled: false
+matrix_media_repo_enabled: false
+matrix_media_repo_container_network: "{{ matrix_nginx_proxy_container_network if matrix_playbook_reverse_proxy_type == 'playbook-managed-nginx' else matrix_media_repo_identifier }}"
+
+matrix_media_repo_container_additional_networks: |
+  {{
+    (
+      ([matrix_playbook_reverse_proxyable_services_additional_network] if matrix_playbook_reverse_proxyable_services_additional_network else [])
+      +
+      ([devture_postgres_container_network] if devture_postgres_enabled and devture_postgres_container_network != matrix_media_repo_container_network else [])
+    ) | unique
+  }}
+
+matrix_media_repo_container_labels_traefik_enabled: "{{ matrix_playbook_traefik_labels_enabled }}"
 matrix_media_repo_container_labels_traefik_docker_network: "{{ matrix_playbook_reverse_proxyable_services_additional_network }}"
 matrix_media_repo_container_labels_traefik_entrypoints: "{{ devture_traefik_entrypoint_primary }}"
 matrix_media_repo_container_labels_traefik_tls_certResolver: "{{ devture_traefik_certResolver_primary }}"

--- a/roles/custom/matrix-media-repo/defaults/main.yml
+++ b/roles/custom/matrix-media-repo/defaults/main.yml
@@ -34,7 +34,7 @@ matrix_media_repo_systemd_required_services_list: ["docker.service"]
 matrix_media_repo_systemd_wanted_services_list: []
 
 # The base container network. It will be auto-created by this role if it doesn't exist already.
-matrix_media_repo_container_network: "{{ matrix_docker_network }}"
+matrix_media_repo_container_network: "{{ matrix_media_repo_identifier }}"
 
 # A list of additional container networks that the container would be connected to.
 # The role does not create these networks, so make sure they already exist.
@@ -53,6 +53,97 @@ matrix_media_repo_container_metrics_host_bind_port: ""
 
 # Extra arguments for the Docker container
 matrix_media_repo_container_extra_arguments: []
+
+# matrix_media_repo_container_labels_traefik_enabled controls whether labels to assist a Traefik reverse-proxy will be attached to the container.
+# See `../templates/labels.j2` for details.
+#
+# To inject your own other container labels, see `matrix_media_repo_container_labels_additional_labels`.
+matrix_media_repo_container_labels_traefik_enabled: true
+matrix_media_repo_container_labels_traefik_docker_network: "{{ matrix_media_repo_container_network }}"
+
+matrix_media_repo_container_labels_traefik_media_path_prefix: "/_matrix/media"
+matrix_media_repo_container_labels_traefik_media_rule: "Host(`{{ matrix_server_fqn_matrix }}`) && PathPrefix(`{{ matrix_media_repo_container_labels_traefik_media_path_prefix | quote }}`)"
+matrix_media_repo_container_labels_traefik_media_priority: 0
+matrix_media_repo_container_labels_traefik_media_entrypoints: web-secure
+matrix_media_repo_container_labels_traefik_media_tls: "{{ matrix_media_repo_container_labels_traefik_media_entrypoints != 'web' }}"
+matrix_media_repo_container_labels_traefik_media_tls_certResolver: default  # noqa var-naming
+
+# /_matrix/client/r0/logout
+# /_matrix/client/r0/logout/all
+matrix_media_repo_container_labels_traefik_logout_path_prefix: "/_matrix/client/{version:(r0|v1|v3|unstable)}/{endpoint:(logout|logout/all)}"
+matrix_media_repo_container_labels_traefik_logout_rule: "Host(`{{ matrix_server_fqn_matrix }}`) && PathPrefix(`{{ matrix_media_repo_container_labels_traefik_logout_path_prefix }}`)"
+matrix_media_repo_container_labels_traefik_logout_priority: 0
+matrix_media_repo_container_labels_traefik_logout_entrypoints: web-secure
+matrix_media_repo_container_labels_traefik_logout_tls: "{{ matrix_media_repo_container_labels_traefik_logout_entrypoints != 'web' }}"
+matrix_media_repo_container_labels_traefik_logout_tls_certResolver: default  # noqa var-naming
+
+# /_matrix/client/r0/admin/purge_media_cache
+# /_matrix/client/r0/admin/quarantine_media/{roomId:[^/]+}
+matrix_media_repo_container_labels_traefik_admin_path_prefix: "/_matrix/client/{version:(r0|v1|v3|unstable)}/admin/{endpoint:(purge_media_cache|quarantine_media/.*)}"
+matrix_media_repo_container_labels_traefik_admin_rule: "Host(`{{ matrix_server_fqn_matrix }}`) && PathPrefix(`{{ matrix_media_repo_container_labels_traefik_admin_path_prefix }}`)"
+matrix_media_repo_container_labels_traefik_admin_priority: 0
+matrix_media_repo_container_labels_traefik_admin_entrypoints: web-secure
+matrix_media_repo_container_labels_traefik_admin_tls: "{{ matrix_media_repo_container_labels_traefik_admin_entrypoints != 'web' }}"
+matrix_media_repo_container_labels_traefik_admin_tls_certResolver: default  # noqa var-naming
+
+matrix_media_repo_container_labels_traefik_t2bot_path_prefix: "/_matrix/client/unstable/io.t2bot.media"
+matrix_media_repo_container_labels_traefik_t2bot_rule: "Host(`{{ matrix_server_fqn_matrix }}`) && PathPrefix(`{{ matrix_media_repo_container_labels_traefik_t2bot_path_prefix | quote }}`)"
+matrix_media_repo_container_labels_traefik_t2bot_priority: 0
+matrix_media_repo_container_labels_traefik_t2bot_entrypoints: web-secure
+matrix_media_repo_container_labels_traefik_t2bot_tls: "{{ matrix_media_repo_container_labels_traefik_t2bot_entrypoints != 'web' }}"
+matrix_media_repo_container_labels_traefik_t2bot_tls_certResolver: default  # noqa var-naming
+
+# Traefik federation labels
+matrix_media_repo_container_labels_traefik_media_federation_path_prefix: "/_matrix/media"
+matrix_media_repo_container_labels_traefik_media_federation_rule: "Host(`{{ matrix_server_fqn_matrix }}`) && PathPrefix(`{{ matrix_media_repo_container_labels_traefik_media_path_prefix | quote }}`)"
+matrix_media_repo_container_labels_traefik_media_federation_priority: 0
+matrix_media_repo_container_labels_traefik_media_federation_entrypoints: "{{ matrix_federation_traefik_entrypoint }}"
+matrix_media_repo_container_labels_traefik_media_federation_tls: "{{ matrix_media_repo_container_labels_traefik_media_entrypoints != 'web' }}"
+matrix_media_repo_container_labels_traefik_media_federation_tls_certResolver: default  # noqa var-naming
+
+# /_matrix/client/r0/logout
+# /_matrix/client/r0/logout/all
+matrix_media_repo_container_labels_traefik_logout_federation_path_prefix: "/_matrix/client/{version:(r0|v1|v3|unstable)}/{endpoint:(logout|logout/all)}"
+matrix_media_repo_container_labels_traefik_logout_federation_rule: "Host(`{{ matrix_server_fqn_matrix }}`) && PathPrefix(`{{ matrix_media_repo_container_labels_traefik_logout_path_prefix }}`)"
+matrix_media_repo_container_labels_traefik_logout_federation_priority: 0
+matrix_media_repo_container_labels_traefik_logout_federation_entrypoints: "{{ matrix_federation_traefik_entrypoint }}"
+matrix_media_repo_container_labels_traefik_logout_federation_tls: "{{ matrix_media_repo_container_labels_traefik_logout_entrypoints != 'web' }}"
+matrix_media_repo_container_labels_traefik_logout_federation_tls_certResolver: default  # noqa var-naming
+
+# /_matrix/client/r0/admin/purge_media_cache
+# /_matrix/client/r0/admin/quarantine_media/{roomId:[^/]+}
+matrix_media_repo_container_labels_traefik_admin_federation_path_prefix: "/_matrix/client/{version:(r0|v1|v3|unstable)}/admin/{endpoint:(purge_media_cache|quarantine_media/.*)}"
+matrix_media_repo_container_labels_traefik_admin_federation_rule: "Host(`{{ matrix_server_fqn_matrix }}`) && PathPrefix(`{{ matrix_media_repo_container_labels_traefik_admin_path_prefix }}`)"
+matrix_media_repo_container_labels_traefik_admin_federation_priority: 0
+matrix_media_repo_container_labels_traefik_admin_federation_entrypoints: "{{ matrix_federation_traefik_entrypoint }}"
+matrix_media_repo_container_labels_traefik_admin_federation_tls: "{{ matrix_media_repo_container_labels_traefik_admin_entrypoints != 'web' }}"
+matrix_media_repo_container_labels_traefik_admin_federation_tls_certResolver: default  # noqa var-naming
+
+matrix_media_repo_container_labels_traefik_t2bot_federation_path_prefix: "/_matrix/client/unstable/io.t2bot.media"
+matrix_media_repo_container_labels_traefik_t2bot_federation_rule: "Host(`{{ matrix_server_fqn_matrix }}`) && PathPrefix(`{{ matrix_media_repo_container_labels_traefik_t2bot_path_prefix | quote }}`)"
+matrix_media_repo_container_labels_traefik_t2bot_federation_priority: 0
+matrix_media_repo_container_labels_traefik_t2bot_federation_entrypoints: "{{ matrix_federation_traefik_entrypoint }}"
+matrix_media_repo_container_labels_traefik_t2bot_federation_tls: "{{ matrix_media_repo_container_labels_traefik_t2bot_entrypoints != 'web' }}"
+matrix_media_repo_container_labels_traefik_t2bot_federation_tls_certResolver: default  # noqa var-naming
+
+# Controls which additional headers to attach to all HTTP requests.
+# To add your own headers, use `matrix_media_repo_container_labels_traefik_additional_request_headers_custom`
+matrix_media_repo_container_labels_traefik_additional_request_headers: "{{ matrix_media_repo_container_labels_traefik_additional_request_headers_auto | combine(matrix_media_repo_container_labels_traefik_additional_request_headers_custom) }}"
+matrix_media_repo_container_labels_traefik_additional_request_headers_auto: |
+  {{
+    {}
+    | combine ({'X-Forwarded-Host': matrix_domain} if matrix_domain else {})
+  }}
+matrix_media_repo_container_labels_traefik_additional_request_headers_custom: {}
+
+# matrix_media_repo_container_labels_additional_labels contains a multiline string with additional labels to add to the container label file.
+# See `../templates/labels.j2` for details.
+#
+# Example:
+# matrix_media_repo_container_labels_additional_labels: |
+#   my.label=1
+#   another.label="here"
+matrix_media_repo_container_labels_additional_labels: ''
 
 # matrix_media_repo_dashboard_urls contains a list of URLs with Grafana dashboard definitions.
 # If the Grafana role is enabled, these dashboards will be downloaded.

--- a/roles/custom/matrix-media-repo/defaults/main.yml
+++ b/roles/custom/matrix-media-repo/defaults/main.yml
@@ -9,7 +9,7 @@ matrix_media_repo_enabled: false
 
 # matrix_media_repo_identifier controls the identifier of this media-repo instance, which influences:
 # - the default storage path
-# - the names of systemd services
+# - the names of systemd services and containers
 matrix_media_repo_identifier: matrix-media-repo
 
 matrix_media_repo_container_image_self_build: false

--- a/roles/custom/matrix-media-repo/defaults/main.yml
+++ b/roles/custom/matrix-media-repo/defaults/main.yml
@@ -153,7 +153,7 @@ matrix_media_repo_homeservers_auto:
 
     # This should match the server_name of your homeserver, and the Host header
     # provided to the media repo.
-    name: "{{ matrix_server_fqn_matrix }}"
+    name: "{{ matrix_domain }}"
 
     # The base URL to where the homeserver can actually be reached by MMR.
     csApi: "http://{{ matrix_nginx_proxy_proxy_matrix_client_api_addr_with_container }}"

--- a/roles/custom/matrix-media-repo/tasks/setup_install.yml
+++ b/roles/custom/matrix-media-repo/tasks/setup_install.yml
@@ -27,6 +27,7 @@
     group: "{{ matrix_user_groupname }}"
   with_items:
     - env
+    - labels
 
 - name: Ensure media-repo configuration installed
   ansible.builtin.template:

--- a/roles/custom/matrix-media-repo/templates/media-repo/labels.j2
+++ b/roles/custom/matrix-media-repo/templates/media-repo/labels.j2
@@ -1,0 +1,147 @@
+{% if matrix_media_repo_container_labels_traefik_enabled %}
+traefik.enable=true
+
+{% if matrix_media_repo_container_labels_traefik_docker_network %}
+traefik.docker.network={{ matrix_media_repo_container_labels_traefik_docker_network }}
+{% endif %}
+
+{% set middlewares = [] %}
+
+{% if matrix_media_repo_container_labels_traefik_additional_request_headers.keys() | length > 0 %}
+{% for name, value in matrix_media_repo_container_labels_traefik_additional_request_headers.items() %}
+traefik.http.middlewares.matrix-media-repo-add-headers.headers.customrequestheaders.{{ name }}={{ value }}
+{% endfor %}
+{% set middlewares = middlewares + ['matrix-media-repo-add-headers'] %}
+{% endif %}
+
+# Matrix Client
+traefik.http.routers.matrix-media-repo-media.rule={{ matrix_media_repo_container_labels_traefik_media_rule }}
+{% if matrix_media_repo_container_labels_traefik_media_priority | int > 0 %}
+traefik.http.routers.matrix-media-repo-media.priority={{ matrix_media_repo_container_labels_traefik_media_priority }}
+{% endif %}
+{% if middlewares | length > 0 %}
+traefik.http.routers.matrix-media-repo-media.middlewares={{ middlewares | join(',') }}
+{% endif %}
+traefik.http.routers.matrix-media-repo-media.service=matrix-media-repo
+traefik.http.routers.matrix-media-repo-media.entrypoints={{ matrix_media_repo_container_labels_traefik_media_entrypoints }}
+traefik.http.routers.matrix-media-repo-media.tls={{ matrix_media_repo_container_labels_traefik_media_tls | to_json }}
+{% if matrix_media_repo_container_labels_traefik_media_tls %}
+traefik.http.routers.matrix-media-repo-media.tls.certResolver={{ matrix_media_repo_container_labels_traefik_media_tls_certResolver }}
+{% endif %}
+
+{% if matrix_media_repo_access_tokens_max_cache_time_seconds > 0 %}
+
+traefik.http.routers.matrix-media-repo-logout.rule={{ matrix_media_repo_container_labels_traefik_logout_rule }}
+{% if matrix_media_repo_container_labels_traefik_logout_priority | int > 0 %}
+traefik.http.routers.matrix-media-repo-logout.priority={{ matrix_media_repo_container_labels_traefik_logout_priority }}
+{% endif %}
+{% if middlewares | length > 0 %}
+traefik.http.routers.matrix-media-repo-logout.middlewares={{ middlewares | join(',') }}
+{% endif %}
+traefik.http.routers.matrix-media-repo-logout.service=matrix-media-repo
+traefik.http.routers.matrix-media-repo-logout.entrypoints={{ matrix_media_repo_container_labels_traefik_logout_entrypoints }}
+traefik.http.routers.matrix-media-repo-logout.tls={{ matrix_media_repo_container_labels_traefik_logout_tls | to_json }}
+{% if matrix_media_repo_container_labels_traefik_logout_tls %}
+traefik.http.routers.matrix-media-repo-logout.tls.certResolver={{ matrix_media_repo_container_labels_traefik_logout_tls_certResolver }}
+{% endif %}
+
+{% endif %}
+
+traefik.http.routers.matrix-media-repo-admin-federation.rule={{ matrix_media_repo_container_labels_traefik_admin_rule }}
+{% if matrix_media_repo_container_labels_traefik_admin_priority | int > 0 %}
+traefik.http.routers.matrix-media-repo-admin-federation.priority={{ matrix_media_repo_container_labels_traefik_admin_priority }}
+{% endif %}
+{% if middlewares | length > 0 %}
+traefik.http.routers.matrix-media-repo-admin-federation.middlewares={{ middlewares | join(',') }}
+{% endif %}
+traefik.http.routers.matrix-media-repo-admin-federation.service=matrix-media-repo
+traefik.http.routers.matrix-media-repo-admin-federation.entrypoints={{ matrix_media_repo_container_labels_traefik_admin_entrypoints }}
+traefik.http.routers.matrix-media-repo-admin-federation.tls={{ matrix_media_repo_container_labels_traefik_admin_tls | to_json }}
+{% if matrix_media_repo_container_labels_traefik_admin_tls %}
+traefik.http.routers.matrix-media-repo-admin-federation.tls.certResolver={{ matrix_media_repo_container_labels_traefik_admin_tls_certResolver }}
+{% endif %}
+
+traefik.http.routers.matrix-media-repo-t2bot.rule={{ matrix_media_repo_container_labels_traefik_t2bot_rule }}
+{% if matrix_media_repo_container_labels_traefik_t2bot_priority | int > 0 %}
+traefik.http.routers.matrix-media-repo-t2bot.priority={{ matrix_media_repo_container_labels_traefik_t2bot_priority }}
+{% endif %}
+{% if middlewares | length > 0 %}
+traefik.http.routers.matrix-media-repo-t2bot.middlewares={{ middlewares | join(',') }}
+{% endif %}
+traefik.http.routers.matrix-media-repo-t2bot.service=matrix-media-repo
+traefik.http.routers.matrix-media-repo-t2bot.entrypoints={{ matrix_media_repo_container_labels_traefik_t2bot_entrypoints }}
+traefik.http.routers.matrix-media-repo-t2bot.tls={{ matrix_media_repo_container_labels_traefik_t2bot_tls | to_json }}
+{% if matrix_media_repo_container_labels_traefik_t2bot_tls %}
+traefik.http.routers.matrix-media-repo-t2bot.tls.certResolver={{ matrix_media_repo_container_labels_traefik_t2bot_tls_certResolver }}
+{% endif %}
+
+# Matrix Federation
+{% if matrix_nginx_proxy_proxy_matrix_federation_api_enabled %}
+
+traefik.http.routers.matrix-media-repo-media-federation.rule={{ matrix_media_repo_container_labels_traefik_media_federation_rule }}
+{% if matrix_media_repo_container_labels_traefik_media_federation_priority | int > 0 %}
+traefik.http.routers.matrix-media-repo-media-federation.priority={{ matrix_media_repo_container_labels_traefik_media_federation_priority }}
+{% endif %}
+{% if middlewares | length > 0 %}
+traefik.http.routers.matrix-media-repo-media-federation.middlewares={{ middlewares | join(',') }}
+{% endif %}
+traefik.http.routers.matrix-media-repo-media-federation.service=matrix-media-repo
+traefik.http.routers.matrix-media-repo-media-federation.entrypoints={{ matrix_media_repo_container_labels_traefik_media_federation_entrypoints }}
+traefik.http.routers.matrix-media-repo-media-federation.tls={{ matrix_media_repo_container_labels_traefik_media_federation_tls | to_json }}
+{% if matrix_media_repo_container_labels_traefik_media_federation_tls %}
+traefik.http.routers.matrix-media-repo-media-federation.tls.certResolver={{ matrix_media_repo_container_labels_traefik_media_federation_tls_certResolver }}
+{% endif %}
+
+{% if matrix_media_repo_access_tokens_max_cache_time_seconds > 0 %}
+
+traefik.http.routers.matrix-media-repo-logout-federation.rule={{ matrix_media_repo_container_labels_traefik_logout_federation_rule }}
+{% if matrix_media_repo_container_labels_traefik_logout_federation_priority | int > 0 %}
+traefik.http.routers.matrix-media-repo-logout-federation.priority={{ matrix_media_repo_container_labels_traefik_logout_federation_priority }}
+{% endif %}
+{% if middlewares | length > 0 %}
+traefik.http.routers.matrix-media-repo-logout-federation.middlewares={{ middlewares | join(',') }}
+{% endif %}
+traefik.http.routers.matrix-media-repo-logout-federation.service=matrix-media-repo
+traefik.http.routers.matrix-media-repo-logout-federation.entrypoints={{ matrix_media_repo_container_labels_traefik_logout_federation_entrypoints }}
+traefik.http.routers.matrix-media-repo-logout-federation.tls={{ matrix_media_repo_container_labels_traefik_logout_federation_tls | to_json }}
+{% if matrix_media_repo_container_labels_traefik_logout_federation_tls %}
+traefik.http.routers.matrix-media-repo-logout-federation.tls.certResolver={{ matrix_media_repo_container_labels_traefik_logout_federation_tls_certResolver }}
+{% endif %}
+
+{% endif %}
+
+traefik.http.routers.matrix-media-repo-admin.rule={{ matrix_media_repo_container_labels_traefik_admin_federation_rule }}
+{% if matrix_media_repo_container_labels_traefik_admin_federation_priority | int > 0 %}
+traefik.http.routers.matrix-media-repo-admin.priority={{ matrix_media_repo_container_labels_traefik_admin_federation_priority }}
+{% endif %}
+{% if middlewares | length > 0 %}
+traefik.http.routers.matrix-media-repo-admin.middlewares={{ middlewares | join(',') }}
+{% endif %}
+traefik.http.routers.matrix-media-repo-admin.service=matrix-media-repo
+traefik.http.routers.matrix-media-repo-admin.entrypoints={{ matrix_media_repo_container_labels_traefik_admin_federation_entrypoints }}
+traefik.http.routers.matrix-media-repo-admin.tls={{ matrix_media_repo_container_labels_traefik_admin_federation_tls | to_json }}
+{% if matrix_media_repo_container_labels_traefik_admin_federation_tls %}
+traefik.http.routers.matrix-media-repo-admin.tls.certResolver={{ matrix_media_repo_container_labels_traefik_admin_federation_tls_certResolver }}
+{% endif %}
+
+traefik.http.routers.matrix-media-repo-t2bot-federation.rule={{ matrix_media_repo_container_labels_traefik_t2bot_federation_rule }}
+{% if matrix_media_repo_container_labels_traefik_t2bot_federation_priority | int > 0 %}
+traefik.http.routers.matrix-media-repo-t2bot-federation.priority={{ matrix_media_repo_container_labels_traefik_t2bot_federation_priority }}
+{% endif %}
+{% if middlewares | length > 0 %}
+traefik.http.routers.matrix-media-repo-t2bot-federation.middlewares={{ middlewares | join(',') }}
+{% endif %}
+traefik.http.routers.matrix-media-repo-t2bot-federation.service=matrix-media-repo
+traefik.http.routers.matrix-media-repo-t2bot-federation.entrypoints={{ matrix_media_repo_container_labels_traefik_t2bot_federation_entrypoints }}
+traefik.http.routers.matrix-media-repo-t2bot-federation.tls={{ matrix_media_repo_container_labels_traefik_t2bot_federation_tls | to_json }}
+{% if matrix_media_repo_container_labels_traefik_t2bot_federation_tls %}
+traefik.http.routers.matrix-media-repo-t2bot-federation.tls.certResolver={{ matrix_media_repo_container_labels_traefik_t2bot_federation_tls_certResolver }}
+{% endif %}
+
+{% endif %}
+
+traefik.http.services.matrix-media-repo.loadbalancer.server.port={{ matrix_media_repo_port }}
+
+{% endif %}
+
+{{ matrix_media_repo_container_labels_additional_labels }}

--- a/roles/custom/matrix-media-repo/templates/media-repo/systemd/matrix-media-repo.service.j2
+++ b/roles/custom/matrix-media-repo/templates/media-repo/systemd/matrix-media-repo.service.j2
@@ -22,8 +22,9 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			--log-driver=none \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
-			--network={{ matrix_docker_network }} \
+			--network={{ matrix_media_repo_container_network }} \
 			--env-file={{ matrix_media_repo_base_path }}/env \
+			--label-file={{ matrix_media_repo_base_path }}/labels \
 			{% if matrix_media_repo_container_http_host_bind_port %}
 			-p {{ matrix_media_repo_container_http_host_bind_port }}:{{ matrix_media_repo_port }} \
 			{% endif %}

--- a/roles/custom/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
+++ b/roles/custom/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
@@ -110,7 +110,7 @@
 		# Make sure this matches your homeserver in media-repo.yaml
 		# You may have to manually specify it if using delegation or the
 		# incoming Host doesn't match.
-		proxy_set_header Host $host;
+		proxy_set_header Host {{ matrix_domain }};
 
 		proxy_set_header X-Real-IP $remote_addr;
 		proxy_set_header X-Forwarded-For $remote_addr;
@@ -136,7 +136,7 @@
 		# Make sure this matches your homeserver in media-repo.yaml
 		# You may have to manually specify it if using delegation or the
 		# incoming Host doesn't match.
-		proxy_set_header Host $host;
+		proxy_set_header Host {{ matrix_domain }};
 
 		proxy_set_header X-Real-IP $remote_addr;
 		proxy_set_header X-Forwarded-For $remote_addr;
@@ -159,7 +159,7 @@
 		# Make sure this matches your homeserver in media-repo.yaml
 		# You may have to manually specify it if using delegation or the
 		# incoming Host doesn't match.
-		proxy_set_header Host $host;
+		proxy_set_header Host {{ matrix_domain }};
 
 		proxy_set_header X-Real-IP $remote_addr;
 		proxy_set_header X-Forwarded-For $remote_addr;
@@ -180,7 +180,7 @@
 		# Make sure this matches your homeserver in media-repo.yaml
 		# You may have to manually specify it if using delegation or the
 		# incoming Host doesn't match.
-		proxy_set_header Host $host;
+		proxy_set_header Host {{ matrix_domain }};
 
 		proxy_set_header X-Real-IP $remote_addr;
 		proxy_set_header X-Forwarded-For $remote_addr;
@@ -406,7 +406,7 @@ server {
 			# Make sure this matches your homeserver in media-repo.yaml
 			# You may have to manually specify it if using delegation or the
 			# incoming Host doesn't match.
-			proxy_set_header Host $host;
+			proxy_set_header Host {{ matrix_domain }};
 
 			proxy_set_header X-Real-IP $remote_addr;
 			proxy_set_header X-Forwarded-For $remote_addr;
@@ -432,7 +432,7 @@ server {
 			# Make sure this matches your homeserver in media-repo.yaml
 			# You may have to manually specify it if using delegation or the
 			# incoming Host doesn't match.
-			proxy_set_header Host $host;
+			proxy_set_header Host {{ matrix_domain }};
 
 			proxy_set_header X-Real-IP $remote_addr;
 			proxy_set_header X-Forwarded-For $remote_addr;
@@ -455,7 +455,7 @@ server {
 			# Make sure this matches your homeserver in media-repo.yaml
 			# You may have to manually specify it if using delegation or the
 			# incoming Host doesn't match.
-			proxy_set_header Host $host;
+			proxy_set_header Host {{ matrix_domain }};
 
 			proxy_set_header X-Real-IP $remote_addr;
 			proxy_set_header X-Forwarded-For $remote_addr;
@@ -476,7 +476,7 @@ server {
 			# Make sure this matches your homeserver in media-repo.yaml
 			# You may have to manually specify it if using delegation or the
 			# incoming Host doesn't match.
-			proxy_set_header Host $host;
+			proxy_set_header Host {{ matrix_domain }};
 
 			proxy_set_header X-Real-IP $remote_addr;
 			proxy_set_header X-Forwarded-For $remote_addr;

--- a/roles/custom/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
+++ b/roles/custom/matrix-nginx-proxy/templates/nginx/conf.d/matrix-domain.conf.j2
@@ -390,6 +390,99 @@ server {
 		ssl_session_timeout {{ matrix_nginx_proxy_ssl_session_timeout }};
 	{% endif %}
 
+	{% if matrix_nginx_proxy_proxy_media_repo_enabled %}
+		# Redirect all media endpoints to the media-repo
+		location ^~ /_matrix/media {
+			{% if matrix_nginx_proxy_enabled %}
+				{# Use the embedded DNS resolver in Docker containers to discover the service #}
+				resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
+				set $backend "{{ matrix_nginx_proxy_proxy_media_repo_addr_with_container }}";
+				proxy_pass http://$backend;
+			{% else %}
+				{# Generic configuration for use outside of our container setup #}
+				proxy_pass http://{{ matrix_nginx_proxy_proxy_media_repo_addr_sans_container }};
+			{% endif %}
+
+			# Make sure this matches your homeserver in media-repo.yaml
+			# You may have to manually specify it if using delegation or the
+			# incoming Host doesn't match.
+			proxy_set_header Host $host;
+
+			proxy_set_header X-Real-IP $remote_addr;
+			proxy_set_header X-Forwarded-For $remote_addr;
+
+			client_body_buffer_size {{ ((matrix_media_repo_max_bytes | int) / 4) | int }};
+			client_max_body_size {{ matrix_media_repo_max_bytes }};
+		}
+
+		# Redirect other endpoints registered by the media-repo to its container
+		# /_matrix/client/r0/logout
+		# /_matrix/client/r0/logout/all
+		location ~ ^/_matrix/client/(r0|v1|v3|unstable)/(logout|logout/all) {
+			{% if matrix_nginx_proxy_enabled %}
+				{# Use the embedded DNS resolver in Docker containers to discover the service #}
+				resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
+				set $backend "{{ matrix_nginx_proxy_proxy_media_repo_addr_with_container }}";
+				proxy_pass http://$backend;
+			{% else %}
+				{# Generic configuration for use outside of our container setup #}
+				proxy_pass http://{{ matrix_nginx_proxy_proxy_media_repo_addr_sans_container }};
+			{% endif %}
+
+			# Make sure this matches your homeserver in media-repo.yaml
+			# You may have to manually specify it if using delegation or the
+			# incoming Host doesn't match.
+			proxy_set_header Host $host;
+
+			proxy_set_header X-Real-IP $remote_addr;
+			proxy_set_header X-Forwarded-For $remote_addr;
+		}
+
+		# Redirect other endpoints registered by the media-repo to its container
+		# /_matrix/client/r0/admin/purge_media_cache
+		# /_matrix/client/r0/admin/quarantine_media/{roomId:[^/]+}
+		location ~ ^/_matrix/client/(r0|v1|v3|unstable)/admin/(purge_media_cache|quarantine_media/.*) {
+			{% if matrix_nginx_proxy_enabled %}
+				{# Use the embedded DNS resolver in Docker containers to discover the service #}
+				resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
+				set $backend "{{ matrix_nginx_proxy_proxy_media_repo_addr_with_container }}";
+				proxy_pass http://$backend;
+			{% else %}
+				{# Generic configuration for use outside of our container setup #}
+				proxy_pass http://{{ matrix_nginx_proxy_proxy_media_repo_addr_sans_container }};
+			{% endif %}
+
+			# Make sure this matches your homeserver in media-repo.yaml
+			# You may have to manually specify it if using delegation or the
+			# incoming Host doesn't match.
+			proxy_set_header Host $host;
+
+			proxy_set_header X-Real-IP $remote_addr;
+			proxy_set_header X-Forwarded-For $remote_addr;
+		}
+
+		# Redirect other endpoints registered by the media-repo to its container
+		location ^~ /_matrix/client/unstable/io.t2bot.media {
+			{% if matrix_nginx_proxy_enabled %}
+				{# Use the embedded DNS resolver in Docker containers to discover the service #}
+				resolver {{ matrix_nginx_proxy_http_level_resolver }} valid=5s;
+				set $backend "{{ matrix_nginx_proxy_proxy_media_repo_addr_with_container }}";
+				proxy_pass http://$backend;
+			{% else %}
+				{# Generic configuration for use outside of our container setup #}
+				proxy_pass http://{{ matrix_nginx_proxy_proxy_media_repo_addr_sans_container }};
+			{% endif %}
+
+			# Make sure this matches your homeserver in media-repo.yaml
+			# You may have to manually specify it if using delegation or the
+			# incoming Host doesn't match.
+			proxy_set_header Host $host;
+
+			proxy_set_header X-Real-IP $remote_addr;
+			proxy_set_header X-Forwarded-For $remote_addr;
+		}
+	{% endif %}
+
 	location / {
 		{% if matrix_nginx_proxy_enabled %}
 			{# Use the embedded DNS resolver in Docker containers to discover the service #}


### PR DESCRIPTION
Changes:
* Added Traefik support for the MMR role
* Fixed federation media download failures when using NGINX
* Changed internal MXC link format from `mxc://matrix.DOMAIN/hash` to `mxc://DOMAIN/hash`