### PR TITLE
Fix documentation bug in configuring-playbook-bridge-mautrix-signal.md

### DIFF
--- a/docs/configuring-playbook-bridge-mautrix-signal.md
+++ b/docs/configuring-playbook-bridge-mautrix-signal.md
@@ -45,7 +45,7 @@ This will add the admin permission to the specific user, while keeping the defau
 
 In case you want to replace the default permissions settings **completely**, populate the following item within your `vars.yml` file:
 ```yaml
-matrix_mautrix_signal_bridge_permissions: |
+matrix_mautrix_signal_bridge_permissions:
   '@ADMIN:YOUR_DOMAIN': admin
   '@USER:YOUR_DOMAIN' : user
 ```


### PR DESCRIPTION
With the `|` the yaml is interpreted and saved to the configuration as a string and mautrix-signal doesn't start with the failure:
```

Feb 20 19:05:28 h3002795.stratoserver.net matrix-mautrix-signal[685899]: Ignoring incorrect config field type !!str at bridge->permissions
Feb 20 19:05:28 h3002795.stratoserver.net matrix-mautrix-signal[685899]: Feb 20, 2024 18:05:28 FTL Configuration error error="bridge.permissions not configured"
```

Without the `|` it is written to the config correctly.