### PR TITLE
Remove line breaks from docs/configuring-playbook-bot-maubot.md for consistency

### DIFF
--- a/docs/configuring-playbook-bot-maubot.md
+++ b/docs/configuring-playbook-bot-maubot.md
@@ -34,9 +34,7 @@ After configuring the playbook, run the [installation](installing.md) command ag
 
 **Notes**:
 
-- if you change the bot password (`matrix_bot_maubot_initial_password` in your `vars.yml` file) subsequently,
-  the bot user's credentials on the homeserver won't be updated automatically.
-  If you'd like to change the bot user's password, use a tool like [synapse-admin](configuring-playbook-synapse-admin.md) to change it.
+- if you change the bot password (`matrix_bot_maubot_initial_password` in your `vars.yml` file) subsequently, the bot user's credentials on the homeserver won't be updated automatically. If you'd like to change the bot user's password, use a tool like [synapse-admin](configuring-playbook-synapse-admin.md) to change it.
 
 ## Usage
 
@@ -45,7 +43,7 @@ You can visit `matrix.<your-domain>/_matrix/maubot/` to manage your available pl
 You should start in the following order
 1. **Create one or more clients:** A client is a matrix account which the bot will use to message. By default, the playbook creates a `bot.maubot` account (as per the configuration above). You only need to [obtain an access token](#obtaining-an-access-token) for it
 2. **Upload some Plugins:** Plugins can be obtained from [here](https://github.com/maubot/maubot#plugins) or any other source.
-3. **Create an instance:** An instance is the actual bot. You have to specify a client which the bot instance will use 
+3. **Create an instance:** An instance is the actual bot. You have to specify a client which the bot instance will use
 and the plugin (how the bot will behave)
 
 ## Obtaining an access token


### PR DESCRIPTION
Make the paragraph consistent with files such as:

- [docs/configuring-playbook-bot-baibot.md](https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/13b9c8b1bf61e62a2a0a6e20e5d81b40c29c6761/docs/configuring-playbook-bot-baibot.md?plain=1#L389C1-L389C112)
- [docs/configuring-playbook-bot-buscarron.md](https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/13b9c8b1bf61e62a2a0a6e20e5d81b40c29c6761/docs/configuring-playbook-bot-honoroit.md?plain=1#L44)
- [docs/configuring-playbook-bot-honoroit.md](https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/13b9c8b1bf61e62a2a0a6e20e5d81b40c29c6761/docs/configuring-playbook-bot-buscarron.md?plain=1#L69)