### PR TITLE
Add support for D4A/Draupnir For All to the playbook.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 2024-03-05
+
+## Support for Draupnir-for-all
+
+Thanks to [FSG-Cat](https://github.com/FSG-Cat), the playbook can now install [Draupnir for all](./docs/configuring-playbook-appservice-draupnir-for-all.md) (aka multi-instance Draupnir running in appservice mode).
+
+This is an alternative to [running Draupnir in bot mode](./docs/configuring-playbook-bot-draupnir.md), which is still supported by the playbook.
+
+The documentation page for [Draupnir for all](./docs/configuring-playbook-appservice-draupnir-for-all.md) contains more information on how to install it.
+
+
 # 2024-02-19
 
 ## Support for bridging to Facebook/Messenger via the new mautrix-meta bridge

--- a/docs/configuring-playbook-appservice-draupnir-for-all.md
+++ b/docs/configuring-playbook-appservice-draupnir-for-all.md
@@ -2,7 +2,19 @@
 
 The playbook can install and configure the [Draupnir](https://github.com/the-draupnir-project/Draupnir) moderation tool for you in appservice mode.
 
-Appservice mode can be used together with normal Draupnir or independently. 
+Appservice mode can be used together with the regular [Draupnir bot](configuring-playbook-bot-draupnir.md) or independently.
+
+D4A compared to Draupnir Normal. 
+
+Draupnir for all is the way to go if you need more than 1 Draupnir but you don't need access to Synapse Admin features as they are not accessible thru Draupnir for All (Even tho the commands do show up in help). 
+
+Draupnir for all in the playbook is rate limit exempt automatically as its part of the appservice configuration file if the appservice is rate limited or not. 
+
+Normal Draupnir does come with the benefit of access to Synapse Admin features. You are also able to more easily customise your normal Draupnir than D4A as D4A even on the branch with the Avatar command (To be Upstreamed to Mainline Draupnir) that command is clunky as it requires the use of things like Element devtools. In normal draupnir this is a quick operation where you login to Draupnir with a normal client and set Avatar and Display name normally. 
+
+Draupnir for all does also not support external tooling like [MRU](https://mru.rory.gay) as it cant access Draupnirs user account like is needed to use it. 
+
+Last downside of Draupnir for all is the state of the Admin side of the user experience being Alpha quality. This flaw is not in regular Draupnir and is mostly not in the provisioned Draupnirs either.
 
 ## 1. Create a main management room.
 

--- a/docs/configuring-playbook-appservice-draupnir-for-all.md
+++ b/docs/configuring-playbook-appservice-draupnir-for-all.md
@@ -1,0 +1,87 @@
+# Setting up Draupnir for All/D4A (optional)
+
+The playbook can install and configure the [Draupnir](https://github.com/the-draupnir-project/Draupnir) moderation tool for you in appservice mode.
+
+Appservice mode can be used together with normal Draupnir or independently. 
+
+## 1. Create a main management room.
+
+The playbook does not create a management room for your Main Draupnir. This task you have to do on your own. 
+
+The management room has to be given an alias and be public when you are setting up the bot for the first time as the bot does not differentiate between invites
+and invites to the management room. 
+
+This management room is used to control who has access to your D4A deployment. The room stores this data inside of the control room state so your bot must have sufficient powerlevel to send custom state events. This is default 50 or moderator as Element calls this powerlevel.
+
+As noted in the Draupnir install instructions the control room is sensitive. The following is said about the control room in the Draupnir install instructions. 
+>Anyone in this room can control the bot so it is important that you only invite trusted users to this room. The room must be unencrypted since the playbook does not support installing Pantalaimon yet.
+
+## 2. Give your main management room an alias.
+
+Give the room from step 1 an alias. This alias can be anything you want and its recommended for increased security during the setup phase of the bot that you make this alias be a random string. You can give your room a secondary human readable alias when it has been locked down after setup phase.
+
+## 3. Adjusting the playbook configuration.
+
+Add the following configuration to your `inventory/host_vars/matrix.DOMAIN/vars.yml` file (adapt to your needs):
+
+You must replace `ALIAS_FROM_STEP_2_GOES_HERE` with the alias you created in step 2.
+
+```yaml
+matrix_appservice_draupnir_for_all_enabled: true
+
+matrix_appservice_draupnir_for_all_master_control_room_alias: "ALIAS_FROM_STEP_2_GOES_HERE"
+```
+
+## 4. Installing
+
+After configuring the playbook, run the [installation](installing.md) command:
+
+```
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
+
+# Using Draupnir For All
+
+If you made it thru all the steps above and your main control room was joined by a user called `@draupnir-main:matrix-homeserver-domain` you have succesfully installed Draupnir for All and can now start using it. 
+
+This side of Draupnir for all is very much Alpha quality in the user experience it should be noted. Draupnir for all on the end user side is almost identical to Draupnir normal mode. 
+
+## 1. Granting Users the ability to use D4A
+
+Draupnir for all includes several security measures like that it only allows users that are on its allow list to ask for a bot. To add a user to this list we have 2 primary options. Using the chat to tell Draupnir to do this for us or manually sending the state event via either curl or devtools in Element. 
+
+If you want to give individual users access grants the recommended way is via the chat. To use the chat to tell Draupnir to do things you need to ping it in a specific way. Clients like Element and nheko will do this correctly by default because they send `<a href=\"https://matrix.to/#/@example:example.com\">Example</a>:` when you try to mention a user. Draupnir expects this format and will NOT respond to anything else in the main control room. As mentioned earlier D4A is Alpha in its user experience for the main control room.
+
+The command is `<a href=\"https://matrix.to/#/@example:example.com\">Example</a>: allow mxid`
+
+If you want to allow all users on your homeserver you instead send a `m.policy.rule.user` event with the contents being `{"entity": "@*:matrix-homeserver-domain", "recommendation": "org.matrix.mjolnir.allow"}` and a `state_key` that is `_*:matrix-homeserver-domain`.
+
+Using curl you can send this via `curl --request PUT --url 'https://homeserver_url/_matrix/client/v3/rooms/management_room_room_ID/state/m.policy.rule.user/_*:matrix-homeserver-domain' --header 'Authorization: Bearer ACCESS_TOKEN_HERE' --header 'Content-Type: application/json' --data '{"entity": "@*:matrix-homeserver-domain", "recommendation": "org.matrix.mjolnir.allow"}'`
+
+## 2. How to provision a D4A once you are allowed to.
+
+Open a DM with @draupnir-main:matrix-homeserver-domain and if using Element send a message into this DM to finalise creating it. The bot will reject this invite and you will shortly get invited to the Draupnir control room for your newly provisioned Draupnir. From here its just a normal Draupnir experience. 
+
+Congratulations if you made it all the way here because you now have a fully working Draupnir for all deployment.
+
+## Configuration of D4A
+
+You can refer to the upstream [documentation](https://github.com/the-draupnir-project/Draupnir) for more configuration documentation. Please note that the playbook ships a full copy of the example config that does transfer to provisioned draupnirs in the production-bots.yaml.j2 file in the template directory of the role.
+
+Please note that Config extension does not affect the appservices config as this config is not extensible in current Draupnir anyways. Config extension instead touches the config passed to the Draupnirs that your Appservice creates. So for example below makes all provisioned Draupnirs protect all joined rooms.
+
+You can configure additional options by adding the `matrix_appservice_draupnir_for_all_extension_yaml` variable to your `inventory/host_vars/matrix.DOMAIN/vars.yml` file.
+
+For example to change draupnir's `protectAllJoinedRooms` option to `true` you would add the following to your `vars.yml` file.
+
+```yaml
+matrix_appservice_draupnir_for_all_extension_yaml: |
+  # Your custom YAML configuration goes here.
+  # This configuration extends the default starting configuration (`matrix_appservice_draupnir_for_all_yaml`).
+  #
+  # You can override individual variables from the default configuration, or introduce new ones.
+  #
+  # If you need something more special, you can take full control by
+  # completely redefining `matrix_appservice_draupnir_for_all_yaml`.
+  protectAllJoinedRooms: true
+```

--- a/docs/configuring-playbook-appservice-draupnir-for-all.md
+++ b/docs/configuring-playbook-appservice-draupnir-for-all.md
@@ -2,37 +2,41 @@
 
 The playbook can install and configure the [Draupnir](https://github.com/the-draupnir-project/Draupnir) moderation tool for you in appservice mode.
 
-Appservice mode can be used together with the regular [Draupnir bot](configuring-playbook-bot-draupnir.md) or independently.
+Appservice mode can be used together with the regular [Draupnir bot](configuring-playbook-bot-draupnir.md) or independently. Details about the differences between the 2 modes are described below.
 
-Draupnir Appservice mode compared to Draupnir bot mode. 
 
-The administrative functions for managing the appservice are alpha quality and very limited. However, the experience of using an appservice provisioned Draupnir is on par with the experience of using Draupnir from bot mode except in the case of avatar customisation as described later on in this document.
+## Draupnir Appservice mode compared to Draupnir bot mode
 
-Draupnir for all is the way to go if you need more than 1 Draupnir but you don't need access to Synapse Admin features as they are not accessible thru Draupnir for All (Even tho the commands do show up in help). 
+The administrative functions for managing the appservice are alpha quality and very limited. However, the experience of using an appservice-provisioned Draupnir is on par with the experience of using Draupnir from bot mode except in the case of avatar customisation as described later on in this document.
 
-Draupnir for all in the playbook is rate limit exempt automatically as its part of the appservice configuration file if the appservice is rate limited or not. 
+Draupnir for all is the way to go if you need more than 1 Draupnir instance, but you don't need access to Synapse Admin features as they are not accessible through Draupnir for All (Even though the commands do show up in help).
 
-Normal Draupnir does come with the benefit of access to Synapse Admin features. You are also able to more easily customise your normal Draupnir than D4A as D4A even on the branch with the Avatar command (To be Upstreamed to Mainline Draupnir) that command is clunky as it requires the use of things like Element devtools. In normal draupnir this is a quick operation where you login to Draupnir with a normal client and set Avatar and Display name normally. 
+Draupnir for all in the playbook is rate-limit-exempt automatically as its appservice configuration file does not specify any rate limits.
 
-Draupnir for all does not support external tooling like [MRU](https://mru.rory.gay) as it cant access Draupnirs user account like is needed to use it. 
+Normal Draupnir does come with the benefit of access to Synapse Admin features. You are also able to more easily customise your normal Draupnir than D4A as D4A even on the branch with the Avatar command (To be Upstreamed to Mainline Draupnir) that command is clunky as it requires the use of things like Element devtools. In normal draupnir this is a quick operation where you login to Draupnir with a normal client and set Avatar and Display name normally.
 
-## 1. Create a main management room.
+Draupnir for all does not support external tooling like [MRU](https://mru.rory.gay) as it can't access Draupnir's user account.
 
-The playbook does not create a management room for your Main Draupnir. This task you have to do on your own. 
+
+## Installation
+
+### 1. Create a main management room.
+
+The playbook does not create a management room for your Main Draupnir. This task you have to do on your own.
 
 The management room has to be given an alias and be public when you are setting up the bot for the first time as the bot does not differentiate between invites
-and invites to the management room. 
+and invites to the management room.
 
 This management room is used to control who has access to your D4A deployment. The room stores this data inside of the control room state so your bot must have sufficient powerlevel to send custom state events. This is default 50 or moderator as Element calls this powerlevel.
 
-As noted in the Draupnir install instructions the control room is sensitive. The following is said about the control room in the Draupnir install instructions. 
+As noted in the Draupnir install instructions the control room is sensitive. The following is said about the control room in the Draupnir install instructions.
 >Anyone in this room can control the bot so it is important that you only invite trusted users to this room. The room must be unencrypted since the playbook does not support installing Pantalaimon yet.
 
-## 2. Give your main management room an alias.
+### 2. Give your main management room an alias.
 
 Give the room from step 1 an alias. This alias can be anything you want and its recommended for increased security during the setup phase of the bot that you make this alias be a random string. You can give your room a secondary human readable alias when it has been locked down after setup phase.
 
-## 3. Adjusting the playbook configuration.
+### 3. Adjusting the playbook configuration.
 
 Add the following configuration to your `inventory/host_vars/matrix.DOMAIN/vars.yml` file (adapt to your needs):
 
@@ -44,7 +48,7 @@ matrix_appservice_draupnir_for_all_enabled: true
 matrix_appservice_draupnir_for_all_master_control_room_alias: "ALIAS_FROM_STEP_2_GOES_HERE"
 ```
 
-## 4. Installing
+### 4. Installing
 
 After configuring the playbook, run the [installation](installing.md) command:
 
@@ -52,25 +56,26 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-# Using Draupnir For All
 
-If you made it thru all the steps above and your main control room was joined by a user called `@draupnir-main:matrix-homeserver-domain` you have succesfully installed Draupnir for All and can now start using it. 
+## Usage
 
-This side of Draupnir for all is very much Alpha quality in the user experience it should be noted. Draupnir for all on the end user side is almost identical to Draupnir normal mode. 
+If you made it through all the steps above and your main control room was joined by a user called `@draupnir-main:matrix-homeserver-domain` you have succesfully installed Draupnir for All and can now start using it.
 
-## 1. Granting Users the ability to use D4A
+The installation of Draupnir for all in this playbook is very much Alpha quality. Usage-wise, Draupnir for allis almost identical to Draupnir bot mode.
+
+### 1. Granting Users the ability to use D4A
 
 Draupnir for all includes several security measures like that it only allows users that are on its allow list to ask for a bot. To add a user to this list we have 2 primary options. Using the chat to tell Draupnir to do this for us or if you want to automatically do it by sending `m.policy.rule.user` events that target the subject you want to allow provisioning for with the `org.matrix.mjolnir.allow` recomendation. Using the chat is recomended.
 
 To allow users or whole homeservers you type /plain @draupnir-main:matrix-homeserver-domain allow `target` and target can be either a MXID or a wildcard like `@*:example.com` to allow all users on example.com to register. We use /plain to force the client to not attempt to mess with this command as it can break Wildcard commands especially.
 
-## 2. How to provision a D4A once you are allowed to.
+### 2. How to provision a D4A once you are allowed to.
 
-Open a DM with @draupnir-main:matrix-homeserver-domain and if using Element send a message into this DM to finalise creating it. The bot will reject this invite and you will shortly get invited to the Draupnir control room for your newly provisioned Draupnir. From here its just a normal Draupnir experience. 
+Open a DM with @draupnir-main:matrix-homeserver-domain and if using Element send a message into this DM to finalise creating it. The bot will reject this invite and you will shortly get invited to the Draupnir control room for your newly provisioned Draupnir. From here its just a normal Draupnir experience.
 
 Congratulations if you made it all the way here because you now have a fully working Draupnir for all deployment.
 
-## Configuration of D4A
+### Configuration of D4A
 
 You can refer to the upstream [documentation](https://github.com/the-draupnir-project/Draupnir) for more configuration documentation. Please note that the playbook ships a full copy of the example config that does transfer to provisioned draupnirs in the production-bots.yaml.j2 file in the template directory of the role.
 

--- a/docs/configuring-playbook-appservice-draupnir-for-all.md
+++ b/docs/configuring-playbook-appservice-draupnir-for-all.md
@@ -60,15 +60,9 @@ This side of Draupnir for all is very much Alpha quality in the user experience 
 
 ## 1. Granting Users the ability to use D4A
 
-Draupnir for all includes several security measures like that it only allows users that are on its allow list to ask for a bot. To add a user to this list we have 2 primary options. Using the chat to tell Draupnir to do this for us or manually sending the state event via either curl or devtools in Element. 
+Draupnir for all includes several security measures like that it only allows users that are on its allow list to ask for a bot. To add a user to this list we have 2 primary options. Using the chat to tell Draupnir to do this for us or if you want to automatically do it by sending `m.policy.rule.user` events that target the subject you want to allow provisioning for with the `org.matrix.mjolnir.allow` recomendation. Using the chat is recomended.
 
-If you want to give individual users access grants the recommended way is via the chat. To use the chat to tell Draupnir to do things you need to ping it in a specific way. Clients like Element and nheko will do this correctly by default because they send `<a href=\"https://matrix.to/#/@example:example.com\">Example</a>:` when you try to mention a user. Draupnir expects this format and will NOT respond to anything else in the main control room. As mentioned earlier D4A is Alpha in its user experience for the main control room.
-
-The command is `<a href=\"https://matrix.to/#/@example:example.com\">Example</a>: allow mxid`
-
-If you want to allow all users on your homeserver you instead send a `m.policy.rule.user` event with the contents being `{"entity": "@*:matrix-homeserver-domain", "recommendation": "org.matrix.mjolnir.allow"}` and a `state_key` that is `_*:matrix-homeserver-domain`.
-
-Using curl you can send this via `curl --request PUT --url 'https://homeserver_url/_matrix/client/v3/rooms/management_room_room_ID/state/m.policy.rule.user/_*:matrix-homeserver-domain' --header 'Authorization: Bearer ACCESS_TOKEN_HERE' --header 'Content-Type: application/json' --data '{"entity": "@*:matrix-homeserver-domain", "recommendation": "org.matrix.mjolnir.allow"}'`
+To allow users or whole homeservers you type /plain @draupnir-main:matrix-homeserver-domain allow `target` and target can be either a MXID or a wildcard like `@*:example.com` to allow all users on example.com to register. We use /plain to force the client to not attempt to mess with this command as it can break Wildcard commands especially.
 
 ## 2. How to provision a D4A once you are allowed to.
 

--- a/docs/configuring-playbook-appservice-draupnir-for-all.md
+++ b/docs/configuring-playbook-appservice-draupnir-for-all.md
@@ -4,7 +4,9 @@ The playbook can install and configure the [Draupnir](https://github.com/the-dra
 
 Appservice mode can be used together with the regular [Draupnir bot](configuring-playbook-bot-draupnir.md) or independently.
 
-D4A compared to Draupnir Normal. 
+Draupnir Appservice mode compared to Draupnir bot mode. 
+
+The administrative functions for managing the appservice are alpha quality and very limited. However, the experience of using an appservice provisioned Draupnir is on par with the experience of using Draupnir from bot mode except in the case of avatar customisation as described later on in this document.
 
 Draupnir for all is the way to go if you need more than 1 Draupnir but you don't need access to Synapse Admin features as they are not accessible thru Draupnir for All (Even tho the commands do show up in help). 
 
@@ -12,9 +14,7 @@ Draupnir for all in the playbook is rate limit exempt automatically as its part 
 
 Normal Draupnir does come with the benefit of access to Synapse Admin features. You are also able to more easily customise your normal Draupnir than D4A as D4A even on the branch with the Avatar command (To be Upstreamed to Mainline Draupnir) that command is clunky as it requires the use of things like Element devtools. In normal draupnir this is a quick operation where you login to Draupnir with a normal client and set Avatar and Display name normally. 
 
-Draupnir for all does also not support external tooling like [MRU](https://mru.rory.gay) as it cant access Draupnirs user account like is needed to use it. 
-
-Last downside of Draupnir for all is the state of the Admin side of the user experience being Alpha quality. This flaw is not in regular Draupnir and is mostly not in the provisioned Draupnirs either.
+Draupnir for all does not support external tooling like [MRU](https://mru.rory.gay) as it cant access Draupnirs user account like is needed to use it. 
 
 ## 1. Create a main management room.
 

--- a/docs/configuring-playbook-bot-draupnir.md
+++ b/docs/configuring-playbook-bot-draupnir.md
@@ -4,6 +4,9 @@ The playbook can install and configure the [draupnir](https://github.com/the-dra
 
 See the project's [documentation](https://github.com/the-draupnir-project/Draupnir) to learn what it does and why it might be useful to you.
 
+This documentation page is about installing Draupnir in bot mode. As an alternative, you can run a multi-instance Draupnir deployment by installing [Draupnir in appservice mode](./configuring-playbook-appservice-draupnir-for-all.md) (called Draupnir-for-all) instead.
+
+
 If your migrating from Mjolnir skip to step 5b.
 
 ## 1. Register the bot account

--- a/docs/configuring-playbook.md
+++ b/docs/configuring-playbook.md
@@ -195,6 +195,8 @@ When you're done with all the configuration you'd like to do, continue with [Ins
 
 - [Setting up Draupnir](configuring-playbook-bot-draupnir.md) - a moderation tool/bot, forked from Mjolnir and maintained by its former leader developer (optional)
 
+- [Setting up Draupnir for all](configuring-playbook-appservice-draupnir-for-all.md) - like the [Draupnir bot](configuring-playbook-bot-draupnir.md) mentioned above, but running in appservice mode and supporting multiple instances (optional)
+
 - [Setting up Buscarron](configuring-playbook-bot-buscarron.md) - a bot you can use to send any form (HTTP POST, HTML) to a (encrypted) Matrix room (optional)
 
 

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -71,6 +71,8 @@ matrix_homeserver_container_extra_arguments_auto: |
   {{
     (['--mount type=bind,src=' + matrix_appservice_discord_config_path + '/registration.yaml,dst=/matrix-appservice-discord-registration.yaml,ro'] if matrix_appservice_discord_enabled else [])
     +
+    (['--mount type=bind,src=' + matrix_appservice_draupnir_for_all_config_path + '/draupnir-for-all-registration.yaml,dst=/matrix-appservice-draupnir-for-all-registration.yaml,ro'] if matrix_appservice_draupnir_for_all_enabled else [])
+    +    
     (['--mount type=bind,src=' + matrix_appservice_irc_config_path + '/registration.yaml,dst=/matrix-appservice-irc-registration.yaml,ro'] if matrix_appservice_irc_enabled else [])
     +
     (['--mount type=bind,src=' + matrix_appservice_kakaotalk_config_path + '/registration.yaml,dst=/matrix-appservice-kakaotalk-registration.yaml,ro'] if matrix_appservice_kakaotalk_enabled else [])
@@ -138,6 +140,8 @@ matrix_homeserver_app_service_config_files_auto: |
   {{
     (['/matrix-appservice-discord-registration.yaml'] if matrix_appservice_discord_enabled else [])
     +
+    (['/matrix-appservice-draupnir-for-all-registration.yaml'] if matrix_appservice_draupnir_for_all_enabled else [])
+    +    
     (['/matrix-appservice-irc-registration.yaml'] if matrix_appservice_irc_enabled else [])
     +
     (['/matrix-appservice-kakaotalk-registration.yaml'] if matrix_appservice_kakaotalk_enabled else [])
@@ -270,6 +274,8 @@ devture_systemd_service_manager_services_list_auto: |
     +
     ([{'name': 'matrix-appservice-discord.service', 'priority': 2000, 'groups': ['matrix', 'bridges', 'appservice-discord']}] if matrix_appservice_discord_enabled else [])
     +
+    ([{'name': 'matrix-appservice-draupnir-for-all.service', 'priority': 4000, 'groups': ['matrix', 'bridges', 'draupnir-for-all', 'appservice-draupnir-for-all']}] if matrix_appservice_draupnir_for_all_enabled else [])
+    +    
     ([{'name': 'matrix-appservice-irc.service', 'priority': 2000, 'groups': ['matrix', 'bridges', 'appservice-irc']}] if matrix_appservice_irc_enabled else [])
     +
     ([{'name': 'matrix-appservice-kakaotalk.service', 'priority': 2000, 'groups': ['matrix', 'bridges', 'appservice-kakaotalk']}] if matrix_appservice_kakaotalk_enabled else [])
@@ -2626,6 +2632,7 @@ matrix_bot_mjolnir_container_additional_networks_auto: |-
 #
 ######################################################################
 
+
 ######################################################################
 #
 # matrix-bot-draupnir
@@ -2652,6 +2659,48 @@ matrix_bot_draupnir_container_additional_networks_auto: |-
 ######################################################################
 #
 # /matrix-bot-draupnir
+#
+######################################################################
+
+
+######################################################################
+#
+# matrix-appservice-draupnir-for-all
+#
+######################################################################
+
+# We don't enable bots by default.
+matrix_appservice_draupnir_for_all_enabled: false
+
+matrix_appservice_draupnir_for_all_systemd_required_services_list_auto: |
+  {{
+    matrix_addons_homeserver_systemd_services_list
+    +
+    ([devture_postgres_identifier ~ '.service'] if (devture_postgres_enabled and matrix_appservice_draupnir_for_all_database_hostname == devture_postgres_connection_hostname) else [])
+  }}
+
+matrix_appservice_draupnir_for_all_container_image_self_build: "{{ matrix_architecture not in ['amd64', 'arm64'] }}"
+
+matrix_appservice_draupnir_for_all_container_network: "{{ matrix_addons_container_network }}"
+
+matrix_appservice_draupnir_for_all_container_additional_networks_auto: |-
+  {{
+    (
+      ([] if matrix_addons_homeserver_container_network == '' else [matrix_addons_homeserver_container_network])
+      +
+      ([devture_postgres_container_network] if (devture_postgres_enabled and matrix_appservice_draupnir_for_all_database_hostname == devture_postgres_connection_hostname and matrix_appservice_draupnir_for_all_container_network != devture_postgres_container_network) else [])
+    ) | unique
+  }}
+
+matrix_appservice_draupnir_for_all_appservice_token: "{{ '%s' | format(matrix_homeserver_generic_secret_key) | password_hash('sha512', 'd4a.as.token', rounds=655555) | to_uuid }}"
+matrix_appservice_draupnir_for_all_homeserver_token: "{{ '%s' | format(matrix_homeserver_generic_secret_key) | password_hash('sha512', 'd4a.hs.token', rounds=655555) | to_uuid }}"
+
+matrix_appservice_draupnir_for_all_database_hostname: "{{ devture_postgres_connection_hostname if devture_postgres_enabled else '' }}"
+matrix_appservice_draupnir_for_all_database_password: "{{ '%s' | format(matrix_homeserver_generic_secret_key) | password_hash('sha512', 'as.d4a.db', rounds=655555) | to_uuid }}"
+
+######################################################################
+#
+# /matrix-appservice-draupnir-for-all
 #
 ######################################################################
 
@@ -3541,6 +3590,12 @@ devture_postgres_managed_databases_auto: |
       'password': matrix_appservice_discord_database_password,
     }] if (matrix_appservice_discord_enabled and matrix_appservice_discord_database_engine == 'postgres' and matrix_appservice_discord_database_hostname == devture_postgres_connection_hostname) else [])
     +
+    ([{
+      'name': matrix_appservice_draupnir_for_all_database_name,
+      'username': matrix_appservice_draupnir_for_all_database_username,
+      'password': matrix_appservice_draupnir_for_all_database_password,
+    }] if (matrix_appservice_draupnir_for_all_enabled and matrix_appservice_draupnir_for_all_database_hostname == devture_postgres_connection_hostname) else [])
+    +    
     ([{
       'name': matrix_appservice_slack_database_name,
       'username': matrix_appservice_slack_database_username,

--- a/roles/custom/matrix-appservice-draupnir-for-all/defaults/main.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/defaults/main.yml
@@ -5,14 +5,14 @@
 matrix_appservice_draupnir_for_all_enabled: true
 
 # renovate: datasource=docker depName=gnuxie/draupnir
-matrix_appservice_draupnir_for_all_version: "v1.86.2"
+matrix_appservice_draupnir_for_all_version: "develop"
 
 matrix_appservice_draupnir_for_all_container_image_self_build: false
 matrix_appservice_draupnir_for_all_container_image_self_build_repo: "https://github.com/the-draupnir-project/Draupnir.git"
 
 matrix_appservice_draupnir_for_all_docker_image: "{{ matrix_appservice_draupnir_for_all_docker_image_name_prefix }}gnuxie/draupnir:{{ matrix_appservice_draupnir_for_all_version }}"
 matrix_appservice_draupnir_for_all_docker_image_name_prefix: "{{ 'localhost/' if matrix_appservice_draupnir_for_all_container_image_self_build else matrix_container_global_registry_prefix }}"
-matrix_appservice_draupnir_for_all_docker_image_force_pull: "{{ matrix_appservice_draupnir_for_all_docker_image.endswith(':latest') }}"
+matrix_appservice_draupnir_for_all_docker_image_force_pull: "{{ matrix_appservice_draupnir_for_all_docker_image.endswith(':develop') }}"
 
 matrix_appservice_draupnir_for_all_base_path: "{{ matrix_base_data_path }}/draupnir-for-all"
 matrix_appservice_draupnir_for_all_config_path: "{{ matrix_appservice_draupnir_for_all_base_path }}/config"

--- a/roles/custom/matrix-appservice-draupnir-for-all/defaults/main.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/defaults/main.yml
@@ -1,0 +1,103 @@
+---
+# A moderation tool for Matrix
+# Project source code URL: https://github.com/the-draupnir-project/Draupnir
+
+matrix_appservice_draupnir_for_all_enabled: true
+
+# renovate: datasource=docker depName=gnuxie/draupnir
+matrix_appservice_draupnir_for_all_version: "v1.86.2"
+
+matrix_appservice_draupnir_for_all_container_image_self_build: false
+matrix_appservice_draupnir_for_all_container_image_self_build_repo: "https://github.com/the-draupnir-project/Draupnir.git"
+
+matrix_appservice_draupnir_for_all_docker_image: "{{ matrix_appservice_draupnir_for_all_docker_image_name_prefix }}gnuxie/draupnir:{{ matrix_appservice_draupnir_for_all_version }}"
+matrix_appservice_draupnir_for_all_docker_image_name_prefix: "{{ 'localhost/' if matrix_appservice_draupnir_for_all_container_image_self_build else matrix_container_global_registry_prefix }}"
+matrix_appservice_draupnir_for_all_docker_image_force_pull: "{{ matrix_appservice_draupnir_for_all_docker_image.endswith(':latest') }}"
+
+matrix_appservice_draupnir_for_all_base_path: "{{ matrix_base_data_path }}/draupnir-for-all"
+matrix_appservice_draupnir_for_all_config_path: "{{ matrix_appservice_draupnir_for_all_base_path }}/config"
+matrix_appservice_draupnir_for_all_data_path: "{{ matrix_appservice_draupnir_for_all_base_path }}/data"
+matrix_appservice_draupnir_for_all_docker_src_files_path: "{{ matrix_appservice_draupnir_for_all_base_path }}/docker-src"
+
+matrix_appservice_draupnir_for_all_container_network: ""
+
+matrix_appservice_draupnir_for_all_container_additional_networks: "{{ matrix_appservice_draupnir_for_all_container_additional_networks_auto + matrix_appservice_draupnir_for_all_container_additional_networks_custom }}"
+matrix_appservice_draupnir_for_all_container_additional_networks_auto: []
+matrix_appservice_draupnir_for_all_container_additional_networks_custom: []
+
+# A list of extra arguments to pass to the container
+matrix_appservice_draupnir_for_all_container_extra_arguments: []
+
+# List of systemd services that matrix-bot-draupnir.service depends on
+matrix_appservice_draupnir_for_all_systemd_required_services_list: "{{ matrix_appservice_draupnir_for_all_systemd_required_services_list_default + matrix_appservice_draupnir_for_all_systemd_required_services_list_auto + matrix_appservice_draupnir_for_all_systemd_required_services_list_custom }}"
+matrix_appservice_draupnir_for_all_systemd_required_services_list_default: ['docker.service']
+matrix_appservice_draupnir_for_all_systemd_required_services_list_auto: []
+matrix_appservice_draupnir_for_all_systemd_required_services_list_custom: []
+
+# List of systemd services that matrix-bot-draupnir.service wants
+matrix_appservice_draupnir_for_all_systemd_wanted_services_list: []
+
+# The room ID where people can use the bot. The bot has no access controls, so
+# anyone in this room can use the bot - secure your room!
+# This should be a room alias - not a matrix.to URL.
+# Note: draupnir is fairly verbose - expect a lot of messages from it.
+# This room is diffrent for Appservice Mode compared to normal mode.
+# In Appservice mode it provides functions like user management.
+matrix_appservice_draupnir_for_all_master_control_room_alias: ""
+
+# Placeholder Remenant of the fact that Cat belived Master Control Room to be separated from Access Control Policy List.
+# The alias of the Policy list used to control who can provision a bot for them selfs.
+# This should be a room alias - not a matrix.to URL.
+# matrix_appservice_draupnir_for_all_management_policy_list_alias: ""
+
+matrix_appservice_draupnir_for_all_database_username: matrix_appservice_draupnir_for_all
+matrix_appservice_draupnir_for_all_database_password: 'some-passsword'
+matrix_appservice_draupnir_for_all_database_hostname: ''
+matrix_appservice_draupnir_for_all_database_port: 5432
+matrix_appservice_draupnir_for_all_database_name: matrix_appservice_draupnir_for_all
+matrix_appservice_draupnir_for_all_database_sslmode: disable
+
+matrix_appservice_draupnir_for_all_appservice_port: "9001"
+matrix_appservice_draupnir_for_all_appservice_url: 'http://matrix-appservice-draupnir-for-all'
+
+matrix_appservice_draupnir_for_all_database_connection_string: 'postgresql://{{ matrix_appservice_draupnir_for_all_database_username }}:{{ matrix_appservice_draupnir_for_all_database_password }}@{{ matrix_appservice_draupnir_for_all_database_hostname }}:{{ matrix_appservice_draupnir_for_all_database_port }}/{{ matrix_appservice_draupnir_for_all_database_name }}?sslmode={{ matrix_appservice_draupnir_for_all_database_sslmode }}'
+
+matrix_appservice_draupnir_for_all_user_prefix: "draupnir_"
+
+matrix_appservice_draupnir_for_all_registration_yaml: |
+  id: "draupnir-for-all"
+  as_token: "{{ matrix_appservice_draupnir_for_all_appservice_token }}"
+  hs_token: "{{ matrix_appservice_draupnir_for_all_homeserver_token }}"
+  url: "{{ matrix_appservice_draupnir_for_all_appservice_url }}:{{ matrix_appservice_draupnir_for_all_appservice_port }}"
+  sender_localpart: draupnir-main
+  namespaces:
+    users:
+    - exclusive: true
+      regex: '@{{ matrix_appservice_draupnir_for_all_user_prefix }}*'
+  rate_limited: false
+
+matrix_appservice_draupnir_for_all_registration: "{{ matrix_appservice_draupnir_for_all_registration_yaml | from_yaml }}"
+matrix_appservice_draupnir_for_all_configuration_appservice: "{{ lookup('template', 'templates/production-appservice.yaml.j2') | from_yaml }}"
+
+# Default configuration template which covers the generic use case.
+# You can customize it by controlling the various variables inside it.
+#
+# For a more advanced customization, you can extend the default (see `matrix_appservice_draupnir_for_all_configuration_extension_yaml`)
+# or completely replace this variable with your own template.
+
+matrix_appservice_draupnir_for_all_configuration_yaml: "{{ lookup('template', 'templates/production-bots.yaml.j2') }}"
+
+matrix_appservice_draupnir_for_all_configuration_extension_yaml: |
+  # Your custom YAML configuration goes here.
+  # This configuration extends the default starting configuration (`matrix_appservice_draupnir_for_all_configuration_yaml`).
+  #
+  # You can override individual variables from the default configuration, or introduce new ones.
+  #
+  # If you need something more special, you can take full control by
+  # completely redefining `matrix_appservice_draupnir_for_all_configuration_yaml`.
+
+matrix_appservice_draupnir_for_all_configuration_extension: "{{ matrix_appservice_draupnir_for_all_configuration_extension_yaml | from_yaml if matrix_appservice_draupnir_for_all_configuration_extension_yaml | from_yaml is mapping else {} }}"
+
+# Holds the final configuration (a combination of the default and its extension).
+# You most likely don't need to touch this variable. Instead, see `matrix_appservice_draupnir_for_all_configuration_yaml`.
+matrix_appservice_draupnir_for_all_configuration: "{{ matrix_appservice_draupnir_for_all_configuration_yaml | from_yaml | combine(matrix_appservice_draupnir_for_all_configuration_extension, recursive=True) }}"

--- a/roles/custom/matrix-appservice-draupnir-for-all/tasks/main.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+
+- tags:
+    - setup-all
+    - setup-appservice-draupnir-for-all
+    - install-all
+    - install-appservice-draupnir-for-all
+  block:
+    - when: matrix_appservice_draupnir_for_all_enabled | bool
+      ansible.builtin.include_tasks: "{{ role_path }}/tasks/validate_config.yml"
+
+    - when: matrix_appservice_draupnir_for_all_enabled | bool
+      ansible.builtin.include_tasks: "{{ role_path }}/tasks/setup_install.yml"
+
+- tags:
+    - setup-all
+    - setup-appservice-draupnir-for-all
+  block:
+    - when: not matrix_appservice_draupnir_for_all_enabled | bool
+      ansible.builtin.include_tasks: "{{ role_path }}/tasks/setup_uninstall.yml"

--- a/roles/custom/matrix-appservice-draupnir-for-all/tasks/setup_install.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/tasks/setup_install.yml
@@ -1,0 +1,95 @@
+---
+
+- ansible.builtin.set_fact:
+    matrix_appservice_draupnir_for_all_requires_restart: false
+
+- name: Ensure matrix-appservice-draupnir-for-all paths exist
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: directory
+    mode: 0750
+    owner: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
+  with_items:
+    - {path: "{{ matrix_appservice_draupnir_for_all_base_path }}", when: true}
+    - {path: "{{ matrix_appservice_draupnir_for_all_config_path }}", when: true}
+    - {path: "{{ matrix_appservice_draupnir_for_all_data_path }}", when: true}
+    - {path: "{{ matrix_appservice_draupnir_for_all_docker_src_files_path }}", when: "{{ matrix_appservice_draupnir_for_all_container_image_self_build }}"}
+  when: "item.when | bool"
+
+- name: Ensure draupnir Docker image is pulled
+  community.docker.docker_image:
+    name: "{{ matrix_appservice_draupnir_for_all_docker_image }}"
+    source: "{{ 'pull' if ansible_version.major > 2 or ansible_version.minor > 7 else omit }}"
+    force_source: "{{ matrix_appservice_draupnir_for_all_docker_image_force_pull if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
+    force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_appservice_draupnir_for_all_docker_image_force_pull }}"
+  when: "not matrix_appservice_draupnir_for_all_container_image_self_build | bool"
+  register: result
+  retries: "{{ devture_playbook_help_container_retries_count }}"
+  delay: "{{ devture_playbook_help_container_retries_delay }}"
+  until: result is not failed
+
+- name: Ensure draupnir repository is present on self-build
+  ansible.builtin.git:
+    repo: "{{ matrix_appservice_draupnir_for_all_container_image_self_build_repo }}"
+    dest: "{{ matrix_appservice_draupnir_for_all_docker_src_files_path }}"
+    version: "{{ matrix_appservice_draupnir_for_all_docker_image.split(':')[1] }}"
+    force: "yes"
+  become: true
+  become_user: "{{ matrix_user_username }}"
+  register: matrix_appservice_draupnir_for_all_git_pull_results
+  when: "matrix_appservice_draupnir_for_all_container_image_self_build | bool"
+
+- name: Ensure draupnir Docker image is built
+  community.docker.docker_image:
+    name: "{{ matrix_appservice_draupnir_for_all_docker_image }}"
+    source: build
+    force_source: "{{ matrix_appservice_draupnir_for_all_git_pull_results.changed }}"
+    build:
+      dockerfile: Dockerfile
+      path: "{{ matrix_appservice_draupnir_for_all_docker_src_files_path }}"
+      pull: true
+  when: "matrix_appservice_draupnir_for_all_container_image_self_build | bool"
+
+- name: Ensure matrix-appservice-draupnir-for-all appservice config installed
+  ansible.builtin.copy:
+    content: "{{ matrix_appservice_draupnir_for_all_configuration_appservice | to_nice_yaml(indent=2, width=999999) }}"
+    dest: "{{ matrix_appservice_draupnir_for_all_config_path }}/production-appservice.yaml"
+    mode: 0644
+    owner: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
+
+- name: Ensure matrix-appservice-draupnir-for-all bot config installed
+  ansible.builtin.copy:
+    content: "{{ matrix_appservice_draupnir_for_all_configuration | to_nice_yaml(indent=2, width=999999) }}"
+    dest: "{{ matrix_appservice_draupnir_for_all_config_path }}/production-bots.yaml"
+    mode: 0644
+    owner: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
+
+- name: Ensure matrix-appservice-draupnir-for-all registration.yaml installed
+  ansible.builtin.copy:
+    content: "{{ matrix_appservice_draupnir_for_all_registration | to_nice_yaml(indent=2, width=999999) }}"
+    dest: "{{ matrix_appservice_draupnir_for_all_config_path }}/draupnir-for-all-registration.yaml"
+    mode: 0644
+    owner: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
+
+- name: Ensure matrix-appservice-draupnir-for-all container network is created
+  community.general.docker_network:
+    name: "{{ matrix_appservice_draupnir_for_all_container_network }}"
+    driver: bridge
+
+- name: Ensure matrix-appservice-draupnir-for-all.service installed
+  ansible.builtin.template:
+    src: "{{ role_path }}/templates/systemd/matrix-appservice-draupnir-for-all.service.j2"
+    dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-appservice-draupnir-for-all.service"
+    mode: 0644
+  register: matrix_appservice_draupnir_for_all_systemd_service_result
+
+- name: Ensure matrix-appservice-draupnir-for-all.service restarted, if necessary
+  ansible.builtin.service:
+    name: "matrix-appservice-draupnir-for-all.service"
+    state: restarted
+    daemon_reload: true
+  when: "matrix_appservice_draupnir_for_all_requires_restart | bool"

--- a/roles/custom/matrix-appservice-draupnir-for-all/tasks/setup_uninstall.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/tasks/setup_uninstall.yml
@@ -1,0 +1,25 @@
+---
+
+- name: Check existence of matrix-appservice-draupnir-for-all service
+  ansible.builtin.stat:
+    path: "{{ devture_systemd_docker_base_systemd_path }}/matrix-appservice-draupnir-for-all.service"
+  register: matrix_bot_draupnir_service_stat
+
+- when: matrix_bot_draupnir_service_stat.stat.exists | bool
+  block:
+    - name: Ensure matrix-appservice-draupnir-for-all is stopped
+      ansible.builtin.service:
+        name: matrix-appservice-draupnir-for-all
+        state: stopped
+        enabled: false
+        daemon_reload: true
+
+    - name: Ensure matrix-appservice-draupnir-for-all.service doesn't exist
+      ansible.builtin.file:
+        path: "{{ devture_systemd_docker_base_systemd_path }}/matrix-appservice-draupnir-for-all.service"
+        state: absent
+
+    - name: Ensure matrix-appservice-draupnir-for-all paths don't exist
+      ansible.builtin.file:
+        path: "{{ matrix_bot_draupnir_base_path }}"
+        state: absent

--- a/roles/custom/matrix-appservice-draupnir-for-all/tasks/validate_config.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/tasks/validate_config.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Fail if required matrix-bot-draupnir variables are undefined
+  ansible.builtin.fail:
+    msg: "The `{{ item }}` variable must be defined and have a non-null value."
+  with_items:
+    - "matrix_appservice_draupnir_for_all_master_control_room_alias"
+    - "matrix_bot_draupnir_container_network"
+  when: "vars[item] == '' or vars[item] is none"

--- a/roles/custom/matrix-appservice-draupnir-for-all/templates/production-appservice.yaml.j2
+++ b/roles/custom/matrix-appservice-draupnir-for-all/templates/production-appservice.yaml.j2
@@ -1,0 +1,18 @@
+homeserver:
+  # The Matrix server name, this will be the name of the server in your matrix id.
+  domain: "{{ matrix_domain }}"
+  # The url for the appservice to call the client server API from.
+  url: "{{ matrix_homeserver_url }}"
+
+# Database configuration for storing which Mjolnirs have been provisioned.
+db:
+  engine: "postgres"
+  connectionString: "{{ matrix_appservice_draupnir_for_all_database_connection_string }}"
+
+# A room you have created that scopes who can access the appservice.
+# See docs/access_control.md
+adminRoom: "{{ matrix_appservice_draupnir_for_all_master_control_room_alias }}"
+
+# This is a web api that the widget connects to in order to interact with the appservice.
+webAPI:
+  port: 9000

--- a/roles/custom/matrix-appservice-draupnir-for-all/templates/production-bots.yaml.j2
+++ b/roles/custom/matrix-appservice-draupnir-for-all/templates/production-bots.yaml.j2
@@ -1,0 +1,83 @@
+# The log level of terminal (or container) output,
+# can be one of DEBUG, INFO, WARN and ERROR, in increasing order of importance and severity.
+#
+# This should be at INFO or DEBUG in order to get support for Draupnir problems.
+logLevel: "INFO"
+
+# Whether or not Draupnir should synchronize policy lists immediately after startup.
+# Equivalent to running '!draupnir sync'.
+syncOnStartup: true
+
+# Whether or not Draupnir should check moderation permissions in all protected rooms on startup.
+# Equivalent to running `!draupnir verify`.
+verifyPermissionsOnStartup: true
+
+# Whether Draupnir should check member lists quicker (by using a different endpoint),
+# keep in mind that enabling this will miss invited (but not joined) users.
+#
+# Turn on if your bot is in (very) large rooms, or in large amounts of rooms.
+fasterMembershipChecks: false
+
+# A case-insensitive list of ban reasons to have the bot also automatically redact the user's messages for.
+#
+# If the bot sees you ban a user with a reason that is an (exact case-insensitive) match to this list,
+# it will also remove the user's messages automatically.
+#
+# Typically this is useful to avoid having to give two commands to the bot.
+# Advanced: Use asterisks to have the reason match using "globs"
+# (f.e. "spam*testing" would match "spam for testing" as well as "spamtesting").
+#
+# See here for more info: https://www.digitalocean.com/community/tools/glob
+# Note: Keep in mind that glob is NOT regex!
+automaticallyRedactForReasons:
+  - "spam"
+  - "advertising"
+
+# Whether or not to add all joined rooms to the "protected rooms" list
+# (excluding the management room and watched policy list rooms, see below).
+#
+# Note that this effectively makes the protectedRooms and associated commands useless
+# for regular rooms.
+#
+# Note: the management room is *excluded* from this condition.
+# Explicitly add it as a protected room to protect it.
+#
+# Note: Ban list rooms the bot is watching but didn't create will not be protected.
+# Explicitly add these rooms as a protected room list if you want them protected.
+protectAllJoinedRooms: false
+
+# Increase this delay to have Draupnir wait longer between two consecutive backgrounded
+# operations. The total duration of operations will be longer, but the homeserver won't
+# be affected as much. Conversely, decrease this delay to have Draupnir chain operations
+# faster. The total duration of operations will generally be shorter, but the performance
+# of the homeserver may be more impacted.
+backgroundDelayMS: 500
+
+# Misc options for command handling and commands
+commands:
+  # Whether or not the `!draupnir` prefix is necessary to submit commands.
+  #
+  # If `true`, will allow commands like `!ban`, `!help`, etc.
+  #
+  # Note: Draupnir can also be pinged by display name instead of having to use
+  # the !draupnir prefix. For example, "my_moderator_bot: ban @spammer:example.org"
+  # will address only my_moderator_bot.
+  allowNoPrefix: false
+
+  # Any additional bot prefixes that Draupnir will listen to. i.e. adding `mod` will allow `!mod help`.
+  additionalPrefixes:
+    - "draupnir-bot"
+    - "draupnir_bot"
+    - "draupnir"
+
+  # Whether or not commands with a wildcard (*) will require an additional `--force` argument
+  # in the command to be able to be submitted.
+  confirmWildcardBan: true
+
+  # The default reasons to be prompted with if the reason is missing from a ban command.
+  ban:
+    defaultReasons: 
+      - "spam"
+      - "brigading"
+      - "harassment"
+      - "disagreement"

--- a/roles/custom/matrix-appservice-draupnir-for-all/templates/systemd/matrix-appservice-draupnir-for-all.service.j2
+++ b/roles/custom/matrix-appservice-draupnir-for-all/templates/systemd/matrix-appservice-draupnir-for-all.service.j2
@@ -1,0 +1,48 @@
+#jinja2: lstrip_blocks: "True"
+[Unit]
+Description=Matrix Draupnir for All appservice
+{% for service in matrix_appservice_draupnir_for_all_systemd_wanted_services_list %}
+Requires={{ service }}
+After={{ service }}
+{% endfor %}
+{% for service in matrix_appservice_draupnir_for_all_systemd_required_services_list %}
+Wants={{ service }}
+{% endfor %}
+DefaultDependencies=no
+
+[Service]
+Type=simple
+Environment="HOME={{ devture_systemd_docker_base_systemd_unit_home_path }}"
+ExecStartPre=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} stop --time={{ devture_systemd_docker_base_container_stop_grace_time_seconds }} matrix-appservice-draupnir-for-all 2>/dev/null || true'
+ExecStartPre=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} rm matrix-appservice-draupnir-for-all 2>/dev/null || true'
+
+ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
+			--rm \
+			--name=matrix-appservice-draupnir-for-all \
+			--log-driver=none \
+			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
+			--cap-drop=ALL \
+			--read-only \
+			--network={{ matrix_appservice_draupnir_for_all_container_network }} \
+			--mount type=bind,src={{ matrix_appservice_draupnir_for_all_config_path }},dst=/data/config,ro \
+			--mount type=bind,src={{ matrix_appservice_draupnir_for_all_data_path }},dst=/data \
+			{% for arg in matrix_appservice_draupnir_for_all_container_extra_arguments %}
+			{{ arg }} \
+			{% endfor %}
+			{{ matrix_appservice_draupnir_for_all_docker_image }} \
+			appservice -c /data/config/production-appservice.yaml -f /data/config/draupnir-for-all-registration.yaml -p {{ matrix_appservice_draupnir_for_all_appservice_port }} --draupnir-config /data/config/production-bots.yaml
+
+{% for network in matrix_appservice_draupnir_for_all_container_additional_networks %}
+ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-appservice-draupnir-for-all
+{% endfor %}
+
+ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-appservice-draupnir-for-all
+
+ExecStop=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} stop --time={{ devture_systemd_docker_base_container_stop_grace_time_seconds }} matrix-appservice-draupnir-for-all 2>/dev/null || true'
+ExecStop=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} rm matrix-appservice-draupnir-for-all 2>/dev/null || true'
+Restart=always
+RestartSec=30
+SyslogIdentifier=matrix-appservice-draupnir-for-all
+
+[Install]
+WantedBy=multi-user.target

--- a/setup.yml
+++ b/setup.yml
@@ -49,6 +49,7 @@
 
     - galaxy/redis
     - custom/matrix-corporal
+    - custom/matrix-appservice-draupnir-for-all
     - custom/matrix-bridge-appservice-discord
     - custom/matrix-bridge-appservice-slack
     - custom/matrix-bridge-appservice-webhooks


### PR DESCRIPTION
This PR adds Draupnir for all support to the playbook. 

This is my first role that uses an AS and my first role that has a database involved so i took inspiration from multiple roles, Slack and AS Discord are roles that have inspired this one in parts. But this is also a straight clone of Draupnir in as many places as possible as well Draupnir For All and Draupnir are the same thing in a lot of ways. Since its the Appservice operating mode of Draupnir.

If this PR is merged this will resolve #3143 

The State of the PR as of when it was marked Ready for review is that the PR works. It deploys and you can succesfully configure a D4A. 

Edit: D4A is pinned to develop due to that there are patches in main currently waiting for the next release that are REQUIRED to make D4A work in mdad. A few hours of work together with MTRNord maintainer of the only D4A deployment besides this capability in the playbook and Gnuxie maintainer of Draupnir it self where involved in this and we could not get it working without the patches. (It works on Kubernetes without the patches for some reason but not on Docker.)