### PR TITLE
Update broken links in reverse proxies docs

### DIFF
--- a/examples/reverse-proxies/apache/README.md
+++ b/examples/reverse-proxies/apache/README.md
@@ -4,7 +4,7 @@ This directory contains sample files that show you how to front the integrated [
 
 ## Prerequisite configuration
 
-To get started, first follow the [front the integrated reverse-proxy webserver with another reverse-proxy](../../docs/configuring-playbook-own-webserver.md#fronting-the-integrated-reverse-proxy-webserver-with-another-reverse-proxy) instructions and update your playbook's configuration (`inventory/host_vars/matrix.<your-domain>/vars.yml`).
+To get started, first follow the [front the integrated reverse-proxy webserver with another reverse-proxy](../../../docs/configuring-playbook-own-webserver.md#fronting-the-integrated-reverse-proxy-webserver-with-another-reverse-proxy) instructions and update your playbook's configuration (`inventory/host_vars/matrix.<your-domain>/vars.yml`).
 
 ## Using the Apache configuration
 

--- a/examples/reverse-proxies/caddy2/README.md
+++ b/examples/reverse-proxies/caddy2/README.md
@@ -5,7 +5,7 @@ This directory contains a sample config that shows you how to front the integrat
 
 ## Prerequisite configuration
 
-To get started, first follow the [front the integrated reverse-proxy webserver with another reverse-proxy](../../docs/configuring-playbook-own-webserver.md#fronting-the-integrated-reverse-proxy-webserver-with-another-reverse-proxy) instructions and update your playbook's configuration (`inventory/host_vars/matrix.<your-domain>/vars.yml`).
+To get started, first follow the [front the integrated reverse-proxy webserver with another reverse-proxy](../../../docs/configuring-playbook-own-webserver.md#fronting-the-integrated-reverse-proxy-webserver-with-another-reverse-proxy) instructions and update your playbook's configuration (`inventory/host_vars/matrix.<your-domain>/vars.yml`).
 
 
 ## Using the Caddyfile

--- a/examples/reverse-proxies/haproxy/README.md
+++ b/examples/reverse-proxies/haproxy/README.md
@@ -4,6 +4,6 @@ This directory contains sample files that show you how to do reverse-proxying us
 
 This is for when you wish to have your own HAproxy instance sitting in front of Matrix services installed by this playbook.
 
-We recommend that you use HAProxy in front of Traefik. See our [Fronting the integrated reverse-proxy webserver with another reverse-proxy](../../docs/configuring-playbook-own-webserver.md#fronting-the-integrated-reverse-proxy-webserver-with-another-reverse-proxy) documentation.
+We recommend that you use HAProxy in front of Traefik. See our [Fronting the integrated reverse-proxy webserver with another reverse-proxy](../../../docs/configuring-playbook-own-webserver.md#fronting-the-integrated-reverse-proxy-webserver-with-another-reverse-proxy) documentation.
 
 You can then use the configuration files from this directory as an example for how to configure your HAproxy reverse proxy.

--- a/examples/reverse-proxies/nginx/README.md
+++ b/examples/reverse-proxies/nginx/README.md
@@ -5,7 +5,7 @@ This directory contains a sample config that shows you how to use the [nginx](ht
 
 ## Prerequisite configuration
 
-To get started, first follow the [front the integrated reverse-proxy webserver with another reverse-proxy](../../docs/configuring-playbook-own-webserver.md#fronting-the-integrated-reverse-proxy-webserver-with-another-reverse-proxy) instructions and update your playbook's configuration (`inventory/host_vars/matrix.<your-domain>/vars.yml`).
+To get started, first follow the [front the integrated reverse-proxy webserver with another reverse-proxy](../../../docs/configuring-playbook-own-webserver.md#fronting-the-integrated-reverse-proxy-webserver-with-another-reverse-proxy) instructions and update your playbook's configuration (`inventory/host_vars/matrix.<your-domain>/vars.yml`).
 
 
 ## Using the nginx configuration
@@ -14,4 +14,4 @@ Copy the [matrix.conf](matrix.conf) file to your nginx server's filesystem, modi
 
 This configuration **disables SSL certificate retrieval**, so you will **need to obtain SSL certificates manually** (e.g. by using [certbot](https://certbot.eff.org/)) and set the appropriate path in `matrix.conf`. In the example nginx configuration, a single certificate is used for all subdomains (`matrix.DOMAIN`, `element.DOMAIN`, etc.). For your setup, may wish to change this and use separate `server` blocks and separate certificate files for each host.
 
-Also note that your copy of the `matrix.conf` file has to be adapted to whatever services you are using. For example, remove `element.domain.com` from the `server_name` list if you don't use [Element](../../docs/configuring-playbook-client-element.md) web client or add `dimension.domain.com` to it if you do use the [Dimension](../../docs/configuring-playbook-dimension.md) integration manager.
+Also note that your copy of the `matrix.conf` file has to be adapted to whatever services you are using. For example, remove `element.domain.com` from the `server_name` list if you don't use [Element](../../../docs/configuring-playbook-client-element.md) web client or add `dimension.domain.com` to it if you do use the [Dimension](../../../docs/configuring-playbook-dimension.md) integration manager.


### PR DESCRIPTION
Just a few broken links in docs I was looking at right when the repo changed :dizzy_face:

Did the clickity-click test on the PR version and they point at current locations.