### PR TITLE
Update nginx fronting example: http2 config and enable quic+http3

### DIFF
--- a/examples/reverse-proxies/nginx/matrix.conf
+++ b/examples/reverse-proxies/nginx/matrix.conf
@@ -1,7 +1,14 @@
 server {
+    # TODO: once per IP and port you should add `reuseport`, if you don't have that in any other nginx config file, add it here by uncommenting the lines below and commenting the one after with `quic` but without `reuseport`
+    #listen 443 quic reuseport;
+    listen 443 quic;
     listen 443 ssl;
+	# TODO: if you replaced the line above for port 443 and IPv4, you probably want to do the same for port 443 IPv6 by switching the two lines below
+	#listen [::]:443 quic reuseport;
+    listen [::]:443 quic;
     listen [::]:443 ssl;
     http2 on;
+    http3 on;
 
     # TODO: add/remove services and their subdomains if you use/don't use them
     # this example is using hosting something on the base domain and an element web client, so example.com and element.example.com are listed in addition to matrix.example.com
@@ -25,6 +32,9 @@ server {
         # Nginx by default only allows file uploads up to 1M in size
         # Increase client_max_body_size to match max_upload_size defined in homeserver.yaml
         client_max_body_size 50M;
+
+        # required for browsers to direct them to quic port
+        add_header Alt-Svc 'h3=":443"; ma=86400';
     }
 
     # TODO: adapt the path to your ssl certificate for the domains listed on server_name
@@ -38,9 +48,16 @@ server {
 # settings for matrix federation
 server {
     # For the federation port
+    # TODO: once per IP and port you should add `reuseport`, if you don't have that in any other nginx config file, add it here by uncommenting the lines below and commenting the one after with `quic` but without `reuseport`
+    #listen 8448 quic reuseport;
+    listen 8448 quic;
     listen 8448 ssl default_server;
+    # TODO: if you replaced the line above for port 8448 and IPv4, you probably want to do the same for port 8448 IPv6 by switching the two lines below
+    #listen [::]:8448 quic reuseport;
+    listen [::]:8448 quic;
     listen [::]:8448 ssl default_server;
     http2 on;
+    http3 on;
 
     server_name matrix.example.com;
 
@@ -56,6 +73,9 @@ server {
         # Nginx by default only allows file uploads up to 1M in size
         # Increase client_max_body_size to match max_upload_size defined in homeserver.yaml
         client_max_body_size 50M;
+
+		# required for browsers to direct them to quic port
+        add_header Alt-Svc 'h3=":8448"; ma=86400';
     }
     # TODO: adapt the path to your ssl certificate for the domains listed on server_name
     ssl_certificate /etc/letsencrypt/live/example.com/fullchain.pem; # managed by Certbot

--- a/examples/reverse-proxies/nginx/matrix.conf
+++ b/examples/reverse-proxies/nginx/matrix.conf
@@ -1,6 +1,7 @@
 server {
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
 
     # TODO: add/remove services and their subdomains if you use/don't use them
     # this example is using hosting something on the base domain and an element web client, so example.com and element.example.com are listed in addition to matrix.example.com
@@ -37,8 +38,9 @@ server {
 # settings for matrix federation
 server {
     # For the federation port
-    listen 8448 ssl http2 default_server;
-    listen [::]:8448 ssl http2 default_server;
+    listen 8448 ssl default_server;
+    listen [::]:8448 ssl default_server;
+    http2 on;
 
     server_name matrix.example.com;
 


### PR DESCRIPTION
Two things changed (and I'm late to both parties):
1. Previous way of configuring HTTP2 was deprecated a while back, I updated it so less warnings are thrown.
2. I added support for QUIC and HTTP3

Hope the comments explaining the possible `quic reuseport` declaration are understandable, if someone sees this and has a better way of putting it, please do.