### PR TITLE
Sync grafana datasource and prometheus scrape intervals.

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -4851,6 +4851,9 @@ grafana_provisioning_datasources: |
       'type': 'prometheus',
       'access': 'proxy',
       'url': ('http://' + prometheus_identifier + ':9090'),
+      'jsonData': {
+        'timeInterval': prometheus_config_global_scrape_interval,
+      }
     }] if prometheus_enabled else [])
   }}
 


### PR DESCRIPTION
Fix for empty panels in grafana for some prometheus metrics. Solution from https://github.com/rfmoz/grafana-dashboards/issues/137