### PR TITLE
Add missing configuration for synapse-auto-accept-invite role.

### DIFF
--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -1227,6 +1227,8 @@ matrix_synapse_ext_synapse_auto_accept_invite_enabled: false
 matrix_synapse_ext_synapse_auto_accept_invite_version: 1.1.3
 # Specifies whether only direct messages (1:1 rooms) will be auto accepted.
 matrix_synapse_ext_synapse_auto_accept_invite_accept_invites_only_direct_messages: false
+# Specifies whether only invites from local users will be auto accepted.
+matrix_synapse_ext_synapse_auto_accept_invite_accept_invites_only_from_local_users: false
 # When Synapse workers enabled it is possible (but not required) to assign a worker to run this module on (null = main process).
 matrix_synapse_ext_synapse_auto_accept_invite_worker_to_run_on: null
 

--- a/roles/custom/matrix-synapse/tasks/ext/synapse-auto-accept-invite/setup_install.yml
+++ b/roles/custom/matrix-synapse/tasks/ext/synapse-auto-accept-invite/setup_install.yml
@@ -10,6 +10,7 @@
             "module": "synapse_auto_accept_invite.InviteAutoAccepter",
             "config": {
               "accept_invites_only_for_direct_messages": matrix_synapse_ext_synapse_auto_accept_invite_accept_invites_only_direct_messages,
+              "accept_invites_only_from_local_users": matrix_synapse_ext_synapse_auto_accept_invite_accept_invites_only_from_local_users,
               "worker_to_run_on": matrix_synapse_ext_synapse_auto_accept_invite_worker_to_run_on,
           },
         }]


### PR DESCRIPTION
Add missing configuration matrix_synapse_ext_synapse_auto_accept_invite_accept_invites_only_from_local_users to specifies whether only invites from local users will be auto accepted.