### PR TITLE
Remove duplicate https from hookshot redirect_uri

### DIFF
--- a/roles/custom/matrix-bridge-hookshot/defaults/main.yml
+++ b/roles/custom/matrix-bridge-hookshot/defaults/main.yml
@@ -93,7 +93,7 @@ matrix_hookshot_github_oauth_client_id: ''  # "Client ID" on the GitHub App page
 matrix_hookshot_github_oauth_client_secret: ''  # "Client Secret" on the GitHub App page
 # Default value of matrix_hookshot_github_oauth_endpoint: "/hookshot/webhooks/oauth"
 matrix_hookshot_github_oauth_endpoint: "{{ matrix_hookshot_webhook_endpoint }}/oauth"
-matrix_hookshot_github_oauth_redirect_uri: "https://{{ matrix_hookshot_urlprefix }}{{ matrix_hookshot_github_oauth_endpoint }}"
+matrix_hookshot_github_oauth_redirect_uri: "{{ matrix_hookshot_urlprefix }}{{ matrix_hookshot_github_oauth_endpoint }}"
 
 # These are the default settings mentioned here and don't need to be modified: https://matrix-org.github.io/matrix-hookshot/usage/room_configuration/github_repo.html#configuration
 matrix_hookshot_github_defaultOptions_ignoreHooks: {}  # noqa var-naming


### PR DESCRIPTION
matrix_hookshot_github_oauth_redirect_uri was adding an extra https in front of matrix_hookshot_urlprefix, which already included that.

```yaml
matrix_hookshot_urlprefix: "https://{{ matrix_hookshot_public_hostname }}{{ matrix_hookshot_public_endpoint }}"
matrix_hookshot_github_oauth_redirect_uri: "https://{{ matrix_hookshot_urlprefix }}{{ matrix_hookshot_github_oauth_endpoint }}"
```

This caused the `redirect_uri` in hookshot's config to have `https://https://{{ url }}`.