### PR TITLE
fix(synapse/goofys): resolve Jinja2 syntax error in systemd service template

### DIFF
--- a/roles/custom/matrix-synapse/templates/goofys/systemd/matrix-goofys.service.j2
+++ b/roles/custom/matrix-synapse/templates/goofys/systemd/matrix-goofys.service.j2
@@ -4,6 +4,7 @@ Description=Matrix Goofys media store
 {% for service in matrix_synapse_goofys_systemd_required_services_list %}
 Requires={{ service }}
 After={{ service }}
+{% endfor %}
 DefaultDependencies=no
 
 [Service]


### PR DESCRIPTION
Commit 42247411308bd301b1c093ed132be0512368b885 missed a endfor statement in the goofys systemd service unit template. This adds it, avoiding a Jinja2 syntax error when using goofys.