### PR TITLE
Revert Mjolnir version to 1.7.0 due to severe breakage.

### DIFF
--- a/roles/custom/matrix-bot-mjolnir/defaults/main.yml
+++ b/roles/custom/matrix-bot-mjolnir/defaults/main.yml
@@ -5,7 +5,7 @@
 matrix_bot_mjolnir_enabled: true
 
 # renovate: datasource=docker depName=matrixdotorg/mjolnir
-matrix_bot_mjolnir_version: "v1.8.1"
+matrix_bot_mjolnir_version: "v1.7.0"
 
 matrix_bot_mjolnir_container_image_self_build: false
 matrix_bot_mjolnir_container_image_self_build_repo: "https://github.com/matrix-org/mjolnir.git"


### PR DESCRIPTION
github.com/matrix-org/mjolnir/issues/531

Any user not using E2EE support and therefore using User password auth is unable to launch updated Mjolnir. Due to this severe breakage its recomended to revert to before this bug is introduced until its fixed.