### PR TITLE
Update docs/configuring-playbook-bridge-mx* - remove line breaks inside a sentence

### DIFF
--- a/docs/configuring-playbook-bridge-mx-puppet-discord.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-discord.md
@@ -4,8 +4,7 @@
 - For using as a Bot we recommend the [Appservice Discord](configuring-playbook-bridge-appservice-discord.md), because it supports plumbing.  
 - For personal use with a discord account we recommend the [mautrix-discord](configuring-playbook-bridge-mautrix-discord.md) bridge, because it is the most fully-featured and stable of the 3 Discord bridges supported by the playbook.
 
-The playbook can install and configure
-[mx-puppet-discord](https://github.com/matrix-discord/mx-puppet-discord) for you.
+The playbook can install and configure [mx-puppet-discord](https://github.com/matrix-discord/mx-puppet-discord) for you.
 
 See the project page to learn what it does and why it might be useful to you.
 
@@ -25,17 +24,12 @@ After configuring the playbook, run the [installation](installing.md) command: `
 
 ## Usage
 
-Once the bot is enabled you need to start a chat with `Discord Puppet Bridge` with
-the handle `@_discordpuppet_bot:example.com` (where `example.com` is your base
-domain, not the `matrix.` domain).
+Once the bot is enabled you need to start a chat with `Discord Puppet Bridge` with the handle `@_discordpuppet_bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
 
-Three authentication methods are available, Legacy Token, OAuth and xoxc token.
-See mx-puppet-discord [documentation](https://github.com/matrix-discord/mx-puppet-discord)
-for more information about how to configure the bridge.
+Three authentication methods are available, Legacy Token, OAuth and xoxc token. See mx-puppet-discord [documentation](https://github.com/matrix-discord/mx-puppet-discord) for more information about how to configure the bridge.
 
 Once logged in, send `list` to the bot user to list the available rooms.
 
-Clicking rooms in the list will result in you receiving an invitation to the
-bridged room.
+Clicking rooms in the list will result in you receiving an invitation to the bridged room.
 
 Also send `help` to the bot to see the commands available.

--- a/docs/configuring-playbook-bridge-mx-puppet-groupme.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-groupme.md
@@ -1,7 +1,6 @@
 # Setting up MX Puppet GroupMe (optional)
 
-The playbook can install and configure
-[mx-puppet-groupme](https://gitlab.com/xangelix-pub/matrix/mx-puppet-groupme) for you.
+The playbook can install and configure [mx-puppet-groupme](https://gitlab.com/xangelix-pub/matrix/mx-puppet-groupme) for you.
 
 See the project page to learn what it does and why it might be useful to you.
 
@@ -19,9 +18,7 @@ After configuring the playbook, run the [installation](installing.md) command: `
 
 ## Usage
 
-Once the bot is enabled you need to start a chat with `GroupMe Puppet Bridge` with
-the handle `@_groupmepuppet_bot:example.com` (where `example.com` is your base
-domain, not the `matrix.` domain).
+Once the bot is enabled you need to start a chat with `GroupMe Puppet Bridge` with the handle `@_groupmepuppet_bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
 
 One authentication method is available.
 
@@ -33,7 +30,6 @@ link <access token>
 
 Once logged in, send `listrooms` to the bot user to list the available rooms.
 
-Clicking rooms in the list will result in you receiving an invitation to the
-bridged room.
+Clicking rooms in the list will result in you receiving an invitation to the bridged room.
 
 Also send `help` to the bot to see the commands available.

--- a/docs/configuring-playbook-bridge-mx-puppet-instagram.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-instagram.md
@@ -1,7 +1,6 @@
 # Setting up mx-puppet-instagram (optional)
 
-The playbook can install and configure
-[mx-puppet-instagram](https://github.com/Sorunome/mx-puppet-instagram) for you.
+The playbook can install and configure [mx-puppet-instagram](https://github.com/Sorunome/mx-puppet-instagram) for you.
 
 This allows you to bridge Instagram DirectMessages into Matrix.
 
@@ -19,9 +18,7 @@ After configuring the playbook, run the [installation](installing.md) command: `
 
 ## Usage
 
-Once the bot is enabled, you need to start a chat with `Instagram Puppet Bridge` with
-the handle `@_instagrampuppet_bot:example.com` (where `example.com` is your base
-domain, not the `matrix.` domain).
+Once the bot is enabled, you need to start a chat with `Instagram Puppet Bridge` with the handle `@_instagrampuppet_bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
 
 Send `link <username> <password>` to the bridge bot to link your instagram account.
 

--- a/docs/configuring-playbook-bridge-mx-puppet-slack.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-slack.md
@@ -3,8 +3,7 @@
 **Note**: bridging to [Slack](https://slack.com) can also happen via the
 [matrix-appservice-slack](configuring-playbook-bridge-appservice-slack.md) and [mautrix-slack](configuring-playbook-bridge-mautrix-slack.md) bridges supported by the playbook.
 
-The playbook can install and configure [Beeper](https://www.beeper.com/)-maintained fork of
-[mx-puppet-slack](https://gitlab.com/beeper/mx-puppet-monorepo) for you.
+The playbook can install and configure [Beeper](https://www.beeper.com/)-maintained fork of [mx-puppet-slack](https://gitlab.com/beeper/mx-puppet-monorepo) for you.
 
 See the project page to learn what it does and why it might be useful to you.
 
@@ -33,17 +32,12 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 
 ## Usage
 
-Once the bot is enabled you need to start a chat with `Slack Puppet Bridge` with
-the handle `@_slackpuppet_bot:example.com` (where `example.com` is your base
-domain, not the `matrix.` domain).
+Once the bot is enabled you need to start a chat with `Slack Puppet Bridge` with the handle `@_slackpuppet_bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
 
-Three authentication methods are available, Legacy Token, OAuth and xoxc token.
-See mx-puppet-slack [documentation](https://github.com/Sorunome/mx-puppet-slack)
-for more information about how to configure the bridge.
+Three authentication methods are available, Legacy Token, OAuth and xoxc token. See mx-puppet-slack [documentation](https://github.com/Sorunome/mx-puppet-slack) for more information about how to configure the bridge.
 
 Once logged in, send `list` to the bot user to list the available rooms.
 
-Clicking rooms in the list will result in you receiving an invitation to the
-bridged room.
+Clicking rooms in the list will result in you receiving an invitation to the bridged room.
 
 Also send `help` to the bot to see the commands available.

--- a/docs/configuring-playbook-bridge-mx-puppet-steam.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-steam.md
@@ -1,7 +1,6 @@
 # Setting up MX Puppet Steam (optional)
 
-The playbook can install and configure
-[mx-puppet-steam](https://github.com/icewind1991/mx-puppet-steam) for you.
+The playbook can install and configure [mx-puppet-steam](https://github.com/icewind1991/mx-puppet-steam) for you.
 
 See the project page to learn what it does and why it might be useful to you.
 
@@ -19,17 +18,12 @@ After configuring the playbook, run the [installation](installing.md) command: `
 
 ## Usage
 
-Once the bot is enabled you need to start a chat with `Steam Puppet Bridge` with
-the handle `@_steampuppet_bot:example.com` (where `example.com` is your base
-domain, not the `matrix.` domain).
+Once the bot is enabled you need to start a chat with `Steam Puppet Bridge` with the handle `@_steampuppet_bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
 
-Three authentication methods are available, Legacy Token, OAuth and xoxc token.
-See mx-puppet-steam [documentation](https://github.com/icewind1991/mx-puppet-steam)
-for more information about how to configure the bridge.
+Three authentication methods are available, Legacy Token, OAuth and xoxc token. See mx-puppet-steam [documentation](https://github.com/icewind1991/mx-puppet-steam) for more information about how to configure the bridge.
 
 Once logged in, send `list` to the bot user to list the available rooms.
 
-Clicking rooms in the list will result in you receiving an invitation to the
-bridged room.
+Clicking rooms in the list will result in you receiving an invitation to the bridged room.
 
 Also send `help` to the bot to see the commands available.

--- a/docs/configuring-playbook-bridge-mx-puppet-twitter.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-twitter.md
@@ -2,8 +2,7 @@
 
 **Note**: bridging to [Twitter](https://twitter.com/) can also happen via the [mautrix-twitter](configuring-playbook-bridge-mautrix-twitter.md) bridge supported by the playbook.
 
-The playbook can install and configure
-[mx-puppet-twitter](https://github.com/Sorunome/mx-puppet-twitter) for you.
+The playbook can install and configure [mx-puppet-twitter](https://github.com/Sorunome/mx-puppet-twitter) for you.
 
 See the project page to learn what it does and why it might be useful to you.
 
@@ -30,15 +29,12 @@ After configuring the playbook, run the [installation](installing.md) command: `
 
 ## Usage
 
-Once the bot is enabled you need to start a chat with `Twitter Puppet Bridge` with
-the handle `@_twitterpuppet_bot:example.com` (where `example.com` is your base
-domain, not the `matrix.` domain).
+Once the bot is enabled you need to start a chat with `Twitter Puppet Bridge` with the handle `@_twitterpuppet_bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
 
 To log in, use `link` and click the link.
 
 Once logged in, send `list` to the bot user to list the available rooms.
 
-Clicking rooms in the list will result in you receiving an invitation to the
-bridged room.
+Clicking rooms in the list will result in you receiving an invitation to the bridged room.
 
 Also send `help` to the bot to see the commands available.


### PR DESCRIPTION
This intends to remove line breaks inside a sentence on documentation (docs/configuring-playbook-bridge-mx*) so that translation can be managed easily.