### PR TITLE
Ensure reports always land on the synapse main process

### DIFF
--- a/roles/custom/matrix-synapse-reverse-proxy-companion/defaults/main.yml
+++ b/roles/custom/matrix-synapse-reverse-proxy-companion/defaults/main.yml
@@ -226,7 +226,7 @@ matrix_synapse_reverse_proxy_companion_synapse_stream_writer_receipts_stream_wor
 matrix_synapse_reverse_proxy_companion_synapse_stream_writer_presence_stream_worker_client_server_locations: []
 matrix_synapse_reverse_proxy_companion_synapse_media_repository_locations: []
 matrix_synapse_reverse_proxy_companion_synapse_user_dir_locations: []
-matrix_synapse_reverse_proxy_companion_client_server_main_override_locations_regex: ^/_matrix/client/(api/v1|r0|v3|unstable)/(account/3pid/|directory/list/room/|pushrules/|rooms/[^/]+/(forget|upgrade)|login/sso/redirect/|register)
+matrix_synapse_reverse_proxy_companion_client_server_main_override_locations_regex: ^/_matrix/client/(api/v1|r0|v3|unstable)/(account/3pid/|directory/list/room/|pushrules/|rooms/[^/]+/(forget|upgrade|report)|login/sso/redirect/|register)
 matrix_synapse_reverse_proxy_companion_client_server_sso_override_locations_regex: ^(/_matrix/client/(api/v1|r0|v3|unstable)/login/sso/redirect|/_synapse/client/(pick_username|(new_user_consent|oidc/callback|pick_idp|sso_register)$))
 matrix_synapse_reverse_proxy_companion_federation_override_locations_regex: ^/_matrix/federation/v1/openid/userinfo$
 


### PR DESCRIPTION
We noticed that the reporting function in Element is broken, at least when using the 'specialized-workers' preset. Requests seem to land on a worker, which is then confused and returns 404.

This changes the `main_override_locations_regex` of the reverse proxy companion to ensure that requests to `/_matrix/client/v3/rooms/<roomid>/report/<message>` always land on the main process.