### PR TITLE
Add a global config option for Docker network MTU

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -27,9 +27,6 @@ matrix_playbook_docker_installation_daemon_options_auto:
 
 matrix_playbook_docker_installation_daemon_options_custom: {}
 
-# Default MTU for Docker networks
-matrix_playbook_docker_network_mtu: 1500
-
 # Controls whether to attach Traefik labels to services.
 # This is separate from `devture_traefik_enabled`, because you may wish to disable Traefik installation by the playbook,
 # yet still use Traefik installed in another way.

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -27,6 +27,9 @@ matrix_playbook_docker_installation_daemon_options_auto:
 
 matrix_playbook_docker_installation_daemon_options_custom: {}
 
+# Default MTU for Docker networks
+matrix_playbook_docker_network_mtu: 1500
+
 # Controls whether to attach Traefik labels to services.
 # This is separate from `devture_traefik_enabled`, because you may wish to disable Traefik installation by the playbook,
 # yet still use Traefik installed in another way.

--- a/requirements.yml
+++ b/requirements.yml
@@ -61,7 +61,7 @@
   version: v7.2.5-0
   name: redis
 - src: git+https://github.com/devture/com.devture.ansible.role.systemd_docker_base.git
-  version: v1.2.0-0
+  version: v1.3.0-0
   name: systemd_docker_base
 - src: git+https://github.com/devture/com.devture.ansible.role.systemd_service_manager.git
   version: v1.0.0-4

--- a/requirements.yml
+++ b/requirements.yml
@@ -16,22 +16,22 @@
   version: 129c8590e106b83e6f4c259649a613c6279e937a
   name: docker_sdk_for_python
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-etherpad.git
-  version: v2.2.2-0
+  version: v2.2.2-1
   name: etherpad
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-exim-relay.git
-  version: v4.98-r0-1-0
+  version: v4.98-r0-1-1
   name: exim_relay
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-grafana.git
-  version: v11.1.4-0
+  version: v11.1.4-1
   name: grafana
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-jitsi.git
-  version: v9646-0
+  version: v9646-1
   name: jitsi
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-keydb.git
-  version: v6.3.4-2
+  version: v6.3.4-3
   name: keydb
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-ntfy.git
-  version: v2.10.0-1
+  version: v2.10.0-2
   name: ntfy
 - src: git+https://github.com/devture/com.devture.ansible.role.playbook_help.git
   version: 201c939eed363de269a83ba29784fc3244846048
@@ -43,22 +43,22 @@
   version: ff2fd42e1c1a9e28e3312bbd725395f9c2fc7f16
   name: playbook_state_preserver
 - src: git+https://github.com/devture/com.devture.ansible.role.postgres.git
-  version: v16.3-2
+  version: v16.3-3
   name: postgres
 - src: git+https://github.com/devture/com.devture.ansible.role.postgres_backup.git
-  version: 8c3585fb4857dbac026b2974bb6525289240effb
+  version: ccfd8db07fd8725119f0e06ba5144b8f58a67890
   name: postgres_backup
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-prometheus.git
-  version: v2.54.1-0
+  version: v2.54.1-1
   name: prometheus
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-prometheus-node-exporter.git
-  version: v1.8.2-0
+  version: v1.8.2-1
   name: prometheus_node_exporter
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-prometheus-postgres-exporter.git
-  version: v0.14.0-5
+  version: v0.14.0-6
   name: prometheus_postgres_exporter
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-redis.git
-  version: v7.2.5-0
+  version: v7.2.5-1
   name: redis
 - src: git+https://github.com/devture/com.devture.ansible.role.systemd_docker_base.git
   version: v1.3.0-0
@@ -70,7 +70,7 @@
   version: v1.0.0-0
   name: timesync
 - src: git+https://github.com/devture/com.devture.ansible.role.traefik.git
-  version: v3.1.3-0
+  version: v3.1.3-1
   name: traefik
 - src: git+https://github.com/devture/com.devture.ansible.role.traefik_certs_dumper.git
   version: v2.8.3-4

--- a/roles/custom/matrix-alertmanager-receiver/tasks/install.yml
+++ b/roles/custom/matrix-alertmanager-receiver/tasks/install.yml
@@ -72,6 +72,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_alertmanager_receiver_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-alertmanager-receiver.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-alertmanager-receiver/tasks/install.yml
+++ b/roles/custom/matrix-alertmanager-receiver/tasks/install.yml
@@ -72,8 +72,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_alertmanager_receiver_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-alertmanager-receiver.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-appservice-draupnir-for-all/tasks/setup_install.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/tasks/setup_install.yml
@@ -80,8 +80,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_appservice_draupnir_for_all_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-appservice-draupnir-for-all.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-appservice-draupnir-for-all/tasks/setup_install.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/tasks/setup_install.yml
@@ -80,6 +80,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_appservice_draupnir_for_all_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-appservice-draupnir-for-all.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bot-buscarron/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-buscarron/tasks/setup_install.yml
@@ -97,6 +97,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_buscarron_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-bot-buscarron.service restarted, if necessary
   ansible.builtin.service:

--- a/roles/custom/matrix-bot-buscarron/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-buscarron/tasks/setup_install.yml
@@ -97,8 +97,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_buscarron_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-bot-buscarron.service restarted, if necessary
   ansible.builtin.service:

--- a/roles/custom/matrix-bot-chatgpt/tasks/install.yml
+++ b/roles/custom/matrix-bot-chatgpt/tasks/install.yml
@@ -61,8 +61,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_chatgpt_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-bot-chatgpt.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bot-chatgpt/tasks/install.yml
+++ b/roles/custom/matrix-bot-chatgpt/tasks/install.yml
@@ -61,6 +61,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_chatgpt_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-bot-chatgpt.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bot-draupnir/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-draupnir/tasks/setup_install.yml
@@ -75,6 +75,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_draupnir_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-bot-draupnir.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bot-draupnir/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-draupnir/tasks/setup_install.yml
@@ -75,8 +75,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_draupnir_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-bot-draupnir.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bot-go-neb/tasks/install.yml
+++ b/roles/custom/matrix-bot-go-neb/tasks/install.yml
@@ -48,8 +48,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_go_neb_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-bot-go-neb.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bot-go-neb/tasks/install.yml
+++ b/roles/custom/matrix-bot-go-neb/tasks/install.yml
@@ -48,6 +48,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_go_neb_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-bot-go-neb.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bot-honoroit/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-honoroit/tasks/setup_install.yml
@@ -91,8 +91,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_honoroit_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-bot-honoroit.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bot-honoroit/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-honoroit/tasks/setup_install.yml
@@ -91,6 +91,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_honoroit_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-bot-honoroit.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bot-matrix-registration-bot/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-matrix-registration-bot/tasks/setup_install.yml
@@ -61,8 +61,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_matrix_registration_bot_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-bot-matrix-registration-bot.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bot-matrix-registration-bot/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-matrix-registration-bot/tasks/setup_install.yml
@@ -61,6 +61,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_matrix_registration_bot_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-bot-matrix-registration-bot.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bot-matrix-reminder-bot/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-matrix-reminder-bot/tasks/setup_install.yml
@@ -89,8 +89,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_matrix_reminder_bot_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-bot-matrix-reminder-bot.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bot-matrix-reminder-bot/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-matrix-reminder-bot/tasks/setup_install.yml
@@ -89,6 +89,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_matrix_reminder_bot_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-bot-matrix-reminder-bot.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bot-maubot/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-maubot/tasks/setup_install.yml
@@ -75,8 +75,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_maubot_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-bot-maubot.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bot-maubot/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-maubot/tasks/setup_install.yml
@@ -75,6 +75,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_maubot_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-bot-maubot.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bot-mjolnir/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-mjolnir/tasks/setup_install.yml
@@ -64,6 +64,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_mjolnir_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-bot-mjolnir.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bot-mjolnir/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-mjolnir/tasks/setup_install.yml
@@ -64,8 +64,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_mjolnir_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-bot-mjolnir.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bot-postmoogle/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-postmoogle/tasks/setup_install.yml
@@ -84,6 +84,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_postmoogle_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-bot-postmoogle.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bot-postmoogle/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-postmoogle/tasks/setup_install.yml
@@ -84,8 +84,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_postmoogle_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-bot-postmoogle.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-appservice-discord/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-appservice-discord/tasks/setup_install.yml
@@ -109,8 +109,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_appservice_discord_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-appservice-discord.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-appservice-discord/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-appservice-discord/tasks/setup_install.yml
@@ -109,6 +109,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_appservice_discord_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-appservice-discord.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-appservice-irc/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-appservice-irc/tasks/setup_install.yml
@@ -193,8 +193,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_appservice_irc_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-appservice-irc.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-appservice-irc/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-appservice-irc/tasks/setup_install.yml
@@ -193,6 +193,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_appservice_irc_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-appservice-irc.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-appservice-kakaotalk/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-appservice-kakaotalk/tasks/setup_install.yml
@@ -102,6 +102,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_appservice_kakaotalk_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-appservice-kakaotalk-node.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-appservice-kakaotalk/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-appservice-kakaotalk/tasks/setup_install.yml
@@ -102,8 +102,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_appservice_kakaotalk_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-appservice-kakaotalk-node.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-appservice-slack/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-appservice-slack/tasks/setup_install.yml
@@ -87,6 +87,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_appservice_slack_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-appservice-slack support files installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-appservice-slack/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-appservice-slack/tasks/setup_install.yml
@@ -87,8 +87,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_appservice_slack_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-appservice-slack support files installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-appservice-webhooks/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-appservice-webhooks/tasks/setup_install.yml
@@ -86,6 +86,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_appservice_webhooks_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-appservice-webhooks support files installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-appservice-webhooks/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-appservice-webhooks/tasks/setup_install.yml
@@ -86,8 +86,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_appservice_webhooks_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-appservice-webhooks support files installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-beeper-linkedin/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-beeper-linkedin/tasks/setup_install.yml
@@ -88,8 +88,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_beeper_linkedin_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-beeper-linkedin.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-beeper-linkedin/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-beeper-linkedin/tasks/setup_install.yml
@@ -88,6 +88,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_beeper_linkedin_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-beeper-linkedin.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-go-skype-bridge/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-go-skype-bridge/tasks/setup_install.yml
@@ -131,6 +131,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_go_skype_bridge_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-go-skype-bridge.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-go-skype-bridge/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-go-skype-bridge/tasks/setup_install.yml
@@ -131,8 +131,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_go_skype_bridge_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-go-skype-bridge.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-heisenbridge/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-heisenbridge/tasks/setup_install.yml
@@ -44,6 +44,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_heisenbridge_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-heisenbridge.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-heisenbridge/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-heisenbridge/tasks/setup_install.yml
@@ -44,8 +44,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_heisenbridge_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-heisenbridge.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-hookshot/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-hookshot/tasks/setup_install.yml
@@ -112,6 +112,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_hookshot_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure mautrix-hookshot support files installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-hookshot/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-hookshot/tasks/setup_install.yml
@@ -112,8 +112,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_hookshot_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure mautrix-hookshot support files installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mautrix-discord/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-discord/tasks/setup_install.yml
@@ -98,8 +98,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_discord_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-mautrix-discord.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mautrix-discord/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-discord/tasks/setup_install.yml
@@ -98,6 +98,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_discord_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-mautrix-discord.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mautrix-facebook/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-facebook/tasks/setup_install.yml
@@ -128,6 +128,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_facebook_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-mautrix-facebook.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mautrix-facebook/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-facebook/tasks/setup_install.yml
@@ -128,8 +128,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_facebook_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-mautrix-facebook.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mautrix-gmessages/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-gmessages/tasks/setup_install.yml
@@ -147,8 +147,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_gmessages_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-mautrix-gmessages.service restarted, if necessary
   ansible.builtin.service:

--- a/roles/custom/matrix-bridge-mautrix-gmessages/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-gmessages/tasks/setup_install.yml
@@ -147,6 +147,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_gmessages_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-mautrix-gmessages.service restarted, if necessary
   ansible.builtin.service:

--- a/roles/custom/matrix-bridge-mautrix-googlechat/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-googlechat/tasks/setup_install.yml
@@ -128,8 +128,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_googlechat_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-mautrix-googlechat.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mautrix-googlechat/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-googlechat/tasks/setup_install.yml
@@ -128,6 +128,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_googlechat_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-mautrix-googlechat.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mautrix-hangouts/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-hangouts/tasks/setup_install.yml
@@ -128,6 +128,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_hangouts_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-mautrix-hangouts.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mautrix-hangouts/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-hangouts/tasks/setup_install.yml
@@ -128,8 +128,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_hangouts_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-mautrix-hangouts.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mautrix-instagram/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-instagram/tasks/setup_install.yml
@@ -80,6 +80,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_instagram_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-mautrix-instagram.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mautrix-instagram/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-instagram/tasks/setup_install.yml
@@ -80,8 +80,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_instagram_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-mautrix-instagram.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mautrix-meta-instagram/tasks/install.yml
+++ b/roles/custom/matrix-bridge-mautrix-meta-instagram/tasks/install.yml
@@ -107,8 +107,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_meta_instagram_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure mautrix-meta-instagram.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mautrix-meta-instagram/tasks/install.yml
+++ b/roles/custom/matrix-bridge-mautrix-meta-instagram/tasks/install.yml
@@ -107,6 +107,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_meta_instagram_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure mautrix-meta-instagram.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mautrix-meta-messenger/tasks/install.yml
+++ b/roles/custom/matrix-bridge-mautrix-meta-messenger/tasks/install.yml
@@ -107,8 +107,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_meta_messenger_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure mautrix-meta-messenger.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mautrix-meta-messenger/tasks/install.yml
+++ b/roles/custom/matrix-bridge-mautrix-meta-messenger/tasks/install.yml
@@ -107,6 +107,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_meta_messenger_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure mautrix-meta-messenger.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mautrix-signal/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-signal/tasks/setup_install.yml
@@ -141,8 +141,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_signal_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-mautrix-signal.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mautrix-signal/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-signal/tasks/setup_install.yml
@@ -141,6 +141,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_signal_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-mautrix-signal.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mautrix-slack/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-slack/tasks/setup_install.yml
@@ -98,8 +98,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_slack_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-mautrix-slack.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mautrix-slack/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-slack/tasks/setup_install.yml
@@ -98,6 +98,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_slack_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-mautrix-slack.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mautrix-telegram/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-telegram/tasks/setup_install.yml
@@ -153,6 +153,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_telegram_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-mautrix-telegram.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mautrix-telegram/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-telegram/tasks/setup_install.yml
@@ -153,8 +153,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_telegram_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-mautrix-telegram.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mautrix-twitter/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-twitter/tasks/setup_install.yml
@@ -82,6 +82,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_twitter_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-mautrix-twitter.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mautrix-twitter/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-twitter/tasks/setup_install.yml
@@ -82,8 +82,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_twitter_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-mautrix-twitter.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mautrix-whatsapp/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-whatsapp/tasks/setup_install.yml
@@ -141,8 +141,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_whatsapp_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-mautrix-whatsapp.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mautrix-whatsapp/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-whatsapp/tasks/setup_install.yml
@@ -141,6 +141,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_whatsapp_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-mautrix-whatsapp.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mautrix-wsproxy/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-wsproxy/tasks/setup_install.yml
@@ -96,8 +96,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_wsproxy_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-mautrix-wsproxy.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mautrix-wsproxy/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-wsproxy/tasks/setup_install.yml
@@ -96,6 +96,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_wsproxy_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-mautrix-wsproxy.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mx-puppet-discord/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-discord/tasks/setup_install.yml
@@ -117,6 +117,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mx_puppet_discord_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-mx-puppet-discord.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mx-puppet-discord/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-discord/tasks/setup_install.yml
@@ -117,8 +117,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mx_puppet_discord_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-mx-puppet-discord.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mx-puppet-groupme/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-groupme/tasks/setup_install.yml
@@ -118,8 +118,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mx_puppet_groupme_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-mx-puppet-groupme.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mx-puppet-groupme/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-groupme/tasks/setup_install.yml
@@ -118,6 +118,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mx_puppet_groupme_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-mx-puppet-groupme.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mx-puppet-instagram/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-instagram/tasks/setup_install.yml
@@ -97,6 +97,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mx_puppet_instagram_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-mx-puppet-instagram.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mx-puppet-instagram/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-instagram/tasks/setup_install.yml
@@ -97,8 +97,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mx_puppet_instagram_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-mx-puppet-instagram.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mx-puppet-slack/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-slack/tasks/setup_install.yml
@@ -128,6 +128,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mx_puppet_slack_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-mx-puppet-slack.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mx-puppet-slack/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-slack/tasks/setup_install.yml
@@ -128,8 +128,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mx_puppet_slack_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-mx-puppet-slack.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mx-puppet-steam/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-steam/tasks/setup_install.yml
@@ -118,8 +118,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mx_puppet_steam_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-mx-puppet-steam.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mx-puppet-steam/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-steam/tasks/setup_install.yml
@@ -118,6 +118,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mx_puppet_steam_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-mx-puppet-steam.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mx-puppet-twitter/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-twitter/tasks/setup_install.yml
@@ -128,8 +128,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mx_puppet_twitter_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-mx-puppet-twitter.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-mx-puppet-twitter/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-twitter/tasks/setup_install.yml
@@ -128,6 +128,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mx_puppet_twitter_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-mx-puppet-twitter.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-sms/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-sms/tasks/setup_install.yml
@@ -51,6 +51,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_sms_bridge_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-sms-bridge.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-sms/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-sms/tasks/setup_install.yml
@@ -51,8 +51,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_sms_bridge_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-sms-bridge.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-wechat/tasks/install.yml
+++ b/roles/custom/matrix-bridge-wechat/tasks/install.yml
@@ -113,6 +113,8 @@
   community.general.docker_network:
     name: "{{ matrix_wechat_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-wechat.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-wechat/tasks/install.yml
+++ b/roles/custom/matrix-bridge-wechat/tasks/install.yml
@@ -113,8 +113,7 @@
   community.general.docker_network:
     name: "{{ matrix_wechat_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-wechat.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-cactus-comments-client/tasks/install.yml
+++ b/roles/custom/matrix-cactus-comments-client/tasks/install.yml
@@ -76,8 +76,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_cactus_comments_client_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-cactus-comments-client.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-cactus-comments-client/tasks/install.yml
+++ b/roles/custom/matrix-cactus-comments-client/tasks/install.yml
@@ -76,6 +76,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_cactus_comments_client_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-cactus-comments-client.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-client-cinny/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-cinny/tasks/setup_install.yml
@@ -69,6 +69,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_client_cinny_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-client-cinny.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-client-cinny/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-cinny/tasks/setup_install.yml
@@ -69,8 +69,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_client_cinny_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-client-cinny.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-client-element/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-element/tasks/setup_install.yml
@@ -103,8 +103,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_client_element_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-client-element.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-client-element/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-element/tasks/setup_install.yml
@@ -103,6 +103,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_client_element_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-client-element.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-client-hydrogen/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-hydrogen/tasks/setup_install.yml
@@ -81,8 +81,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_client_hydrogen_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-client-hydrogen.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-client-hydrogen/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-hydrogen/tasks/setup_install.yml
@@ -81,6 +81,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_client_hydrogen_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-client-hydrogen.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-client-schildichat/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-schildichat/tasks/setup_install.yml
@@ -102,8 +102,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_client_schildichat_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-client-schildichat.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-client-schildichat/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-schildichat/tasks/setup_install.yml
@@ -102,6 +102,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_client_schildichat_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-client-schildichat.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-conduit/tasks/setup_install.yml
+++ b/roles/custom/matrix-conduit/tasks/setup_install.yml
@@ -39,8 +39,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_conduit_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure Conduit container image is pulled
   community.docker.docker_image:

--- a/roles/custom/matrix-conduit/tasks/setup_install.yml
+++ b/roles/custom/matrix-conduit/tasks/setup_install.yml
@@ -39,6 +39,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_conduit_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure Conduit container image is pulled
   community.docker.docker_image:

--- a/roles/custom/matrix-corporal/tasks/setup_install.yml
+++ b/roles/custom/matrix-corporal/tasks/setup_install.yml
@@ -71,8 +71,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_corporal_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-corporal.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-corporal/tasks/setup_install.yml
+++ b/roles/custom/matrix-corporal/tasks/setup_install.yml
@@ -71,6 +71,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_corporal_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-corporal.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-coturn/tasks/setup_install.yml
+++ b/roles/custom/matrix-coturn/tasks/setup_install.yml
@@ -99,6 +99,8 @@
   community.docker.docker_network:
     name: "{{ matrix_coturn_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-coturn.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-coturn/tasks/setup_install.yml
+++ b/roles/custom/matrix-coturn/tasks/setup_install.yml
@@ -99,8 +99,7 @@
   community.docker.docker_network:
     name: "{{ matrix_coturn_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-coturn.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-dendrite/tasks/setup_install.yml
+++ b/roles/custom/matrix-dendrite/tasks/setup_install.yml
@@ -112,6 +112,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_dendrite_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure Dendrite support files installed
   ansible.builtin.template:

--- a/roles/custom/matrix-dendrite/tasks/setup_install.yml
+++ b/roles/custom/matrix-dendrite/tasks/setup_install.yml
@@ -112,8 +112,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_dendrite_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure Dendrite support files installed
   ansible.builtin.template:

--- a/roles/custom/matrix-dimension/tasks/setup_install.yml
+++ b/roles/custom/matrix-dimension/tasks/setup_install.yml
@@ -133,6 +133,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_dimension_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-dimension.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-dimension/tasks/setup_install.yml
+++ b/roles/custom/matrix-dimension/tasks/setup_install.yml
@@ -133,8 +133,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_dimension_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-dimension.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-dynamic-dns/tasks/setup_install.yml
+++ b/roles/custom/matrix-dynamic-dns/tasks/setup_install.yml
@@ -61,6 +61,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_dynamic_dns_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-dynamic-dns.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-dynamic-dns/tasks/setup_install.yml
+++ b/roles/custom/matrix-dynamic-dns/tasks/setup_install.yml
@@ -61,8 +61,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_dynamic_dns_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-dynamic-dns.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-email2matrix/tasks/setup_install.yml
+++ b/roles/custom/matrix-email2matrix/tasks/setup_install.yml
@@ -61,6 +61,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_email2matrix_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-email2matrix.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-email2matrix/tasks/setup_install.yml
+++ b/roles/custom/matrix-email2matrix/tasks/setup_install.yml
@@ -61,8 +61,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_email2matrix_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-email2matrix.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-ldap-registration-proxy/tasks/setup_install.yml
+++ b/roles/custom/matrix-ldap-registration-proxy/tasks/setup_install.yml
@@ -56,6 +56,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_ldap_registration_proxy_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-ldap-registration-proxy.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-ldap-registration-proxy/tasks/setup_install.yml
+++ b/roles/custom/matrix-ldap-registration-proxy/tasks/setup_install.yml
@@ -56,8 +56,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_ldap_registration_proxy_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-ldap-registration-proxy.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-ma1sd/tasks/setup_install.yml
+++ b/roles/custom/matrix-ma1sd/tasks/setup_install.yml
@@ -137,6 +137,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_ma1sd_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-ma1sd.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-ma1sd/tasks/setup_install.yml
+++ b/roles/custom/matrix-ma1sd/tasks/setup_install.yml
@@ -137,8 +137,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_ma1sd_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-ma1sd.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-media-repo/tasks/setup_install.yml
+++ b/roles/custom/matrix-media-repo/tasks/setup_install.yml
@@ -139,8 +139,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_media_repo_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure media-repo service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-media-repo/tasks/setup_install.yml
+++ b/roles/custom/matrix-media-repo/tasks/setup_install.yml
@@ -139,6 +139,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_media_repo_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure media-repo service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-pantalaimon/tasks/install.yml
+++ b/roles/custom/matrix-pantalaimon/tasks/install.yml
@@ -59,6 +59,8 @@
   community.general.docker_network:
     name: "{{ matrix_pantalaimon_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-pantalaimon.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-pantalaimon/tasks/install.yml
+++ b/roles/custom/matrix-pantalaimon/tasks/install.yml
@@ -59,8 +59,7 @@
   community.general.docker_network:
     name: "{{ matrix_pantalaimon_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-pantalaimon.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-prometheus-nginxlog-exporter/tasks/setup_install.yml
+++ b/roles/custom/matrix-prometheus-nginxlog-exporter/tasks/setup_install.yml
@@ -45,6 +45,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_prometheus_nginxlog_exporter_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-prometheus-nginxlog-exporter.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-prometheus-nginxlog-exporter/tasks/setup_install.yml
+++ b/roles/custom/matrix-prometheus-nginxlog-exporter/tasks/setup_install.yml
@@ -45,8 +45,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_prometheus_nginxlog_exporter_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-prometheus-nginxlog-exporter.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-rageshake/tasks/install.yml
+++ b/roles/custom/matrix-rageshake/tasks/install.yml
@@ -70,8 +70,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_rageshake_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-rageshake.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-rageshake/tasks/install.yml
+++ b/roles/custom/matrix-rageshake/tasks/install.yml
@@ -70,6 +70,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_rageshake_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-rageshake.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-registration/tasks/setup_install.yml
+++ b/roles/custom/matrix-registration/tasks/setup_install.yml
@@ -112,8 +112,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_registration_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-registration.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-registration/tasks/setup_install.yml
+++ b/roles/custom/matrix-registration/tasks/setup_install.yml
@@ -112,6 +112,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_registration_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-registration.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-sliding-sync/tasks/install.yml
+++ b/roles/custom/matrix-sliding-sync/tasks/install.yml
@@ -63,6 +63,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_sliding_sync_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-sliding-sync.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-sliding-sync/tasks/install.yml
+++ b/roles/custom/matrix-sliding-sync/tasks/install.yml
@@ -63,8 +63,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_sliding_sync_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-sliding-sync.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-static-files/tasks/install.yml
+++ b/roles/custom/matrix-static-files/tasks/install.yml
@@ -86,8 +86,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_static_files_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-static-files systemd service is installed
   ansible.builtin.template:

--- a/roles/custom/matrix-static-files/tasks/install.yml
+++ b/roles/custom/matrix-static-files/tasks/install.yml
@@ -86,6 +86,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_static_files_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-static-files systemd service is installed
   ansible.builtin.template:

--- a/roles/custom/matrix-sygnal/tasks/install.yml
+++ b/roles/custom/matrix-sygnal/tasks/install.yml
@@ -44,6 +44,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_sygnal_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-sygnal.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-sygnal/tasks/install.yml
+++ b/roles/custom/matrix-sygnal/tasks/install.yml
@@ -44,8 +44,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_sygnal_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-sygnal.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-synapse-admin/tasks/setup_install.yml
+++ b/roles/custom/matrix-synapse-admin/tasks/setup_install.yml
@@ -69,8 +69,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_synapse_admin_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-synapse-admin.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-synapse-admin/tasks/setup_install.yml
+++ b/roles/custom/matrix-synapse-admin/tasks/setup_install.yml
@@ -69,6 +69,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_synapse_admin_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-synapse-admin.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-synapse-auto-compressor/tasks/install.yml
+++ b/roles/custom/matrix-synapse-auto-compressor/tasks/install.yml
@@ -81,6 +81,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_synapse_auto_compressor_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-synapse-auto-compressor systemd service and timer are installed
   ansible.builtin.template:

--- a/roles/custom/matrix-synapse-auto-compressor/tasks/install.yml
+++ b/roles/custom/matrix-synapse-auto-compressor/tasks/install.yml
@@ -81,8 +81,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_synapse_auto_compressor_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-synapse-auto-compressor systemd service and timer are installed
   ansible.builtin.template:

--- a/roles/custom/matrix-synapse-reverse-proxy-companion/tasks/setup_install.yml
+++ b/roles/custom/matrix-synapse-reverse-proxy-companion/tasks/setup_install.yml
@@ -44,8 +44,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_synapse_reverse_proxy_companion_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-synapse-reverse-proxy-companion.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-synapse-reverse-proxy-companion/tasks/setup_install.yml
+++ b/roles/custom/matrix-synapse-reverse-proxy-companion/tasks/setup_install.yml
@@ -44,6 +44,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_synapse_reverse_proxy_companion_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-synapse-reverse-proxy-companion.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-synapse-usage-exporter/tasks/setup_install.yml
+++ b/roles/custom/matrix-synapse-usage-exporter/tasks/setup_install.yml
@@ -69,6 +69,8 @@
   community.general.docker_network:
     name: "{{ matrix_synapse_usage_exporter_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure synapse-usage-exporter service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-synapse-usage-exporter/tasks/setup_install.yml
+++ b/roles/custom/matrix-synapse-usage-exporter/tasks/setup_install.yml
@@ -69,8 +69,7 @@
   community.general.docker_network:
     name: "{{ matrix_synapse_usage_exporter_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure synapse-usage-exporter service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-synapse/tasks/synapse/setup_install.yml
+++ b/roles/custom/matrix-synapse/tasks/synapse/setup_install.yml
@@ -120,6 +120,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_synapse_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure Synapse support files installed
   ansible.builtin.template:

--- a/roles/custom/matrix-synapse/tasks/synapse/setup_install.yml
+++ b/roles/custom/matrix-synapse/tasks/synapse/setup_install.yml
@@ -120,8 +120,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_synapse_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure Synapse support files installed
   ansible.builtin.template:

--- a/roles/custom/matrix-user-verification-service/tasks/setup_install.yml
+++ b/roles/custom/matrix-user-verification-service/tasks/setup_install.yml
@@ -60,8 +60,7 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_user_verification_service_container_network }}"
     driver: bridge
-    driver_options:
-      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
+    driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure matrix-user-verification-service.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-user-verification-service/tasks/setup_install.yml
+++ b/roles/custom/matrix-user-verification-service/tasks/setup_install.yml
@@ -60,6 +60,8 @@
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_user_verification_service_container_network }}"
     driver: bridge
+    driver_options:
+      com.docker.network.driver.mtu: "{{ matrix_playbook_docker_network_mtu }}"
 
 - name: Ensure matrix-user-verification-service.service installed
   ansible.builtin.template:


### PR DESCRIPTION
When using this playbook in...annoying network environments, it may be required to set the MTU of Docker networks to a lower value than the default of 1500. Also annoyingly, it is not sufficient to set a default MTU using Docker daemon options, as that gets ignored when custom networks are created.

This PR introduces a new config option `matrix_playbook_docker_network_mtu`, that needs to get referenced *every time* a new Docker network is created. I currently do not know a simpler way to achieve this outcome, but I'm open to suggestions 😃 

Please let me know if you'd like the option to be named differently.