### PR TITLE
Update docs/configuring-playbook-bot-maubot.md for consistency

### DIFF
--- a/docs/configuring-playbook-bot-maubot.md
+++ b/docs/configuring-playbook-bot-maubot.md
@@ -34,7 +34,7 @@ After configuring the playbook, run the [installation](installing.md) command ag
 
 **Notes**:
 
-- if you change the bot password (`matrix_bot_maubot_initial_password` in your `vars.yml` file) subsequently, the bot user's credentials on the homeserver won't be updated automatically. If you'd like to change the bot user's password, use a tool like [synapse-admin](configuring-playbook-synapse-admin.md) to change it.
+- if you change the bot password (`matrix_bot_maubot_initial_password` in your `vars.yml` file) subsequently, the bot user's credentials on the homeserver won't be updated automatically. If you'd like to change the bot user's password, use a tool like [synapse-admin](configuring-playbook-synapse-admin.md) to change it, and then update `matrix_bot_maubot_initial_password` to let the bot know its new password
 
 ## Usage
 


### PR DESCRIPTION
Follow-up to https://github.com/spantaleev/matrix-docker-ansible-deploy/pull/3593

Update docs/configuring-playbook-bot-maubot.md for consistent expression for installing by making the paragraph consistent with files such as:

- [docs/configuring-playbook-bot-baibot.md](https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/13b9c8b1bf61e62a2a0a6e20e5d81b40c29c6761/docs/configuring-playbook-bot-baibot.md?plain=1#L389C1-L389C112)
- [docs/configuring-playbook-bot-buscarron.md](https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/13b9c8b1bf61e62a2a0a6e20e5d81b40c29c6761/docs/configuring-playbook-bot-honoroit.md?plain=1#L44)
- [docs/configuring-playbook-bot-honoroit.md](https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/13b9c8b1bf61e62a2a0a6e20e5d81b40c29c6761/docs/configuring-playbook-bot-buscarron.md?plain=1#L69)