### PR TITLE
Use a common expression for password setting

### DIFF
--- a/docs/configuring-playbook-bot-baibot.md
+++ b/docs/configuring-playbook-bot-baibot.md
@@ -46,7 +46,7 @@ matrix_bot_baibot_enabled: true
 matrix_bot_baibot_config_user_password: 'PASSWORD_FOR_THE_BOT'
 
 # An optional passphrase to use for backing up and recovering the bot's encryption keys.
-# You can use any string here. Consider generating it with `pwgen -s 64 1`.
+# You can put any string here, but generating a strong one is preferred (e.g. `pwgen -s 64 1`).
 #
 # If set to null, the recovery module will not be used and losing your session/database
 # will mean you lose access to old messages in encrypted room.

--- a/docs/configuring-playbook-matrix-registration.md
+++ b/docs/configuring-playbook-matrix-registration.md
@@ -24,7 +24,7 @@ Add the following configuration to your `inventory/host_vars/matrix.DOMAIN/vars.
 ```yaml
 matrix_registration_enabled: true
 
-# Generate a strong secret using: `pwgen -s 64 1`.
+# Generate a strong secret here. Consider generating it with `pwgen -s 64 1`
 matrix_registration_admin_secret: "ENTER_SOME_SECRET_HERE"
 ```
 

--- a/docs/configuring-playbook-shared-secret-auth.md
+++ b/docs/configuring-playbook-shared-secret-auth.md
@@ -10,11 +10,10 @@ Add the following configuration to your `inventory/host_vars/matrix.DOMAIN/vars.
 
 ```yaml
 matrix_synapse_ext_password_provider_shared_secret_auth_enabled: true
+
+# Generate a strong shared secret here. Consider generating it with `pwgen -s 64 1`
 matrix_synapse_ext_password_provider_shared_secret_auth_shared_secret: YOUR_SHARED_SECRET_GOES_HERE
 ```
-
-You can generate a strong shared secret with a command like this: `pwgen -s 64 1`
-
 
 ## Authenticating only using a password provider
 


### PR DESCRIPTION
This PR intends to use a common expression for a password or secret: "Generate a strong secret (or password) here. Consider generating it with pwgen -s 64 1".