### PR TITLE
Add setting to enable ipv6 in docker networks

### DIFF
--- a/roles/custom/matrix-appservice-draupnir-for-all/tasks/setup_install.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/tasks/setup_install.yml
@@ -77,6 +77,7 @@
 
 - name: Ensure matrix-appservice-draupnir-for-all container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_appservice_draupnir_for_all_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-base/defaults/main.yml
+++ b/roles/custom/matrix-base/defaults/main.yml
@@ -156,6 +156,9 @@ matrix_homeserver_url: "https://{{ matrix_server_fqn_matrix }}"
 # Specifies on which container network the homeserver is.
 matrix_homeserver_container_network: "matrix-homeserver"
 
+# enable ipv6 for all created networks
+matrix_ipv6_enabled: false
+
 # Specifies whether the homeserver will federate at all.
 # Disable this to completely isolate your server from the rest of the Matrix network.
 matrix_homeserver_federation_enabled: true

--- a/roles/custom/matrix-base/defaults/main.yml
+++ b/roles/custom/matrix-base/defaults/main.yml
@@ -156,7 +156,23 @@ matrix_homeserver_url: "https://{{ matrix_server_fqn_matrix }}"
 # Specifies on which container network the homeserver is.
 matrix_homeserver_container_network: "matrix-homeserver"
 
-# enable ipv6 for all created networks
+# Controls whether to enable IPv6 for all Docker container networks used by the various services.
+# This only affects Matrix services that are part of this playbook (`roles/custom/matrix-*`),
+# but doesn't affect external (non-Matrix-related) roles (`roles/galaxy/*`).
+#
+# For this to work the Docker daemon needs to be configured for IPv6: https://docs.docker.com/config/daemon/ipv6/
+# You may be able to apply the required Docker Daemon settings via Ansible by using the `docker_daemon_options` variable.
+# See: https://github.com/geerlingguy/ansible-role-docker/blob/dc1c9a16066506c09f426713544581dc9b38e747/defaults/main.yml#L58
+# Example:
+# docker_daemon_options:
+#   experimental: true
+#   ip6tables: true
+#
+# Changing `matrix_ipv6_enabled` subsequently may not adjust existing container networks.
+# When changing `matrix_ipv6_enabled`, consider:
+# - stopping all services (`just stop-all`)
+# - deleting all container networks on the server: `docker network rm $(docker network ls -q)`
+# - re-running the playbook fully: `just install-all`
 matrix_ipv6_enabled: false
 
 # Specifies whether the homeserver will federate at all.

--- a/roles/custom/matrix-bot-buscarron/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-buscarron/tasks/setup_install.yml
@@ -94,6 +94,7 @@
 
 - name: Ensure buscarron container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_bot_buscarron_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bot-chatgpt/tasks/install.yml
+++ b/roles/custom/matrix-bot-chatgpt/tasks/install.yml
@@ -58,6 +58,7 @@
 
 - name: Ensure chatgpt container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_bot_chatgpt_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bot-draupnir/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-draupnir/tasks/setup_install.yml
@@ -61,6 +61,7 @@
 
 - name: Ensure matrix-bot-draupnir container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_bot_draupnir_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bot-go-neb/tasks/install.yml
+++ b/roles/custom/matrix-bot-go-neb/tasks/install.yml
@@ -45,6 +45,7 @@
 
 - name: Ensure go-neb container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_bot_go_neb_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bot-honoroit/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-honoroit/tasks/setup_install.yml
@@ -111,6 +111,7 @@
 
 - name: Ensure honoroit container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_bot_honoroit_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bot-matrix-registration-bot/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-matrix-registration-bot/tasks/setup_install.yml
@@ -58,6 +58,7 @@
 
 - name: Ensure matrix-registration-bot container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_bot_matrix_registration_bot_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bot-matrix-reminder-bot/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-matrix-reminder-bot/tasks/setup_install.yml
@@ -86,6 +86,7 @@
 
 - name: Ensure matrix-reminder-bot container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_bot_matrix_reminder_bot_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bot-maubot/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-maubot/tasks/setup_install.yml
@@ -72,6 +72,7 @@
 
 - name: Ensure maubot container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_bot_maubot_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bot-mjolnir/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-mjolnir/tasks/setup_install.yml
@@ -61,6 +61,7 @@
 
 - name: Ensure matrix-bot-mjolnir container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_bot_mjolnir_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bot-postmoogle/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-postmoogle/tasks/setup_install.yml
@@ -81,6 +81,7 @@
 
 - name: Ensure postmoogle container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_bot_postmoogle_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-appservice-discord/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-appservice-discord/tasks/setup_install.yml
@@ -106,6 +106,7 @@
 
 - name: Ensure matrix-appservice-discord container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_appservice_discord_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-appservice-irc/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-appservice-irc/tasks/setup_install.yml
@@ -190,6 +190,7 @@
 
 - name: Ensure matrix-appservice-irc container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_appservice_irc_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-appservice-kakaotalk/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-appservice-kakaotalk/tasks/setup_install.yml
@@ -99,6 +99,7 @@
 
 - name: Ensure matrix-appservice-kakaotalk container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_appservice_kakaotalk_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-appservice-slack/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-appservice-slack/tasks/setup_install.yml
@@ -84,6 +84,7 @@
 
 - name: Ensure matrix-appservice-slack container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_appservice_slack_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-appservice-webhooks/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-appservice-webhooks/tasks/setup_install.yml
@@ -83,6 +83,7 @@
 
 - name: Ensure matrix-appservice-webhooks container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_appservice_webhooks_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-beeper-linkedin/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-beeper-linkedin/tasks/setup_install.yml
@@ -85,6 +85,7 @@
 
 - name: Ensure beeper-linkedin container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_beeper_linkedin_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-go-skype-bridge/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-go-skype-bridge/tasks/setup_install.yml
@@ -128,6 +128,7 @@
 
 - name: Ensure matrix-go-skype-bridge container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_go_skype_bridge_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-heisenbridge/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-heisenbridge/tasks/setup_install.yml
@@ -31,6 +31,7 @@
 
 - name: Ensure heisenbridge container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_heisenbridge_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-hookshot/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-hookshot/tasks/setup_install.yml
@@ -109,6 +109,7 @@
 
 - name: Ensure matrix-hookshot container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_hookshot_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-mautrix-discord/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-discord/tasks/setup_install.yml
@@ -95,6 +95,7 @@
 
 - name: Ensure mautrix-discord container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_mautrix_discord_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-mautrix-facebook/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-facebook/tasks/setup_install.yml
@@ -125,6 +125,7 @@
 
 - name: Ensure matrix-mautrix-facebook container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_mautrix_facebook_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-mautrix-gmessages/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-gmessages/tasks/setup_install.yml
@@ -144,6 +144,7 @@
 
 - name: Ensure matrix-mautrix-gmessages container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_mautrix_gmessages_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-mautrix-googlechat/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-googlechat/tasks/setup_install.yml
@@ -125,6 +125,7 @@
 
 - name: Ensure matrix-mautrix-googlechat container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_mautrix_googlechat_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-mautrix-hangouts/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-hangouts/tasks/setup_install.yml
@@ -125,6 +125,7 @@
 
 - name: Ensure matrix-mautrix-hangouts container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_mautrix_hangouts_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-mautrix-instagram/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-instagram/tasks/setup_install.yml
@@ -77,6 +77,7 @@
 
 - name: Ensure matrix-mautrix-instagram container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_mautrix_instagram_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-mautrix-meta-instagram/tasks/install.yml
+++ b/roles/custom/matrix-bridge-mautrix-meta-instagram/tasks/install.yml
@@ -104,6 +104,7 @@
 
 - name: Ensure mautrix-meta-instagram container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_mautrix_meta_instagram_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-mautrix-meta-messenger/tasks/install.yml
+++ b/roles/custom/matrix-bridge-mautrix-meta-messenger/tasks/install.yml
@@ -104,6 +104,7 @@
 
 - name: Ensure mautrix-meta-messenger container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_mautrix_meta_messenger_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-mautrix-signal/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-signal/tasks/setup_install.yml
@@ -138,6 +138,7 @@
 
 - name: Ensure matrix-mautrix-signal container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_mautrix_signal_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-mautrix-slack/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-slack/tasks/setup_install.yml
@@ -95,6 +95,7 @@
 
 - name: Ensure matrix-mautrix-slack container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_mautrix_slack_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-mautrix-telegram/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-telegram/tasks/setup_install.yml
@@ -150,6 +150,7 @@
 
 - name: Ensure matrix-mautrix-telegram container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_mautrix_telegram_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-mautrix-twitter/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-twitter/tasks/setup_install.yml
@@ -79,6 +79,7 @@
 
 - name: Ensure matrix-mautrix-twitter container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_mautrix_twitter_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-mautrix-whatsapp/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-whatsapp/tasks/setup_install.yml
@@ -138,6 +138,7 @@
 
 - name: Ensure matrix-mautrix-whatsapp container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_mautrix_whatsapp_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-mautrix-wsproxy/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-wsproxy/tasks/setup_install.yml
@@ -93,6 +93,7 @@
 
 - name: Ensure mautrix-wsproxy container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_mautrix_wsproxy_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-mx-puppet-discord/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-discord/tasks/setup_install.yml
@@ -114,6 +114,7 @@
 
 - name: Ensure mx-puppet-discord container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_mx_puppet_discord_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-mx-puppet-groupme/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-groupme/tasks/setup_install.yml
@@ -115,6 +115,7 @@
 
 - name: Ensure mx-puppet-groupme container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_mx_puppet_groupme_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-mx-puppet-instagram/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-instagram/tasks/setup_install.yml
@@ -94,6 +94,7 @@
 
 - name: Ensure mx-puppet-instagram container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_mx_puppet_instagram_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-mx-puppet-slack/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-slack/tasks/setup_install.yml
@@ -125,6 +125,7 @@
 
 - name: Ensure mx-puppet-slack container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_mx_puppet_slack_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-mx-puppet-steam/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-steam/tasks/setup_install.yml
@@ -115,6 +115,7 @@
 
 - name: Ensure mx-puppet-steam container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_mx_puppet_steam_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-mx-puppet-twitter/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-twitter/tasks/setup_install.yml
@@ -125,6 +125,7 @@
 
 - name: Ensure mx-puppet-twitter container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_mx_puppet_twitter_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-bridge-sms/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-sms/tasks/setup_install.yml
@@ -48,6 +48,7 @@
 
 - name: Ensure matrix-sms-bridge container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_sms_bridge_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-cactus-comments-client/tasks/install.yml
+++ b/roles/custom/matrix-cactus-comments-client/tasks/install.yml
@@ -73,6 +73,7 @@
 
 - name: Ensure matrix-cactus-comments-client container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_cactus_comments_client_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-client-cinny/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-cinny/tasks/setup_install.yml
@@ -66,6 +66,7 @@
 
 - name: Ensure Cinny container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_client_cinny_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-client-element/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-element/tasks/setup_install.yml
@@ -100,6 +100,7 @@
 
 - name: Ensure Element container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_client_element_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-client-hydrogen/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-hydrogen/tasks/setup_install.yml
@@ -78,6 +78,7 @@
 
 - name: Ensure Hydrogen container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_client_hydrogen_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-client-schildichat/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-schildichat/tasks/setup_install.yml
@@ -99,6 +99,7 @@
 
 - name: Ensure schildichat container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_client_schildichat_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-conduit/tasks/setup_install.yml
+++ b/roles/custom/matrix-conduit/tasks/setup_install.yml
@@ -36,6 +36,7 @@
 
 - name: Ensure Conduit container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_conduit_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-corporal/tasks/setup_install.yml
+++ b/roles/custom/matrix-corporal/tasks/setup_install.yml
@@ -68,6 +68,7 @@
 
 - name: Ensure Matrix Corporal container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_corporal_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-dendrite/tasks/setup_install.yml
+++ b/roles/custom/matrix-dendrite/tasks/setup_install.yml
@@ -109,6 +109,7 @@
 
 - name: Ensure Dendrite container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_dendrite_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-dimension/tasks/setup_install.yml
+++ b/roles/custom/matrix-dimension/tasks/setup_install.yml
@@ -130,6 +130,7 @@
 
 - name: Ensure Dimension container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_dimension_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-dynamic-dns/tasks/setup_install.yml
+++ b/roles/custom/matrix-dynamic-dns/tasks/setup_install.yml
@@ -58,6 +58,7 @@
 
 - name: Ensure matrix-dynamic-dns container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_dynamic_dns_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-email2matrix/tasks/setup_install.yml
+++ b/roles/custom/matrix-email2matrix/tasks/setup_install.yml
@@ -58,6 +58,7 @@
 
 - name: Ensure matrix-email2matrix container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_email2matrix_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-ldap-registration-proxy/tasks/setup_install.yml
+++ b/roles/custom/matrix-ldap-registration-proxy/tasks/setup_install.yml
@@ -53,6 +53,7 @@
 
 - name: Ensure matrix-ldap-registration-proxy container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_ldap_registration_proxy_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-ma1sd/tasks/setup_install.yml
+++ b/roles/custom/matrix-ma1sd/tasks/setup_install.yml
@@ -134,6 +134,7 @@
 
 - name: Ensure ma1sd container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_ma1sd_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-media-repo/tasks/setup_install.yml
+++ b/roles/custom/matrix-media-repo/tasks/setup_install.yml
@@ -79,6 +79,7 @@
 
 - name: Ensure media-repo container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_media_repo_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-prometheus-nginxlog-exporter/tasks/setup_install.yml
+++ b/roles/custom/matrix-prometheus-nginxlog-exporter/tasks/setup_install.yml
@@ -42,6 +42,7 @@
 
 - name: Ensure prometheus-nginxlog-exporter container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_prometheus_nginxlog_exporter_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-rageshake/tasks/install.yml
+++ b/roles/custom/matrix-rageshake/tasks/install.yml
@@ -67,6 +67,7 @@
 
 - name: Ensure rageshake container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_rageshake_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-registration/tasks/setup_install.yml
+++ b/roles/custom/matrix-registration/tasks/setup_install.yml
@@ -109,6 +109,7 @@
 
 - name: Ensure matrix-registration container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_registration_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-sliding-sync/tasks/install.yml
+++ b/roles/custom/matrix-sliding-sync/tasks/install.yml
@@ -60,6 +60,7 @@
 
 - name: Ensure matrix-sliding-sync container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_sliding_sync_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-static-files/tasks/install.yml
+++ b/roles/custom/matrix-static-files/tasks/install.yml
@@ -83,6 +83,7 @@
 
 - name: Ensure matrix-static-files container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_static_files_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-sygnal/tasks/install.yml
+++ b/roles/custom/matrix-sygnal/tasks/install.yml
@@ -41,6 +41,7 @@
 
 - name: Ensure Sygnal container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_sygnal_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-synapse-admin/tasks/setup_install.yml
+++ b/roles/custom/matrix-synapse-admin/tasks/setup_install.yml
@@ -53,6 +53,7 @@
 
 - name: Ensure matrix-synapse-admin container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_synapse_admin_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-synapse-auto-compressor/tasks/install.yml
+++ b/roles/custom/matrix-synapse-auto-compressor/tasks/install.yml
@@ -70,6 +70,7 @@
 
 - name: Ensure matrix-synapse-auto-compressor container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_synapse_auto_compressor_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-synapse-reverse-proxy-companion/tasks/setup_install.yml
+++ b/roles/custom/matrix-synapse-reverse-proxy-companion/tasks/setup_install.yml
@@ -41,6 +41,7 @@
 
 - name: Ensure matrix-synapse-reverse-proxy-companion container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_synapse_reverse_proxy_companion_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-synapse/tasks/synapse/setup_install.yml
+++ b/roles/custom/matrix-synapse/tasks/synapse/setup_install.yml
@@ -117,6 +117,7 @@
 
 - name: Ensure Synapse container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_synapse_container_network }}"
     driver: bridge
 

--- a/roles/custom/matrix-user-verification-service/tasks/setup_install.yml
+++ b/roles/custom/matrix-user-verification-service/tasks/setup_install.yml
@@ -57,6 +57,7 @@
 
 - name: Ensure matrix-user-verification-service container network is created
   community.general.docker_network:
+    enable_ipv6: "{{ matrix_ipv6_enabled }}"
     name: "{{ matrix_user_verification_service_container_network }}"
     driver: bridge
 


### PR DESCRIPTION
For this to work the docker daemon has to be configured for ipv6: https://docs.docker.com/config/daemon/ipv6/