### PR TITLE
Add DNS-01 challenge to configuring-playbook-ssl-certificates.md

### DIFF
--- a/docs/configuring-playbook-ssl-certificates.md
+++ b/docs/configuring-playbook-ssl-certificates.md
@@ -99,9 +99,14 @@ aux_file_definitions:
               keyFile: /ssl/privkey.pem
 ```
 
-## Configuring DNS-01 ACME Challenges
+## Using a DNS-01 ACME challenge type, instead of HTTP-01
 
-You can configure traefik to use the DNS-01 validation for Let's Encrypt. This is less frequent than using the normal HTTP challenge, but it can be helpful to hide your public IP from Let's Encrypt logs or if your matrix server is running behind a proxy that prevents the HTTP challenge to succeed. This is an example for how to edit the `vars.yml` file if you're using Cloudflare:
+You can configure Traefik to use the [DNS-01 challenge type](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge) for Let's Encrypt. This is less commonly used than the default [HTTP-01 challenge type](https://letsencrypt.org/docs/challenge-types/#http-01-challenge), but it can be helpful to:
+
+- hide your public IP from Let's Encrypt logs
+- allow you to obtain SSL certificates for servers which are not accessible (via HTTP) from the public internet (and for which the HTTP-01 challenge would fail)
+
+This is an example for how to edit the `vars.yml` file if you're using Cloudflare:
 
 ```yaml
 devture_traefik_config_certificatesResolvers_acme_dnsChallenge_enabled: true
@@ -116,6 +121,6 @@ devture_traefik_environment_variables_additional_variables: |
   LEGO_DISABLE_CNAME_SUPPORT=true
 ```
 
-Make sure to change the value of "provider" to your particular DNS solution, and provide the appropriate environment variables. The full list of supported providers is available here: https://doc.traefik.io/traefik/https/acme/#providers
+Make sure to change the value of "provider" to your particular DNS solution, and provide the appropriate environment variables. The full list of supported providers is available [here](https://doc.traefik.io/traefik/https/acme/#providers).
 
 This example assumes you're using Cloudflare to manage your DNS zone. Note that it requires the use of two tokens: one for reading all zones (`CF_ZONE_API_TOKEN`) and another that must be able to edit the particular domain you're using (`CF_DNS_API_TOKEN`). For security, it's recommended that you create two fine-grained tokens for this purpose, but you might choose to use the same token for both.

--- a/docs/configuring-playbook-ssl-certificates.md
+++ b/docs/configuring-playbook-ssl-certificates.md
@@ -98,3 +98,24 @@ aux_file_definitions:
               certFile: /ssl/cert.pem
               keyFile: /ssl/privkey.pem
 ```
+
+## Configuring DNS-01 ACME Challenges
+
+You can configure traefik to use the DNS-01 validation for Let's Encrypt. This is less frequent than using the normal HTTP challenge, but it can be helpful to hide your public IP from Let's Encrypt logs or if your matrix server is running behind a proxy that prevents the HTTP challenge to succeed. This is an example for how to edit the `vars.yml` file if you're using Cloudflare:
+
+```yaml
+devture_traefik_config_certificatesResolvers_acme_dnsChallenge_enabled: true
+devture_traefik_config_certificatesResolvers_acme_dnsChallenge_provider: "cloudflare"
+devture_traefik_config_certificatesResolvers_acme_dnsChallenge_delayBeforeCheck: 60
+devture_traefik_config_certificatesResolvers_acme_dnsChallenge_resolvers:
+  - "1.1.1.1:53"
+devture_traefik_environment_variables_additional_variables: |
+  CF_API_EMAIL=redacted
+  CF_ZONE_API_TOKEN=redacted
+  CF_DNS_API_TOKEN=redacted
+  LEGO_DISABLE_CNAME_SUPPORT=true
+```
+
+Make sure to change the value of "provider" to your particular DNS solution, and provide the appropriate environment variables. The full list of supported providers is available here: https://doc.traefik.io/traefik/https/acme/#providers
+
+This example assumes you're using Cloudflare to manage your DNS zone. Note that it requires the use of two tokens: one for reading all zones (`CF_ZONE_API_TOKEN`) and another that must be able to edit the particular domain you're using (`CF_DNS_API_TOKEN`). For security, it's recommended that you create two fine-grained tokens for this purpose, but you might choose to use the same token for both.


### PR DESCRIPTION
I found https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/2673#issuecomment-1547488680 to be extremely useful, and I thought it would be good to include it in the official documentation. This configuration worked for me after setting `devture_traefik_config_certificatesResolvers_acme_dnsChallenge_enabled` to true, which was missing on the example of the commenter in the above issue. Also, after taking a look at https://github.com/devture/com.devture.ansible.role.traefik/blob/main/defaults/main.yml#L75-L103 I changed the options to reflect their example.