### PR TITLE
Update `matrix-appservice-irc` version

### DIFF
--- a/roles/custom/matrix-bridge-appservice-irc/defaults/main.yml
+++ b/roles/custom/matrix-bridge-appservice-irc/defaults/main.yml
@@ -12,7 +12,7 @@ matrix_appservice_irc_docker_src_files_path: "{{ matrix_base_data_path }}/appser
 # matrix_appservice_irc_version used to contain the full Docker image tag (e.g. `release-X.X.X`).
 # It's a bare version number now. We try to somewhat retain compatibility below.
 # renovate: datasource=docker depName=docker.io/matrixdotorg/matrix-appservice-irc
-matrix_appservice_irc_version: 1.0.1
+matrix_appservice_irc_version: 2.0.1
 matrix_appservice_irc_docker_image: "{{ matrix_container_global_registry_prefix }}matrixdotorg/matrix-appservice-irc:{{ matrix_appservice_irc_docker_image_tag }}"
 matrix_appservice_irc_docker_image_tag: "{{ 'latest' if matrix_appservice_irc_version == 'latest' else ('release-' + matrix_appservice_irc_version) }}"
 matrix_appservice_irc_docker_image_force_pull: "{{ matrix_appservice_irc_docker_image.endswith(':latest') }}"


### PR DESCRIPTION
The update to `3.0` brings with it that it now uses MediaProxy.