### PR TITLE
feat: support mautrix bridgev2 / megabridge APIs

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -1963,6 +1963,8 @@ matrix_mautrix_whatsapp_container_labels_traefik_tls_certResolver: "{{ devture_t
 matrix_mautrix_whatsapp_container_labels_metrics_middleware_basic_auth_enabled: "{{ matrix_metrics_exposure_http_basic_auth_enabled }}"
 matrix_mautrix_whatsapp_container_labels_metrics_middleware_basic_auth_users: "{{ matrix_metrics_exposure_http_basic_auth_users }}"
 
+matrix_mautrix_whatsapp_container_labels_bridgev2_traefik_hostname: "{{ matrix_server_fqn_matrix }}"
+
 matrix_mautrix_whatsapp_systemd_required_services_list_auto: |
   {{
     matrix_addons_homeserver_systemd_services_list
@@ -1971,6 +1973,7 @@ matrix_mautrix_whatsapp_systemd_required_services_list_auto: |
   }}
 
 matrix_mautrix_whatsapp_appservice_token: "{{ '%s' | format(matrix_homeserver_generic_secret_key) | password_hash('sha512', 'whats.as.token', rounds=655555) | to_uuid }}"
+matrix_mautrix_whatsapp_appservice_bridgev2_enabled: false
 
 matrix_mautrix_whatsapp_homeserver_address: "{{ matrix_addons_homeserver_client_api_url }}"
 matrix_mautrix_whatsapp_homeserver_token: "{{ '%s' | format(matrix_homeserver_generic_secret_key) | password_hash('sha512', 'whats.hs.token', rounds=655555) | to_uuid }}"

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -5581,6 +5581,15 @@ matrix_static_files_file_matrix_client_property_m_tile_server_map_style_url: "{{
 
 matrix_static_files_file_matrix_server_property_m_server: "{{ matrix_server_fqn_matrix_federation }}:{{ matrix_federation_public_port }}"
 
+# mautrix-manager auto-configuration disabled by default
+matrix_static_files_file_matrix_mautrix_enabled: false
+matrix_static_files_file_matrix_mautrix_property_fi_mau_bridges:
+  - "https://bridges.example.com/signal"
+  # TODO populate with enabled bridges
+
+matrix_static_files_file_matrix_mautrix_property_fi_mau_external_bridge_servers:
+  []
+
 matrix_static_files_scheme: "{{ 'https' if matrix_playbook_ssl_enabled else 'http' }}"
 
 matrix_static_files_self_check_hostname_matrix: "{{ matrix_server_fqn_matrix }}"

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -1491,7 +1491,10 @@ matrix_mautrix_meta_messenger_container_labels_traefik_tls_certResolver: "{{ dev
 matrix_mautrix_meta_messenger_container_labels_metrics_middleware_basic_auth_enabled: "{{ matrix_metrics_exposure_http_basic_auth_enabled }}"
 matrix_mautrix_meta_messenger_container_labels_metrics_middleware_basic_auth_users: "{{ matrix_metrics_exposure_http_basic_auth_users }}"
 
+matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_hostname: "{{ matrix_server_fqn_matrix }}"
+
 matrix_mautrix_meta_messenger_appservice_token: "{{ '%s' | format(matrix_homeserver_generic_secret_key) | password_hash('sha512', 'mau.meta.fb.as', rounds=655555) | to_uuid }}"
+matrix_mautrix_meta_messenger_appservice_bridgev2_enabled: false
 
 matrix_mautrix_meta_messenger_homeserver_address: "{{ matrix_addons_homeserver_client_api_url }}"
 

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -1568,7 +1568,10 @@ matrix_mautrix_meta_instagram_container_labels_traefik_tls_certResolver: "{{ dev
 matrix_mautrix_meta_instagram_container_labels_metrics_middleware_basic_auth_enabled: "{{ matrix_metrics_exposure_http_basic_auth_enabled }}"
 matrix_mautrix_meta_instagram_container_labels_metrics_middleware_basic_auth_users: "{{ matrix_metrics_exposure_http_basic_auth_users }}"
 
+matrix_mautrix_meta_instagram_container_labels_bridgev2_traefik_hostname: "{{ matrix_server_fqn_matrix }}"
+
 matrix_mautrix_meta_instagram_appservice_token: "{{ '%s' | format(matrix_homeserver_generic_secret_key) | password_hash('sha512', 'mau.meta.ig.as', rounds=655555) | to_uuid }}"
+matrix_mautrix_meta_instagram_appservice_bridgev2_enabled: false
 
 matrix_mautrix_meta_instagram_homeserver_address: "{{ matrix_addons_homeserver_client_api_url }}"
 

--- a/roles/custom/matrix-bridge-mautrix-meta-instagram/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-meta-instagram/defaults/main.yml
@@ -55,6 +55,17 @@ matrix_mautrix_meta_instagram_container_labels_metrics_middleware_basic_auth_ena
 # See: https://doc.traefik.io/traefik/middlewares/http/basicauth/#users
 matrix_mautrix_meta_instagram_container_labels_metrics_middleware_basic_auth_users: ''
 
+# Controls whether labels will be added that expose the bridge's bridgev2 API endpoints
+matrix_mautrix_meta_instagram_container_labels_bridgev2_enabled: "{{ matrix_mautrix_meta_instagram_appservice_bridgev2_enabled }}"
+matrix_mautrix_meta_instagram_container_labels_bridgev2_traefik_hostname: ""
+# Following two variables should be RegEx-escaped, see https://doc.traefik.io/traefik/middlewares/http/replacepathregex/
+matrix_mautrix_meta_instagram_container_labels_bridgev2_traefik_stripprefix: "/_matrix/{{ matrix_mautrix_meta_instagram_identifier }}"
+matrix_mautrix_meta_instagram_container_labels_bridgev2_traefik_rule: "Host(`{{ matrix_mautrix_meta_instagram_container_labels_bridgev2_traefik_hostname }}`) && PathPrefix(`{{ matrix_mautrix_meta_instagram_container_labels_bridgev2_traefik_stripprefix }}`)"
+matrix_mautrix_meta_instagram_container_labels_bridgev2_traefik_priority: 0
+matrix_mautrix_meta_instagram_container_labels_bridgev2_traefik_entrypoints: "{{ matrix_mautrix_meta_instagram_container_labels_traefik_entrypoints }}"
+matrix_mautrix_meta_instagram_container_labels_bridgev2_traefik_tls: "{{ matrix_mautrix_meta_instagram_container_labels_metrics_traefik_entrypoints != 'web' }}"
+matrix_mautrix_meta_instagram_container_labels_bridgev2_traefik_tls_certResolver: "{{ matrix_mautrix_meta_instagram_container_labels_traefik_tls_certResolver }}"  # noqa var-naming
+
 # matrix_mautrix_meta_instagram_container_labels_additional_labels contains a multiline string with additional labels to add to the container label file.
 # See `../templates/labels.j2` for details.
 #
@@ -143,6 +154,10 @@ matrix_mautrix_meta_instagram_appservice_database_uri: |-
   }}
 
 matrix_mautrix_meta_instagram_appservice_token: ''
+
+# Whether to make public the bridgev2 API endpoints.
+# See https://spec.mau.fi/megabridge/
+matrix_mautrix_meta_instagram_appservice_bridgev2_enabled: false
 
 # Controls which service this bridge is for.
 # Valid options:

--- a/roles/custom/matrix-bridge-mautrix-meta-instagram/tasks/validate_config.yml
+++ b/roles/custom/matrix-bridge-mautrix-meta-instagram/tasks/validate_config.yml
@@ -8,6 +8,7 @@
   with_items:
     - {'name': 'matrix_mautrix_meta_instagram_metrics_proxying_hostname', when: "{{ matrix_mautrix_meta_instagram_metrics_proxying_enabled }}"}
     - {'name': 'matrix_mautrix_meta_instagram_metrics_proxying_path_prefix', when: "{{ matrix_mautrix_meta_instagram_metrics_proxying_enabled }}"}
+    - {'name': 'matrix_mautrix_meta_instagram_container_labels_bridgev2_traefik_hostname', when: "{{ matrix_mautrix_meta_instagram_container_labels_bridgev2_enabled }}"}
     - {'name': 'matrix_mautrix_meta_instagram_appservice_token', when: true}
     - {'name': 'matrix_mautrix_meta_instagram_homeserver_token', when: true}
     - {'name': 'matrix_mautrix_meta_instagram_container_network', when: true}

--- a/roles/custom/matrix-bridge-mautrix-meta-instagram/templates/labels.j2
+++ b/roles/custom/matrix-bridge-mautrix-meta-instagram/templates/labels.j2
@@ -43,6 +43,38 @@ traefik.http.routers.{{ matrix_mautrix_meta_instagram_identifier }}-metrics.tls.
 {% endif %}
 
 
+{% if matrix_mautrix_meta_instagram_container_labels_bridgev2_enabled %}
+############################################################
+#                                                          #
+# Appservice Bridgev2 API                                  #
+#                                                          #
+############################################################
+
+traefik.http.middlewares.{{ matrix_mautrix_meta_instagram_identifier }}-bridgev2-stripprefix.stripprefix.prefixes={{ matrix_mautrix_meta_instagram_container_labels_bridgev2_traefik_stripprefix }}
+traefik.http.routers.{{ matrix_mautrix_meta_instagram_identifier }}-bridgev2.middlewares={{ matrix_mautrix_meta_instagram_identifier }}-bridgev2-stripprefix
+
+traefik.http.routers.{{ matrix_mautrix_meta_instagram_identifier }}-bridgev2.rule={{ matrix_mautrix_meta_instagram_container_labels_bridgev2_traefik_rule }}
+
+{% if matrix_mautrix_meta_instagram_container_labels_bridgev2_traefik_priority | int > 0 %}
+traefik.http.routers.{{ matrix_mautrix_meta_instagram_identifier }}-bridgev2.priority={{ matrix_mautrix_meta_instagram_container_labels_bridgev2_traefik_priority }}
+{% endif %}
+
+traefik.http.routers.{{ matrix_mautrix_meta_instagram_identifier }}-bridgev2.service={{ matrix_mautrix_meta_instagram_identifier }}-appservice
+traefik.http.routers.{{ matrix_mautrix_meta_instagram_identifier }}-bridgev2.entrypoints={{ matrix_mautrix_meta_instagram_container_labels_bridgev2_traefik_entrypoints }}
+
+traefik.http.routers.{{ matrix_mautrix_meta_instagram_identifier }}-bridgev2.tls={{ matrix_mautrix_meta_instagram_container_labels_bridgev2_traefik_tls | to_json }}
+{% if matrix_mautrix_meta_instagram_container_labels_bridgev2_traefik_tls %}
+traefik.http.routers.{{ matrix_mautrix_meta_instagram_identifier }}-bridgev2.tls.certResolver={{ matrix_mautrix_meta_instagram_container_labels_bridgev2_traefik_tls_certResolver }}
+{% endif %}
+
+############################################################
+#                                                          #
+# /Appservice Bridgev2 API                                 #
+#                                                          #
+############################################################
+{% endif %}
+
+
 {% endif %}
 
 {{ matrix_mautrix_meta_instagram_container_labels_additional_labels }}

--- a/roles/custom/matrix-bridge-mautrix-meta-messenger/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-meta-messenger/defaults/main.yml
@@ -59,9 +59,8 @@ matrix_mautrix_meta_messenger_container_labels_metrics_middleware_basic_auth_use
 matrix_mautrix_meta_messenger_container_labels_bridgev2_enabled: "{{ matrix_mautrix_meta_messenger_appservice_bridgev2_enabled }}"
 matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_hostname: ""
 # Following two variables should be RegEx-escaped, see https://doc.traefik.io/traefik/middlewares/http/replacepathregex/
-matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_path_external: "/_matrix/{{ matrix_mautrix_meta_messenger_identifier }}/provision"
-matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_path_internal: "/_matrix/provision"
-matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_rule: "Host(`{{ matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_hostname }}`) && PathPrefix(`{{ matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_path_external }}`)"
+matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_stripprefix: "/_matrix/{{ matrix_mautrix_meta_messenger_identifier }}"
+matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_rule: "Host(`{{ matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_hostname }}`) && PathPrefix(`{{ matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_stripprefix }}`)"
 matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_priority: 0
 matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_entrypoints: "{{ matrix_mautrix_meta_messenger_container_labels_traefik_entrypoints }}"
 matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_tls: "{{ matrix_mautrix_meta_messenger_container_labels_metrics_traefik_entrypoints != 'web' }}"

--- a/roles/custom/matrix-bridge-mautrix-meta-messenger/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-meta-messenger/defaults/main.yml
@@ -55,6 +55,18 @@ matrix_mautrix_meta_messenger_container_labels_metrics_middleware_basic_auth_ena
 # See: https://doc.traefik.io/traefik/middlewares/http/basicauth/#users
 matrix_mautrix_meta_messenger_container_labels_metrics_middleware_basic_auth_users: ''
 
+# Controls whether labels will be added that expose the bridge's bridgev2 API endpoints
+matrix_mautrix_meta_messenger_container_labels_bridgev2_enabled: "{{ matrix_mautrix_meta_messenger_appservice_bridgev2_enabled }}"
+matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_hostname: ""
+# Following two variables should be RegEx-escaped, see https://doc.traefik.io/traefik/middlewares/http/replacepathregex/
+matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_path_external: "/_matrix/{{ matrix_mautrix_meta_messenger_identifier }}/provision"
+matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_path_internal: "/_matrix/provision"
+matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_rule: "Host(`{{ matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_hostname }}`) && PathPrefix(`{{ matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_path_external }}`)"
+matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_priority: 0
+matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_entrypoints: "{{ matrix_mautrix_meta_messenger_container_labels_traefik_entrypoints }}"
+matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_tls: "{{ matrix_mautrix_meta_messenger_container_labels_metrics_traefik_entrypoints != 'web' }}"
+matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_tls_certResolver: "{{ matrix_mautrix_meta_messenger_container_labels_traefik_tls_certResolver }}"  # noqa var-naming
+
 # matrix_mautrix_meta_messenger_container_labels_additional_labels contains a multiline string with additional labels to add to the container label file.
 # See `../templates/labels.j2` for details.
 #
@@ -143,6 +155,10 @@ matrix_mautrix_meta_messenger_appservice_database_uri: |-
   }}
 
 matrix_mautrix_meta_messenger_appservice_token: ''
+
+# Whether to make public the bridgev2 API endpoints.
+# See https://spec.mau.fi/megabridge/
+matrix_mautrix_meta_messenger_appservice_bridgev2_enabled: false
 
 # Controls which service this bridge is for.
 # Valid options:

--- a/roles/custom/matrix-bridge-mautrix-meta-messenger/tasks/validate_config.yml
+++ b/roles/custom/matrix-bridge-mautrix-meta-messenger/tasks/validate_config.yml
@@ -8,6 +8,7 @@
   with_items:
     - {'name': 'matrix_mautrix_meta_messenger_metrics_proxying_hostname', when: "{{ matrix_mautrix_meta_messenger_metrics_proxying_enabled }}"}
     - {'name': 'matrix_mautrix_meta_messenger_metrics_proxying_path_prefix', when: "{{ matrix_mautrix_meta_messenger_metrics_proxying_enabled }}"}
+    - {'name': 'matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_hostname', when: "{{ matrix_mautrix_meta_messenger_metrics_proxying_enabled }}"}
     - {'name': 'matrix_mautrix_meta_messenger_appservice_token', when: true}
     - {'name': 'matrix_mautrix_meta_messenger_homeserver_token', when: true}
     - {'name': 'matrix_mautrix_meta_messenger_container_network', when: true}

--- a/roles/custom/matrix-bridge-mautrix-meta-messenger/tasks/validate_config.yml
+++ b/roles/custom/matrix-bridge-mautrix-meta-messenger/tasks/validate_config.yml
@@ -8,7 +8,7 @@
   with_items:
     - {'name': 'matrix_mautrix_meta_messenger_metrics_proxying_hostname', when: "{{ matrix_mautrix_meta_messenger_metrics_proxying_enabled }}"}
     - {'name': 'matrix_mautrix_meta_messenger_metrics_proxying_path_prefix', when: "{{ matrix_mautrix_meta_messenger_metrics_proxying_enabled }}"}
-    - {'name': 'matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_hostname', when: "{{ matrix_mautrix_meta_messenger_metrics_proxying_enabled }}"}
+    - {'name': 'matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_hostname', when: "{{ matrix_mautrix_meta_messenger_container_labels_bridgev2_enabled }}"}
     - {'name': 'matrix_mautrix_meta_messenger_appservice_token', when: true}
     - {'name': 'matrix_mautrix_meta_messenger_homeserver_token', when: true}
     - {'name': 'matrix_mautrix_meta_messenger_container_network', when: true}

--- a/roles/custom/matrix-bridge-mautrix-meta-messenger/templates/labels.j2
+++ b/roles/custom/matrix-bridge-mautrix-meta-messenger/templates/labels.j2
@@ -43,6 +43,39 @@ traefik.http.routers.{{ matrix_mautrix_meta_messenger_identifier }}-metrics.tls.
 {% endif %}
 
 
+{% if matrix_mautrix_meta_messenger_container_labels_bridgev2_enabled %}
+############################################################
+#                                                          #
+# Appservice Bridgev2 API                                  #
+#                                                          #
+############################################################
+
+traefik.http.middlewares.{{ matrix_mautrix_meta_messenger_identifier }}-bridgev2-replacepathregex.replacepathregex.regex=^{{ matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_path_external }}/(.*)
+traefik.http.middlewares.{{ matrix_mautrix_meta_messenger_identifier }}-bridgev2-replacepathregex.replacepathregex.replacement={{ matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_path_internal }}/$1
+traefik.http.routers.{{ matrix_mautrix_meta_messenger_identifier }}-bridgev2.middlewares={{ matrix_mautrix_meta_messenger_identifier }}-bridgev2-replacepathregex
+
+traefik.http.routers.{{ matrix_mautrix_meta_messenger_identifier }}-bridgev2.rule={{ matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_rule }}
+
+{% if matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_priority | int > 0 %}
+traefik.http.routers.{{ matrix_mautrix_meta_messenger_identifier }}-bridgev2.priority={{ matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_priority }}
+{% endif %}
+
+traefik.http.routers.{{ matrix_mautrix_meta_messenger_identifier }}-bridgev2.service={{ matrix_mautrix_meta_messenger_identifier }}-appservice
+traefik.http.routers.{{ matrix_mautrix_meta_messenger_identifier }}-bridgev2.entrypoints={{ matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_entrypoints }}
+
+traefik.http.routers.{{ matrix_mautrix_meta_messenger_identifier }}-bridgev2.tls={{ matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_tls | to_json }}
+{% if matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_tls %}
+traefik.http.routers.{{ matrix_mautrix_meta_messenger_identifier }}-bridgev2.tls.certResolver={{ matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_tls_certResolver }}
+{% endif %}
+
+############################################################
+#                                                          #
+# /Appservice Bridgev2 API                                 #
+#                                                          #
+############################################################
+{% endif %}
+
+
 {% endif %}
 
 {{ matrix_mautrix_meta_messenger_container_labels_additional_labels }}

--- a/roles/custom/matrix-bridge-mautrix-meta-messenger/templates/labels.j2
+++ b/roles/custom/matrix-bridge-mautrix-meta-messenger/templates/labels.j2
@@ -50,9 +50,8 @@ traefik.http.routers.{{ matrix_mautrix_meta_messenger_identifier }}-metrics.tls.
 #                                                          #
 ############################################################
 
-traefik.http.middlewares.{{ matrix_mautrix_meta_messenger_identifier }}-bridgev2-replacepathregex.replacepathregex.regex=^{{ matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_path_external }}/(.*)
-traefik.http.middlewares.{{ matrix_mautrix_meta_messenger_identifier }}-bridgev2-replacepathregex.replacepathregex.replacement={{ matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_path_internal }}/$1
-traefik.http.routers.{{ matrix_mautrix_meta_messenger_identifier }}-bridgev2.middlewares={{ matrix_mautrix_meta_messenger_identifier }}-bridgev2-replacepathregex
+traefik.http.middlewares.{{ matrix_mautrix_meta_messenger_identifier }}-bridgev2-stripprefix.stripprefix.prefixes={{ matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_stripprefix }}
+traefik.http.routers.{{ matrix_mautrix_meta_messenger_identifier }}-bridgev2.middlewares={{ matrix_mautrix_meta_messenger_identifier }}-bridgev2-stripprefix
 
 traefik.http.routers.{{ matrix_mautrix_meta_messenger_identifier }}-bridgev2.rule={{ matrix_mautrix_meta_messenger_container_labels_bridgev2_traefik_rule }}
 

--- a/roles/custom/matrix-bridge-mautrix-whatsapp/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-whatsapp/defaults/main.yml
@@ -4,6 +4,8 @@
 
 matrix_mautrix_whatsapp_enabled: true
 
+matrix_mautrix_whatsapp_identifier: matrix-mautrix-whatsapp
+
 matrix_mautrix_whatsapp_container_image_self_build: false
 matrix_mautrix_whatsapp_container_image_self_build_repo: "https://mau.dev/mautrix/whatsapp.git"
 matrix_mautrix_whatsapp_container_image_self_build_branch: "{{ 'master' if matrix_mautrix_whatsapp_version == 'latest' else matrix_mautrix_whatsapp_version }}"
@@ -24,6 +26,10 @@ matrix_mautrix_whatsapp_docker_src_files_path: "{{ matrix_mautrix_whatsapp_base_
 matrix_mautrix_whatsapp_homeserver_address: ""
 matrix_mautrix_whatsapp_homeserver_domain: "{{ matrix_domain }}"
 matrix_mautrix_whatsapp_appservice_address: "http://matrix-mautrix-whatsapp:8080"
+
+# Whether to make public the bridgev2 API endpoints.
+# See https://spec.mau.fi/megabridge/
+matrix_mautrix_whatsapp_appservice_bridgev2_enabled: false
 
 matrix_mautrix_whatsapp_extev_polls: false
 
@@ -54,6 +60,17 @@ matrix_mautrix_whatsapp_container_labels_metrics_traefik_tls_certResolver: "{{ m
 matrix_mautrix_whatsapp_container_labels_metrics_middleware_basic_auth_enabled: false
 # See: https://doc.traefik.io/traefik/middlewares/http/basicauth/#users
 matrix_mautrix_whatsapp_container_labels_metrics_middleware_basic_auth_users: ''
+
+# Controls whether labels will be added that expose the bridge's bridgev2 API endpoints
+matrix_mautrix_whatsapp_container_labels_bridgev2_enabled: "{{ matrix_mautrix_whatsapp_appservice_bridgev2_enabled }}"
+matrix_mautrix_whatsapp_container_labels_bridgev2_traefik_hostname: ""
+# Following two variables should be RegEx-escaped, see https://doc.traefik.io/traefik/middlewares/http/replacepathregex/
+matrix_mautrix_whatsapp_container_labels_bridgev2_traefik_stripprefix: "/_matrix/{{ matrix_mautrix_whatsapp_identifier }}"
+matrix_mautrix_whatsapp_container_labels_bridgev2_traefik_rule: "Host(`{{ matrix_mautrix_whatsapp_container_labels_bridgev2_traefik_hostname }}`) && PathPrefix(`{{ matrix_mautrix_whatsapp_container_labels_bridgev2_traefik_stripprefix }}`)"
+matrix_mautrix_whatsapp_container_labels_bridgev2_traefik_priority: 0
+matrix_mautrix_whatsapp_container_labels_bridgev2_traefik_entrypoints: "{{ matrix_mautrix_whatsapp_container_labels_traefik_entrypoints }}"
+matrix_mautrix_whatsapp_container_labels_bridgev2_traefik_tls: "{{ matrix_mautrix_whatsapp_container_labels_metrics_traefik_entrypoints != 'web' }}"
+matrix_mautrix_whatsapp_container_labels_bridgev2_traefik_tls_certResolver: "{{ matrix_mautrix_whatsapp_container_labels_traefik_tls_certResolver }}"  # noqa var-naming
 
 # matrix_mautrix_whatsapp_container_labels_additional_labels contains a multiline string with additional labels to add to the container label file.
 # See `../templates/labels.j2` for details.

--- a/roles/custom/matrix-bridge-mautrix-whatsapp/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-whatsapp/defaults/main.yml
@@ -25,7 +25,7 @@ matrix_mautrix_whatsapp_docker_src_files_path: "{{ matrix_mautrix_whatsapp_base_
 
 matrix_mautrix_whatsapp_homeserver_address: ""
 matrix_mautrix_whatsapp_homeserver_domain: "{{ matrix_domain }}"
-matrix_mautrix_whatsapp_appservice_address: "http://matrix-mautrix-whatsapp:8080"
+matrix_mautrix_whatsapp_appservice_address: "http://{{ matrix_mautrix_whatsapp_identifier }}:8080"
 
 # Whether to make public the bridgev2 API endpoints.
 # See https://spec.mau.fi/megabridge/

--- a/roles/custom/matrix-bridge-mautrix-whatsapp/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-whatsapp/tasks/setup_install.yml
@@ -22,7 +22,7 @@
               caller: "{{ role_path | basename }}"
               engine_variable_name: 'matrix_mautrix_whatsapp_database_engine'
               engine_old: 'sqlite'
-              systemd_services_to_stop: ['matrix-mautrix-whatsapp.service']
+              systemd_services_to_stop: ['{{ matrix_mautrix_whatsapp_identifier }}.service']
               pgloader_options: ['--with "quote identifiers"']
 
         - ansible.builtin.set_fact:
@@ -89,7 +89,7 @@
 
 - name: (Data relocation) Ensure matrix-mautrix-whatsapp.service is stopped
   ansible.builtin.service:
-    name: matrix-mautrix-whatsapp
+    name: "{{ matrix_mautrix_whatsapp_identifier }}"
     state: stopped
     enabled: false
     daemon_reload: true
@@ -146,12 +146,12 @@
 - name: Ensure matrix-mautrix-whatsapp.service installed
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-mautrix-whatsapp.service.j2"
-    dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-mautrix-whatsapp.service"
+    dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ matrix_mautrix_whatsapp_identifier }}.service"
     mode: 0644
 
 - name: Ensure matrix-mautrix-whatsapp.service restarted, if necessary
   ansible.builtin.service:
-    name: "matrix-mautrix-whatsapp.service"
+    name: "{{ matrix_mautrix_whatsapp_identifier }}.service"
     state: restarted
     daemon_reload: true
   when: "matrix_mautrix_whatsapp_requires_restart | bool"

--- a/roles/custom/matrix-bridge-mautrix-whatsapp/tasks/setup_uninstall.yml
+++ b/roles/custom/matrix-bridge-mautrix-whatsapp/tasks/setup_uninstall.yml
@@ -2,19 +2,19 @@
 
 - name: Check existence of matrix-mautrix-whatsapp service
   ansible.builtin.stat:
-    path: "{{ devture_systemd_docker_base_systemd_path }}/matrix-mautrix-whatsapp.service"
+    path: "{{ devture_systemd_docker_base_systemd_path }}/{{ matrix_mautrix_whatsapp_identifier }}.service"
   register: matrix_mautrix_whatsapp_service_stat
 
 - when: matrix_mautrix_whatsapp_service_stat.stat.exists | bool
   block:
     - name: Ensure matrix-mautrix-whatsapp is stopped
       ansible.builtin.service:
-        name: matrix-mautrix-whatsapp
+        name: "{{ matrix_mautrix_whatsapp_identifier }}"
         state: stopped
         enabled: false
         daemon_reload: true
 
     - name: Ensure matrix-mautrix-whatsapp.service doesn't exist
       ansible.builtin.file:
-        path: "{{ devture_systemd_docker_base_systemd_path }}/matrix-mautrix-whatsapp.service"
+        path: "{{ devture_systemd_docker_base_systemd_path }}/{{ matrix_mautrix_whatsapp_identifier }}.service"
         state: absent

--- a/roles/custom/matrix-bridge-mautrix-whatsapp/tasks/validate_config.yml
+++ b/roles/custom/matrix-bridge-mautrix-whatsapp/tasks/validate_config.yml
@@ -10,6 +10,7 @@
     - {'name': 'matrix_mautrix_whatsapp_homeserver_address', when: true}
     - {'name': 'matrix_mautrix_whatsapp_homeserver_token', when: true}
     - {'name': 'matrix_mautrix_whatsapp_database_hostname', when: "{{ matrix_mautrix_whatsapp_database_engine == 'postgres' }}"}
+    - {'name': 'matrix_mautrix_whatsapp_container_labels_bridgev2_traefik_hostname', when: "{{ matrix_mautrix_whatsapp_container_labels_bridgev2_enabled }}"}
 
 - name: (Deprecation) Catch and report renamed settings
   ansible.builtin.fail:

--- a/roles/custom/matrix-bridge-mautrix-whatsapp/templates/labels.j2
+++ b/roles/custom/matrix-bridge-mautrix-whatsapp/templates/labels.j2
@@ -6,7 +6,7 @@ traefik.docker.network={{ matrix_mautrix_whatsapp_container_labels_traefik_docke
 {% endif %}
 
 traefik.http.services.{{ matrix_mautrix_whatsapp_identifier }}-appservice.loadbalancer.server.port=8080
-traefik.http.services.matrix-mautrix-whatsapp-metrics.loadbalancer.server.port=8001
+traefik.http.services.{{ matrix_mautrix_whatsapp_identifier }}-metrics.loadbalancer.server.port=8001
 
 {% if matrix_mautrix_whatsapp_container_labels_metrics_enabled %}
 ############################################################
@@ -16,22 +16,22 @@ traefik.http.services.matrix-mautrix-whatsapp-metrics.loadbalancer.server.port=8
 ############################################################
 
 {% if matrix_mautrix_whatsapp_container_labels_metrics_middleware_basic_auth_enabled %}
-traefik.http.middlewares.matrix-mautrix-whatsapp-metrics-basic-auth.basicauth.users={{ matrix_mautrix_whatsapp_container_labels_metrics_middleware_basic_auth_users }}
-traefik.http.routers.matrix-mautrix-whatsapp-metrics.middlewares=matrix-mautrix-whatsapp-metrics-basic-auth
+traefik.http.middlewares.{{ matrix_mautrix_whatsapp_identifier }}-metrics-basic-auth.basicauth.users={{ matrix_mautrix_whatsapp_container_labels_metrics_middleware_basic_auth_users }}
+traefik.http.routers.{{ matrix_mautrix_whatsapp_identifier }}-metrics.middlewares={{ matrix_mautrix_whatsapp_identifier }}-metrics-basic-auth
 {% endif %}
 
-traefik.http.routers.matrix-mautrix-whatsapp-metrics.rule={{ matrix_mautrix_whatsapp_container_labels_metrics_traefik_rule }}
+traefik.http.routers.{{ matrix_mautrix_whatsapp_identifier }}-metrics.rule={{ matrix_mautrix_whatsapp_container_labels_metrics_traefik_rule }}
 
 {% if matrix_mautrix_whatsapp_container_labels_metrics_traefik_priority | int > 0 %}
-traefik.http.routers.matrix-mautrix-whatsapp-metrics.priority={{ matrix_mautrix_whatsapp_container_labels_metrics_traefik_priority }}
+traefik.http.routers.{{ matrix_mautrix_whatsapp_identifier }}-metrics.priority={{ matrix_mautrix_whatsapp_container_labels_metrics_traefik_priority }}
 {% endif %}
 
-traefik.http.routers.matrix-mautrix-whatsapp-metrics.service=matrix-mautrix-whatsapp-metrics
-traefik.http.routers.matrix-mautrix-whatsapp-metrics.entrypoints={{ matrix_mautrix_whatsapp_container_labels_metrics_traefik_entrypoints }}
+traefik.http.routers.{{ matrix_mautrix_whatsapp_identifier }}-metrics.service={{ matrix_mautrix_whatsapp_identifier }}-metrics
+traefik.http.routers.{{ matrix_mautrix_whatsapp_identifier }}-metrics.entrypoints={{ matrix_mautrix_whatsapp_container_labels_metrics_traefik_entrypoints }}
 
-traefik.http.routers.matrix-mautrix-whatsapp-metrics.tls={{ matrix_mautrix_whatsapp_container_labels_metrics_traefik_tls | to_json }}
+traefik.http.routers.{{ matrix_mautrix_whatsapp_identifier }}-metrics.tls={{ matrix_mautrix_whatsapp_container_labels_metrics_traefik_tls | to_json }}
 {% if matrix_mautrix_whatsapp_container_labels_metrics_traefik_tls %}
-traefik.http.routers.matrix-mautrix-whatsapp-metrics.tls.certResolver={{ matrix_mautrix_whatsapp_container_labels_metrics_traefik_tls_certResolver }}
+traefik.http.routers.{{ matrix_mautrix_whatsapp_identifier }}-metrics.tls.certResolver={{ matrix_mautrix_whatsapp_container_labels_metrics_traefik_tls_certResolver }}
 {% endif %}
 
 ############################################################

--- a/roles/custom/matrix-bridge-mautrix-whatsapp/templates/labels.j2
+++ b/roles/custom/matrix-bridge-mautrix-whatsapp/templates/labels.j2
@@ -5,6 +5,7 @@ traefik.enable=true
 traefik.docker.network={{ matrix_mautrix_whatsapp_container_labels_traefik_docker_network }}
 {% endif %}
 
+traefik.http.services.{{ matrix_mautrix_whatsapp_identifier }}-appservice.loadbalancer.server.port=8080
 traefik.http.services.matrix-mautrix-whatsapp-metrics.loadbalancer.server.port=8001
 
 {% if matrix_mautrix_whatsapp_container_labels_metrics_enabled %}
@@ -40,6 +41,36 @@ traefik.http.routers.matrix-mautrix-whatsapp-metrics.tls.certResolver={{ matrix_
 ############################################################
 {% endif %}
 
+{% if matrix_mautrix_whatsapp_container_labels_bridgev2_enabled %}
+############################################################
+#                                                          #
+# Appservice Bridgev2 API                                  #
+#                                                          #
+############################################################
+
+traefik.http.middlewares.{{ matrix_mautrix_whatsapp_identifier }}-bridgev2-stripprefix.stripprefix.prefixes={{ matrix_mautrix_whatsapp_container_labels_bridgev2_traefik_stripprefix }}
+traefik.http.routers.{{ matrix_mautrix_whatsapp_identifier }}-bridgev2.middlewares={{ matrix_mautrix_whatsapp_identifier }}-bridgev2-stripprefix
+
+traefik.http.routers.{{ matrix_mautrix_whatsapp_identifier }}-bridgev2.rule={{ matrix_mautrix_whatsapp_container_labels_bridgev2_traefik_rule }}
+
+{% if matrix_mautrix_whatsapp_container_labels_bridgev2_traefik_priority | int > 0 %}
+traefik.http.routers.{{ matrix_mautrix_whatsapp_identifier }}-bridgev2.priority={{ matrix_mautrix_whatsapp_container_labels_bridgev2_traefik_priority }}
+{% endif %}
+
+traefik.http.routers.{{ matrix_mautrix_whatsapp_identifier }}-bridgev2.service={{ matrix_mautrix_whatsapp_identifier }}-appservice
+traefik.http.routers.{{ matrix_mautrix_whatsapp_identifier }}-bridgev2.entrypoints={{ matrix_mautrix_whatsapp_container_labels_bridgev2_traefik_entrypoints }}
+
+traefik.http.routers.{{ matrix_mautrix_whatsapp_identifier }}-bridgev2.tls={{ matrix_mautrix_whatsapp_container_labels_bridgev2_traefik_tls | to_json }}
+{% if matrix_mautrix_whatsapp_container_labels_bridgev2_traefik_tls %}
+traefik.http.routers.{{ matrix_mautrix_whatsapp_identifier }}-bridgev2.tls.certResolver={{ matrix_mautrix_whatsapp_container_labels_bridgev2_traefik_tls_certResolver }}
+{% endif %}
+
+############################################################
+#                                                          #
+# /Appservice Bridgev2 API                                 #
+#                                                          #
+############################################################
+{% endif %}
 
 {% endif %}
 

--- a/roles/custom/matrix-bridge-mautrix-whatsapp/templates/systemd/matrix-mautrix-whatsapp.service.j2
+++ b/roles/custom/matrix-bridge-mautrix-whatsapp/templates/systemd/matrix-mautrix-whatsapp.service.j2
@@ -13,12 +13,12 @@ DefaultDependencies=no
 [Service]
 Type=simple
 Environment="HOME={{ devture_systemd_docker_base_systemd_unit_home_path }}"
-ExecStartPre=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} stop --time={{ devture_systemd_docker_base_container_stop_grace_time_seconds }} matrix-mautrix-whatsapp 2>/dev/null || true'
-ExecStartPre=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} rm matrix-mautrix-whatsapp 2>/dev/null || true'
+ExecStartPre=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} stop --time={{ devture_systemd_docker_base_container_stop_grace_time_seconds }} {{ matrix_mautrix_whatsapp_identifier }} 2>/dev/null || true'
+ExecStartPre=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} rm {{ matrix_mautrix_whatsapp_identifier }} 2>/dev/null || true'
 
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			--rm \
-			--name=matrix-mautrix-whatsapp \
+			--name={{ matrix_mautrix_whatsapp_identifier }} \
 			--log-driver=none \
 			--user={{ matrix_user_uid }}:{{ matrix_user_gid }} \
 			--cap-drop=ALL \
@@ -34,16 +34,16 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			/usr/bin/mautrix-whatsapp -c /config/config.yaml -r /config/registration.yaml
 
 {% for network in matrix_mautrix_whatsapp_container_additional_networks %}
-ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-mautrix-whatsapp
+ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} {{ matrix_mautrix_whatsapp_identifier }}
 {% endfor %}
 
-ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-mautrix-whatsapp
+ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach {{ matrix_mautrix_whatsapp_identifier }}
 
-ExecStop=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} stop --time={{ devture_systemd_docker_base_container_stop_grace_time_seconds }} matrix-mautrix-whatsapp 2>/dev/null || true'
-ExecStop=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} rm matrix-mautrix-whatsapp 2>/dev/null || true'
+ExecStop=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} stop --time={{ devture_systemd_docker_base_container_stop_grace_time_seconds }} {{ matrix_mautrix_whatsapp_identifier }} 2>/dev/null || true'
+ExecStop=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} rm {{ matrix_mautrix_whatsapp_identifier }} 2>/dev/null || true'
 Restart=always
 RestartSec=30
-SyslogIdentifier=matrix-mautrix-whatsapp
+SyslogIdentifier={{ matrix_mautrix_whatsapp_identifier }}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/custom/matrix-static-files/defaults/main.yml
+++ b/roles/custom/matrix-static-files/defaults/main.yml
@@ -332,6 +332,65 @@ matrix_static_files_file_matrix_support_configuration: "{{ matrix_static_files_f
 #                                                                      #
 ########################################################################
 
+########################################################################
+#                                                                      #
+# Related to /.well-known/matrix/mautrix                               #
+#                                                                      #
+########################################################################
+
+# Controls whether a `/.well-known/matrix/mautrix` file is generated and used at all.
+# For details about this file, see mautrix/manager auto-configuration section : https://github.com/mautrix/manager#auto-configuration
+#
+# This is not enabled by default, as for it to be useful, other information is necessary.
+# See `matrix_static_files_file_matrix_mautrix_property_fi_mau_bridges`, `matrix_static_files_file_matrix_mautrix_property_fi_mau_external_bridge_servers`, etc.
+matrix_static_files_file_matrix_mautrix_enabled: false
+
+# Controls the fi.mau.bridges property in the /.well-known/matrix/mautrix file
+# It indexes local bridges implementing the bridgev2 API
+# Example entry : https://bridges.example.com/signal
+matrix_static_files_file_matrix_mautrix_property_fi_mau_bridges: []
+
+# Controls the fi.mau.external_bridge_servers property in the /.well-known/matrix/mautrix file
+# It indexes remote servers with bridges implementing the bridgev2 API
+# Example entry : anotherserver.example.org
+matrix_static_files_file_matrix_mautrix_property_fi_mau_external_bridge_servers:
+  []
+
+# Default /.well-known/matrix/mautrix configuration template which covers the generic use case.
+# You can customize it by controlling the various variables inside it.
+#
+# For a more advanced customization, you can extend the default (see `matrix_static_files_file_matrix_mautrix_configuration_extension_json`)
+# or completely replace this variable with your own template.
+matrix_static_files_file_matrix_mautrix_configuration_json: "{{ lookup('template', 'templates/public/.well-known/matrix/mautrix.j2') }}"
+
+# Your custom JSON configuration for /.well-known/matrix/mautrix should go to `matrix_static_files_file_matrix_mautrix_configuration_extension_json`.
+# This configuration extends the default starting configuration (`matrix_static_files_file_matrix_mautrix_configuration_extension_json`).
+#
+# You can override individual variables from the default configuration, or introduce new ones.
+#
+# If you need something more special, you can take full control by
+# completely redefining `matrix_static_files_file_matrix_mautrix_configuration_json`.
+#
+# Example configuration extension follows:
+#
+# matrix_static_files_file_matrix_mautrix_configuration_extension_json: |
+#   {
+#     "m.another": "value",
+#     "m.yet_another": 3
+#   }
+matrix_static_files_file_matrix_mautrix_configuration_extension_json: "{}"
+
+matrix_static_files_file_matrix_mautrix_configuration_extension: "{{ matrix_static_files_file_matrix_mautrix_configuration_extension_json | from_json if matrix_static_files_file_matrix_mautrix_configuration_extension_json | from_json is mapping else {} }}"
+
+# Holds the final /.well-known/matrix/mautrix configuration (a combination of the default and its extension).
+# You most likely don't need to touch this variable. Instead, see `matrix_static_files_file_matrix_mautrix_configuration_json` or `matrix_static_files_file_matrix_mautrix_configuration_extension_json`.
+matrix_static_files_file_matrix_mautrix_configuration: "{{ matrix_static_files_file_matrix_mautrix_configuration_json | combine(matrix_static_files_file_matrix_mautrix_configuration_extension, recursive=True) }}"
+
+########################################################################
+#                                                                      #
+# /Related to /.well-known/matrix/mautrix                              #
+#                                                                      #
+########################################################################
 
 ########################################################################
 #                                                                      #

--- a/roles/custom/matrix-static-files/tasks/install.yml
+++ b/roles/custom/matrix-static-files/tasks/install.yml
@@ -52,6 +52,10 @@
       dest: "{{ matrix_static_files_public_well_known_matrix_path }}/support"
       when: "{{ matrix_static_files_file_matrix_support_enabled }}"
 
+    - content: "{{ matrix_static_files_file_matrix_mautrix_configuration | to_nice_json }}"
+      dest: "{{ matrix_static_files_public_well_known_matrix_path }}/mautrix"
+      when: "{{ matrix_static_files_file_matrix_mautrix_enabled }}"
+
     # This one will not be deleted if `matrix_static_files_file_index_html_enabled` flips to `false`.
     # See the comment for `matrix_static_files_file_index_html_enabled` to learn why.
     - content: "{{ matrix_static_files_file_index_html_template }}"
@@ -69,6 +73,12 @@
     path: "{{ matrix_static_files_public_well_known_matrix_path }}/support"
     state: absent
   when: "not matrix_static_files_file_matrix_support_enabled | bool"
+
+- name: Ensure /.well-known/matrix/mautrix file deleted if not enabled
+  ansible.builtin.file:
+    path: "{{ matrix_static_files_public_well_known_matrix_path }}/mautrix"
+    state: absent
+  when: "not matrix_static_files_file_matrix_mautrix_enabled | bool"
 
 - name: Ensure matrix-static-files container image is pulled
   community.docker.docker_image:

--- a/roles/custom/matrix-static-files/tasks/self_check_well_known.yml
+++ b/roles/custom/matrix-static-files/tasks/self_check_well_known.yml
@@ -24,6 +24,21 @@
       ansible.builtin.set_fact:
         well_known_file_checks: "{{ well_known_file_checks + [well_known_file_check_matrix_server] }}"
 
+- when: matrix_static_files_file_matrix_mautrix_enabled | bool
+  block:
+    - name: Prepare /.well-known/matrix/mautrix to well-known files to check, if enabled
+      ansible.builtin.set_fact:
+        well_known_file_check_matrix_mautrix:
+          path: /.well-known/matrix/mautrix
+          purpose: Mautrix bridge discovery
+          cors: true
+          follow_redirects: safe
+          validate_certs: "{{ matrix_static_files_self_check_validate_certificates }}"
+
+    - name: Inject /.well-known/matrix/mautrix to well-known files to check, if enabled
+      ansible.builtin.set_fact:
+        well_known_file_checks: "{{ well_known_file_checks + [well_known_file_check_matrix_mautrix] }}"
+
 - name: Perform well-known checks
   ansible.builtin.include_tasks: "{{ role_path }}/tasks/self_check_well_known_file.yml"
   with_items: "{{ well_known_file_checks }}"

--- a/roles/custom/matrix-static-files/templates/public/.well-known/matrix/mautrix.j2
+++ b/roles/custom/matrix-static-files/templates/public/.well-known/matrix/mautrix.j2
@@ -1,0 +1,4 @@
+{
+  "fi.mau.bridges": {{ matrix_static_files_file_matrix_mautrix_property_fi_mau_bridges|to_json }},
+  "fi.mau.external_bridge_servers": {{ matrix_static_files_file_matrix_mautrix_property_fi_mau_external_bridge_servers|to_json }}
+}


### PR DESCRIPTION
Closes https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/3912

[New versions of the mautrix go bridges][mautrix-bridges] include standardized HTTP endpoints that can be used to log in and manage sessions ([spec][bridgev2-spec]). Some clients may choose to provide interfaces. At this time, [mautrix-manager][mautrix-manager] can consume these endpoints. An [auto-discovery][auto-discovery] `.well-known` file can be set. 

This PR aims to make these endpoints public and setup auto-discovery.

Please let me know : 
- whether this can be useful
- whether the mautrix-messenger implementation is acceptable, to serve as a baseline for the next bridges
- any recommendations


[mautrix-bridges]: https://mau.fi/blog/2024-09-mautrix-release/
[bridgev2-spec]: https://spec.mau.fi/megabridge/
[mautrix-manager]: https://github.com/mautrix/manager
[auto-discovery]: https://github.com/mautrix/manager#auto-configuration