### PR TITLE
Autocreate webhook in Gitlab instance with Hookshot bot

### DIFF
--- a/roles/custom/matrix-bridge-hookshot/defaults/main.yml
+++ b/roles/custom/matrix-bridge-hookshot/defaults/main.yml
@@ -125,7 +125,7 @@ matrix_hookshot_gitlab_instances:
 
 # This will be the "Secret token" you have to enter into all GitLab instances for authentication
 matrix_hookshot_gitlab_webhook_secret: ''
-matrix_hookshot_gitlab_webhook_publicUrl: "{{ matrix_hookshot_urlprefix }}{{ matrix_hookshot_webhook_endpoint }}"
+matrix_hookshot_gitlab_webhook_publicUrl: "{{ matrix_hookshot_urlprefix }}{{ matrix_hookshot_webhook_endpoint }}"  # noqa var-naming
 
 
 matrix_hookshot_figma_enabled: false

--- a/roles/custom/matrix-bridge-hookshot/defaults/main.yml
+++ b/roles/custom/matrix-bridge-hookshot/defaults/main.yml
@@ -125,6 +125,7 @@ matrix_hookshot_gitlab_instances:
 
 # This will be the "Secret token" you have to enter into all GitLab instances for authentication
 matrix_hookshot_gitlab_webhook_secret: ''
+matrix_hookshot_gitlab_webhook_publicUrl: "{{ matrix_hookshot_urlprefix }}{{ matrix_hookshot_webhook_endpoint }}"
 
 
 matrix_hookshot_figma_enabled: false

--- a/roles/custom/matrix-bridge-hookshot/templates/config.yml.j2
+++ b/roles/custom/matrix-bridge-hookshot/templates/config.yml.j2
@@ -47,6 +47,7 @@ gitlab:
   instances: {{ matrix_hookshot_gitlab_instances | to_json }}
   webhook:
     secret: {{ matrix_hookshot_gitlab_webhook_secret | to_json }}
+    publicUrl: {{ matrix_hookshot_gitlab_webhook_publicUrl | to_json }}
 {% endif %}
 {% if matrix_hookshot_figma_enabled %}
 figma:


### PR DESCRIPTION
Currently the webhooks for gitlab need to be manually added in your gitlab instance after adding a project using the hookshot bot. However according to the [Matrix Hookshot Documentation](https://matrix-org.github.io/matrix-hookshot/latest/usage/room_configuration/gitlab_project.html#setting-up) this step can be automated by adding the public url for the webhook endpoint. The needed configuration for the template is stated [here](https://matrix-org.github.io/matrix-hookshot/latest/setup/gitlab.html).