### PR TITLE
Add keydb

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -402,6 +402,8 @@ devture_systemd_service_manager_services_list_auto: |
     +
     ([{'name': (redis_identifier + '.service'), 'priority': 750, 'groups': ['matrix', 'redis']}] if redis_enabled else [])
     +
+    ([{'name': (keydb_identifier + '.service'), 'priority': 750, 'groups': ['matrix', 'keydb']}] if keydb_enabled else [])
+    +
     ([{'name': 'matrix-pantalaimon.service', 'priority': 4000, 'groups': ['matrix', 'pantalaimon']}] if matrix_pantalaimon_enabled else [])
     +
     ([{'name': 'matrix-registration.service', 'priority': 4000, 'groups': ['matrix', 'registration', 'matrix-registration']}] if matrix_registration_enabled else [])
@@ -1862,12 +1864,14 @@ matrix_hookshot_systemd_wanted_services_list: |
     matrix_addons_homeserver_systemd_services_list
     +
     ([(redis_identifier + '.service')] if redis_enabled and matrix_hookshot_queue_host == redis_identifier else [])
+    +
+    ([(keydb_identifier + '.service')] if keydb_enabled and matrix_hookshot_queue_host == keydb_identifier else [])
   }}
 
 # Hookshot's experimental encryption feature (and possibly others) may benefit from Redis, if available.
 # We only connect to Redis if encryption is enabled (not for everyone who has Redis enabled),
 # because connectivity is still potentially troublesome and is to be investigated.
-matrix_hookshot_queue_host: "{{ redis_identifier if redis_enabled and matrix_hookshot_experimental_encryption_enabled else '' }}"
+matrix_hookshot_queue_host: "{{ redis_identifier if redis_enabled and matrix_hookshot_experimental_encryption_enabled else keydb_identifier if keydb_enabled and matrix_hookshot_experimental_encryption_enabled else '' }}"
 
 matrix_hookshot_container_network: "{{ matrix_addons_container_network }}"
 
@@ -1877,6 +1881,8 @@ matrix_hookshot_container_additional_networks_auto: |
       ([] if matrix_addons_homeserver_container_network == '' else [matrix_addons_homeserver_container_network])
       +
       ([redis_container_network] if redis_enabled and matrix_hookshot_queue_host == redis_identifier else [])
+      +
+      ([keydb_container_network] if keydb_enabled and matrix_hookshot_queue_host == keydb_identifier else [])
       +
       ([matrix_playbook_reverse_proxyable_services_additional_network] if matrix_playbook_reverse_proxyable_services_additional_network and matrix_hookshot_container_labels_traefik_enabled else [])
     ) | unique
@@ -3956,7 +3962,7 @@ ntfy_visitor_request_limit_exempt_hosts_hostnames_auto: |
 #
 ######################################################################
 
-redis_enabled: "{{ matrix_synapse_workers_enabled or (matrix_hookshot_enabled and matrix_hookshot_experimental_encryption_enabled) }}"
+redis_enabled: "{{ not keydb_enabled and (matrix_synapse_workers_enabled or (matrix_hookshot_enabled and matrix_hookshot_experimental_encryption_enabled)) }}"
 
 redis_identifier: matrix-redis
 
@@ -3967,7 +3973,28 @@ redis_base_path: "{{ matrix_base_data_path }}/redis"
 
 ######################################################################
 #
-# /etle/redis
+# /etke/redis
+#
+######################################################################
+
+######################################################################
+#
+# keydb
+#
+######################################################################
+
+keydb_enabled: "{{ matrix_synapse_workers_enabled or (matrix_hookshot_enabled and matrix_hookshot_experimental_encryption_enabled) }}"
+
+keydb_identifier: matrix-keydb
+
+keydb_uid: "{{ matrix_user_uid }}"
+keydb_gid: "{{ matrix_user_gid }}"
+
+keydb_base_path: "{{ matrix_base_data_path }}/keydb"
+
+######################################################################
+#
+# keydb
 #
 ######################################################################
 
@@ -4174,6 +4201,8 @@ matrix_synapse_container_additional_networks_auto: |
       +
       ([redis_container_network] if matrix_synapse_redis_enabled and matrix_synapse_redis_host == redis_identifier else [])
       +
+      ([keydb_container_network] if matrix_synapse_redis_enabled and matrix_synapse_redis_host == keydb_identifier else [])
+      +
       ([exim_relay_container_network] if (exim_relay_enabled and matrix_synapse_email_enabled and matrix_synapse_email_smtp_host == exim_relay_identifier and matrix_synapse_container_network != exim_relay_container_network) else [])
       +
       ([matrix_ma1sd_container_network] if (matrix_ma1sd_enabled and matrix_synapse_account_threepid_delegates_msisdn == matrix_synapse_account_threepid_delegates_msisdn_mas1sd_url and matrix_synapse_container_network != matrix_ma1sd_container_network) else [])
@@ -4256,6 +4285,8 @@ matrix_synapse_systemd_required_services_list_auto: |
     +
     ([redis_identifier ~ '.service'] if matrix_synapse_redis_enabled and matrix_synapse_redis_host == redis_identifier else [])
     +
+    ([keydb_identifier ~ '.service'] if matrix_synapse_redis_enabled and matrix_synapse_redis_host == keydb_identifier else [])
+    +
     (['matrix-goofys.service'] if matrix_s3_media_store_enabled else [])
   }}
 
@@ -4267,9 +4298,9 @@ matrix_synapse_systemd_wanted_services_list_auto: |
   }}
 
 # Synapse workers (used for parallel load-scaling) need Redis for IPC.
-matrix_synapse_redis_enabled: "{{ redis_enabled }}"
-matrix_synapse_redis_host: "{{ redis_identifier if redis_enabled else '' }}"
-matrix_synapse_redis_password: "{{ redis_connection_password if redis_enabled else '' }}"
+matrix_synapse_redis_enabled: "{{ redis_enabled or keydb_enabled }}"
+matrix_synapse_redis_host: "{{ redis_identifier if redis_enabled else keydb_identifier if keydb_enabled else '' }}"
+matrix_synapse_redis_password: "{{ redis_connection_password if redis_enabled else keydb_connection_password if keydb_enabled else '' }}"
 
 matrix_synapse_container_extra_arguments_auto: "{{ matrix_homeserver_container_extra_arguments_auto }}"
 matrix_synapse_app_service_config_files_auto: "{{ matrix_homeserver_app_service_config_files_auto }}"

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,6 +3,9 @@
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-aux.git
   version: v1.0.0-3
   name: auxiliary
+- src: git+https://github.com/mother-of-all-self-hosting/ansible-role-keydb.git
+  version: v6.3.4-0
+  name: keydb
 - src: git+https://gitlab.com/etke.cc/roles/backup_borg.git
   version: v1.2.7-1.8.6-0
   name: backup_borg

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,9 +3,6 @@
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-aux.git
   version: v1.0.0-3
   name: auxiliary
-- src: git+https://github.com/mother-of-all-self-hosting/ansible-role-keydb.git
-  version: v6.3.4-0
-  name: keydb
 - src: git+https://gitlab.com/etke.cc/roles/backup_borg.git
   version: v1.2.7-1.8.6-0
   name: backup_borg
@@ -30,6 +27,9 @@
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-jitsi.git
   version: v9364-1
   name: jitsi
+- src: git+https://github.com/mother-of-all-self-hosting/ansible-role-keydb.git
+  version: v6.3.4-0
+  name: keydb
 - src: git+https://gitlab.com/etke.cc/roles/ntfy.git
   version: v2.10.0-0
   name: ntfy

--- a/setup.yml
+++ b/setup.yml
@@ -48,6 +48,7 @@
     - role: galaxy/postgres
 
     - galaxy/redis
+    - galaxy/keydb
     - custom/matrix-corporal
     - custom/matrix-appservice-draupnir-for-all
     - custom/matrix-bridge-appservice-discord


### PR DESCRIPTION
Due to https://redis.com/blog/redis-adopts-dual-source-available-licensing/

KeyDB is open source drop-in Redis replacement with (optional) additional features.

The PR implements seamless migration with the only requirement to run `just setup-all`.

For anyone who wants to continue with Redis - just set `keydb_enabled: false` in your vars.yml