### PR TITLE
Update docs/configuring-playbook-cactus-comments.md: fix the example domain

### DIFF
--- a/docs/configuring-playbook-cactus-comments.md
+++ b/docs/configuring-playbook-cactus-comments.md
@@ -16,7 +16,7 @@ You can enable whichever component you need (typically both).
 
 ## Configuration
 
-Add the following configuration to your `inventory/host_vars/matrix.DOMAIN/vars.yml` file:
+Add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:
 
 ```yaml
 #################


### PR DESCRIPTION
This is a follow-up to https://github.com/spantaleev/matrix-docker-ansible-deploy/pull/3638.