### PR TITLE
[#3082] Analog Signal spaces configuration with rest of playbook

### DIFF
--- a/roles/custom/matrix-bridge-mautrix-signal/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-signal/defaults/main.yml
@@ -161,6 +161,8 @@ matrix_mautrix_signal_bridge_encryption_allow: "{{ matrix_bridges_encryption_ena
 matrix_mautrix_signal_bridge_encryption_default: "{{ matrix_mautrix_signal_bridge_encryption_allow }}"
 matrix_mautrix_signal_bridge_encryption_key_sharing_allow: "{{ matrix_mautrix_signal_bridge_encryption_allow }}"
 
+matrix_mautrix_signal_bridge_personal_filtering_spaces: true
+
 # On conduit versions before 0.5.0 this option prevented users from joining spaces created by the bridge.
 # Setting this to false fixed the issue.
 matrix_mautrix_signal_bridge_restricted_rooms: true

--- a/roles/custom/matrix-bridge-mautrix-signal/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mautrix-signal/templates/config.yaml.j2
@@ -111,7 +111,7 @@ bridge:
 
     # Should the bridge create a space for each logged-in user and add bridged rooms to it?
     # Users who logged in before turning this on should run `!signal sync-space` to create and fill the space for the first time.
-    personal_filtering_spaces: false
+    personal_filtering_spaces: {{ matrix_mautrix_signal_bridge_personal_filtering_spaces | to_json }}
     # Should the bridge send a read receipt from the bridge bot when a message has been sent to Signal?
     delivery_receipts: false
     # Whether the bridge should send the message status as a custom com.beeper.message_send_status event.


### PR DESCRIPTION
As mentioned here https://github.com/spantaleev/matrix-docker-ansible-deploy/pull/3079#issuecomment-1877373963 here is an analog configuration with the whatsapp bridge.

The value can still be overridden in the inventory vars.
Default to `true`