### PR TITLE
[Conduit] Fix internal client API Traefik config

### DIFF
--- a/roles/custom/matrix-conduit/templates/labels.j2
+++ b/roles/custom/matrix-conduit/templates/labels.j2
@@ -83,14 +83,14 @@ traefik.http.routers.matrix-conduit-public-client-api.tls.certResolver={{ matrix
 #                                                          #
 ############################################################
 
-traefik.http.routers.matrix-conduit-public-client-api.rule={{ matrix_conduit_container_labels_internal_client_api_traefik_rule }}
+traefik.http.routers.matrix-conduit-internal-client-api.rule={{ matrix_conduit_container_labels_internal_client_api_traefik_rule }}
 
 {% if matrix_conduit_container_labels_internal_client_api_traefik_priority | int > 0 %}
-traefik.http.routers.matrix-conduit-public-client-api.priority={{ matrix_conduit_container_labels_internal_client_api_traefik_priority }}
+traefik.http.routers.matrix-conduit-internal-client-api.priority={{ matrix_conduit_container_labels_internal_client_api_traefik_priority }}
 {% endif %}
 
-traefik.http.routers.matrix-conduit-public-client-api.service=matrix-conduit
-traefik.http.routers.matrix-conduit-public-client-api.entrypoints={{ matrix_conduit_container_labels_internal_client_api_traefik_entrypoints }}
+traefik.http.routers.matrix-conduit-internal-client-api.service=matrix-conduit
+traefik.http.routers.matrix-conduit-internal-client-api.entrypoints={{ matrix_conduit_container_labels_internal_client_api_traefik_entrypoints }}
 
 ############################################################
 #                                                          #


### PR DESCRIPTION
I have to preface this with an image macro that we refer to as `dogscience` at work, since I have no experience with Traefik and very little experience with Ansible.

![ihave](https://github.com/spantaleev/matrix-docker-ansible-deploy/assets/91933/307ed91b-a104-444e-8a74-95e355ab4ee1)

I was trying out all three homeserver implementations. Synapse and Dendrite worked fine, but Conduit kept throwing this error in Element:

> Can't connect to homeserver - please check your connectivity,

All requests (e.g. to `https://matrix.example.com/_matrix/client/versions`) were throwing `404 page not found` errors.

Inspecting the Docker container using `sudo docker inspect`, I found that the working Dendrite container had these two labels:
```
"traefik.http.routers.matrix-dendrite-public-client-api.entrypoints": "web-secure",
"traefik.http.routers.matrix-dendrite-public-client-api.rule": "Host(`matrix.example.com`) && PathPrefix(`/_matrix`)",
```

while the Conduit container had different ones:
```
"traefik.http.routers.matrix-conduit-public-client-api.entrypoints": "matrix-internal-matrix-client-api",
"traefik.http.routers.matrix-conduit-public-client-api.rule": "PathPrefix(`/_matrix`)",
```

This seemed weird, so I searched for where `matrix-internal-matrix-client-api` came from, and traced things back to this `labels.j2` file. I diffed the Dendrite version to the Conduit version and noticed that the Conduit one appeared to be overwriting the public API HTTP routing config with the internal API config, whereas the Dendrite one had a separate `internal-client-api` config.

Fixing these labels *seems* to have fixed everything without any ill effects. Conduit seems noticeably faster to join large federated rooms so I'm glad I have it a try.
