### PR TITLE
exim-relay: fix dkim permissions, fix sender address

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -3364,7 +3364,7 @@ exim_relay_container_image_self_build: "{{ matrix_architecture not in ['amd64', 
 
 exim_relay_hostname: "{{ matrix_server_fqn_matrix }}"
 
-exim_relay_sender_address: "matrix@{{ matrix_domain }}"
+exim_relay_sender_address: "matrix@{{ exim_relay_hostname }}"
 
 ########################################################################
 #                                                                      #

--- a/requirements.yml
+++ b/requirements.yml
@@ -19,7 +19,7 @@
   version: v2.0.1-2
   name: etherpad
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-exim-relay.git
-  version: v4.97.1-r0-0-1
+  version: v4.97.1-r0-0-2
   name: exim_relay
 - src: git+https://gitlab.com/etke.cc/roles/grafana.git
   version: v10.4.2-0


### PR DESCRIPTION
Emails are supposed to be sent from matrix@matrix.DOMAIN, not matrix@DOMAIN by default, especially when you care about deliverability and have SPF, DMARC, DKIM, and rDNS set to matrix.DOMAIN to have fully-featured email service on the DOMAIN and don't have conflicts between them