### PR TITLE
Update SRV delegation docs

### DIFF
--- a/docs/howto-srv-server-delegation.md
+++ b/docs/howto-srv-server-delegation.md
@@ -27,7 +27,7 @@ Also, all instructions below are from an older version of the playbook and may n
 
 ```yaml
 # To serve the federation from any domain, as long as the path matches
-matrix_synapse_container_labels_public_federation_api_traefik_rule: PathPrefix(`/_matrix/federation`)
+matrix_synapse_container_labels_public_federation_api_traefik_rule: PathPrefix(`/_matrix/`)
 ```
 
 This is because with SRV federation, some servers / tools (one of which being the federation tester) try to access the federation API using the resolved IP address instead of the domain name (or they are not using SNI). This change will make Traefik route all traffic for which the path match this rule go to the federation endpoint.


### PR DESCRIPTION
The path rule was not working because for federation fo work it needs several endpoints.

Two of them are not under /_matrix/federation : 

- /_matrix/key
- /_matrix/media