### PR TITLE
[Element] Fix translation on welcome screen

### DIFF
--- a/roles/custom/matrix-client-element/defaults/main.yml
+++ b/roles/custom/matrix-client-element/defaults/main.yml
@@ -160,8 +160,8 @@ matrix_client_element_welcome_logo: "themes/element/img/logos/element-logo.svg"
 # URL of link on welcome image
 matrix_client_element_welcome_logo_link: "https://element.io"
 
-matrix_client_element_welcome_headline: "_t('Welcome to Element')"
-matrix_client_element_welcome_text: "_t('Decentralised, encrypted chat &amp; collaboration powered by [matrix]')"
+matrix_client_element_welcome_headline: "_t(\"welcome_to_element\")"
+matrix_client_element_welcome_text: "_t(\"powered_by_matrix_with_logo\")"
 
 # Links, shown in footer of welcome page:
 # [{"text": "Link text", "url": "https://link.target"}, {"text": "Other link"}]

--- a/roles/custom/matrix-client-element/templates/welcome.html.j2
+++ b/roles/custom/matrix-client-element/templates/welcome.html.j2
@@ -178,11 +178,11 @@ we don't have an account and should hide them. No account == no guest account ei
     <div class="mx_ButtonGroup">
         <div class="mx_ButtonRow">
             <a href="#/login" class="mx_ButtonParent mx_ButtonSignIn mx_Button_iconSignIn">
-                <div class="mx_ButtonLabel">_t("Sign In")</div>
+                <div class="mx_ButtonLabel">_t("action|sign_in")</div>
             </a>
 {% if matrix_client_element_registration_enabled %}
             <a href="#/register" class="mx_ButtonParent mx_ButtonCreateAccount mx_Button_iconCreateAccount">
-                <div class="mx_ButtonLabel">_t("Create Account")</div>
+                <div class="mx_ButtonLabel">_t("action|create_account")</div>
             </a>
 {% endif %}
         </div>
@@ -195,7 +195,7 @@ we don't have an account and should hide them. No account == no guest account ei
         <div class="mx_ButtonRow mx_WelcomePage_guestFunctions">
             <div>
                 <a href="#/directory" class="mx_ButtonParent mx_SecondaryButton mx_Button_iconRoomDirectory">
-                    <div class="mx_ButtonLabel">_t("Explore rooms")</div>
+                    <div class="mx_ButtonLabel">_t("action|explore_rooms")</div>
                 </a>
             </div>
         </div>


### PR DESCRIPTION
- Provoked by: [Migrate translations to keys and switch to Localazy](https://github.com/element-hq/element-web/commit/c525b633bdb4801086999048295d0d4e5e296d6f#diff-3bbccf505f97c801dfb746d577c2ded291ce3f2ba9fdec55ac856565608a93e4)
- Schildi-Chat: Not affected yet (still using Weblate)