### PR TITLE
Fix for 'enable_presence_by_hs_url' Element config option.

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -4049,7 +4049,7 @@ matrix_client_element_self_check_validate_certificates: "{{ matrix_playbook_ssl_
 
 matrix_client_element_registration_enabled: "{{ matrix_synapse_enable_registration }}"
 
-matrix_client_element_enable_presence_by_hs_url: |
+matrix_client_element_enable_presence_by_hs_url: |-
   {{
     none
     if matrix_synapse_presence_enabled
@@ -4166,7 +4166,7 @@ matrix_client_schildichat_self_check_validate_certificates: "{{ matrix_playbook_
 
 matrix_client_schildichat_registration_enabled: "{{ matrix_synapse_enable_registration }}"
 
-matrix_client_schildichat_enable_presence_by_hs_url: |
+matrix_client_schildichat_enable_presence_by_hs_url: |-
   {{
     none
     if matrix_synapse_presence_enabled


### PR DESCRIPTION
When generate `config.json` for element and/or schildichat web client the option `enable_presence_by_hs_url` get `"\n"` value if not `matrix_synapse_presence_enabled`. This PR changes yaml multiline formatting to strip trailing newline so it's value now just `""`.