### PR TITLE
add automatic registration of chatgpt bot's user (if password is provided)

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -4304,6 +4304,12 @@ matrix_user_creator_users_auto: |
     }] if matrix_bot_matrix_registration_bot_enabled else [])
     +
     ([{
+      'username': matrix_bot_chatgpt_matrix_bot_username_localpart,
+      'initial_password': matrix_bot_chatgpt_matrix_bot_password,
+      'initial_type': 'bot',
+    }] if matrix_bot_chatgpt_enabled and matrix_bot_chatgpt_matrix_bot_password | length > 0 else [])
+    +
+    ([{
       'username': matrix_bot_matrix_reminder_bot_matrix_user_id_localpart,
       'initial_password': matrix_bot_matrix_reminder_bot_matrix_user_password,
       'initial_type': 'bot',


### PR DESCRIPTION
However, bot still needs manual access token adjustments, ref: https://github.com/matrixgpt/matrix-chatgpt-bot/issues/258