### PR TITLE
Use grafana_dashboard_template_files according to galaxy changes

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -5421,7 +5421,7 @@ grafana_dashboard_download_urls: |
     (matrix_synapse_usage_exporter_dashboard_urls if matrix_synapse_usage_exporter_enabled else [])
   }}
 
-grafana_provisioning_dashboard_template_files: |
+grafana_dashboard_template_files: |
   {{
     ([{
         'path': 'roles/custom/matrix-prometheus-nginxlog-exporter/templates/grafana/nginx-proxy.json',

--- a/requirements.yml
+++ b/requirements.yml
@@ -21,8 +21,8 @@
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-exim-relay.git
   version: v4.98-r0-1-1
   name: exim_relay
-- src: git+https://github.com/mother-of-all-self-hosting/ansible-role-grafana.git
-  version: v11.2.2-0
+- src: git+https://github.com/ginta1337/ansible-role-grafana.git
+  version: grafana_dashboard_template_files
   name: grafana
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-jitsi.git
   version: v9753-0

--- a/requirements.yml
+++ b/requirements.yml
@@ -21,8 +21,8 @@
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-exim-relay.git
   version: v4.98-r0-1-1
   name: exim_relay
-- src: git+https://github.com/ginta1337/ansible-role-grafana.git
-  version: grafana_dashboard_template_files
+- src: git+https://github.com/mother-of-all-self-hosting/ansible-role-grafana.git
+  version: v11.2.2-0
   name: grafana
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-jitsi.git
   version: v9753-0


### PR DESCRIPTION
Use grafana_dashboard_template_files variable according to [latest galaxy/ansible-role-grafana changes](https://github.com/mother-of-all-self-hosting/ansible-role-grafana/pull/1).