### PR TITLE
Fixed Traefik routing when using Synapse workers

### DIFF
--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -192,7 +192,7 @@ matrix_synapse_container_labels_public_client_root_redirection_url: ""
 # Controls whether labels will be added that expose the Client-Server API on a public Traefik entrypoint.
 # Regardless of whether this is enabled, it may or may not take effect due to the value of other variables.
 # See `matrix_synapse_container_labels_traefik_enabled` or `matrix_synapse_container_labels_matrix_related_labels_enabled`
-matrix_synapse_container_labels_public_client_api_enabled: true
+matrix_synapse_container_labels_public_client_api_enabled: "{{ not matrix_synapse_reverse_proxy_companion_enabled }}"
 matrix_synapse_container_labels_public_client_api_traefik_hostname: "{{ matrix_synapse_container_labels_traefik_hostname }}"
 matrix_synapse_container_labels_public_client_api_traefik_path_prefix: /_matrix
 matrix_synapse_container_labels_public_client_api_traefik_rule: "Host(`{{ matrix_synapse_container_labels_public_client_api_traefik_hostname }}`) && PathPrefix(`{{ matrix_synapse_container_labels_public_client_api_traefik_path_prefix }}`)"
@@ -215,7 +215,7 @@ matrix_synapse_container_labels_internal_client_api_traefik_entrypoints: ""
 # When workers are enabled, we do not capture these requests, because they may be load-balanaced to some specific worker.
 # Regardless of whether this is enabled, it may or may not take effect due to the value of other variables.
 # See `matrix_synapse_container_labels_traefik_enabled` or `matrix_synapse_container_labels_matrix_related_labels_enabled`
-matrix_synapse_container_labels_public_client_synapse_client_api_enabled: true
+matrix_synapse_container_labels_public_client_synapse_client_api_enabled: "{{ not matrix_synapse_reverse_proxy_companion_enabled }}"
 matrix_synapse_container_labels_public_client_synapse_client_api_traefik_hostname: "{{ matrix_synapse_container_labels_traefik_hostname }}"
 matrix_synapse_container_labels_public_client_synapse_client_api_traefik_path_prefix: /_synapse/client
 matrix_synapse_container_labels_public_client_synapse_client_api_traefik_rule: "Host(`{{ matrix_synapse_container_labels_public_client_synapse_client_api_traefik_hostname }}`) && PathPrefix(`{{ matrix_synapse_container_labels_public_client_synapse_client_api_traefik_path_prefix }}`)"
@@ -228,7 +228,7 @@ matrix_synapse_container_labels_public_client_synapse_client_api_traefik_tls_cer
 # Enable this if you need OpenID Connect authentication support.
 # Regardless of whether this is enabled, it may or may not take effect due to the value of other variables.
 # See `matrix_synapse_container_labels_traefik_enabled` or `matrix_synapse_container_labels_matrix_related_labels_enabled`
-matrix_synapse_container_labels_public_client_synapse_oidc_api_enabled: "{{ matrix_synapse_oidc_enabled }}"
+matrix_synapse_container_labels_public_client_synapse_oidc_api_enabled: "{{ matrix_synapse_oidc_enabled and not matrix_synapse_reverse_proxy_companion_enabled }}"
 matrix_synapse_container_labels_public_client_synapse_oidc_api_traefik_hostname: "{{ matrix_synapse_container_labels_traefik_hostname }}"
 matrix_synapse_container_labels_public_client_synapse_oidc_api_traefik_path_prefix: /_synapse/oidc
 matrix_synapse_container_labels_public_client_synapse_oidc_api_traefik_rule: "Host(`{{ matrix_synapse_container_labels_public_client_synapse_oidc_api_traefik_hostname }}`) && PathPrefix(`{{ matrix_synapse_container_labels_public_client_synapse_oidc_api_traefik_path_prefix }}`)"
@@ -253,7 +253,7 @@ matrix_synapse_container_labels_public_client_synapse_admin_api_traefik_tls_cert
 # Controls whether labels will be added that expose the Server-Server API (Federation API).
 # Regardless of whether this is enabled, it may or may not take effect due to the value of other variables.
 # See `matrix_synapse_container_labels_traefik_enabled` or `matrix_synapse_container_labels_matrix_related_labels_enabled`
-matrix_synapse_container_labels_public_federation_api_enabled: "{{ matrix_synapse_federation_enabled and matrix_synapse_federation_port_enabled and not matrix_synapse_workers_enabled }}"
+matrix_synapse_container_labels_public_federation_api_enabled: "{{ matrix_synapse_federation_enabled and matrix_synapse_federation_port_enabled and not matrix_synapse_workers_enabled and not matrix_synapse_reverse_proxy_companion_enabled }}"
 matrix_synapse_container_labels_public_federation_api_traefik_hostname: "{{ matrix_synapse_container_labels_traefik_hostname }}"
 matrix_synapse_container_labels_public_federation_api_traefik_path_prefix: /_matrix
 matrix_synapse_container_labels_public_federation_api_traefik_rule: "Host(`{{ matrix_synapse_container_labels_public_federation_api_traefik_hostname }}`) && PathPrefix(`{{ matrix_synapse_container_labels_public_federation_api_traefik_path_prefix }}`)"

--- a/roles/custom/matrix-synapse/templates/synapse/labels.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/labels.j2
@@ -82,7 +82,7 @@ traefik.http.routers.matrix-synapse-public-client-api.tls.certResolver={{ matrix
 
 
 
-{% if matrix_synapse_container_labels_internal_client_api_enabled %}
+{% if matrix_synapse_container_labels_internal_client_api_enabled and not matrix_synapse_reverse_proxy_companion_enabled %}
 ############################################################
 #                                                          #
 # Internal Client-API (/_matrix)                           #


### PR DESCRIPTION
Traefik seems to have routing priority conflicts when using the reverse proxy companion (and likely MMR as well, though I did not have an issue on my server). With the [default priority](https://doc.traefik.io/traefik/routing/routers/#priority) rules  being used, I have seen requests being routed directly to the Synapse container instead of the reverse proxy companion container.

I went with disabling registration of Synapse routes instead of adjusting priority values  if the reverse proxy companion is enabled. Tested the changes for correct behavior of the reverse proxy companion and MMR routing, but I don't use any of the bridges/bots, so those roles have not been tested.