### PR TITLE
Update Cinny nginx.conf.j2 to include service worker rewrite

### DIFF
--- a/roles/custom/matrix-client-cinny/templates/nginx.conf.j2
+++ b/roles/custom/matrix-client-cinny/templates/nginx.conf.j2
@@ -59,6 +59,7 @@ http {
 			rewrite ^/manifest.json$ /manifest.json break;
 
 			rewrite ^.*/olm.wasm$ /olm.wasm break;
+            rewrite ^/sw.js$ /sw.js break;
 			rewrite ^/pdf.worker.min.js$ /pdf.worker.min.js break;
 
 			rewrite ^/public/(.*)$ /public/$1 break;


### PR DESCRIPTION
Cinny has added a service worker to support authenticated media and requires /sw,js to resolve to the serviceworker js file