### PR TITLE
Revert Grafana Version to v11.1.1-0

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -22,7 +22,7 @@
   version: v4.98-r0-0-0
   name: exim_relay
 - src: git+https://gitlab.com/etke.cc/roles/grafana.git
-  version: v11.1.3-0
+  version: v11.1.1-0
   name: grafana
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-jitsi.git
   version: v9584-1


### PR DESCRIPTION
Latest available tag is 11.1.1 https://hub.docker.com/r/grafana/grafana/tags