### PR TITLE
fix(hookshot): incorrect Redis port

### DIFF
--- a/roles/custom/matrix-bridge-hookshot/defaults/main.yml
+++ b/roles/custom/matrix-bridge-hookshot/defaults/main.yml
@@ -44,7 +44,7 @@ matrix_hookshot_appservice_endpoint: "{{ matrix_hookshot_public_endpoint }}/_mat
 # Using caching is required when experimental encryption is enabled (`matrix_hookshot_experimental_encryption_enabled`)
 # but may also speed up Hookshot startup, etc.
 matrix_hookshot_cache_redis_host: ''
-matrix_hookshot_cache_redis_port: 6739
+matrix_hookshot_cache_redis_port: 6379
 matrix_hookshot_cache_redisUri: "{{ ('redis://' + matrix_hookshot_cache_redis_host + ':' + matrix_hookshot_cache_redis_port) if matrix_hookshot_cache_redis_host else '' }}"  # noqa var-naming
 
 # Controls whether the experimental end-to-bridge encryption support is enabled.


### PR DESCRIPTION
Hookshot tries to connect to Redis/KeyDB on the wrong port when enabling encryption. Ending up with this:
```
Apr 19 11:14:21 matrix matrix-hookshot[764426]: [ioredis] Unhandled error event: Error: connect ECONNREFUSED 172.20.0.2:6739
Apr 19 11:14:21 matrix matrix-hookshot[764426]:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1595:16)
Apr 19 11:14:21 matrix matrix-hookshot[764426]: [ioredis] Unhandled error event: Error: connect ECONNREFUSED 172.20.0.2:6739
Apr 19 11:14:21 matrix matrix-hookshot[764426]:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1595:16)
Apr 19 11:14:21 matrix matrix-hookshot[764426]: [ioredis] Unhandled error event: Error: connect ECONNREFUSED 172.20.0.2:6739
Apr 19 11:14:21 matrix matrix-hookshot[764426]:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1595:16)
Apr 19 11:14:21 matrix matrix-hookshot[764426]: [ioredis] Unhandled error event: Error: connect ECONNREFUSED 172.20.0.2:6739
Apr 19 11:14:21 matrix matrix-hookshot[764426]:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1595:16)
Apr 19 11:14:22 matrix matrix-hookshot[764426]: [ioredis] Unhandled error event: Error: connect ECONNREFUSED 172.20.0.2:6739
Apr 19 11:14:22 matrix matrix-hookshot[764426]:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1595:16)
Apr 19 11:14:22 matrix matrix-hookshot[764426]: [ioredis] Unhandled error event: Error: connect ECONNREFUSED 172.20.0.2:6739
Apr 19 11:14:22 matrix matrix-hookshot[764426]:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1595:16)
Apr 19 11:14:22 matrix matrix-hookshot[764426]: [ioredis] Unhandled error event: Error: connect ECONNREFUSED 172.20.0.2:6739
Apr 19 11:14:22 matrix matrix-hookshot[764426]:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1595:16)
Apr 19 11:14:23 matrix matrix-hookshot[764426]: [ioredis] Unhandled error event: Error: connect ECONNREFUSED 172.20.0.2:6739
Apr 19 11:14:23 matrix matrix-hookshot[764426]:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1595:16)
Apr 19 11:14:23 matrix matrix-hookshot[764426]: [ioredis] Unhandled error event: Error: connect ECONNREFUSED 172.20.0.2:6739
Apr 19 11:14:23 matrix matrix-hookshot[764426]:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1595:16)
Apr 19 11:14:23 matrix matrix-hookshot[764426]: [ioredis] Unhandled error event: Error: connect ECONNREFUSED 172.20.0.2:6739
Apr 19 11:14:23 matrix matrix-hookshot[764426]:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1595:16)
Apr 19 11:14:24 matrix matrix-hookshot[764426]: [ioredis] Unhandled error event: Error: connect ECONNREFUSED 172.20.0.2:6739
Apr 19 11:14:24 matrix matrix-hookshot[764426]:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1595:16)
Apr 19 11:14:24 matrix matrix-hookshot[764426]: [ioredis] Unhandled error event: Error: connect ECONNREFUSED 172.20.0.2:6739
Apr 19 11:14:24 matrix matrix-hookshot[764426]:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1595:16)
Apr 19 11:14:25 matrix matrix-hookshot[764426]: [ioredis] Unhandled error event: Error: connect ECONNREFUSED 172.20.0.2:6739
Apr 19 11:14:25 matrix matrix-hookshot[764426]:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1595:16)
Apr 19 11:14:26 matrix matrix-hookshot[764426]: [ioredis] Unhandled error event: Error: connect ECONNREFUSED 172.20.0.2:6739
Apr 19 11:14:26 matrix matrix-hookshot[764426]:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1595:16)
Apr 19 11:14:26 matrix matrix-hookshot[764426]: [ioredis] Unhandled error event: Error: connect ECONNREFUSED 172.20.0.2:6739
Apr 19 11:14:26 matrix matrix-hookshot[764426]:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1595:16)
Apr 19 11:14:27 matrix matrix-hookshot[764426]: [ioredis] Unhandled error event: Error: connect ECONNREFUSED 172.20.0.2:6739
Apr 19 11:14:27 matrix matrix-hookshot[764426]:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1595:16)
Apr 19 11:14:28 matrix matrix-hookshot[764426]: [ioredis] Unhandled error event: Error: connect ECONNREFUSED 172.20.0.2:6739
Apr 19 11:14:28 matrix matrix-hookshot[764426]:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1595:16)
Apr 19 11:14:29 matrix matrix-hookshot[764426]: [ioredis] Unhandled error event: Error: connect ECONNREFUSED 172.20.0.2:6739
Apr 19 11:14:29 matrix matrix-hookshot[764426]:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1595:16)
Apr 19 11:14:30 matrix matrix-hookshot[764426]: [ioredis] Unhandled error event: Error: connect ECONNREFUSED 172.20.0.2:6739
Apr 19 11:14:30 matrix matrix-hookshot[764426]:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1595:16)
Apr 19 11:14:31 matrix matrix-hookshot[764426]: [ioredis] Unhandled error event: Error: connect ECONNREFUSED 172.20.0.2:6739
Apr 19 11:14:31 matrix matrix-hookshot[764426]:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1595:16)
Apr 19 11:14:32 matrix matrix-hookshot[764426]: [ioredis] Unhandled error event: Error: connect ECONNREFUSED 172.20.0.2:6739
Apr 19 11:14:32 matrix matrix-hookshot[764426]:     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1595:16)
Apr 19 11:14:32 matrix matrix-hookshot[764426]: WARN 11:14:32:176 [RedisASProvider] Failed to set expiry time on as.completed_transactions MaxRetriesPerRequestError: Reached the max retries per request limit (which is 20). Refer to "maxRe>
Apr 19 11:14:32 matrix matrix-hookshot[764426]:     at Socket.<anonymous> (/usr/bin/matrix-hookshot/node_modules/ioredis/built/redis/event_handler.js:182:37)
Apr 19 11:14:32 matrix matrix-hookshot[764426]:     at Object.onceWrapper (node:events:633:26)
Apr 19 11:14:32 matrix matrix-hookshot[764426]:     at Socket.emit (node:events:518:28)
Apr 19 11:14:32 matrix matrix-hookshot[764426]:     at Socket.emit (node:domain:488:12)
Apr 19 11:14:32 matrix matrix-hookshot[764426]:     at TCP.<anonymous> (node:net:337:12)
Apr 19 11:14:32 matrix matrix-hookshot[764426]: WARN 11:14:32:178 [RedisASProvider] Failed to set expiry time on storedfiles. MaxRetriesPerRequestError: Reached the max retries per request limit (which is 20). Refer to "maxRetriesPerReque>
Apr 19 11:14:32 matrix matrix-hookshot[764426]:     at Socket.<anonymous> (/usr/bin/matrix-hookshot/node_modules/ioredis/built/redis/event_handler.js:182:37)
Apr 19 11:14:32 matrix matrix-hookshot[764426]:     at Object.onceWrapper (node:events:633:26)
Apr 19 11:14:32 matrix matrix-hookshot[764426]:     at Socket.emit (node:events:518:28)
Apr 19 11:14:32 matrix matrix-hookshot[764426]:     at Socket.emit (node:domain:488:12)
Apr 19 11:14:32 matrix matrix-hookshot[764426]:     at TCP.<anonymous> (node:net:337:12)
Apr 19 11:14:32 matrix matrix-hookshot[764426]: ERROR 11:14:32:178 [RedisASProvider] Could not ping the redis instance, is it reachable?
Apr 19 11:14:32 matrix matrix-hookshot[764426]: ERROR 11:14:32:179 [App] BridgeApp encountered an error and has stopped: MaxRetriesPerRequestError: Reached the max retries per request limit (which is 20). Refer to "maxRetriesPerRequest" o>
Apr 19 11:14:32 matrix matrix-hookshot[764426]:     at Socket.<anonymous> (/usr/bin/matrix-hookshot/node_modules/ioredis/built/redis/event_handler.js:182:37)
Apr 19 11:14:32 matrix matrix-hookshot[764426]:     at Object.onceWrapper (node:events:633:26)
Apr 19 11:14:32 matrix matrix-hookshot[764426]:     at Socket.emit (node:events:518:28)
Apr 19 11:14:32 matrix matrix-hookshot[764426]:     at Socket.emit (node:domain:488:12)
Apr 19 11:14:32 matrix matrix-hookshot[764426]:     at TCP.<anonymous> (node:net:337:12)
```

After a bit of searching I found out that the default port in the role is incorrect. The default Redis port is 6379, not 6739.