### PR TITLE
Use common sentences on documentation regarding installation

### DIFF
--- a/docs/configuring-playbook-alertmanager-receiver.md
+++ b/docs/configuring-playbook-alertmanager-receiver.md
@@ -63,7 +63,7 @@ Steps 3 and 4 need to be done for each new room you'd like the bot to deliver al
 
 ## Installation
 
-Now that you've [prepared the bot account and room](#account-and-room-preparation) and have [configured the playbook](#configuration), you can re-run the [installation](./installing.md) process (`just install-all`).
+Now that you've [prepared the bot account and room](#account-and-room-preparation) and have [configured the playbook](#configuration), you can run the [installation](installing.md) command: `just install-all`
 
 Then, you can proceed to [Usage](#usage).
 

--- a/docs/configuring-playbook-appservice-double-puppet.md
+++ b/docs/configuring-playbook-appservice-double-puppet.md
@@ -14,4 +14,10 @@ To enable the Appservice Double Puppet service, add the following configuration 
 matrix_appservice_double_puppet_enabled: true
 ```
 
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+
+## Usage
+
 When enabled, double puppeting will automatically be enabled for all bridges that support double puppeting via the appservice method.

--- a/docs/configuring-playbook-backup-borg.md
+++ b/docs/configuring-playbook-backup-borg.md
@@ -68,7 +68,7 @@ Check the [backup_borg role](https://github.com/mother-of-all-self-hosting/ansib
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command again:
+After configuring the playbook, run the [installation](installing.md) command:
 
 ```
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start

--- a/docs/configuring-playbook-bot-baibot.md
+++ b/docs/configuring-playbook-bot-baibot.md
@@ -376,7 +376,7 @@ matrix_bot_baibot_config_initial_global_config_handler_image_generation: null
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command again:
+After configuring the playbook, run the [installation](installing.md) command:
 
 ```sh
 just run-tags install-all,ensure-matrix-users-created,start

--- a/docs/configuring-playbook-bot-buscarron.md
+++ b/docs/configuring-playbook-bot-buscarron.md
@@ -56,7 +56,7 @@ matrix_bot_buscarron_spamlist: [] # (optional) list of emails/domains/hosts (wit
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command again:
+After configuring the playbook, run the [installation](installing.md) command:
 
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start

--- a/docs/configuring-playbook-bot-chatgpt.md
+++ b/docs/configuring-playbook-bot-chatgpt.md
@@ -57,7 +57,7 @@ You will need to get tokens for ChatGPT.
 
 ## 4. Installing
 
-After configuring the playbook, run the [installation](installing.md) command again:
+After configuring the playbook, run the [installation](installing.md) command:
 
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=install-all,start

--- a/docs/configuring-playbook-bot-honoroit.md
+++ b/docs/configuring-playbook-bot-honoroit.md
@@ -31,7 +31,7 @@ matrix_bot_honoroit_roomid: "!yourRoomID:DOMAIN"
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command again:
+After configuring the playbook, run the [installation](installing.md) command:
 
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start

--- a/docs/configuring-playbook-bot-matrix-registration-bot.md
+++ b/docs/configuring-playbook-bot-matrix-registration-bot.md
@@ -34,7 +34,7 @@ The bot account will be created automatically.
 
 ## Installing
 
-After configuring the playbook, re-run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
 
 ## Usage
 

--- a/docs/configuring-playbook-bot-matrix-registration-bot.md
+++ b/docs/configuring-playbook-bot-matrix-registration-bot.md
@@ -34,7 +34,7 @@ The bot account will be created automatically.
 
 ## Installing
 
-After configuring the playbook, re-run the [installation](installing.md) command again: `just install-all` or `just setup-all`
+After configuring the playbook, re-run the [installation](installing.md) command: `just install-all` or `just setup-all`
 
 ## Usage
 

--- a/docs/configuring-playbook-bot-matrix-reminder-bot.md
+++ b/docs/configuring-playbook-bot-matrix-reminder-bot.md
@@ -27,7 +27,7 @@ matrix_bot_matrix_reminder_bot_reminders_timezone: Europe/London
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command again:
+After configuring the playbook, run the [installation](installing.md) command:
 
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start

--- a/docs/configuring-playbook-bot-maubot.md
+++ b/docs/configuring-playbook-bot-maubot.md
@@ -30,7 +30,7 @@ You can add multiple admins. The admin accounts are only used to access the maub
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command again: `just install-all`
+After configuring the playbook, run the [installation](installing.md) command: `just install-all`
 
 **Notes**:
 

--- a/docs/configuring-playbook-bot-maubot.md
+++ b/docs/configuring-playbook-bot-maubot.md
@@ -30,7 +30,7 @@ You can add multiple admins. The admin accounts are only used to access the maub
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command again (`just install-all`):
+After configuring the playbook, run the [installation](installing.md) command again: `just install-all`
 
 **Notes**:
 

--- a/docs/configuring-playbook-bot-postmoogle.md
+++ b/docs/configuring-playbook-bot-postmoogle.md
@@ -54,7 +54,7 @@ See [Configuring DNS](configuring-dns.md).
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command again:
+After configuring the playbook, run the [installation](installing.md) command:
 
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start

--- a/docs/configuring-playbook-bridge-appservice-irc.md
+++ b/docs/configuring-playbook-bridge-appservice-irc.md
@@ -60,4 +60,10 @@ matrix_appservice_irc_ircService_servers:
       lineLimit: 3
 ```
 
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+
+## Usage
+
 You then need to start a chat with `@irc_bot:YOUR_DOMAIN` (where `YOUR_DOMAIN` is your base domain, not the `matrix.` domain).

--- a/docs/configuring-playbook-bridge-appservice-kakaotalk.md
+++ b/docs/configuring-playbook-bridge-appservice-kakaotalk.md
@@ -17,7 +17,13 @@ matrix_appservice_kakaotalk_enabled: true
 
 You may optionally wish to add some [Additional configuration](#additional-configuration), or to [prepare for double-puppeting](#set-up-double-puppeting) before the initial installation.
 
-After adjusting your `vars.yml` file, re-run the playbook and restart all services: `ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start`
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command:
+
+```
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 To make use of the Kakaotalk bridge, see [Usage](#usage) below.
 

--- a/docs/configuring-playbook-bridge-beeper-linkedin.md
+++ b/docs/configuring-playbook-bridge-beeper-linkedin.md
@@ -33,6 +33,9 @@ matrix_beeper_linkedin_configuration_extension_yaml: |
 
 You may wish to look at `roles/custom/matrix-bridge-beeper-linkedin/templates/config.yaml.j2` to find other things you would like to configure.
 
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
 
 ## Set up Double Puppeting by enabling Appservice Double Puppet or Shared Secret Auth
 

--- a/docs/configuring-playbook-bridge-go-skype-bridge.md
+++ b/docs/configuring-playbook-bridge-go-skype-bridge.md
@@ -13,6 +13,9 @@ To enable the [Skype](https://www.skype.com/) bridge, add the following configur
 matrix_go_skype_bridge_enabled: true
 ```
 
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-heisenbridge.md
+++ b/docs/configuring-playbook-bridge-heisenbridge.md
@@ -31,7 +31,7 @@ If you are not using a local user you must set it as otherwise you can't DM it a
 
 ## Installing
 
-After configuring the playbook, re-run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-heisenbridge.md
+++ b/docs/configuring-playbook-bridge-heisenbridge.md
@@ -29,6 +29,10 @@ That's it! A registration file is automatically generated during the setup phase
 Setting the owner is optional as the first local user to DM `@heisenbridge:your-homeserver` will be made the owner.
 If you are not using a local user you must set it as otherwise you can't DM it at all.
 
+## Installing
+
+After configuring the playbook, re-run the [installation](installing.md) command: `just install-all` or `just setup-all`
+
 ## Usage
 
 After the bridge is successfully running just DM `@heisenbridge:your-homeserver` to start setting it up.

--- a/docs/configuring-playbook-bridge-matrix-bridge-sms.md
+++ b/docs/configuring-playbook-bridge-matrix-bridge-sms.md
@@ -31,6 +31,9 @@ matrix_sms_bridge_provider_android_truststore_password: 123
 
 ```
 
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mautrix-discord.md
+++ b/docs/configuring-playbook-bridge-mautrix-discord.md
@@ -25,7 +25,13 @@ matrix_mautrix_discord_enabled: true
 
 You may optionally wish to add some [Additional configuration](#additional-configuration), or to [prepare for double-puppeting](#set-up-double-puppeting) before the initial installation.
 
-After adjusting your `vars.yml` file, re-run the playbook and restart all services: `ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start`
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command:
+
+```
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 To make use of the bridge, see [Usage](#usage) below.
 

--- a/docs/configuring-playbook-bridge-mautrix-facebook.md
+++ b/docs/configuring-playbook-bridge-mautrix-facebook.md
@@ -47,6 +47,9 @@ matrix_mautrix_facebook_configuration_extension_yaml: |
 
 You may wish to look at `roles/custom/matrix-bridge-mautrix-facebook/templates/config.yaml.j2` and `roles/custom/matrix-bridge-mautrix-facebook/defaults/main.yml` to find other things you would like to configure.
 
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
 
 ## Set up Double Puppeting
 

--- a/docs/configuring-playbook-bridge-mautrix-gmessages.md
+++ b/docs/configuring-playbook-bridge-mautrix-gmessages.md
@@ -12,6 +12,10 @@ To enable the bridge, add the following configuration to your `inventory/host_va
 matrix_mautrix_gmessages_enabled: true
 ```
 
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+
 ## Set up Double Puppeting
 
 If you'd like to use [Double Puppeting](https://docs.mau.fi/bridges/general/double-puppeting.html) (hint: you most likely do), you have 2 ways of going about it.

--- a/docs/configuring-playbook-bridge-mautrix-googlechat.md
+++ b/docs/configuring-playbook-bridge-mautrix-googlechat.md
@@ -12,6 +12,9 @@ To enable the [Google Chat](https://chat.google.com/) bridge, add the following 
 matrix_mautrix_googlechat_enabled: true
 ```
 
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
 
 ## Set up Double Puppeting
 

--- a/docs/configuring-playbook-bridge-mautrix-hangouts.md
+++ b/docs/configuring-playbook-bridge-mautrix-hangouts.md
@@ -14,6 +14,9 @@ To enable the [Google Hangouts](https://hangouts.google.com/) bridge, add the fo
 matrix_mautrix_hangouts_enabled: true
 ```
 
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
 
 ## Set up Double Puppeting
 

--- a/docs/configuring-playbook-bridge-mautrix-instagram.md
+++ b/docs/configuring-playbook-bridge-mautrix-instagram.md
@@ -40,6 +40,9 @@ matrix_mautrix_instagram_configuration_extension_yaml: |
 
 You may wish to look at `roles/custom/matrix-bridge-mautrix-instagram/templates/config.yaml.j2` and `roles/custom/matrix-bridge-mautrix-instagram/defaults/main.yml` to find other things you would like to configure.
 
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mautrix-meta-instagram.md
+++ b/docs/configuring-playbook-bridge-mautrix-meta-instagram.md
@@ -62,6 +62,10 @@ matrix_mautrix_meta_instagram_bridge_permissions_custom:
 
 You may wish to look at `roles/custom/matrix-bridge-mautrix-meta-instagram/templates/config.yaml.j2` to find more information on the permissions settings and other options you would like to configure.
 
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+
 ## Set up Double Puppeting
 
 If you'd like to use [Double Puppeting](https://docs.mau.fi/bridges/general/double-puppeting.html) (hint: you most likely do), you have 2 ways of going about it.

--- a/docs/configuring-playbook-bridge-mautrix-meta-messenger.md
+++ b/docs/configuring-playbook-bridge-mautrix-meta-messenger.md
@@ -72,6 +72,10 @@ matrix_mautrix_meta_messenger_bridge_permissions_custom:
 
 You may wish to look at `roles/custom/matrix-bridge-mautrix-meta-messenger/templates/config.yaml.j2` to find more information on the permissions settings and other options you would like to configure.
 
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+
 ## Set up Double Puppeting
 
 If you'd like to use [Double Puppeting](https://docs.mau.fi/bridges/general/double-puppeting.html) (hint: you most likely do), you have 2 ways of going about it.

--- a/docs/configuring-playbook-bridge-mautrix-signal.md
+++ b/docs/configuring-playbook-bridge-mautrix-signal.md
@@ -54,6 +54,10 @@ matrix_mautrix_signal_bridge_permissions:
 
 You may wish to look at `roles/custom/matrix-bridge-mautrix-signal/templates/config.yaml.j2` to find more information on the permissions settings and other options you would like to configure.
 
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+
 ## Set up Double Puppeting
 
 If you'd like to use [Double Puppeting](https://docs.mau.fi/bridges/general/double-puppeting.html) (hint: you most likely do), you have 2 ways of going about it.

--- a/docs/configuring-playbook-bridge-mautrix-slack.md
+++ b/docs/configuring-playbook-bridge-mautrix-slack.md
@@ -28,7 +28,13 @@ matrix_mautrix_slack_enabled: true
 
 You may optionally wish to add some [Additional configuration](#additional-configuration), or to [prepare for double-puppeting](#set-up-double-puppeting) before the initial installation.
 
-After adjusting your `vars.yml` file, re-run the playbook and restart all services: `ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start`
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command:
+
+```
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 To make use of the bridge, see [Usage](#usage) below.
 

--- a/docs/configuring-playbook-bridge-mautrix-telegram.md
+++ b/docs/configuring-playbook-bridge-mautrix-telegram.md
@@ -14,6 +14,10 @@ matrix_mautrix_telegram_api_id: YOUR_TELEGRAM_APP_ID
 matrix_mautrix_telegram_api_hash: YOUR_TELEGRAM_API_HASH
 ```
 
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+
 ## Set up Double Puppeting
 
 If you'd like to use [Double Puppeting](https://docs.mau.fi/bridges/general/double-puppeting.html) (hint: you most likely do), you have 2 ways of going about it.

--- a/docs/configuring-playbook-bridge-mautrix-twitter.md
+++ b/docs/configuring-playbook-bridge-mautrix-twitter.md
@@ -14,6 +14,9 @@ To enable the bridge, add the following configuration to your `inventory/host_va
 matrix_mautrix_twitter_enabled: true
 ```
 
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
 
 ## Set up Double Puppeting
 

--- a/docs/configuring-playbook-bridge-mautrix-whatsapp.md
+++ b/docs/configuring-playbook-bridge-mautrix-whatsapp.md
@@ -27,6 +27,10 @@ matrix_mautrix_whatsapp_bridge_relay_admin_only: false
 If you want to activate the relay bot in a room, use `!wa set-relay`.
 Use `!wa unset-relay` to deactivate.
 
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+
 ## Set up Double Puppeting
 
 If you'd like to use [Double Puppeting](https://docs.mau.fi/bridges/general/double-puppeting.html) (hint: you most likely do), you have 2 ways of going about it.

--- a/docs/configuring-playbook-bridge-mautrix-wsproxy.md
+++ b/docs/configuring-playbook-bridge-mautrix-wsproxy.md
@@ -26,6 +26,9 @@ matrix_mautrix_wsproxy_syncproxy_shared_secret: 'secret token from bridge'
 
 Note that the tokens must match what is compiled into the [mautrix-imessage](https://github.com/mautrix/imessage) bridge running on your Mac or Android device.
 
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mx-puppet-discord.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-discord.md
@@ -19,6 +19,9 @@ To enable the [Discord](https://discordapp.com/) bridge, add the following confi
 matrix_mx_puppet_discord_enabled: true
 ```
 
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mx-puppet-groupme.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-groupme.md
@@ -13,6 +13,9 @@ To enable the [GroupMe](https://groupme.com/) bridge, add the following configur
 matrix_mx_puppet_groupme_enabled: true
 ```
 
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mx-puppet-instagram.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-instagram.md
@@ -13,6 +13,9 @@ To enable the [Instagram](https://www.instagram.com/) bridge, add the following 
 matrix_mx_puppet_instagram_enabled: true
 ```
 
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mx-puppet-steam.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-steam.md
@@ -13,6 +13,9 @@ To enable the [Steam](https://steampowered.com/) bridge, add the following confi
 matrix_mx_puppet_steam_enabled: true
 ```
 
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mx-puppet-twitter.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-twitter.md
@@ -24,6 +24,9 @@ matrix_mx_puppet_twitter_access_token_secret: ''
 matrix_mx_puppet_twitter_environment: ''
 ```
 
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-wechat.md
+++ b/docs/configuring-playbook-bridge-wechat.md
@@ -12,6 +12,10 @@ To enable the bridge, add the following configuration to your `inventory/host_va
 matrix_wechat_enabled: true
 ```
 
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+
 ## Usage
 
 Once the bridge is installed, start a chat with `@wechatbot:YOUR_DOMAIN` (where `YOUR_DOMAIN` is your base domain, not the `matrix.` domain).

--- a/docs/configuring-playbook-cactus-comments.md
+++ b/docs/configuring-playbook-cactus-comments.md
@@ -46,8 +46,7 @@ matrix_cactus_comments_client_enabled: true
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command again.
-
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
 
 ## Usage
 

--- a/docs/configuring-playbook-client-cinny.md
+++ b/docs/configuring-playbook-client-cinny.md
@@ -4,18 +4,26 @@ This playbook can install the [cinny](https://github.com/ajbura/cinny) Matrix we
 Cinny is a web client focusing primarily on simple, elegant and secure interface.
 Cinny can be installed alongside or instead of Element.
 
-If you'd like Cinny to be installed, add the following to your configuration file (`inventory/host_vars/matrix.<your-domain>/vars.yml`):
+## DNS
+
+You need to add a `cinny.DOMAIN` DNS record so that Cinny can be accessed.
+By default Cinny will use https://cinny.DOMAIN so you will need to create an CNAME record
+for `cinny`. See [Configuring DNS](configuring-dns.md).
+
+If you would like to use a different domain, add the following configuration to your `inventory/host_vars/matrix.DOMAIN/vars.yml` file (changing it to use your preferred domain):
+
+```yaml
+ matrix_server_fqn_cinny: "app.{{ matrix_domain }}"
+```
+
+## Adjusting the playbook configuration
+
+To enable Cinny, add the following configuration to your `inventory/host_vars/matrix.DOMAIN/vars.yml` file:
 
 ```yaml
 matrix_client_cinny_enabled: true
 ```
 
-You will also need to add a DNS record so that Cinny can be accessed.
-By default Cinny will use https://cinny.DOMAIN so you will need to create an CNAME record
-for `cinny`. See [Configuring DNS](configuring-dns.md).
+## Installing
 
-If you would like to use a different domain, add the following to your configuration file (changing it to use your preferred domain):
-
-```yaml
- matrix_server_fqn_cinny: "app.{{ matrix_domain }}"
-```
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`

--- a/docs/configuring-playbook-client-element.md
+++ b/docs/configuring-playbook-client-element.md
@@ -1,6 +1,6 @@
 # Configuring Element (optional)
 
-By default, this playbook installs the [Element](https://github.com/element-hq/element-web) Matrix client web application.
+By default, this playbook installs the [Element](https://github.com/element-hq/element-web) Matrix web client for you.
 If that's okay, you can skip this document.
 
 

--- a/docs/configuring-playbook-client-hydrogen.md
+++ b/docs/configuring-playbook-client-hydrogen.md
@@ -4,18 +4,26 @@ This playbook can install the [Hydrogen](https://github.com/element-hq/hydrogen-
 Hydrogen is a lightweight web client that supports mobile and legacy web browsers.
 Hydrogen can be installed alongside or instead of Element.
 
-If you'd like Hydrogen to be installed, add the following to your configuration file (`inventory/host_vars/matrix.<your-domain>/vars.yml`):
+## DNS
+
+You need to add a `hydrogen.DOMAIN` DNS record so that Hydrogen can be accessed.
+By default Hydrogen will use https://hydrogen.DOMAIN so you will need to create an CNAME record
+for `hydrogen`. See [Configuring DNS](configuring-dns.md).
+
+If you would like to use a different domain, add the following configuration to your `inventory/host_vars/matrix.DOMAIN/vars.yml` file (changing it to use your preferred domain):
+
+```yaml
+ matrix_server_fqn_hydrogen: "helium.{{ matrix_domain }}"
+```
+
+## Adjusting the playbook configuration
+
+To enable Hydrogen, add the following configuration to your `inventory/host_vars/matrix.DOMAIN/vars.yml` file:
 
 ```yaml
 matrix_client_hydrogen_enabled: true
 ```
 
-You will also need to add a DNS record so that Hydrogen can be accessed. 
-By default Hydrogen will use https://hydrogen.DOMAIN so you will need to create an CNAME record
-for `hydrogen`. See [Configuring DNS](configuring-dns.md).
+## Installing
 
-If you would like to use a different domain, add the following to your configuration file (changing it to use your preferred domain):
-
-```yaml
- matrix_server_fqn_hydrogen: "helium.{{ matrix_domain }}"
-```
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`

--- a/docs/configuring-playbook-client-schildichat.md
+++ b/docs/configuring-playbook-client-schildichat.md
@@ -6,17 +6,25 @@ SchildiChat can be installed alongside or instead of Element.
 
 **WARNING**: SchildiChat Web is based on Element-web, but its releases are lagging behind. As an example (from 2024-02-26), SchildiChat Web is 22 releases behind (it being based on element-web `v1.11.36`, while element-web is now on `v1.11.58`). Element-web frequently suffers from security issues, so running something based on an ancient Element-web release is **dangerous**. Use SchildiChat Web at your own risk!
 
+## DNS
 
-## Enabling SchildiChat
+You need to add a `schildichat.DOMAIN` DNS record so that SchildiChat can be accessed.
+By default SchildiChat will use https://schildichat.DOMAIN so you will need to create an CNAME record
+for `schildichat`. See [Configuring DNS](configuring-dns.md).
 
-If you'd like for the playbook to install SchildiChat, you can enable it in your configuration file (`inventory/host_vars/matrix.<your-domain>/vars.yml`):
+If you would like to use a different domain, add the following configuration to your `inventory/host_vars/matrix.DOMAIN/vars.yml` file (changing it to use your preferred domain):
+
+```yaml
+ matrix_server_fqn_schildichat: "sc.{{ matrix_domain }}"
+```
+
+## Adjusting the playbook configuration
+
+To enable SchildiChat, add the following configuration to your `inventory/host_vars/matrix.DOMAIN/vars.yml` file:
 
 ```yaml
 matrix_client_schildichat_enabled: true
 ```
-
-
-## Configuring SchildiChat settings
 
 The playbook provides some customization variables you could use to change schildichat's settings.
 
@@ -32,8 +40,7 @@ Alternatively, **if there is no pre-defined variable** for an schildichat settin
 
 - or, if extending the configuration is still not powerful enough for your needs, you can **override the configuration completely** using `matrix_client_schildichat_configuration_default` (or `matrix_client_schildichat_configuration`). You can find information about this in [`roles/custom/matrix-client-schildichat/defaults/main.yml`](../roles/custom/matrix-client-schildichat/defaults/main.yml).
 
-
-## Themes
+### Themes
 
 To change the look of schildichat, you can define your own themes manually by using the `matrix_client_schildichat_setting_defaults_custom_themes` setting.
 
@@ -42,3 +49,7 @@ Or better yet, you can automatically pull it all themes provided by the [aaronra
 If you make your own theme, we encourage you to submit it to the **aaronraimist/element-themes** project, so that the whole community could easily enjoy it.
 
 Note that for a custom theme to work well, all schildichat instances that you use must have the same theme installed.
+
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`

--- a/docs/configuring-playbook-client-schildichat.md
+++ b/docs/configuring-playbook-client-schildichat.md
@@ -1,6 +1,7 @@
 # Configuring SchildiChat (optional)
 
 This playbook can install the [SchildiChat](https://github.com/SchildiChat/schildichat-desktop) Matrix web client for you.
+SchildiChat is a feature-rich messenger for Matrix based on Element with some extras and tweaks.
 SchildiChat can be installed alongside or instead of Element.
 
 **WARNING**: SchildiChat Web is based on Element-web, but its releases are lagging behind. As an example (from 2024-02-26), SchildiChat Web is 22 releases behind (it being based on element-web `v1.11.36`, while element-web is now on `v1.11.58`). Element-web frequently suffers from security issues, so running something based on an ancient Element-web release is **dangerous**. Use SchildiChat Web at your own risk!

--- a/docs/configuring-playbook-client-schildichat.md
+++ b/docs/configuring-playbook-client-schildichat.md
@@ -1,6 +1,7 @@
 # Configuring SchildiChat (optional)
 
-By default, this playbook does not install the [SchildiChat](https://github.com/SchildiChat/schildichat-desktop) Matrix client web application.
+This playbook can install the [SchildiChat](https://github.com/SchildiChat/schildichat-desktop) Matrix web client for you.
+SchildiChat can be installed alongside or instead of Element.
 
 **WARNING**: SchildiChat Web is based on Element-web, but its releases are lagging behind. As an example (from 2024-02-26), SchildiChat Web is 22 releases behind (it being based on element-web `v1.11.36`, while element-web is now on `v1.11.58`). Element-web frequently suffers from security issues, so running something based on an ancient Element-web release is **dangerous**. Use SchildiChat Web at your own risk!
 

--- a/docs/configuring-playbook-etherpad.md
+++ b/docs/configuring-playbook-etherpad.md
@@ -40,8 +40,9 @@ etherpad_enabled: true
 # etherpad_admin_password: some-password
 ```
 
-Then, [run the installation process](installing.md) again (e.g. `just install-all`).
+## Installing
 
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
 
 ## Usage
 

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -17,7 +17,7 @@ You may also need to open the following ports to your server:
 - `10000/udp` - RTP media over UDP. Depending on your firewall/NAT setup, incoming RTP packets on port `10000` may have the external IP of your firewall as destination address, due to the usage of STUN in JVB (see [`jitsi_jvb_stun_servers`](https://github.com/mother-of-all-self-hosting/ansible-role-jitsi/blob/main/defaults/main.yml)).
 
 
-## Installation
+## Adjusting the playbook configuration
 
 Add the following configuration to your `inventory/host_vars/matrix.DOMAIN/vars.yml` file:
 
@@ -271,10 +271,13 @@ jitsi_disable_gravatar: false
 **Beware:** This leaks information to a third party, namely the Gravatar-Service (unless configured otherwise: gravatar.com).
 Besides metadata, this includes the matrix user_id and possibly the room identifier (via `referrer` header).
 
-## Apply changes
+## Installing
 
-Then re-run the playbook: `ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start`
+After configuring the playbook, run the [installation](installing.md) command:
 
+```
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Usage
 

--- a/docs/configuring-playbook-ma1sd.md
+++ b/docs/configuring-playbook-ma1sd.md
@@ -35,6 +35,9 @@ matrix_ma1sd_matrixorg_forwarding_enabled: true
 If you'd like to change the default email templates used by ma1sd, take a look at the `matrix_ma1sd_threepid_medium_email_custom_` variables
 (in the `roles/custom/matrix-ma1sd/defaults/main.yml` file.
 
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
 
 ## ma1sd-controlled Registration
 

--- a/docs/configuring-playbook-matrix-corporal.md
+++ b/docs/configuring-playbook-matrix-corporal.md
@@ -117,7 +117,7 @@ To learn more about what the policy configuration, see the matrix-corporal docum
 
 ## Installing
 
-After configuring the playbook, re-run the [installation](installing.md) command again (`--tags=setup-all,start` or `--tags=setup-aux-files,setup-corporal,start`).
+After configuring the playbook, run the [installation](installing.md) command (`--tags=setup-all,start` or `--tags=setup-aux-files,setup-corporal,start`).
 
 
 ## Matrix Corporal files

--- a/docs/configuring-playbook-matrix-corporal.md
+++ b/docs/configuring-playbook-matrix-corporal.md
@@ -115,7 +115,9 @@ aux_file_definitions:
 
 To learn more about what the policy configuration, see the matrix-corporal documentation on [policy](https://github.com/devture/matrix-corporal/blob/master/docs/policy.md).
 
-Each time you update the policy in your `vars.yml` file, you'd need to re-run the playbook and restart matrix-corporal (`--tags=setup-all,start` or `--tags=setup-aux-files,setup-corporal,start`).
+## Installing
+
+After configuring the playbook, re-run the [installation](installing.md) command again (`--tags=setup-all,start` or `--tags=setup-aux-files,setup-corporal,start`).
 
 
 ## Matrix Corporal files

--- a/docs/configuring-playbook-matrix-ldap-registration-proxy.md
+++ b/docs/configuring-playbook-matrix-ldap-registration-proxy.md
@@ -34,3 +34,6 @@ matrix_ldap_registration_proxy_systemd_wanted_services_list_custom:
   - matrix-synapse.service
 ```
 
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`

--- a/docs/configuring-playbook-matrix-registration.md
+++ b/docs/configuring-playbook-matrix-registration.md
@@ -17,9 +17,9 @@ Use matrix-registration to **create unique registration links**, which people ca
 - **a user registration page**, where people can use these registration tokens. By default, exposed at `https://matrix.DOMAIN/matrix-registration`
 
 
-## Installing
+## Adjusting the playbook configuration
 
-Adjust your playbook configuration (your `inventory/host_vars/matrix.DOMAIN/vars.yml` file):
+Add the following configuration to your `inventory/host_vars/matrix.DOMAIN/vars.yml` file:
 
 ```yaml
 matrix_registration_enabled: true
@@ -28,7 +28,9 @@ matrix_registration_enabled: true
 matrix_registration_admin_secret: "ENTER_SOME_SECRET_HERE"
 ```
 
-Then, run the [installation](installing.md) command again:
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command:
 
 ```
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start

--- a/docs/configuring-playbook-mautrix-bridges.md
+++ b/docs/configuring-playbook-mautrix-bridges.md
@@ -92,6 +92,9 @@ Can be used to set the username for the bridge.
 
 You may wish to look at `roles/custom/matrix-bridge-mautrix-SERVICENAME/templates/config.yaml.j2` and `roles/custom/matrix-bridge-mautrix-SERVICENAME/defaults/main.yml` to find other things you would like to configure.
 
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
 
 ## Set up Double Puppeting
 

--- a/docs/configuring-playbook-ntfy.md
+++ b/docs/configuring-playbook-ntfy.md
@@ -38,7 +38,7 @@ For a complete list of ntfy config options that you could put in `ntfy_configura
 
 Don't forget to add `ntfy.<your-domain>` to DNS as described in [Configuring DNS](configuring-dns.md) before running the playbook.
 
-After configuring the playbook, run the [installation](installing.md) command again:
+After configuring the playbook, run the [installation](installing.md) command:
 
 ```
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start

--- a/docs/configuring-playbook-pantalaimon.md
+++ b/docs/configuring-playbook-pantalaimon.md
@@ -18,4 +18,4 @@ The default configuration should suffice. For advanced configuration, you can ov
 
 ## 2. Installing
 
-After configuring the playbook, run the [installation](installing.md) command.
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`

--- a/docs/configuring-playbook-postgres-backup.md
+++ b/docs/configuring-playbook-postgres-backup.md
@@ -29,7 +29,7 @@ Refer to the table below for additional configuration variables and their defaul
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command again:
+After configuring the playbook, run the [installation](installing.md) command:
 
 ```
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start

--- a/docs/configuring-playbook-prometheus-nginxlog.md
+++ b/docs/configuring-playbook-prometheus-nginxlog.md
@@ -20,7 +20,9 @@ Add the following configuration to your `inventory/host_vars/matrix.DOMAIN/vars.
 matrix_prometheus_nginxlog_exporter_enabled: true
 ```
 
-Then, re-run the playbook. See [installation](./installing.md).
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
 
 ## Docker Image Compatibility
 

--- a/docs/configuring-playbook-prometheus-postgres.md
+++ b/docs/configuring-playbook-prometheus-postgres.md
@@ -10,6 +10,10 @@ To enable the postgres exporter, add the following configuration to your `invent
 prometheus_postgres_exporter_enabled: true
 ```
 
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+
 ## What does it do?
 
 Name | Description

--- a/docs/configuring-playbook-rageshake.md
+++ b/docs/configuring-playbook-rageshake.md
@@ -51,7 +51,7 @@ matrix_rageshake_configuration_extension_yaml: |
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command again:
+After configuring the playbook, run the [installation](installing.md) command:
 
 ```
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start

--- a/docs/configuring-playbook-rest-auth.md
+++ b/docs/configuring-playbook-rest-auth.md
@@ -23,3 +23,7 @@ If you wish for users to **authenticate only against configured password provide
 ```yaml
 matrix_synapse_password_config_localdb_enabled: false
 ```
+
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`

--- a/docs/configuring-playbook-riot-web.md
+++ b/docs/configuring-playbook-riot-web.md
@@ -30,5 +30,4 @@ There are a few options for handling this:
 
 ### Re-running the playbook
 
-As always, after making the necessary DNS and configuration adjustments, [re-run the playbook](./installing.md) to apply the changes.
-```
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`

--- a/docs/configuring-playbook-shared-secret-auth.md
+++ b/docs/configuring-playbook-shared-secret-auth.md
@@ -23,3 +23,7 @@ If you wish for users to **authenticate only against configured password provide
 ```yaml
 matrix_synapse_password_config_localdb_enabled: false
 ```
+
+## Installing
+
+After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`

--- a/docs/configuring-playbook-synapse-admin.md
+++ b/docs/configuring-playbook-synapse-admin.md
@@ -25,7 +25,7 @@ By default, synapse-admin installation will be [restricted to only work with one
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command again (`just install-all`).
+After configuring the playbook, run the [installation](installing.md) command again: `just install-all`
 
 
 ## Usage

--- a/docs/configuring-playbook-synapse-admin.md
+++ b/docs/configuring-playbook-synapse-admin.md
@@ -25,7 +25,7 @@ By default, synapse-admin installation will be [restricted to only work with one
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command again: `just install-all`
+After configuring the playbook, run the [installation](installing.md) command: `just install-all`
 
 
 ## Usage

--- a/docs/configuring-playbook-synapse-auto-compressor.md
+++ b/docs/configuring-playbook-synapse-auto-compressor.md
@@ -18,7 +18,7 @@ matrix_synapse_auto_compressor_enabled: true
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command again:
+After configuring the playbook, run the [installation](installing.md) command:
 
 ```
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start


### PR DESCRIPTION
This PR intends to make documentation on regarding installation consistent.

While it will adopt `just` installation commands to files where installation process has not been described, for now it intentionally tries to respect the existing commands to re-run the playbook, avoiding to change the format such as `ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start`.

Migration from the old command which still works as expected should eventually take place on another instance.

This also intends to update documentation for web clients (Cinny, Hydrogen, and SchildiChat Web) with the same structure.
