### PR TITLE
mautrix-meta: enable spaces; add a hint into the display name

### DIFF
--- a/roles/custom/matrix-bridge-mautrix-meta-instagram/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-meta-instagram/defaults/main.yml
@@ -179,7 +179,17 @@ matrix_mautrix_meta_instagram_bridge_username_prefix: |-
 # Changing this may require that you change the regex in the appservice.
 matrix_mautrix_meta_instagram_bridge_username_template: "{{ matrix_mautrix_meta_instagram_bridge_username_prefix + '{{.}}' }}"
 
-matrix_mautrix_meta_instagram_bridge_displayname_template: '{% raw %}{{or .DisplayName .Username "Unknown user"}} (IG){% endraw %}'
+matrix_mautrix_meta_instagram_bridge_displayname_suffix: |-
+  {{
+    ({
+      'facebook': '(FB)',
+      'facebook-tor': '(FB)',
+      'messenger': '(FB)',
+      'instagram': '(IG)',
+    })[matrix_mautrix_meta_instagram_meta_mode]
+  }}
+
+matrix_mautrix_meta_instagram_bridge_displayname_template: '{% raw %}{{or .DisplayName .Username "Unknown user"}}{% endraw %} {{ matrix_mautrix_meta_instagram_bridge_displayname_suffix }}'
 
 # The prefix for commands. Only required in non-management rooms.
 # If set to "default", will be determined based on meta -> mode (`matrix_mautrix_meta_instagram_meta_mode`):

--- a/roles/custom/matrix-bridge-mautrix-meta-instagram/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-meta-instagram/defaults/main.yml
@@ -179,7 +179,7 @@ matrix_mautrix_meta_instagram_bridge_username_prefix: |-
 # Changing this may require that you change the regex in the appservice.
 matrix_mautrix_meta_instagram_bridge_username_template: "{{ matrix_mautrix_meta_instagram_bridge_username_prefix + '{{.}}' }}"
 
-matrix_mautrix_meta_instagram_bridge_displayname_template: '{% raw %}{{or .DisplayName .Username "Unknown user"}}{% endraw %}'
+matrix_mautrix_meta_instagram_bridge_displayname_template: '{% raw %}{{or .DisplayName .Username "Unknown user"}} (IG){% endraw %}'
 
 # The prefix for commands. Only required in non-management rooms.
 # If set to "default", will be determined based on meta -> mode (`matrix_mautrix_meta_instagram_meta_mode`):
@@ -190,6 +190,10 @@ matrix_mautrix_meta_instagram_bridge_command_prefix: default
 # Whether or not created rooms should have federation enabled.
 # If false, created portal rooms will never be federated.
 matrix_mautrix_meta_instagram_bridge_federate_rooms: true
+
+# Should the bridge create a space for each logged-in user and add bridged rooms to it?
+# Users who logged in before turning this on should run `!meta sync-space` to create and fill the space for the first time.
+matrix_mautrix_meta_instagram_bridge_personal_filtering_spaces: true
 
 # Enable End-to-bridge encryption
 matrix_mautrix_meta_instagram_bridge_encryption_allow: "{{ matrix_bridges_encryption_enabled }}"

--- a/roles/custom/matrix-bridge-mautrix-meta-instagram/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-meta-instagram/defaults/main.yml
@@ -189,7 +189,7 @@ matrix_mautrix_meta_instagram_bridge_displayname_suffix: |-
     })[matrix_mautrix_meta_instagram_meta_mode]
   }}
 
-matrix_mautrix_meta_instagram_bridge_displayname_template: '{% raw %}{{or .DisplayName .Username "Unknown user"}}{% endraw %} {{ matrix_mautrix_meta_instagram_bridge_displayname_suffix }}'
+matrix_mautrix_meta_instagram_bridge_displayname_template: '{% raw %}{{or .DisplayName .Username "Unknown user"}}{% endraw %}{{ (" " ~ matrix_mautrix_meta_instagram_bridge_displayname_suffix) if matrix_mautrix_meta_instagram_bridge_displayname_suffix else "" }}'
 
 # The prefix for commands. Only required in non-management rooms.
 # If set to "default", will be determined based on meta -> mode (`matrix_mautrix_meta_instagram_meta_mode`):

--- a/roles/custom/matrix-bridge-mautrix-meta-instagram/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mautrix-meta-instagram/templates/config.yaml.j2
@@ -124,7 +124,7 @@ bridge:
 
     # Should the bridge create a space for each logged-in user and add bridged rooms to it?
     # Users who logged in before turning this on should run `!meta sync-space` to create and fill the space for the first time.
-    personal_filtering_spaces: false
+    personal_filtering_spaces: {{ matrix_mautrix_meta_instagram_bridge_personal_filtering_spaces | to_json }}
     # Should Matrix m.notice-type messages be bridged?
     bridge_notices: true
     # Should the bridge send a read receipt from the bridge bot when a message has been sent to FB/IG?

--- a/roles/custom/matrix-bridge-mautrix-meta-messenger/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-meta-messenger/defaults/main.yml
@@ -179,7 +179,7 @@ matrix_mautrix_meta_messenger_bridge_username_prefix: |-
 # Changing this may require that you change the regex in the appservice.
 matrix_mautrix_meta_messenger_bridge_username_template: "{{ matrix_mautrix_meta_messenger_bridge_username_prefix + '{{.}}' }}"
 
-matrix_mautrix_meta_messenger_bridge_displayname_template: '{% raw %}{{or .DisplayName .Username "Unknown user"}}{% endraw %}'
+matrix_mautrix_meta_messenger_bridge_displayname_template: '{% raw %}{{or .DisplayName .Username "Unknown user"}} (FB){% endraw %}'
 
 # The prefix for commands. Only required in non-management rooms.
 # If set to "default", will be determined based on meta -> mode (`matrix_mautrix_meta_messenger_meta_mode`):
@@ -190,6 +190,10 @@ matrix_mautrix_meta_messenger_bridge_command_prefix: default
 # Whether or not created rooms should have federation enabled.
 # If false, created portal rooms will never be federated.
 matrix_mautrix_meta_messenger_bridge_federate_rooms: true
+
+# Should the bridge create a space for each logged-in user and add bridged rooms to it?
+# Users who logged in before turning this on should run `!meta sync-space` to create and fill the space for the first time.
+matrix_mautrix_meta_messenger_bridge_personal_filtering_spaces: true
 
 # Enable End-to-bridge encryption
 matrix_mautrix_meta_messenger_bridge_encryption_allow: "{{ matrix_bridges_encryption_enabled }}"

--- a/roles/custom/matrix-bridge-mautrix-meta-messenger/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-meta-messenger/defaults/main.yml
@@ -179,7 +179,17 @@ matrix_mautrix_meta_messenger_bridge_username_prefix: |-
 # Changing this may require that you change the regex in the appservice.
 matrix_mautrix_meta_messenger_bridge_username_template: "{{ matrix_mautrix_meta_messenger_bridge_username_prefix + '{{.}}' }}"
 
-matrix_mautrix_meta_messenger_bridge_displayname_template: '{% raw %}{{or .DisplayName .Username "Unknown user"}} (FB){% endraw %}'
+matrix_mautrix_meta_messenger_bridge_displayname_suffix: |-
+  {{
+    ({
+      'facebook': '(FB)',
+      'facebook-tor': '(FB)',
+      'messenger': '(FB)',
+      'instagram': '(IG)',
+    })[matrix_mautrix_meta_messenger_meta_mode]
+  }}
+
+matrix_mautrix_meta_messenger_bridge_displayname_template: '{% raw %}{{or .DisplayName .Username "Unknown user"}}{% endraw %} {{ matrix_mautrix_meta_messenger_bridge_displayname_suffix }}'
 
 # The prefix for commands. Only required in non-management rooms.
 # If set to "default", will be determined based on meta -> mode (`matrix_mautrix_meta_messenger_meta_mode`):

--- a/roles/custom/matrix-bridge-mautrix-meta-messenger/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-meta-messenger/defaults/main.yml
@@ -189,7 +189,7 @@ matrix_mautrix_meta_messenger_bridge_displayname_suffix: |-
     })[matrix_mautrix_meta_messenger_meta_mode]
   }}
 
-matrix_mautrix_meta_messenger_bridge_displayname_template: '{% raw %}{{or .DisplayName .Username "Unknown user"}}{% endraw %} {{ matrix_mautrix_meta_messenger_bridge_displayname_suffix }}'
+matrix_mautrix_meta_messenger_bridge_displayname_template: '{% raw %}{{or .DisplayName .Username "Unknown user"}}{% endraw %}{{ (" " ~ matrix_mautrix_meta_messenger_bridge_displayname_suffix) if matrix_mautrix_meta_messenger_bridge_displayname_suffix else "" }}'
 
 # The prefix for commands. Only required in non-management rooms.
 # If set to "default", will be determined based on meta -> mode (`matrix_mautrix_meta_messenger_meta_mode`):

--- a/roles/custom/matrix-bridge-mautrix-meta-messenger/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mautrix-meta-messenger/templates/config.yaml.j2
@@ -124,7 +124,7 @@ bridge:
 
     # Should the bridge create a space for each logged-in user and add bridged rooms to it?
     # Users who logged in before turning this on should run `!meta sync-space` to create and fill the space for the first time.
-    personal_filtering_spaces: false
+    personal_filtering_spaces: {{ matrix_mautrix_meta_messenger_bridge_personal_filtering_spaces | to_json }}
     # Should Matrix m.notice-type messages be bridged?
     bridge_notices: true
     # Should the bridge send a read receipt from the bridge bot when a message has been sent to FB/IG?


### PR DESCRIPTION
unifying with other mautrix bridges