### PR TITLE
Fixed docker network access for Prometheus Postgres exporter

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -4183,7 +4183,7 @@ prometheus_postgres_exporter_hostname: "{{ matrix_server_fqn_matrix }}"
 
 prometheus_postgres_exporter_container_network: "{{ matrix_monitoring_container_network }}"
 
-prometheus_postgres_exporter_container_additional_networks: "{{ [matrix_playbook_reverse_proxyable_services_additional_network] if matrix_playbook_reverse_proxyable_services_additional_network else [] }}"
+prometheus_postgres_exporter_container_additional_networks: "{{ [matrix_playbook_reverse_proxyable_services_additional_network] + [devture_postgres_identifier] if matrix_playbook_reverse_proxyable_services_additional_network else [devture_postgres_identifier] }}"
 
 prometheus_postgres_exporter_container_labels_traefik_enabled: "{{ matrix_metrics_exposure_enabled }}"
 prometheus_postgres_exporter_container_labels_traefik_docker_network: "{{ matrix_playbook_reverse_proxyable_services_additional_network }}"


### PR DESCRIPTION
With the updates to the proxy and Docker networks, the Prometheus Postgres exporter no longer has access to the Postgres Docker network. This PR addresses that issue.