### PR TITLE
Authenticated Media Configuration options

### DIFF
--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -981,6 +981,11 @@ matrix_synapse_workers_media_repository_workers_container_arguments: []
 # Adjusting this value manually is generally not necessary.
 matrix_synapse_enable_media_repo: "{{ not matrix_synapse_ext_media_repo_enabled and (not matrix_synapse_workers_enabled or (matrix_synapse_workers_enabled_list | selectattr('type', 'equalto', 'media_repository') | list | length == 0)) }}"
 
+# matrix_synapse_enable_authenticated_media controls if authenticated media is enabled. If enabled all "old" media remains accessible over the legacy endpoints but new media is blocked.
+# while this option is enabled all media access and downloads have to be done via authenticated endpoints.
+# FIX_ME_WHEN_DEFAULT_TRUE: This option is going to become set to default true in Synapse at a later date.
+matrix_synapse_enable_authenticated_media: false
+
 # matrix_synapse_media_instance_running_background_jobs populates the `media_instance_running_background_jobs` Synapse configuration used when Synapse workers are in use (`matrix_synapse_workers_enabled`).
 # `media_instance_running_background_jobs` is meant to point to a single media-repository worker, which is dedicated to running background tasks that maintain the media repository.
 # Multiple `media_repository` workers may be enabled. We always pick the first one as the background tasks worker.

--- a/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -1028,6 +1028,13 @@ federation_rr_transactions_per_room_per_second: {{ matrix_synapse_federation_rr_
 #enable_media_repo: false
 enable_media_repo: {{ matrix_synapse_enable_media_repo | to_json }}
 
+# Enable authenticated media.
+# enable_authenticated_media blocks access to new media from the legacy endpoints
+# and freezes the unauthenticated media repo by blocking all downloads that are not using
+# the new authenticated endpoints. If this option is turned off all media reverts to being considered "old"
+
+enable_authenticated_media: {{ matrix_synapse_enable_authenticated_media | to_json }}
+
 # Directory where uploaded images and attachments are stored.
 #
 media_store_path: "/matrix-media-store-parent/{{ matrix_synapse_media_store_directory_name }}"


### PR DESCRIPTION
This PR adds authenticated media configuration options ahead of this setting switching to default True. This is provided to easily enable users to set this to true prematurely before it becomes upstream default or to manually switch this off to extend the support window for clients that are not updated in time.


Edit: Please note that before Synapse 1.114.0rc1 this configuration option is supposedly broken with a workers deployment.
Edit 2: This option is according to reports in TWIM not broken on workers deployments if they are correctly configured but the RC removes the extra configuration burden.