### PR TITLE
Add temp suffix for container name to avoid conflict

### DIFF
--- a/roles/custom/matrix-media-repo/tasks/setup_install.yml
+++ b/roles/custom/matrix-media-repo/tasks/setup_install.yml
@@ -89,7 +89,7 @@
         cmd: |
           {{ devture_systemd_docker_base_host_command_docker }} run
           --rm
-          --name={{ matrix_media_repo_identifier }}
+          --name={{ matrix_media_repo_identifier }}-temp
           --user={{ matrix_synapse_uid }}:{{ matrix_synapse_gid }}
           --cap-drop=ALL
           --mount type=bind,src={{ matrix_media_repo_config_path }},dst=/config
@@ -104,7 +104,7 @@
         cmd: |
           {{ devture_systemd_docker_base_host_command_docker }} run
           --rm
-          --name={{ matrix_media_repo_identifier }}
+          --name={{ matrix_media_repo_identifier }}-temp
           --user={{ matrix_synapse_uid }}:{{ matrix_synapse_gid }}
           --cap-drop=ALL
           --mount type=bind,src={{ matrix_media_repo_config_path }},dst=/config


### PR DESCRIPTION
Fixes issue #3516

Already running container had the same name `matrix_media_repo`.
Creating signing key using temporary container was not possible.

Adding suffix `-temp` to name made it work.