### PR TITLE
Updated nginx proxy fronting with NPM guide

### DIFF
--- a/examples/reverse-proxies/nginx/README.md
+++ b/examples/reverse-proxies/nginx/README.md
@@ -15,3 +15,75 @@ Copy the [matrix.conf](matrix.conf) file to your nginx server's filesystem, modi
 This configuration **disables SSL certificate retrieval**, so you will **need to obtain SSL certificates manually** (e.g. by using [certbot](https://certbot.eff.org/)) and set the appropriate path in `matrix.conf`. In the example nginx configuration, a single certificate is used for all subdomains (`matrix.DOMAIN`, `element.DOMAIN`, etc.). For your setup, may wish to change this and use separate `server` blocks and separate certificate files for each host.
 
 Also note that your copy of the `matrix.conf` file has to be adapted to whatever services you are using. For example, remove `element.domain.com` from the `server_name` list if you don't use [Element](../../../docs/configuring-playbook-client-element.md) web client or add `dimension.domain.com` to it if you do use the [Dimension](../../../docs/configuring-playbook-dimension.md) integration manager.
+
+## Using Nginx Proxy Manager
+
+Similar to standard nginx, [Nginx Proxy Manager](https://nginxproxymanager.com/) provides nginx capabilities but inside a pre-built Docker container. With the ability for managing proxy hosts and automatic SSL certificates via a simple web interface.
+
+If Matrix federation is enabled, then you will need to make changes to [NPM's Docker configuration](https://nginxproxymanager.com/guide/#quick-setup). By default NPM has access to ports 443, 80 and 81, but you would also need to **provide access to the fedderation ports** `8448` and `8449`.
+
+
+### Creating proxy hosts in Nginx Proxy Manager
+
+Open the 'Proxy Hosts' page in the NPM web interface and select `Add Proxy Host`, the first being for matrix web traffic. Apply the proxys configuration like this:
+
+```md
+# Details
+# Matrix web proxy config
+Domain Names: matrix.DOMAIN
+Scheme: http
+Forward Hostname/IP: IP-ADDRESS-OF-YOUR-MATRIX
+Forward Port: 81
+
+# Custom locations
+# Add one custom location
+Define location: /
+Scheme: http
+Forward Hostname/IP: IP-ADDRESS-OF-YOUR-MATRIX
+Forward Port: 81
+Custom config:
+    proxy_set_header X-Forwarded-For $remote_addr;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Real-IP $remote_addr;
+    client_max_body_size 50M;
+
+# SSL
+# Either 'Request a new certificate' or select an existing one
+SSL Certificate: matrix.DOMAIN or *.DOMAIN
+Force SSL: true
+HTTP/2 Support: true
+```
+
+Again, under the 'Proxy Hosts' page select `Add Proxy Host`, this time for your federation traffic. Apply the proxys configuration like this:
+
+```md
+# Details
+# Matrix Federation proxy config
+Domain Names: matrix.DOMAIN:8448
+Scheme: http
+Forward Hostname/IP: IP-ADDRESS-OF-YOUR-MATRIX
+Forward Port: 8449
+
+# Custom locations
+# Add one custom location
+Define location: /
+Scheme: http
+Forward Hostname/IP: IP-ADDRESS-OF-YOUR-MATRIX
+Forward Port: 8449
+Custom config:
+    proxy_set_header X-Forwarded-For $remote_addr;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    client_max_body_size 50M;
+
+# SSL
+# Either 'Request a new certificate' or select an existing one
+SSL Certificate: matrix.DOMAIN or *.DOMAIN
+Force SSL: true
+HTTP/2 Support: true
+
+# Advanced
+# Allows NPM to listen on the federation port
+Custom Nginx Configuration: listen 8448 ssl http2;
+```
+
+Also note, NPM would need to be configured for whatever other services you are using. For example, you would need to create additional proxy hosts for `element.DOMAIN` or `jitsi.DOMAIN`, which would use the forwarding port `81`.


### PR DESCRIPTION
TL;DR: Updated the 'nginx reverse-proxy fronting' documentation with a guide for Nginx Proxy Manager, as you can't use the pre-existing nginx matrix.conf

---

I use Nginx Proxy Manager because its nice and simple, but also because it allows for snippets of custom nginx configuration when things get more advanced. Whilst setting up matrix with NPM via fronting the internal proxy, the playbook configuration was very easy (amazing documentation btw). But trying to translate a full [nginx config](https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/8f06e2bf05cf543da6b0317873a5f89d2638109f/examples/reverse-proxies/nginx/matrix.conf) into the web interface of NPM was very confusing (NPM has very little guidance on how its web ui translates to nginx configuration + doesn't have a config import tool).

So after a couple of hours, and coming across a few help threads of people asking "NPM+ matrix playbook how?" it all made sense in the end. And so here's a write up of the basic setup for others to follow, so no one else has to have the headache I had.