### PR TITLE
Move colons outside of asterisks

### DIFF
--- a/docs/configuring-playbook-bot-maubot.md
+++ b/docs/configuring-playbook-bot-maubot.md
@@ -41,9 +41,9 @@ After configuring the playbook, run the [installation](installing.md) command: `
 You can visit `matrix.<your-domain>/_matrix/maubot/` to manage your available plugins, clients and instances.
 
 You should start in the following order
-1. **Create one or more clients:** A client is a matrix account which the bot will use to message. By default, the playbook creates a `bot.maubot` account (as per the configuration above). You only need to [obtain an access token](#obtaining-an-access-token) for it
-2. **Upload some Plugins:** Plugins can be obtained from [here](https://github.com/maubot/maubot#plugins) or any other source.
-3. **Create an instance:** An instance is the actual bot. You have to specify a client which the bot instance will use
+1. **Create one or more clients**: A client is a matrix account which the bot will use to message. By default, the playbook creates a `bot.maubot` account (as per the configuration above). You only need to [obtain an access token](#obtaining-an-access-token) for it
+2. **Upload some Plugins**: Plugins can be obtained from [here](https://github.com/maubot/maubot#plugins) or any other source.
+3. **Create an instance**: An instance is the actual bot. You have to specify a client which the bot instance will use
 and the plugin (how the bot will behave)
 
 ## Obtaining an access token

--- a/docs/configuring-playbook-cactus-comments.md
+++ b/docs/configuring-playbook-cactus-comments.md
@@ -56,7 +56,7 @@ To get started, send a `help` message to the `@bot.cactusbot:your-homeserver.com
 Then, register a site by typing: `register <sitename>`. You will then be invited into a moderation room.
 Now you are good to go and can include the comment section on your website!
 
-**Careful:** To really make use of self-hosting you need change a few things in comparison to the official docs!
+**Careful**: To really make use of self-hosting you need change a few things in comparison to the official docs!
 
 Insert the following snippet into you page and make sure to replace `example.com` with your base domain!
 

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -61,7 +61,7 @@ jitsi_prosody_auth_internal_accounts:
     password: "another-password"
 ```
 
-**Caution:** Accounts added here and subsequently removed will not be automatically removed from the Prosody server until user account cleaning is integrated into the playbook.
+**Caution**: Accounts added here and subsequently removed will not be automatically removed from the Prosody server until user account cleaning is integrated into the playbook.
 
 **If you get an error** like this: "Error: Account creation/modification not supported.", it's likely that you had previously installed Jitsi without auth/guest support. In such a case, you should look into [Rebuilding your Jitsi installation](#rebuilding-your-jitsi-installation).
 
@@ -268,7 +268,7 @@ To enable Gravatar set:
 jitsi_disable_gravatar: false
 ```
 
-**Beware:** This leaks information to a third party, namely the Gravatar-Service (unless configured otherwise: gravatar.com).
+**Beware**: This leaks information to a third party, namely the Gravatar-Service (unless configured otherwise: gravatar.com).
 Besides metadata, this includes the matrix user_id and possibly the room identifier (via `referrer` header).
 
 ## Installing


### PR DESCRIPTION
This PR should move all colons on documentation outside of asterisks.

Please note that this does not touch files inside `.github` though there are files where colons are inside of them, as they indeed should look better if unchanged.