### PR TITLE
add matrix_synapse_redis_dbid var

### DIFF
--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -1038,6 +1038,7 @@ matrix_synapse_redis_enabled: false
 matrix_synapse_redis_host: ""
 matrix_synapse_redis_port: 6379
 matrix_synapse_redis_password: ""
+matrix_synapse_redis_dbid: 0
 
 # Controls whether Synapse starts a replication listener necessary for workers.
 #

--- a/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -2921,6 +2921,9 @@ redis:
   host: {{ matrix_synapse_redis_host }}
   port: {{ matrix_synapse_redis_port }}
 
+  # Optional database ID to connect to. Defaults to 0.
+  dbid: {{ matrix_synapse_redis_dbid }}
+
   # Optional password if configured on the Redis instance
   #
   password: {{ matrix_synapse_redis_password }}


### PR DESCRIPTION
That allows using different logical db id if needed