### PR TITLE
Fix s3-storage migrate and shell

### DIFF
--- a/roles/custom/matrix-synapse/templates/synapse/ext/s3-storage-provider/bin/migrate.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/ext/s3-storage-provider/bin/migrate.j2
@@ -8,6 +8,7 @@
 	--mount type=bind,src={{ matrix_synapse_ext_s3_storage_provider_data_path }},dst=/data \
 	--workdir=/data \
 	--network={{ matrix_synapse_container_network }} \
+	--network={{ devture_postgres_container_network }} \
 	--entrypoint=/bin/bash \
 	{{ matrix_synapse_docker_image_final }} \
 	-c 's3_media_upload update-db $UPDATE_DB_DURATION && s3_media_upload --no-progress check-deleted $MEDIA_PATH && s3_media_upload --no-progress upload $MEDIA_PATH $BUCKET --delete --storage-class $STORAGE_CLASS --endpoint-url $ENDPOINT {% if matrix_synapse_ext_synapse_s3_storage_provider_config_sse_customer_enabled %}--sse-customer-algo $SSE_CUSTOMER_ALGO --sse-customer-key $SSE_CUSTOMER_KEY{% endif %}'

--- a/roles/custom/matrix-synapse/templates/synapse/ext/s3-storage-provider/bin/migrate.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/ext/s3-storage-provider/bin/migrate.j2
@@ -1,14 +1,23 @@
 #jinja2: lstrip_blocks: "True"
 #!/bin/bash
+set -euo pipefail
 
-{{ devture_systemd_docker_base_host_command_docker }} run \
+container_id=$(\
+	{{ devture_systemd_docker_base_host_command_docker }} create \
 	--rm \
 	--env-file={{ matrix_synapse_ext_s3_storage_provider_base_path }}/env \
 	--mount type=bind,src={{ matrix_synapse_storage_path }},dst=/matrix-media-store-parent,bind-propagation=slave \
 	--mount type=bind,src={{ matrix_synapse_ext_s3_storage_provider_data_path }},dst=/data \
 	--workdir=/data \
 	--network={{ matrix_synapse_container_network }} \
-	--network={{ devture_postgres_container_network }} \
 	--entrypoint=/bin/bash \
 	{{ matrix_synapse_docker_image_final }} \
-	-c 's3_media_upload update-db $UPDATE_DB_DURATION && s3_media_upload --no-progress check-deleted $MEDIA_PATH && s3_media_upload --no-progress upload $MEDIA_PATH $BUCKET --delete --storage-class $STORAGE_CLASS --endpoint-url $ENDPOINT {% if matrix_synapse_ext_synapse_s3_storage_provider_config_sse_customer_enabled %}--sse-customer-algo $SSE_CUSTOMER_ALGO --sse-customer-key $SSE_CUSTOMER_KEY{% endif %}'
+	-c 's3_media_upload update-db $UPDATE_DB_DURATION && s3_media_upload --no-progress check-deleted $MEDIA_PATH && s3_media_upload --no-progress upload $MEDIA_PATH $BUCKET --delete --storage-class $STORAGE_CLASS --endpoint-url $ENDPOINT {% if matrix_synapse_ext_synapse_s3_storage_provider_config_sse_customer_enabled %}--sse-customer-algo $SSE_CUSTOMER_ALGO --sse-customer-key $SSE_CUSTOMER_KEY{% endif %}' \
+)
+
+{# We need to connect to the Postgres network, which should be in this list. #}
+{% for network in matrix_synapse_container_additional_networks %}
+{{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} $container_id
+{% endfor %}
+
+{{ devture_systemd_docker_base_host_command_docker }} start --attach $container_id

--- a/roles/custom/matrix-synapse/templates/synapse/ext/s3-storage-provider/bin/shell.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/ext/s3-storage-provider/bin/shell.j2
@@ -1,14 +1,24 @@
 #jinja2: lstrip_blocks: "True"
 #!/bin/bash
+set -euo pipefail
 
-{{ devture_systemd_docker_base_host_command_docker }} run \
+container_id=$(\
+	{{ devture_systemd_docker_base_host_command_docker }} create \
 	-it \
 	--rm \
+	--name=matrix-synapse-s3-storage-provider-shell \
 	--env-file={{ matrix_synapse_ext_s3_storage_provider_base_path }}/env \
 	--mount type=bind,src={{ matrix_synapse_storage_path }},dst=/matrix-media-store-parent,bind-propagation=slave \
 	--mount type=bind,src={{ matrix_synapse_ext_s3_storage_provider_data_path }},dst=/data \
 	--workdir=/data \
 	--network={{ matrix_synapse_container_network }} \
-	--network={{ devture_postgres_container_network }} \
 	--entrypoint=/bin/bash \
-	{{ matrix_synapse_docker_image_final }}
+	{{ matrix_synapse_docker_image_final }} \
+)
+
+{# We need to connect to the Postgres network, which should be in this list. #}
+{% for network in matrix_synapse_container_additional_networks %}
+{{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} $container_id
+{% endfor %}
+
+{{ devture_systemd_docker_base_host_command_docker }} start --attach -i $container_id

--- a/roles/custom/matrix-synapse/templates/synapse/ext/s3-storage-provider/bin/shell.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/ext/s3-storage-provider/bin/shell.j2
@@ -9,5 +9,6 @@
 	--mount type=bind,src={{ matrix_synapse_ext_s3_storage_provider_data_path }},dst=/data \
 	--workdir=/data \
 	--network={{ matrix_synapse_container_network }} \
+	--network={{ devture_postgres_container_network }} \
 	--entrypoint=/bin/bash \
 	{{ matrix_synapse_docker_image_final }}


### PR DESCRIPTION
Container needs attachment to postgres network also.

When trying to run the s3 storage migration (or shell) script this issue popped up:
```
s3_media_upload: error: Could not connect to postgres database: could not translate host name "matrix-postgres" to address: Temporary failure in name resolution
```

This PR fixes that