### PR TITLE
fix redis port type

### DIFF
--- a/roles/custom/matrix-bridge-hookshot/defaults/main.yml
+++ b/roles/custom/matrix-bridge-hookshot/defaults/main.yml
@@ -44,7 +44,7 @@ matrix_hookshot_appservice_endpoint: "{{ matrix_hookshot_public_endpoint }}/_mat
 # Using caching is required when experimental encryption is enabled (`matrix_hookshot_experimental_encryption_enabled`)
 # but may also speed up Hookshot startup, etc.
 matrix_hookshot_cache_redis_host: ''
-matrix_hookshot_cache_redis_port: 6379
+matrix_hookshot_cache_redis_port: "6379"
 matrix_hookshot_cache_redisUri: "{{ ('redis://' + matrix_hookshot_cache_redis_host + ':' + matrix_hookshot_cache_redis_port) if matrix_hookshot_cache_redis_host else '' }}"  # noqa var-naming
 
 # Controls whether the experimental end-to-bridge encryption support is enabled.


### PR DESCRIPTION
The conditional check 'matrix_hookshot_experimental_encryption_enabled and matrix_hookshot_cache_redisUri == ''' failed. The error was: An unhandled exception occurred while templating '{{ ('redis://' + matrix_hookshot_cache_redis_host + ':' + matrix_hookshot_cache_redis_port) if matrix_hookshot_cache_redis_host else '' }}'. Error was a <class 'ansible.errors.AnsibleError'>, original message: Unexpected templating type error occurred on ({{ ('redis://' + matrix_hookshot_cache_redis_host + ':' + matrix_hookshot_cache_redis_port) if matrix_hookshot_cache_redis_host else '' }}): can only concatenate str (not \"int\") to str. can only concatenate str (not \"int\") to str