### PR TITLE
Update `roles/custom/matrix-bridge-mx-puppet-*`

### DIFF
--- a/roles/custom/matrix-bridge-mx-puppet-discord/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-discord/defaults/main.yml
@@ -33,15 +33,15 @@ matrix_mx_puppet_discord_appservice_address: 'http://matrix-mx-puppet-discord:{{
 
 matrix_mx_puppet_discord_bridge_mediaUrl: "{{ matrix_homeserver_url }}"  # noqa var-naming
 
-# "@user:example.com" to allow specific user
+# "@user:example.com" to allow a specific user
 # "@.*:example.com" to allow users on a specific homeserver
 # "@.*" to allow anyone
 matrix_mx_puppet_discord_provisioning_whitelist:
   - "@.*:{{ matrix_domain | regex_escape }}"
 
 # Leave empty to disable blacklist
-# "@user:example.com" disallow a specific user
-# "@.*:example.com" disallow users on a specific homeserver
+# "@user:example.com" to disallow a specific user
+# "@.*:example.com" to disallow users on a specific homeserver
 matrix_mx_puppet_discord_provisioning_blacklist: []
 
 matrix_mx_puppet_discord_container_network: ""

--- a/roles/custom/matrix-bridge-mx-puppet-discord/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mx-puppet-discord/templates/config.yaml.j2
@@ -31,17 +31,17 @@ provisioning:
   # Regex of Matrix IDs allowed to use the puppet bridge
   whitelist: {{ matrix_mx_puppet_discord_provisioning_whitelist|to_json }}
     # Allow a specific user
-    #- "@user:server\\.com"
+    #- "@user:example\\.com"
     # Allow users on a specific homeserver
-    #- "@.*:yourserver\\.com"
+    #- "@.*:example\\.com"
     # Allow anyone
     #- ".*"
   # Regex of Matrix IDs forbidden from using the puppet bridge
   #blacklist:
     # Disallow a specific user
-    #- "@user:server\\.com"
+    #- "@user:example\\.com"
     # Disallow users on a specific homeserver
-    #- "@.*:yourserver\\.com"
+    #- "@.*:example\\.com"
   blacklist: {{ matrix_mx_puppet_discord_provisioning_blacklist|to_json }}
 
 relay:

--- a/roles/custom/matrix-bridge-mx-puppet-groupme/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-groupme/defaults/main.yml
@@ -29,15 +29,15 @@ matrix_mx_puppet_groupme_homeserver_address: ""
 matrix_mx_puppet_groupme_homeserver_domain: '{{ matrix_domain }}'
 matrix_mx_puppet_groupme_appservice_address: 'http://matrix-mx-puppet-groupme:{{ matrix_mx_puppet_groupme_appservice_port }}'
 
-# "@user:example.com" to allow specific user
+# "@user:example.com" to allow a specific user
 # "@.*:example.com" to allow users on a specific homeserver
 # "@.*" to allow anyone
 matrix_mx_puppet_groupme_provisioning_whitelist:
   - "@.*:{{ matrix_domain | regex_escape }}"
 
 # Leave empty to disable blacklist
-# "@user:example.com" disallow a specific user
-# "@.*:example.com" disallow users on a specific homeserver
+# "@user:example.com" to disallow a specific user
+# "@.*:example.com" to disallow users on a specific homeserver
 matrix_mx_puppet_groupme_provisioning_blacklist: []
 
 matrix_mx_puppet_groupme_container_network: ""

--- a/roles/custom/matrix-bridge-mx-puppet-groupme/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mx-puppet-groupme/templates/config.yaml.j2
@@ -19,7 +19,7 @@ bridge:
   #
   # This is where GroupMe will download user profile pictures and media
   # from
-  #mediaUrl: https://external-url.org
+  #mediaUrl: https://example.org
 
 presence:
   # Bridge GroupMe online/offline status
@@ -31,17 +31,17 @@ provisioning:
   # Regex of Matrix IDs allowed to use the puppet bridge
   whitelist: {{ matrix_mx_puppet_groupme_provisioning_whitelist|to_json }}
     # Allow a specific user
-    #- "@user:server\\.com"
+    #- "@user:example\\.com"
     # Allow users on a specific homeserver
-    #- "@.*:yourserver\\.com"
+    #- "@.*:example\\.com"
     # Allow anyone
     #- ".*"
   # Regex of Matrix IDs forbidden from using the puppet bridge
   #blacklist:
     # Disallow a specific user
-    #- "@user:server\\.com"
+    #- "@user:example\\.com"
     # Disallow users on a specific homeserver
-    #- "@.*:yourserver\\.com"
+    #- "@.*:example\\.com"
   blacklist: {{ matrix_mx_puppet_groupme_provisioning_blacklist|to_json }}
 
 relay:

--- a/roles/custom/matrix-bridge-mx-puppet-instagram/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-instagram/defaults/main.yml
@@ -24,15 +24,15 @@ matrix_mx_puppet_instagram_homeserver_address: ""
 matrix_mx_puppet_instagram_homeserver_domain: '{{ matrix_domain }}'
 matrix_mx_puppet_instagram_appservice_address: 'http://matrix-mx-puppet-instagram:{{ matrix_mx_puppet_instagram_appservice_port }}'
 
-# "@user:example.com" to allow specific user
+# "@user:example.com" to allow a specific user
 # "@.*:example.com" to allow users on a specific homeserver
 # "@.*" to allow anyone
 matrix_mx_puppet_instagram_provisioning_whitelist:
   - "@.*:{{ matrix_domain | regex_escape }}"
 
 # Leave empty to disable blacklist
-# "@user:example.com" disallow a specific user
-# "@.*:example.com" disallow users on a specific homeserver
+# "@user:example.com" to disallow a specific user
+# "@.*:example.com" to disallow users on a specific homeserver
 matrix_mx_puppet_instagram_provisioning_blacklist: []
 
 matrix_mx_puppet_instagram_container_network: ""

--- a/roles/custom/matrix-bridge-mx-puppet-instagram/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mx-puppet-instagram/templates/config.yaml.j2
@@ -24,17 +24,17 @@ provisioning:
   # Regex of Matrix IDs allowed to use the puppet bridge
   whitelist: {{ matrix_mx_puppet_instagram_provisioning_whitelist|to_json }}
     # Allow a specific user
-    #- "@user:server\\.com"
+    #- "@user:example\\.com"
     # Allow users on a specific homeserver
-    #- "@.*:yourserver\\.com"
+    #- "@.*:example\\.com"
     # Allow anyone
     #- ".*"
   # Regex of Matrix IDs forbidden from using the puppet bridge
   #blacklist:
     # Disallow a specific user
-    #- "@user:server\\.com"
+    #- "@user:example\\.com"
     # Disallow users on a specific homeserver
-    #- "@.*:yourserver\\.com"
+    #- "@.*:example\\.com"
   blacklist: {{ matrix_mx_puppet_instagram_provisioning_blacklist|to_json }}
 
   # Shared secret for the provisioning API for use by integration managers.

--- a/roles/custom/matrix-bridge-mx-puppet-slack/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-slack/defaults/main.yml
@@ -42,15 +42,15 @@ matrix_mx_puppet_slack_oauth_enabled: true
 matrix_mx_puppet_slack_oauth_redirect_path: "{{ matrix_mx_puppet_slack_path_prefix }}"
 matrix_mx_puppet_slack_oauth_redirect_uri: '{{ matrix_mx_puppet_slack_scheme }}://{{ matrix_mx_puppet_slack_hostname }}{{ matrix_mx_puppet_slack_oauth_redirect_path }}'
 
-# "@user:example.com" to allow specific user
+# "@user:example.com" to allow a specific user
 # "@.*:example.com" to allow users on a specific homeserver
 # "@.*" to allow anyone
 matrix_mx_puppet_slack_provisioning_whitelist:
   - "@.*:{{ matrix_domain | regex_escape }}"
 
 # Leave empty to disable blacklist
-# "@user:example.com" disallow a specific user
-# "@.*:example.com" disallow users on a specific homeserver
+# "@user:example.com" to disallow a specific user
+# "@.*:example.com" to disallow users on a specific homeserver
 matrix_mx_puppet_slack_provisioning_blacklist: []
 
 matrix_mx_puppet_slack_container_network: ""

--- a/roles/custom/matrix-bridge-mx-puppet-slack/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mx-puppet-slack/templates/config.yaml.j2
@@ -38,17 +38,17 @@ provisioning:
   # Regex of Matrix IDs allowed to use the puppet bridge
   whitelist: {{ matrix_mx_puppet_slack_provisioning_whitelist|to_json }}
     # Allow a specific user
-    #- "@user:server\\.com"
+    #- "@user:example\\.com"
     # Allow users on a specific homeserver
-    #- "@.*:yourserver\\.com"
+    #- "@.*:example\\.com"
     # Allow anyone
     #- ".*"
   # Regex of Matrix IDs forbidden from using the puppet bridge
   #blacklist:
     # Disallow a specific user
-    #- "@user:server\\.com"
+    #- "@user:example\\.com"
     # Disallow users on a specific homeserver
-    #- "@.*:yourserver\\.com"
+    #- "@.*:example\\.com"
   blacklist: {{ matrix_mx_puppet_slack_provisioning_blacklist|to_json }}
 
   # Shared secret for the provisioning API for use by integration managers.

--- a/roles/custom/matrix-bridge-mx-puppet-steam/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-steam/defaults/main.yml
@@ -30,15 +30,15 @@ matrix_mx_puppet_steam_homeserver_address: ""
 matrix_mx_puppet_steam_homeserver_domain: '{{ matrix_domain }}'
 matrix_mx_puppet_steam_appservice_address: 'http://matrix-mx-puppet-steam:{{ matrix_mx_puppet_steam_appservice_port }}'
 
-# "@user:example.com" to allow specific user
+# "@user:example.com" to allow a specific user
 # "@.*:example.com" to allow users on a specific homeserver
 # "@.*" to allow anyone
 matrix_mx_puppet_steam_provisioning_whitelist:
   - "@.*:{{ matrix_domain | regex_escape }}"
 
 # Leave empty to disable blacklist
-# "@user:example.com" disallow a specific user
-# "@.*:example.com" disallow users on a specific homeserver
+# "@user:example.com" to disallow a specific user
+# "@.*:example.com" to disallow users on a specific homeserver
 matrix_mx_puppet_steam_provisioning_blacklist: []
 
 matrix_mx_puppet_steam_container_network: ""

--- a/roles/custom/matrix-bridge-mx-puppet-steam/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mx-puppet-steam/templates/config.yaml.j2
@@ -31,17 +31,17 @@ provisioning:
   # Regex of Matrix IDs allowed to use the puppet bridge
   whitelist: {{ matrix_mx_puppet_steam_provisioning_whitelist|to_json }}
     # Allow a specific user
-    #- "@user:server\\.com"
+    #- "@user:example\\.com"
     # Allow users on a specific homeserver
-    #- "@.*:yourserver\\.com"
+    #- "@.*:example\\.com"
     # Allow anyone
     #- ".*"
   # Regex of Matrix IDs forbidden from using the puppet bridge
   #blacklist:
     # Disallow a specific user
-    #- "@user:server\\.com"
+    #- "@user:example\\.com"
     # Disallow users on a specific homeserver
-    #- "@.*:yourserver\\.com"
+    #- "@.*:example\\.com"
   blacklist: {{ matrix_mx_puppet_steam_provisioning_blacklist|to_json }}
 
 relay:

--- a/roles/custom/matrix-bridge-mx-puppet-twitter/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-twitter/defaults/main.yml
@@ -42,15 +42,15 @@ matrix_mx_puppet_twitter_environment: ''
 matrix_mx_puppet_twitter_server_path: "{{ matrix_mx_puppet_twitter_path_prefix }}"
 matrix_mx_puppet_twitter_server_url: '{{ matrix_homeserver_url }}{{ matrix_mx_puppet_twitter_server_path }}'
 
-# "@user:example.com" to allow specific user
+# "@user:example.com" to allow a specific user
 # "@.*:example.com" to allow users on a specific homeserver
 # "@.*" to allow anyone
 matrix_mx_puppet_twitter_provisioning_whitelist:
   - "@.*:{{ matrix_domain | regex_escape }}"
 
 # Leave empty to disable blacklist
-# "@user:example.com" disallow a specific user
-# "@.*:example.com" disallow users on a specific homeserver
+# "@user:example.com" to disallow a specific user
+# "@.*:example.com" to disallow users on a specific homeserver
 matrix_mx_puppet_twitter_provisioning_blacklist: []
 
 matrix_mx_puppet_twitter_container_network: ""

--- a/roles/custom/matrix-bridge-mx-puppet-twitter/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mx-puppet-twitter/templates/config.yaml.j2
@@ -34,17 +34,17 @@ provisioning:
   # Regex of Matrix IDs allowed to use the puppet bridge
   whitelist: {{ matrix_mx_puppet_twitter_provisioning_whitelist|to_json }}
     # Allow a specific user
-    #- "@user:server\\.com"
+    #- "@user:example\\.com"
     # Allow users on a specific homeserver
-    #- "@.*:yourserver\\.com"
+    #- "@.*:example\\.com"
     # Allow anyone
     #- ".*"
   # Regex of Matrix IDs forbidden from using the puppet bridge
   #blacklist:
     # Disallow a specific user
-    #- "@user:server\\.com"
+    #- "@user:example\\.com"
     # Disallow users on a specific homeserver
-    #- "@.*:yourserver\\.com"
+    #- "@.*:example\\.com"
   blacklist: {{ matrix_mx_puppet_twitter_provisioning_blacklist|to_json }}
 
   # Shared secret for the provisioning API for use by integration managers.


### PR DESCRIPTION
This should fix domain names (`server`, `yourserver` → `example`) and use same comments. Previously those names were not able to be detected due to escaping.