### PR TITLE
Replace the default hostnames with others on documentation files for components about adjusting the service URL

### DIFF
--- a/docs/configuring-playbook-bridge-mautrix-wsproxy.md
+++ b/docs/configuring-playbook-bridge-mautrix-wsproxy.md
@@ -30,7 +30,7 @@ Example additional configuration for your `inventory/host_vars/matrix.example.co
 
 ```yaml
 # Change the default hostname
-matrix_mautrix_wsproxy_hostname: wsproxy.example.com
+matrix_mautrix_wsproxy_hostname: ws.example.com
 ```
 
 ## Adjusting DNS records

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -33,7 +33,7 @@ Example additional configuration for your `inventory/host_vars/matrix.example.co
 
 ```yaml
 # Change the default hostname
-jitsi_hostname: jitsi.example.com
+jitsi_hostname: call.example.com
 ```
 
 ## Adjusting DNS records

--- a/docs/configuring-playbook-ntfy.md
+++ b/docs/configuring-playbook-ntfy.md
@@ -39,7 +39,7 @@ Example additional configuration for your `inventory/host_vars/matrix.example.co
 
 ```yaml
 # Change the default hostname
-ntfy_hostname: ntfy.example.com
+ntfy_hostname: push.example.com
 ```
 
 ## Adjusting DNS records

--- a/docs/configuring-playbook-prometheus-grafana.md
+++ b/docs/configuring-playbook-prometheus-grafana.md
@@ -42,7 +42,7 @@ Example additional configuration for your `inventory/host_vars/matrix.example.co
 
 ```yaml
 # Change the default hostname
-grafana_hostname: stats.example.com
+grafana_hostname: grafana.example.com
 ```
 
 ## Adjusting DNS records


### PR DESCRIPTION
This is a follow-up to https://github.com/spantaleev/matrix-docker-ansible-deploy/pull/3646.