### PR TITLE
Update room IDs and alias with ones on the Matrix Specification

### DIFF
--- a/docs/configuring-playbook-alertmanager-receiver.md
+++ b/docs/configuring-playbook-alertmanager-receiver.md
@@ -25,12 +25,12 @@ matrix_alertmanager_receiver_config_matrix_access_token: ''
 # Optionally, configure some mappings (URL-friendly room name -> actual Matrix room ID).
 #
 # If you don't configure mappings, you can still deliver alerts using URLs like this:
-# https://matrix.example.com/matrix-alertmanager-receiver-RANDOM_VALUE_HERE/alert/!someRoom:example.com
+# https://matrix.example.com/matrix-alertmanager-receiver-RANDOM_VALUE_HERE/alert/!qporfwt:example.com
 #
 # If a mapping like the one below is configured, you can deliver alerts using friendlier URLs like this:
 # https://matrix.example.com/matrix-alertmanager-receiver-RANDOM_VALUE_HERE/alert/some-room-name
 matrix_alertmanager_receiver_config_matrix_room_mapping:
-  some-room-name: "!someRoom:{{ matrix_domain }}"
+  some-room-name: "!qporfwt:{{ matrix_domain }}"
 ```
 
 See `roles/custom/matrix-alertmanager-receiver/defaults/main.yml` for additional configuration variables.
@@ -102,6 +102,6 @@ route:
     - receiver: matrix
 ```
 
-.. where `URL_HERE` looks like `https://matrix.example.com/matrix-alertmanager-receiver-RANDOM_VALUE_HERE/alert/some-room-name` or `https://matrix.example.com/matrix-alertmanager-receiver-RANDOM_VALUE_HERE/alert/!someRoom:example.com`.
+.. where `URL_HERE` looks like `https://matrix.example.com/matrix-alertmanager-receiver-RANDOM_VALUE_HERE/alert/some-room-name` or `https://matrix.example.com/matrix-alertmanager-receiver-RANDOM_VALUE_HERE/alert/!qporfwt:example.com`.
 
 This bot does **not** accept room invitations automatically (like many other bots do). To deliver messages to rooms, **the bot must be joined to all rooms manually** - see Step 5 of the [Account and room preparation](#account-and-room-preparation) section.

--- a/docs/configuring-playbook-alertmanager-receiver.md
+++ b/docs/configuring-playbook-alertmanager-receiver.md
@@ -25,12 +25,12 @@ matrix_alertmanager_receiver_config_matrix_access_token: ''
 # Optionally, configure some mappings (URL-friendly room name -> actual Matrix room ID).
 #
 # If you don't configure mappings, you can still deliver alerts using URLs like this:
-# https://matrix.example.com/matrix-alertmanager-receiver-RANDOM_VALUE_HERE/alert/!some-room-id:example.com
+# https://matrix.example.com/matrix-alertmanager-receiver-RANDOM_VALUE_HERE/alert/!someRoom:example.com
 #
 # If a mapping like the one below is configured, you can deliver alerts using friendlier URLs like this:
 # https://matrix.example.com/matrix-alertmanager-receiver-RANDOM_VALUE_HERE/alert/some-room-name
 matrix_alertmanager_receiver_config_matrix_room_mapping:
-  some-room-name: "!some-room-id:{{ matrix_domain }}"
+  some-room-name: "!someRoom:{{ matrix_domain }}"
 ```
 
 See `roles/custom/matrix-alertmanager-receiver/defaults/main.yml` for additional configuration variables.
@@ -102,6 +102,6 @@ route:
     - receiver: matrix
 ```
 
-.. where `URL_HERE` looks like `https://matrix.example.com/matrix-alertmanager-receiver-RANDOM_VALUE_HERE/alert/some-room-name` or `https://matrix.example.com/matrix-alertmanager-receiver-RANDOM_VALUE_HERE/alert/!some-room-id:example.com`.
+.. where `URL_HERE` looks like `https://matrix.example.com/matrix-alertmanager-receiver-RANDOM_VALUE_HERE/alert/some-room-name` or `https://matrix.example.com/matrix-alertmanager-receiver-RANDOM_VALUE_HERE/alert/!someRoom:example.com`.
 
 This bot does **not** accept room invitations automatically (like many other bots do). To deliver messages to rooms, **the bot must be joined to all rooms manually** - see Step 5 of the [Account and room preparation](#account-and-room-preparation) section.

--- a/docs/configuring-playbook-bot-buscarron.md
+++ b/docs/configuring-playbook-bot-buscarron.md
@@ -20,7 +20,7 @@ matrix_bot_buscarron_password: PASSWORD_FOR_THE_BOT
 # Adjust accepted forms
 matrix_bot_buscarron_forms:
   - name: contact # (mandatory) Your form name, will be used as endpoint, eg: buscarron.example.com/contact
-    room: "!yourRoomID:{{ matrix_domain }}" # (mandatory) Room ID where form submission will be posted
+    room: "!someRoom:{{ matrix_domain }}" # (mandatory) Room ID where form submission will be posted
     redirect: https://example.com # (mandatory) To what page user will be redirected after the form submission
     ratelimit: 1r/m # (optional) rate limit of the form, format: <max requests>r/<interval:s,m>, eg: 1r/s or 54r/m
     hasemail: 1 # (optional) form has "email" field that should be validated

--- a/docs/configuring-playbook-bot-buscarron.md
+++ b/docs/configuring-playbook-bot-buscarron.md
@@ -20,7 +20,7 @@ matrix_bot_buscarron_password: PASSWORD_FOR_THE_BOT
 # Adjust accepted forms
 matrix_bot_buscarron_forms:
   - name: contact # (mandatory) Your form name, will be used as endpoint, eg: buscarron.example.com/contact
-    room: "!someRoom:{{ matrix_domain }}" # (mandatory) Room ID where form submission will be posted
+    room: "!qporfwt:{{ matrix_domain }}" # (mandatory) Room ID where form submission will be posted
     redirect: https://example.com # (mandatory) To what page user will be redirected after the form submission
     ratelimit: 1r/m # (optional) rate limit of the form, format: <max requests>r/<interval:s,m>, eg: 1r/s or 54r/m
     hasemail: 1 # (optional) form has "email" field that should be validated

--- a/docs/configuring-playbook-bot-draupnir.md
+++ b/docs/configuring-playbook-bot-draupnir.md
@@ -47,7 +47,7 @@ Using your own account, create a new invite only room that you will use to manag
 
 If you make the management room encrypted (E2EE), then you MUST enable and use Pantalaimon (see below).
 
-Once you have created the room you need to copy the room ID so you can tell the bot to use that room. In Element you can do this by going to the room's settings, clicking Advanced, and then copying the internal room ID. The room ID will look something like `!QvgVuKq0ha8glOLGMG:example.com`.
+Once you have created the room you need to copy the room ID so you can tell the bot to use that room. In Element you can do this by going to the room's settings, clicking Advanced, and then copying the internal room ID. The room ID will look something like `!someRoom:example.com`.
 
 Finally invite the `@bot.draupnir:example.com` account you created earlier into the room.
 
@@ -135,7 +135,7 @@ Draupnir can be told to self-join public rooms, but it's better to follow this f
 
 2. [Give the bot permissions to do its job](#giving-draupnir-permissions-to-do-its-job)
 
-3. Tell it to protect the room (using the [rooms command](https://the-draupnir-project.github.io/draupnir-documentation/moderator/managing-protected-rooms#using-the-draupnir-rooms-command)) by sending the following command to the Management Room: `!draupnir rooms add !ROOM_ID:example.com`
+3. Tell it to protect the room (using the [rooms command](https://the-draupnir-project.github.io/draupnir-documentation/moderator/managing-protected-rooms#using-the-draupnir-rooms-command)) by sending the following command to the Management Room: `!draupnir rooms add !someRoom:example.com`
 
 To have Draupnir provide useful room protection, you need do to a bit more work (at least the first time around).
 You may wish to [Subscribe to a public policy list](#subscribing-to-a-public-policy-list), [Create your own own policy and rules](#creating-your-own-policy-lists-and-rules) and [Enabling built-in protections](#enabling-built-in-protections).

--- a/docs/configuring-playbook-bot-draupnir.md
+++ b/docs/configuring-playbook-bot-draupnir.md
@@ -47,7 +47,7 @@ Using your own account, create a new invite only room that you will use to manag
 
 If you make the management room encrypted (E2EE), then you MUST enable and use Pantalaimon (see below).
 
-Once you have created the room you need to copy the room ID so you can tell the bot to use that room. In Element you can do this by going to the room's settings, clicking Advanced, and then copying the internal room ID. The room ID will look something like `!someRoom:example.com`.
+Once you have created the room you need to copy the room ID so you can tell the bot to use that room. In Element you can do this by going to the room's settings, clicking Advanced, and then copying the internal room ID. The room ID will look something like `!qporfwt:example.com`.
 
 Finally invite the `@bot.draupnir:example.com` account you created earlier into the room.
 
@@ -135,7 +135,7 @@ Draupnir can be told to self-join public rooms, but it's better to follow this f
 
 2. [Give the bot permissions to do its job](#giving-draupnir-permissions-to-do-its-job)
 
-3. Tell it to protect the room (using the [rooms command](https://the-draupnir-project.github.io/draupnir-documentation/moderator/managing-protected-rooms#using-the-draupnir-rooms-command)) by sending the following command to the Management Room: `!draupnir rooms add !someRoom:example.com`
+3. Tell it to protect the room (using the [rooms command](https://the-draupnir-project.github.io/draupnir-documentation/moderator/managing-protected-rooms#using-the-draupnir-rooms-command)) by sending the following command to the Management Room: `!draupnir rooms add !qporfwt:example.com`
 
 To have Draupnir provide useful room protection, you need do to a bit more work (at least the first time around).
 You may wish to [Subscribe to a public policy list](#subscribing-to-a-public-policy-list), [Create your own own policy and rules](#creating-your-own-policy-lists-and-rules) and [Enabling built-in protections](#enabling-built-in-protections).

--- a/docs/configuring-playbook-bot-go-neb.md
+++ b/docs/configuring-playbook-bot-go-neb.md
@@ -125,7 +125,7 @@ matrix_bot_go_neb_services:
     Config:
       feeds:
         "http://lorem-rss.herokuapp.com/feed?unit=second&interval=60":
-          rooms: ["!someRoom:{{ matrix_domain }}"]
+          rooms: ["!qporfwt:{{ matrix_domain }}"]
           must_include:
             author:
               - author1
@@ -151,7 +151,7 @@ matrix_bot_go_neb_services:
       RealmID: "github_realm"
       ClientUserID: "@YOUR_USER_ID:{{ matrix_domain }}" # needs to be an authenticated user so Go-NEB can create webhooks. Check the UserID field in the github_realm in matrix_bot_go_neb_sessions.
       Rooms:
-        "!someRoom:example.com":
+        "!qporfwt:example.com":
           Repos:
             "element-hq/synapse":
               Events: ["push", "issues"]
@@ -170,7 +170,7 @@ matrix_bot_go_neb_services:
     Config:
       Hooks:
         "hook1":
-          RoomID: "!someRoom:example.com"
+          RoomID: "!qporfwt:example.com"
           MessageType: "m.text" # default is m.text
 
   - ID: "alertmanager_service"
@@ -184,7 +184,7 @@ matrix_bot_go_neb_services:
       webhook_url: "http://localhost/services/hooks/YWxlcnRtYW5hZ2VyX3NlcnZpY2U"
       # Each room will get the notification with the alert rendered with the given template
       rooms:
-        "!someRoom:example.com":
+        "!qporfwt:example.com":
           text_template: "{% raw %}{{range .Alerts -}} [{{ .Status }}] {{index .Labels \"alertname\" }}: {{index .Annotations \"description\"}} {{ end -}}{% endraw %}"
           html_template: "{% raw %}{{range .Alerts -}}  {{ $severity := index .Labels \"severity\" }}    {{ if eq .Status \"firing\" }}      {{ if eq $severity \"critical\"}}        <font color='red'><b>[FIRING - CRITICAL]</b></font>      {{ else if eq $severity \"warning\"}}        <font color='orange'><b>[FIRING - WARNING]</b></font>      {{ else }}        <b>[FIRING - {{ $severity }}]</b>      {{ end }}    {{ else }}      <font color='green'><b>[RESOLVED]</b></font>    {{ end }}  {{ index .Labels \"alertname\"}} : {{ index .Annotations \"description\"}}   <a href=\"{{ .GeneratorURL }}\">source</a><br/>{{end -}}{% endraw %}"
           msg_type: "m.text"  # Must be either `m.text` or `m.notice`

--- a/docs/configuring-playbook-bot-go-neb.md
+++ b/docs/configuring-playbook-bot-go-neb.md
@@ -151,13 +151,13 @@ matrix_bot_go_neb_services:
       RealmID: "github_realm"
       ClientUserID: "@YOUR_USER_ID:{{ matrix_domain }}" # needs to be an authenticated user so Go-NEB can create webhooks. Check the UserID field in the github_realm in matrix_bot_go_neb_sessions.
       Rooms:
-        "!someroom:id":
+        "!someroom:example.com":
           Repos:
             "element-hq/synapse":
               Events: ["push", "issues"]
             "matrix-org/dendron":
               Events: ["pull_request"]
-        "!anotherroom:id":
+        "!anotherroom:example.com":
           Repos:
             "element-hq/synapse":
               Events: ["push", "issues"]
@@ -170,7 +170,7 @@ matrix_bot_go_neb_services:
     Config:
       Hooks:
         "hook1":
-          RoomID: "!someroom:id"
+          RoomID: "!someroom:example.com"
           MessageType: "m.text" # default is m.text
 
   - ID: "alertmanager_service"

--- a/docs/configuring-playbook-bot-go-neb.md
+++ b/docs/configuring-playbook-bot-go-neb.md
@@ -157,7 +157,7 @@ matrix_bot_go_neb_services:
               Events: ["push", "issues"]
             "matrix-org/dendron":
               Events: ["pull_request"]
-        "!anotherRoom:example.com":
+        "!aaabaa:example.com":
           Repos:
             "element-hq/synapse":
               Events: ["push", "issues"]

--- a/docs/configuring-playbook-bot-go-neb.md
+++ b/docs/configuring-playbook-bot-go-neb.md
@@ -125,7 +125,7 @@ matrix_bot_go_neb_services:
     Config:
       feeds:
         "http://lorem-rss.herokuapp.com/feed?unit=second&interval=60":
-          rooms: ["!qmElAGdFYCHoCJuaNt:{{ matrix_domain }}"]
+          rooms: ["!someRoom:{{ matrix_domain }}"]
           must_include:
             author:
               - author1
@@ -151,7 +151,7 @@ matrix_bot_go_neb_services:
       RealmID: "github_realm"
       ClientUserID: "@YOUR_USER_ID:{{ matrix_domain }}" # needs to be an authenticated user so Go-NEB can create webhooks. Check the UserID field in the github_realm in matrix_bot_go_neb_sessions.
       Rooms:
-        "!someroom:example.com":
+        "!someRoom:example.com":
           Repos:
             "element-hq/synapse":
               Events: ["push", "issues"]
@@ -170,7 +170,7 @@ matrix_bot_go_neb_services:
     Config:
       Hooks:
         "hook1":
-          RoomID: "!someroom:example.com"
+          RoomID: "!someRoom:example.com"
           MessageType: "m.text" # default is m.text
 
   - ID: "alertmanager_service"
@@ -184,7 +184,7 @@ matrix_bot_go_neb_services:
       webhook_url: "http://localhost/services/hooks/YWxlcnRtYW5hZ2VyX3NlcnZpY2U"
       # Each room will get the notification with the alert rendered with the given template
       rooms:
-        "!someroomid:example.com":
+        "!someRoom:example.com":
           text_template: "{% raw %}{{range .Alerts -}} [{{ .Status }}] {{index .Labels \"alertname\" }}: {{index .Annotations \"description\"}} {{ end -}}{% endraw %}"
           html_template: "{% raw %}{{range .Alerts -}}  {{ $severity := index .Labels \"severity\" }}    {{ if eq .Status \"firing\" }}      {{ if eq $severity \"critical\"}}        <font color='red'><b>[FIRING - CRITICAL]</b></font>      {{ else if eq $severity \"warning\"}}        <font color='orange'><b>[FIRING - WARNING]</b></font>      {{ else }}        <b>[FIRING - {{ $severity }}]</b>      {{ end }}    {{ else }}      <font color='green'><b>[RESOLVED]</b></font>    {{ end }}  {{ index .Labels \"alertname\"}} : {{ index .Annotations \"description\"}}   <a href=\"{{ .GeneratorURL }}\">source</a><br/>{{end -}}{% endraw %}"
           msg_type: "m.text"  # Must be either `m.text` or `m.notice`

--- a/docs/configuring-playbook-bot-go-neb.md
+++ b/docs/configuring-playbook-bot-go-neb.md
@@ -157,7 +157,7 @@ matrix_bot_go_neb_services:
               Events: ["push", "issues"]
             "matrix-org/dendron":
               Events: ["pull_request"]
-        "!anotherroom:example.com":
+        "!anotherRoom:example.com":
           Repos:
             "element-hq/synapse":
               Events: ["push", "issues"]

--- a/docs/configuring-playbook-bot-honoroit.md
+++ b/docs/configuring-playbook-bot-honoroit.md
@@ -21,7 +21,7 @@ matrix_bot_honoroit_enabled: true
 matrix_bot_honoroit_password: PASSWORD_FOR_THE_BOT
 
 # Adjust this to your room ID
-matrix_bot_honoroit_roomid: "!someRoom:{{ matrix_domain }}"
+matrix_bot_honoroit_roomid: "!qporfwt:{{ matrix_domain }}"
 ```
 
 ### Adjusting the Honoroit URL

--- a/docs/configuring-playbook-bot-honoroit.md
+++ b/docs/configuring-playbook-bot-honoroit.md
@@ -21,7 +21,7 @@ matrix_bot_honoroit_enabled: true
 matrix_bot_honoroit_password: PASSWORD_FOR_THE_BOT
 
 # Adjust this to your room ID
-matrix_bot_honoroit_roomid: "!yourRoomID:{{ matrix_domain }}"
+matrix_bot_honoroit_roomid: "!someRoom:{{ matrix_domain }}"
 ```
 
 ### Adjusting the Honoroit URL

--- a/docs/configuring-playbook-bot-mjolnir.md
+++ b/docs/configuring-playbook-bot-mjolnir.md
@@ -41,7 +41,7 @@ Using your own account, create a new invite only room that you will use to manag
 
 If you make the management room encrypted (E2EE), then you MUST enable and use Pantalaimon (see below).
 
-Once you have created the room you need to copy the room ID so you can tell the bot to use that room. In Element you can do this by going to the room's settings, clicking Advanced, and then copying the internal room ID. The room ID will look something like `!someRoom:example.com`.
+Once you have created the room you need to copy the room ID so you can tell the bot to use that room. In Element you can do this by going to the room's settings, clicking Advanced, and then copying the internal room ID. The room ID will look something like `!qporfwt:example.com`.
 
 Finally invite the `@bot.mjolnir:example.com` account you created earlier into the room.
 

--- a/docs/configuring-playbook-bot-mjolnir.md
+++ b/docs/configuring-playbook-bot-mjolnir.md
@@ -41,7 +41,7 @@ Using your own account, create a new invite only room that you will use to manag
 
 If you make the management room encrypted (E2EE), then you MUST enable and use Pantalaimon (see below).
 
-Once you have created the room you need to copy the room ID so you can tell the bot to use that room. In Element you can do this by going to the room's settings, clicking Advanced, and then copying the internal room ID. The room ID will look something like `!QvgVuKq0ha8glOLGMG:example.com`.
+Once you have created the room you need to copy the room ID so you can tell the bot to use that room. In Element you can do this by going to the room's settings, clicking Advanced, and then copying the internal room ID. The room ID will look something like `!someRoom:example.com`.
 
 Finally invite the `@bot.mjolnir:example.com` account you created earlier into the room.
 

--- a/docs/configuring-playbook-bridge-appservice-discord.md
+++ b/docs/configuring-playbook-bridge-appservice-discord.md
@@ -81,5 +81,5 @@ There's the Discord bridge's guide for [setting privileges on bridge managed roo
 
 ```sh
 docker exec -it matrix-appservice-discord \
-/bin/sh -c 'cp /cfg/registration.yaml /tmp/discord-registration.yaml && cd /tmp && node /build/tools/adminme.js -c /cfg/config.yaml -m "!someRoom:example.com" -u "@USER:example.com" -p 100'
+/bin/sh -c 'cp /cfg/registration.yaml /tmp/discord-registration.yaml && cd /tmp && node /build/tools/adminme.js -c /cfg/config.yaml -m "!qporfwt:example.com" -u "@USER:example.com" -p 100'
 ```

--- a/docs/configuring-playbook-bridge-appservice-discord.md
+++ b/docs/configuring-playbook-bridge-appservice-discord.md
@@ -81,5 +81,5 @@ There's the Discord bridge's guide for [setting privileges on bridge managed roo
 
 ```sh
 docker exec -it matrix-appservice-discord \
-/bin/sh -c 'cp /cfg/registration.yaml /tmp/discord-registration.yaml && cd /tmp && node /build/tools/adminme.js -c /cfg/config.yaml -m "!ROOM_ID:SERVER" -u "@USER:SERVER" -p 100'
+/bin/sh -c 'cp /cfg/registration.yaml /tmp/discord-registration.yaml && cd /tmp && node /build/tools/adminme.js -c /cfg/config.yaml -m "!ROOM_ID:example.com" -u "@USER:example.com" -p 100'
 ```

--- a/docs/configuring-playbook-bridge-appservice-discord.md
+++ b/docs/configuring-playbook-bridge-appservice-discord.md
@@ -81,5 +81,5 @@ There's the Discord bridge's guide for [setting privileges on bridge managed roo
 
 ```sh
 docker exec -it matrix-appservice-discord \
-/bin/sh -c 'cp /cfg/registration.yaml /tmp/discord-registration.yaml && cd /tmp && node /build/tools/adminme.js -c /cfg/config.yaml -m "!ROOM_ID:example.com" -u "@USER:example.com" -p 100'
+/bin/sh -c 'cp /cfg/registration.yaml /tmp/discord-registration.yaml && cd /tmp && node /build/tools/adminme.js -c /cfg/config.yaml -m "!someRoom:example.com" -u "@USER:example.com" -p 100'
 ```

--- a/docs/configuring-playbook-bridge-appservice-slack.md
+++ b/docs/configuring-playbook-bridge-appservice-slack.md
@@ -90,19 +90,19 @@ loosely based on [this](https://github.com/matrix-org/matrix-appservice-slack#Se
         with file bridging:
 
         ```
-        link --channel_id CHANNELID --room !the-matrix:room.id --slack_bot_token xoxb-xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx --slack_user_token xoxp-xxxxxxxx-xxxxxxxxx-xxxxxxxx-xxxxxxxx
+        link --channel_id CHANNELID --room !the-matrix:example.com --slack_bot_token xoxb-xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx --slack_user_token xoxp-xxxxxxxx-xxxxxxxxx-xxxxxxxx-xxxxxxxx
         ```
 
         without file bridging:
 
         ```
-        link --channel_id CHANNELID --room !the-matrix:room.id --slack_bot_token xoxb-xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx
+        link --channel_id CHANNELID --room !the-matrix:example.com --slack_bot_token xoxb-xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx
         ```
 
         These arguments can be shortened to single-letter forms:
 
         ```
-        link -I CHANNELID -R !the-matrix:room.id -t xoxb-xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx
+        link -I CHANNELID -R !the-matrix:example.com -t xoxb-xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx
         ```
 
         Other configuration options are available via the `matrix_appservice_slack_configuration_extension_yaml` variable.
@@ -112,7 +112,7 @@ loosely based on [this](https://github.com/matrix-org/matrix-appservice-slack#Se
     Channels can be unlinked again like this:
 
     ```
-    unlink --room !the-matrix:room.id
+    unlink --room !the-matrix:example.com
     ```
 
     Unlinking doesn't only disconnect the bridge, but also makes the slackbot leave the bridged Matrix room. So in case you want to re-link later, don't forget to re-invite the slackbot into this room again.

--- a/docs/configuring-playbook-bridge-appservice-slack.md
+++ b/docs/configuring-playbook-bridge-appservice-slack.md
@@ -79,7 +79,7 @@ loosely based on [this](https://github.com/matrix-org/matrix-appservice-slack#Se
 
 11. If Team Sync is not enabled, for each channel you would like to bridge, perform the following steps:
 
-    * Create a Matrix room in the usual manner for your client. Take a note of its Matrix room ID - it will look something like !someRoom:example.com.
+    * Create a Matrix room in the usual manner for your client. Take a note of its Matrix room ID - it will look something like !qporfwt:example.com.
 
     * Invite the bot user to both the Slack and Matrix channels you would like to bridge using `/invite @matrixbot` for Slack and `/invite @slackbot:example.com` for Matrix.
 
@@ -90,19 +90,19 @@ loosely based on [this](https://github.com/matrix-org/matrix-appservice-slack#Se
         with file bridging:
 
         ```
-        link --channel_id CHANNELID --room !someRoom:example.com --slack_bot_token xoxb-xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx --slack_user_token xoxp-xxxxxxxx-xxxxxxxxx-xxxxxxxx-xxxxxxxx
+        link --channel_id CHANNELID --room !qporfwt:example.com --slack_bot_token xoxb-xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx --slack_user_token xoxp-xxxxxxxx-xxxxxxxxx-xxxxxxxx-xxxxxxxx
         ```
 
         without file bridging:
 
         ```
-        link --channel_id CHANNELID --room !someRoom:example.com --slack_bot_token xoxb-xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx
+        link --channel_id CHANNELID --room !qporfwt:example.com --slack_bot_token xoxb-xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx
         ```
 
         These arguments can be shortened to single-letter forms:
 
         ```
-        link -I CHANNELID -R !someRoom:example.com -t xoxb-xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx
+        link -I CHANNELID -R !qporfwt:example.com -t xoxb-xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx
         ```
 
         Other configuration options are available via the `matrix_appservice_slack_configuration_extension_yaml` variable.
@@ -112,7 +112,7 @@ loosely based on [this](https://github.com/matrix-org/matrix-appservice-slack#Se
     Channels can be unlinked again like this:
 
     ```
-    unlink --room !someRoom:example.com
+    unlink --room !qporfwt:example.com
     ```
 
     Unlinking doesn't only disconnect the bridge, but also makes the slackbot leave the bridged Matrix room. So in case you want to re-link later, don't forget to re-invite the slackbot into this room again.

--- a/docs/configuring-playbook-bridge-appservice-slack.md
+++ b/docs/configuring-playbook-bridge-appservice-slack.md
@@ -79,7 +79,7 @@ loosely based on [this](https://github.com/matrix-org/matrix-appservice-slack#Se
 
 11. If Team Sync is not enabled, for each channel you would like to bridge, perform the following steps:
 
-    * Create a Matrix room in the usual manner for your client. Take a note of its Matrix room ID - it will look something like !aBcDeF:example.com.
+    * Create a Matrix room in the usual manner for your client. Take a note of its Matrix room ID - it will look something like !someRoom:example.com.
 
     * Invite the bot user to both the Slack and Matrix channels you would like to bridge using `/invite @matrixbot` for Slack and `/invite @slackbot:example.com` for Matrix.
 
@@ -90,19 +90,19 @@ loosely based on [this](https://github.com/matrix-org/matrix-appservice-slack#Se
         with file bridging:
 
         ```
-        link --channel_id CHANNELID --room !the-matrix:example.com --slack_bot_token xoxb-xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx --slack_user_token xoxp-xxxxxxxx-xxxxxxxxx-xxxxxxxx-xxxxxxxx
+        link --channel_id CHANNELID --room !someRoom:example.com --slack_bot_token xoxb-xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx --slack_user_token xoxp-xxxxxxxx-xxxxxxxxx-xxxxxxxx-xxxxxxxx
         ```
 
         without file bridging:
 
         ```
-        link --channel_id CHANNELID --room !the-matrix:example.com --slack_bot_token xoxb-xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx
+        link --channel_id CHANNELID --room !someRoom:example.com --slack_bot_token xoxb-xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx
         ```
 
         These arguments can be shortened to single-letter forms:
 
         ```
-        link -I CHANNELID -R !the-matrix:example.com -t xoxb-xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx
+        link -I CHANNELID -R !someRoom:example.com -t xoxb-xxxxxxxxxx-xxxxxxxxxxxxxxxxxxxx
         ```
 
         Other configuration options are available via the `matrix_appservice_slack_configuration_extension_yaml` variable.
@@ -112,7 +112,7 @@ loosely based on [this](https://github.com/matrix-org/matrix-appservice-slack#Se
     Channels can be unlinked again like this:
 
     ```
-    unlink --room !the-matrix:example.com
+    unlink --room !someRoom:example.com
     ```
 
     Unlinking doesn't only disconnect the bridge, but also makes the slackbot leave the bridged Matrix room. So in case you want to re-link later, don't forget to re-invite the slackbot into this room again.

--- a/docs/configuring-playbook-email2matrix.md
+++ b/docs/configuring-playbook-email2matrix.md
@@ -59,7 +59,7 @@ matrix_email2matrix_matrix_mappings:
     SkipMarkdown: false
 
   - MailboxName: "mailbox2"
-    MatrixRoomId: "!anotherRoom:{{ matrix_domain }}"
+    MatrixRoomId: "!aaabaa:{{ matrix_domain }}"
     MatrixHomeserverUrl: "{{ matrix_homeserver_url }}"
     MatrixUserId: "@email2matrix:{{ matrix_domain }}"
     MatrixAccessToken: "MATRIX_ACCESS_TOKEN_HERE"

--- a/docs/configuring-playbook-email2matrix.md
+++ b/docs/configuring-playbook-email2matrix.md
@@ -50,7 +50,7 @@ matrix_email2matrix_enabled: true
 
 matrix_email2matrix_matrix_mappings:
   - MailboxName: "mailbox1"
-    MatrixRoomId: "!someRoom:{{ matrix_domain }}"
+    MatrixRoomId: "!qporfwt:{{ matrix_domain }}"
     MatrixHomeserverUrl: "{{ matrix_homeserver_url }}"
     MatrixUserId: "@email2matrix:{{ matrix_domain }}"
     MatrixAccessToken: "MATRIX_ACCESS_TOKEN_HERE"

--- a/roles/custom/matrix-alertmanager-receiver/defaults/main.yml
+++ b/roles/custom/matrix-alertmanager-receiver/defaults/main.yml
@@ -128,7 +128,7 @@ matrix_alertmanager_receiver_config_matrix_access_token: ''
 # Example:
 # matrix_alertmanager_receiver_config_matrix_room:
 #   simple-name: "!qporfwt:example.com"
-#   another-name: "!anotherRoom:example.com"
+#   another-name: "!aaabaa:example.com"
 matrix_alertmanager_receiver_config_matrix_room_mapping: {}
 
 # Controls the `templating.external-url-mapping` configuration setting.

--- a/roles/custom/matrix-alertmanager-receiver/defaults/main.yml
+++ b/roles/custom/matrix-alertmanager-receiver/defaults/main.yml
@@ -127,7 +127,7 @@ matrix_alertmanager_receiver_config_matrix_access_token: ''
 #
 # Example:
 # matrix_alertmanager_receiver_config_matrix_room:
-#   simple-name: "!someRoom:example.com"
+#   simple-name: "!qporfwt:example.com"
 #   another-name: "!anotherRoom:example.com"
 matrix_alertmanager_receiver_config_matrix_room_mapping: {}
 

--- a/roles/custom/matrix-alertmanager-receiver/defaults/main.yml
+++ b/roles/custom/matrix-alertmanager-receiver/defaults/main.yml
@@ -127,8 +127,8 @@ matrix_alertmanager_receiver_config_matrix_access_token: ''
 #
 # Example:
 # matrix_alertmanager_receiver_config_matrix_room:
-#   simple-name: "!qohfwef7qwerf:example.com"
-#   another-name: "!bf3zfio3wbanw:example.com"
+#   simple-name: "!someRoom:example.com"
+#   another-name: "!anotherRoom:example.com"
 matrix_alertmanager_receiver_config_matrix_room_mapping: {}
 
 # Controls the `templating.external-url-mapping` configuration setting.

--- a/roles/custom/matrix-bot-draupnir/templates/production.yaml.j2
+++ b/roles/custom/matrix-bot-draupnir/templates/production.yaml.j2
@@ -38,7 +38,7 @@ autojoinOnlyIfManager: true
 
 # If `autojoinOnlyIfManager` is false, only the members in this space can invite
 # the bot to new rooms.
-#acceptInvitesFromSpace: "!example:example.org"
+#acceptInvitesFromSpace: "!qporfwt:example.com"
 
 # Whether Draupnir should report ignored invites to the management room (if autojoinOnlyIfManager is true).
 recordIgnoredInvites: false

--- a/roles/custom/matrix-bot-draupnir/templates/production.yaml.j2
+++ b/roles/custom/matrix-bot-draupnir/templates/production.yaml.j2
@@ -109,7 +109,7 @@ automaticallyRedactForReasons:
 #
 # Note: These must be matrix.to URLs
 #protectedRooms:
-#  - "https://matrix.to/#/#yourroom:example.org"
+#  - "https://matrix.to/#/#matrix:example.org"
 
 # Whether or not to add all joined rooms to the "protected rooms" list
 # (excluding the management room and watched policy list rooms, see below).

--- a/roles/custom/matrix-bot-go-neb/defaults/main.yml
+++ b/roles/custom/matrix-bot-go-neb/defaults/main.yml
@@ -262,7 +262,7 @@ matrix_bot_go_neb_services: []
 #    Config:
 #      feeds:
 #        "http://lorem-rss.herokuapp.com/feed?unit=second&interval=60":
-#          rooms: ["!qmElAGdFYCHoCJuaNt:localhost"]
+#          rooms: ["!someRoom:localhost"]
 #          must_include:
 #            author:
 #              - author1
@@ -288,7 +288,7 @@ matrix_bot_go_neb_services: []
 #      RealmID: "github_realm"
 #      ClientUserID: "@YOUR_USER_ID:{{ matrix_domain }}" # needs to be an authenticated user so Go-NEB can create webhooks. Check the UserID field in the github_realm in matrix_bot_go_neb_sessions.
 #      Rooms:
-#        "!someroom:example.com":
+#        "!someRoom:example.com":
 #          Repos:
 #            "element-hq/synapse":
 #              Events: ["push", "issues"]
@@ -307,7 +307,7 @@ matrix_bot_go_neb_services: []
 #    Config:
 #      Hooks:
 #        "hook1":
-#          RoomID: "!someroom:example.com"
+#          RoomID: "!someRoom:example.com"
 #          MessageType: "m.text" # default is m.text
 #
 #  - ID: "alertmanager_service"
@@ -321,7 +321,7 @@ matrix_bot_go_neb_services: []
 #      webhook_url: "http://localhost/services/hooks/YWxlcnRtYW5hZ2VyX3NlcnZpY2U"
 #      # Each room will get the notification with the alert rendered with the given template
 #      rooms:
-#        "!someroomid:example.com":
+#        "!someRoom:example.com":
 #          text_template: "{% raw %}{{range .Alerts -}} [{{ .Status }}] {{index .Labels \"alertname\"}}: {{index .Annotations \"description\"}} {{ end -}}{% endraw %}"
 #          html_template: "{% raw %}{{range .Alerts -}}  {{ $severity := index .Labels \"severity\"}}    {{ if eq .Status \"firing\"}}      {{ if eq $severity \"critical\"}}        <font color='red'><b>[FIRING - CRITICAL]</b></font>      {{ else if eq $severity \"warning\"}}        <font color='orange'><b>[FIRING - WARNING]</b></font>      {{ else }}        <b>[FIRING - {{ $severity }}]</b>      {{ end }}    {{ else }}      <font color='green'><b>[RESOLVED]</b></font>    {{ end }}  {{ index .Labels \"alertname\"}} : {{ index .Annotations \"description\"}}   <a href=\"{{ .GeneratorURL }}\">source</a><br/>{{end -}}{% endraw %}"
 #          msg_type: "m.text"  # Must be either `m.text` or `m.notice`

--- a/roles/custom/matrix-bot-go-neb/defaults/main.yml
+++ b/roles/custom/matrix-bot-go-neb/defaults/main.yml
@@ -262,7 +262,7 @@ matrix_bot_go_neb_services: []
 #    Config:
 #      feeds:
 #        "http://lorem-rss.herokuapp.com/feed?unit=second&interval=60":
-#          rooms: ["!someRoom:localhost"]
+#          rooms: ["!qporfwt:localhost"]
 #          must_include:
 #            author:
 #              - author1
@@ -288,7 +288,7 @@ matrix_bot_go_neb_services: []
 #      RealmID: "github_realm"
 #      ClientUserID: "@YOUR_USER_ID:{{ matrix_domain }}" # needs to be an authenticated user so Go-NEB can create webhooks. Check the UserID field in the github_realm in matrix_bot_go_neb_sessions.
 #      Rooms:
-#        "!someRoom:example.com":
+#        "!qporfwt:example.com":
 #          Repos:
 #            "element-hq/synapse":
 #              Events: ["push", "issues"]
@@ -307,7 +307,7 @@ matrix_bot_go_neb_services: []
 #    Config:
 #      Hooks:
 #        "hook1":
-#          RoomID: "!someRoom:example.com"
+#          RoomID: "!qporfwt:example.com"
 #          MessageType: "m.text" # default is m.text
 #
 #  - ID: "alertmanager_service"
@@ -321,7 +321,7 @@ matrix_bot_go_neb_services: []
 #      webhook_url: "http://localhost/services/hooks/YWxlcnRtYW5hZ2VyX3NlcnZpY2U"
 #      # Each room will get the notification with the alert rendered with the given template
 #      rooms:
-#        "!someRoom:example.com":
+#        "!qporfwt:example.com":
 #          text_template: "{% raw %}{{range .Alerts -}} [{{ .Status }}] {{index .Labels \"alertname\"}}: {{index .Annotations \"description\"}} {{ end -}}{% endraw %}"
 #          html_template: "{% raw %}{{range .Alerts -}}  {{ $severity := index .Labels \"severity\"}}    {{ if eq .Status \"firing\"}}      {{ if eq $severity \"critical\"}}        <font color='red'><b>[FIRING - CRITICAL]</b></font>      {{ else if eq $severity \"warning\"}}        <font color='orange'><b>[FIRING - WARNING]</b></font>      {{ else }}        <b>[FIRING - {{ $severity }}]</b>      {{ end }}    {{ else }}      <font color='green'><b>[RESOLVED]</b></font>    {{ end }}  {{ index .Labels \"alertname\"}} : {{ index .Annotations \"description\"}}   <a href=\"{{ .GeneratorURL }}\">source</a><br/>{{end -}}{% endraw %}"
 #          msg_type: "m.text"  # Must be either `m.text` or `m.notice`

--- a/roles/custom/matrix-bot-go-neb/defaults/main.yml
+++ b/roles/custom/matrix-bot-go-neb/defaults/main.yml
@@ -288,13 +288,13 @@ matrix_bot_go_neb_services: []
 #      RealmID: "github_realm"
 #      ClientUserID: "@YOUR_USER_ID:{{ matrix_domain }}" # needs to be an authenticated user so Go-NEB can create webhooks. Check the UserID field in the github_realm in matrix_bot_go_neb_sessions.
 #      Rooms:
-#        "!someroom:id":
+#        "!someroom:example.com":
 #          Repos:
 #            "element-hq/synapse":
 #              Events: ["push", "issues"]
 #            "matrix-org/dendron":
 #              Events: ["pull_request"]
-#        "!anotherroom:id":
+#        "!anotherroom:example.com":
 #          Repos:
 #            "element-hq/synapse":
 #              Events: ["push", "issues"]
@@ -307,7 +307,7 @@ matrix_bot_go_neb_services: []
 #    Config:
 #      Hooks:
 #        "hook1":
-#          RoomID: "!someroom:id"
+#          RoomID: "!someroom:example.com"
 #          MessageType: "m.text" # default is m.text
 #
 #  - ID: "alertmanager_service"

--- a/roles/custom/matrix-bot-go-neb/defaults/main.yml
+++ b/roles/custom/matrix-bot-go-neb/defaults/main.yml
@@ -294,7 +294,7 @@ matrix_bot_go_neb_services: []
 #              Events: ["push", "issues"]
 #            "matrix-org/dendron":
 #              Events: ["pull_request"]
-#        "!anotherRoom:example.com":
+#        "!aaabaa:example.com":
 #          Repos:
 #            "element-hq/synapse":
 #              Events: ["push", "issues"]

--- a/roles/custom/matrix-bot-go-neb/defaults/main.yml
+++ b/roles/custom/matrix-bot-go-neb/defaults/main.yml
@@ -294,7 +294,7 @@ matrix_bot_go_neb_services: []
 #              Events: ["push", "issues"]
 #            "matrix-org/dendron":
 #              Events: ["pull_request"]
-#        "!anotherroom:example.com":
+#        "!anotherRoom:example.com":
 #          Repos:
 #            "element-hq/synapse":
 #              Events: ["push", "issues"]

--- a/roles/custom/matrix-bot-mjolnir/templates/production.yaml.j2
+++ b/roles/custom/matrix-bot-mjolnir/templates/production.yaml.j2
@@ -103,7 +103,7 @@ automaticallyRedactForReasons:
 #
 # Note: These must be matrix.to URLs
 #protectedRooms:
-#  - "https://matrix.to/#/#yourroom:example.org"
+#  - "https://matrix.to/#/#matrix:example.org"
 
 # Whether or not to add all joined rooms to the "protected rooms" list
 # (excluding the management room and watched policy list rooms, see below).

--- a/roles/custom/matrix-bot-mjolnir/templates/production.yaml.j2
+++ b/roles/custom/matrix-bot-mjolnir/templates/production.yaml.j2
@@ -38,7 +38,7 @@ autojoinOnlyIfManager: true
 
 # If `autojoinOnlyIfManager` is false, only the members in this space can invite
 # the bot to new rooms.
-#acceptInvitesFromSpace: "!example:example.org"
+#acceptInvitesFromSpace: "!qporfwt:example.com"
 
 # Whether Mjolnir should report ignored invites to the management room (if autojoinOnlyIfManager is true).
 recordIgnoredInvites: false

--- a/roles/custom/matrix-bridge-appservice-irc/defaults/main.yml
+++ b/roles/custom/matrix-bridge-appservice-irc/defaults/main.yml
@@ -256,7 +256,7 @@ matrix_appservice_irc_ircService_servers: []  # noqa var-naming
 
 #       # Apply specific rules to Matrix rooms. Only matrix-to-IRC takes effect.
 #       rooms:
-#         - room: "!someRoom:localhost"
+#         - room: "!qporfwt:localhost"
 #           matrixToIrc:
 #             initial: false
 #             incremental: false
@@ -273,7 +273,7 @@ matrix_appservice_irc_ircService_servers: []  # noqa var-naming
 #       # The Matrix room must already exist. Your Matrix client should expose
 #       # the room ID in a "settings" page for the room.
 #       "#thepub":
-#         roomIds: ["!someRoom:localhost"]
+#         roomIds: ["!qporfwt:localhost"]
 #         # Channel key/password to use. Optional. If provided, Matrix users do
 #         # not need to know the channel key in order to join the channel.
 #         # key: "secret"

--- a/roles/custom/matrix-bridge-appservice-irc/defaults/main.yml
+++ b/roles/custom/matrix-bridge-appservice-irc/defaults/main.yml
@@ -256,7 +256,7 @@ matrix_appservice_irc_ircService_servers: []  # noqa var-naming
 
 #       # Apply specific rules to Matrix rooms. Only matrix-to-IRC takes effect.
 #       rooms:
-#         - room: "!fuasirouddJoxtwfge:localhost"
+#         - room: "!someRoom:localhost"
 #           matrixToIrc:
 #             initial: false
 #             incremental: false
@@ -273,7 +273,7 @@ matrix_appservice_irc_ircService_servers: []  # noqa var-naming
 #       # The Matrix room must already exist. Your Matrix client should expose
 #       # the room ID in a "settings" page for the room.
 #       "#thepub":
-#         roomIds: ["!kieouiJuedJoxtVdaG:localhost"]
+#         roomIds: ["!someRoom:localhost"]
 #         # Channel key/password to use. Optional. If provided, Matrix users do
 #         # not need to know the channel key in order to join the channel.
 #         # key: "secret"

--- a/roles/custom/matrix-bridge-appservice-slack/defaults/main.yml
+++ b/roles/custom/matrix-bridge-appservice-slack/defaults/main.yml
@@ -141,7 +141,7 @@ matrix_appservice_slack_configuration_extension_yaml: |
     # Optional
     #slack_master_token: "abc-123-def"
     # Optional
-    #matrix_admin_room: "!aBcDeF:matrix.org"
+    #matrix_admin_room: "!aBcDeF:example.com"
     #homeserver:
     #    url: http://localhost:{{ matrix_synapse_container_client_api_port }}
     #    server_name: my.server

--- a/roles/custom/matrix-bridge-appservice-slack/defaults/main.yml
+++ b/roles/custom/matrix-bridge-appservice-slack/defaults/main.yml
@@ -141,7 +141,7 @@ matrix_appservice_slack_configuration_extension_yaml: |
     # Optional
     #slack_master_token: "abc-123-def"
     # Optional
-    #matrix_admin_room: "!aBcDeF:example.com"
+    #matrix_admin_room: "!someRoom:example.com"
     #homeserver:
     #    url: http://localhost:{{ matrix_synapse_container_client_api_port }}
     #    server_name: my.server

--- a/roles/custom/matrix-bridge-appservice-slack/defaults/main.yml
+++ b/roles/custom/matrix-bridge-appservice-slack/defaults/main.yml
@@ -141,7 +141,7 @@ matrix_appservice_slack_configuration_extension_yaml: |
     # Optional
     #slack_master_token: "abc-123-def"
     # Optional
-    #matrix_admin_room: "!someRoom:example.com"
+    #matrix_admin_room: "!qporfwt:example.com"
     #homeserver:
     #    url: http://localhost:{{ matrix_synapse_container_client_api_port }}
     #    server_name: my.server

--- a/roles/custom/matrix-bridge-go-skype-bridge/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-go-skype-bridge/templates/config.yaml.j2
@@ -205,7 +205,7 @@ bridge:
         # The management room for the bot. This is where all status notifications are posted and
         # in this room, you can use `!wa <command>` instead of `!wa relaybot <command>`. Omitting
         # the command prefix completely like in user management rooms is not possible.
-        management: '!foo:example.com'
+        management: '!someRoom:example.com'
         # List of users to invite to all created rooms that include the relaybot.
         invites: []
         # The formats to use when sending messages to Skype via the relaybot.

--- a/roles/custom/matrix-bridge-go-skype-bridge/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-go-skype-bridge/templates/config.yaml.j2
@@ -205,7 +205,7 @@ bridge:
         # The management room for the bot. This is where all status notifications are posted and
         # in this room, you can use `!wa <command>` instead of `!wa relaybot <command>`. Omitting
         # the command prefix completely like in user management rooms is not possible.
-        management: '!someRoom:example.com'
+        management: '!qporfwt:example.com'
         # List of users to invite to all created rooms that include the relaybot.
         invites: []
         # The formats to use when sending messages to Skype via the relaybot.

--- a/roles/custom/matrix-email2matrix/defaults/main.yml
+++ b/roles/custom/matrix-email2matrix/defaults/main.yml
@@ -46,7 +46,7 @@ matrix_email2matrix_smtp_hostname: "{{ matrix_server_fqn_matrix }}"
 # Example:
 # matrix_email2matrix_matrix_mappings:
 #  - MailboxName: "mailbox1"
-#    MatrixRoomId: "!someRoom:{{ matrix_domain }}"
+#    MatrixRoomId: "!qporfwt:{{ matrix_domain }}"
 #    MatrixHomeserverUrl: "{{ matrix_homeserver_url }}"
 #    MatrixUserId: "@email2matrix:{{ matrix_domain }}"
 #    MatrixAccessToken: "MATRIX_ACCESS_TOKEN_HERE"

--- a/roles/custom/matrix-email2matrix/defaults/main.yml
+++ b/roles/custom/matrix-email2matrix/defaults/main.yml
@@ -55,7 +55,7 @@ matrix_email2matrix_smtp_hostname: "{{ matrix_server_fqn_matrix }}"
 #    SkipMarkdown: false
 #
 #  - MailboxName: "mailbox2"
-#    MatrixRoomId: "!anotherRoom:{{ matrix_domain }}"
+#    MatrixRoomId: "!aaabaa:{{ matrix_domain }}"
 #    MatrixHomeserverUrl: "{{ matrix_homeserver_url }}"
 #    MatrixUserId: "@email2matrix:{{ matrix_domain }}"
 #    MatrixAccessToken: "MATRIX_ACCESS_TOKEN_HERE"

--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -1245,7 +1245,7 @@ matrix_synapse_ext_spam_checker_mjolnir_antispam_config_block_usernames: false
 # this list cannot be room aliases or permalinks. This server is expected
 # to already be joined to the room - Mjolnir will not automatically join
 # these rooms.
-# ["!roomid:example.org"]
+# ["!someRoom:example.org"]
 matrix_synapse_ext_spam_checker_mjolnir_antispam_config_ban_lists: []
 # A dictionary with various fields controlling max length.
 # See https://github.com/matrix-org/mjolnir/blob/main/docs/synapse_module.md for details.

--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -1245,7 +1245,7 @@ matrix_synapse_ext_spam_checker_mjolnir_antispam_config_block_usernames: false
 # this list cannot be room aliases or permalinks. This server is expected
 # to already be joined to the room - Mjolnir will not automatically join
 # these rooms.
-# ["!someRoom:example.org"]
+# ["!qporfwt:example.org"]
 matrix_synapse_ext_spam_checker_mjolnir_antispam_config_ban_lists: []
 # A dictionary with various fields controlling max length.
 # See https://github.com/matrix-org/mjolnir/blob/main/docs/synapse_module.md for details.

--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -1245,7 +1245,7 @@ matrix_synapse_ext_spam_checker_mjolnir_antispam_config_block_usernames: false
 # this list cannot be room aliases or permalinks. This server is expected
 # to already be joined to the room - Mjolnir will not automatically join
 # these rooms.
-# ["!qporfwt:example.org"]
+# ["!qporfwt:example.com"]
 matrix_synapse_ext_spam_checker_mjolnir_antispam_config_ban_lists: []
 # A dictionary with various fields controlling max length.
 # See https://github.com/matrix-org/mjolnir/blob/main/docs/synapse_module.md for details.

--- a/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -575,7 +575,7 @@ templates:
 # By default, no room is excluded.
 #
 #exclude_rooms_from_sync:
-#    - !foo:example.com
+#    - !someRoom:example.com
 
 
 # Message retention policy at the server level.

--- a/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -575,7 +575,7 @@ templates:
 # By default, no room is excluded.
 #
 #exclude_rooms_from_sync:
-#    - !someRoom:example.com
+#    - !qporfwt:example.com
 
 
 # Message retention policy at the server level.


### PR DESCRIPTION
Related: https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/3631

This PR intends to update room IDs and alias with ones on the Matrix Specification.

See:
- https://spec.matrix.org/v1.12/#room-structure where the room ID `!qporfwt:matrix.org` is used as an example.
- https://spec.matrix.org/v1.12/#room-aliases where the room ID `!aaabaa:matrix.org` is used as an example.
- https://spec.matrix.org/v1.12/#room-aliases where the room alias `#matrix:example.org` is used as an example.

If I am honest, I do not think those are nice choices... they should be something which looks more as example, but using ones on the specs should help us to keep consistency when they are updated on a future spec version.