### PR TITLE
Add keepalive on worker upstreams and use persistent connections

### DIFF
--- a/roles/custom/matrix-synapse-reverse-proxy-companion/templates/nginx/conf.d/matrix-synapse-reverse-proxy-companion.conf.j2
+++ b/roles/custom/matrix-synapse-reverse-proxy-companion/templates/nginx/conf.d/matrix-synapse-reverse-proxy-companion.conf.j2
@@ -12,6 +12,7 @@
 {% macro render_worker_upstream(name, workers) %}
 {% if workers | length > 0 %}
 	upstream {{ name }} {
+		keepalive {{ workers | length * 2 }};
 		{% for worker in workers %}
 			server "{{ worker.name }}:{{ worker.port }}";
 		{% endfor %}
@@ -24,6 +25,8 @@
 	location ~ {{ location }} {
 		proxy_pass http://{{ upstream_name }}$request_uri;
 		proxy_set_header Host $host;
+		proxy_http_version 1.1;
+		proxy_set_header Connection "";
 	}
 	{% endfor %}
 {% endmacro %}
@@ -39,6 +42,7 @@
 		# ensures that requests from the same client will always be passed
 		# to the same server (except when this server is unavailable)
 		hash $http_x_forwarded_for;
+		keepalive {{ generic_workers | length * 2 }};
 
 		{% for worker in generic_workers %}
 			server "{{ worker.name }}:{{ worker.port }}";


### PR DESCRIPTION
This PR adds `keepalive` on each of the Synapse worker upstreams, and uses HTTP 1.1 with persistent connections.  This allows the reverse proxy companion to re-use its connections to the workers, reducing the need for TCP round-trips for 3-way handshake and teardown.

This is in keeping with Nginx best practices https://www.nginx.com/blog/avoiding-top-10-nginx-configuration-mistakes/#no-keepalives

The expectation is that this change should improve performance when the server is under heavy load.  Load test results can be provided in a day or two to support or refute this hypothesis.