### PR TITLE
wechat: enable spaces by default

### DIFF
--- a/roles/custom/matrix-bridge-wechat/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-wechat/templates/config.yaml.j2
@@ -88,7 +88,7 @@ bridge:
     listen_secret: {{ matrix_wechat_bridge_listen_secret | to_json }}
     # Should the bridge create a space for each logged-in user and add bridged rooms to it?
     # Users who logged in before turning this on should run `!wa sync space` to create and fill the space for the first time.
-    personal_filtering_spaces: false
+    personal_filtering_spaces: true
     # Whether the bridge should send the message status as a custom com.beeper.message_send_status event.
     message_status_events: false
     # Whether the bridge should send error notices via m.notice events when a message fails to bridge.


### PR DESCRIPTION
that's pretty useful to have them enabled, to match with other bridges supporting spaces