### PR TITLE
Pin Draupnir Appservice to 1.87.0 instead of Develop & update Draupnir at the same time to the same version.

### DIFF
--- a/roles/custom/matrix-appservice-draupnir-for-all/defaults/main.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/defaults/main.yml
@@ -5,14 +5,14 @@
 matrix_appservice_draupnir_for_all_enabled: true
 
 # renovate: datasource=docker depName=gnuxie/draupnir
-matrix_appservice_draupnir_for_all_version: "develop"
+matrix_appservice_draupnir_for_all_version: "1.87.0"
 
 matrix_appservice_draupnir_for_all_container_image_self_build: false
 matrix_appservice_draupnir_for_all_container_image_self_build_repo: "https://github.com/the-draupnir-project/Draupnir.git"
 
 matrix_appservice_draupnir_for_all_docker_image: "{{ matrix_appservice_draupnir_for_all_docker_image_name_prefix }}gnuxie/draupnir:{{ matrix_appservice_draupnir_for_all_version }}"
 matrix_appservice_draupnir_for_all_docker_image_name_prefix: "{{ 'localhost/' if matrix_appservice_draupnir_for_all_container_image_self_build else matrix_container_global_registry_prefix }}"
-matrix_appservice_draupnir_for_all_docker_image_force_pull: "{{ matrix_appservice_draupnir_for_all_docker_image.endswith(':develop') }}"
+matrix_appservice_draupnir_for_all_docker_image_force_pull: "{{ matrix_appservice_draupnir_for_all_docker_image.endswith(':latest') }}"
 
 matrix_appservice_draupnir_for_all_base_path: "{{ matrix_base_data_path }}/draupnir-for-all"
 matrix_appservice_draupnir_for_all_config_path: "{{ matrix_appservice_draupnir_for_all_base_path }}/config"

--- a/roles/custom/matrix-bot-draupnir/defaults/main.yml
+++ b/roles/custom/matrix-bot-draupnir/defaults/main.yml
@@ -5,7 +5,7 @@
 matrix_bot_draupnir_enabled: true
 
 # renovate: datasource=docker depName=gnuxie/draupnir
-matrix_bot_draupnir_version: "v1.86.2"
+matrix_bot_draupnir_version: "v1.87.0"
 
 matrix_bot_draupnir_container_image_self_build: false
 matrix_bot_draupnir_container_image_self_build_repo: "https://github.com/the-draupnir-project/Draupnir.git"


### PR DESCRIPTION
Appservice Draupnir for All required Develop before the release of 1.87.0 to work at all in the playbook. Now that we have a release to pin to we will return to being pinned to a release. Especially as Draupnir 2.0.0 push is happening now in main. This will mean that Draupnir develop is expected to be much more unstable than usual for a bit so its important that we pin to a stable release. These releases are validated due to having been dogfooded ever since D4A was merged into the playbook.