### PR TITLE
Resolve Synology DSM 7.2 Docker Command Issue 

### DIFF
--- a/roles/custom/matrix-synapse/tasks/synapse/setup_install.yml
+++ b/roles/custom/matrix-synapse/tasks/synapse/setup_install.yml
@@ -94,7 +94,7 @@
 - name: Generate initial Synapse config and signing key
   ansible.builtin.command:
     cmd: |
-      docker run
+      {{ devture_systemd_docker_base_host_command_docker }} run
       --rm
       --name=matrix-config
       --user={{ matrix_synapse_uid }}:{{ matrix_synapse_gid }}


### PR DESCRIPTION
I managed to make this project work on Synology DSM 7.2 by replacing the original Docker command with the `devture_systemd_docker_base_host_command_docker` variable.

After that, I specified the DSM Docker location in my vars file as follows:
`devture_systemd_docker_base_host_command_docker: "/usr/local/bin/docker`

It would be appreciated if this change can be approved.