### PR TITLE
Update Draupnir to 1.86.0 and include changelog entry about new License

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2024-01-16
+
+## `Draupnir` has been relicensed to AFL-3.0
+
+As of [#204](https://github.com/the-draupnir-project/Draupnir/pull/204) Draupnir changed its licence to AFL-3.0 from the CSL licence. This change affects playbook users who could not run Draupnir under the old license restrictions. The new license is considerably less restrictive and is OSI approved. Draupnir version v1.86.0 and later are covered by this license change.
+
 # 2024-01-15
 
 ## Goodbye, `matrix-nginx-proxy` 🪦

--- a/roles/custom/matrix-bot-draupnir/defaults/main.yml
+++ b/roles/custom/matrix-bot-draupnir/defaults/main.yml
@@ -5,7 +5,7 @@
 matrix_bot_draupnir_enabled: true
 
 # renovate: datasource=docker depName=gnuxie/draupnir
-matrix_bot_draupnir_version: "v1.85.1"
+matrix_bot_draupnir_version: "v1.86.0"
 
 matrix_bot_draupnir_container_image_self_build: false
 matrix_bot_draupnir_container_image_self_build_repo: "https://github.com/the-draupnir-project/Draupnir.git"


### PR DESCRIPTION
When this PR was drafted Renovate had yet to make a PR and also the changelog entry is included in this RR so thats whats going on with why theres a partial duplicate going on.

So here it is the magical Draupnir is now using AFL-3.0 PR that was promissed earlier this Monday. Its Tuseday 02:00 as i am writing this but well i havent slept so its Monday. 