### PR TITLE
Added docu on how to host another server behind traefik.

### DIFF
--- a/docs/configuring-playbook-traefik.md
+++ b/docs/configuring-playbook-traefik.md
@@ -51,20 +51,22 @@ devture_traefik_configuration_extension_yaml: |
 
 ## Reverse-proxying another service behind Traefik
 
-The preferred way to reverse-proxy additional services behind Traefik would be to add the service as another container, configure the container with the corresponding traefik labels, and add it to the `traefik` network. Some services are also already available via the compatible [mash-playbook](https://github.com/mother-of-all-self-hosting/mash-playbook), but take a look at the minor [interoperability adjustments](https://github.com/mother-of-all-self-hosting/mash-playbook/blob/main/docs/interoperability.md).
+The preferred way to reverse-proxy additional services behind Traefik would be to start the service as another container, configure the container with the corresponding Traefik [container labels](https://docs.docker.com/config/labels-custom-metadata/) (see [Traefik & Docker](https://doc.traefik.io/traefik/routing/providers/docker/)), and connect the service to the `traefik` network. Some services are also already available via the compatible [mash-playbook](https://github.com/mother-of-all-self-hosting/mash-playbook), but take a look at the minor [interoperability adjustments](https://github.com/mother-of-all-self-hosting/mash-playbook/blob/main/docs/interoperability.md).
 
-However, if your service is not available as a docker container or runs on another machine, the following configuration mighht be what you are looking for.
+However, if your service does not run on a container or runs on another machine, the following configuration might be what you are looking for.
 
-## Reverse-proxying another HTTP/HTTPS service behind Traefik without using docker
+## Reverse-proxying a remote HTTP/HTTPS service behind Traefik
 
-If you want to host another webserver that is reachable via `my_fancy_website.mydomain.com` from the internet and via `https://<internal webserver IP address>:<internal port>` from inside your network, you can make traefik reverse-proxy the traffic to the correct host.
+If you want to host another webserver would be reachable via `my-fancy-website.mydomain.com` from the internet and via `https://<internal webserver IP address>:<internal port>` from inside your network, you can make the playbook's integrated Traefik instance reverse-proxy the traffic to the correct host.
 
-Prerequisites: DNS and routing for the domain `my_fancy_website.mydomain.com` need to be set up correctly to reach your traefik instance.
+Prerequisites: DNS and routing for the domain `my-fancy-website.mydomain.com` need to be set up correctly. In this case, you'd be pointing the domain name to your Matrix server - `my-fancy-website.mydomain.com` would be a CNAME going to `matrix.example.com`.
 
-First, we have to adjust the static configuration of traefik, so that we can add additional configuration files:
+First, we have to adjust the static configuration of Traefik, so that we can add additional configuration files:
 
 ```yaml
 # We enable all config files in the /config/ folder to be loaded.
+# `/config` is the path as it appears in the Traefik container.
+# On the host, it's actually `/matrix/traefik/config` (as defined in `devture_traefik_config_dir_path`).
 devture_traefik_configuration_extension_yaml: |
   providers:
     file:
@@ -73,7 +75,7 @@ devture_traefik_configuration_extension_yaml: |
       filename: ""
 ```
 
-If you are using a self signed certificate on your webserver, you can tell traefik to trust your own backend servers by adding more configuration to the static configuration file. If you do so, bear in mind the security implications of disabling the certificate validity checks towards your back end.
+If you are using a self-signed certificate on your webserver, you can tell Traefik to trust your own backend servers by adding more configuration to the static configuration file. If you do so, bear in mind the security implications of disabling the certificate validity checks towards your back end.
 
 ```yaml
 # We enable all config files in the /config/ folder to be loaded and
@@ -88,7 +90,7 @@ devture_traefik_configuration_extension_yaml: |
 ```
 
 
-Next, you have to add a new dynamic configuration file for traefik that contains the actual information of the server using the `aux_file_definitions` variable. In this example, we will terminate SSL at the traefik instance and connect to the other server via HTTPS. Traefik will now take care of managing the certificates. 
+Next, you have to add a new dynamic configuration file for Traefik that contains the actual information of the server using the `aux_file_definitions` variable. In this example, we will terminate SSL at the Traefik instance and connect to the other server via HTTPS. Traefik will now take care of managing the certificates. 
 
 ```yaml
 aux_file_definitions:
@@ -107,11 +109,11 @@ aux_file_definitions:
               servers:
                 - url: "https://<internal webserver IP address>:<internal port>"
 ```
-Changing the url to HTTP would allow to connect to the server via HTTP.
+Changing the `url` to one with an `http://` prefix would allow to connect to the server via HTTP.
 
 ## Reverse-proxying another service behind Traefik without terminating SSL
 
-If you do not want to terminate SSL on the traefik instance, you need to adjust the static configuration in the same way as in the previous chapter in order to be able to add our own dynamic configuration files. Afterwards, you can enter the following configuration to the dynamic configuration file:
+If you do not want to terminate SSL at the Traefik instance (for example, because you're already terminating SSL at other webserver), you need to adjust the static configuration in the same way as in the previous chapter in order to be able to add our own dynamic configuration files. Afterwards, you can add the following configuration to your `vars.yml` configuration file:
 
 ```yaml
 aux_file_definitions:
@@ -130,8 +132,8 @@ aux_file_definitions:
               servers:
                 - url: "https://<internal webserver IP address>:<internal port>"
 ```
-Changing the url to HTTP would allow to connect to the server via HTTP.
+Changing the `url` to one with an `http://` prefix would allow to connect to the server via HTTP.
 
 With these changes, all TCP traffic will be reverse-proxied to the target system. 
 
-**WARNING**: This configuration might lead to problems or need additional steps when a certbot behind traefik also tries to manage Let's Encrypt certificates, as traefik captures all traffic to ```PathPrefix(`/.well-known/acme-challenge/`)```. 
+**WARNING**: This configuration might lead to problems or need additional steps when a [certbot](https://certbot.eff.org/) behind Traefik also tries to manage [Let's Encrypt](https://letsencrypt.org/) certificates, as Traefik captures all traffic to ```PathPrefix(`/.well-known/acme-challenge/`)```. 


### PR DESCRIPTION
Added docu on how to host another server behind traefik to the docu file about configuring traefik.

All configuration options were succsessfully tested in my own deployment.