### PR TITLE
Fix "SSL_do_handshake() failed" in nginx reverse-proxy

### DIFF
--- a/docs/configuring-well-known.md
+++ b/docs/configuring-well-known.md
@@ -123,6 +123,7 @@ server {
 	location /.well-known/matrix {
 		proxy_pass https://matrix.example.com/.well-known/matrix;
 		proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_ssl_server_name on;
 	}
 
 	# other configuration


### PR DESCRIPTION
In nginx reverse-proxy, when the upstream server relies on SNI, the reverser-proxy may return 502 by follow error:
```
*10 SSL_do_handshake() failed (SSL: error:0A000410:SSL routines::sslv3 alert handshake failure:SSL alert number 40) while SSL handshaking to upstream, client: 172.19.0.1, server: example.host, request: "GET /.well-known/matrix/client HTTP/2.0", upstream: "https://<ip>/.well-known/matrix/client", host: "<domain>"
```
This problem often arises when the upstream server is behind the CDN, setting `proxy_ssl_server_name` to `on` will solve it.