### PR TITLE
Synchronize document titles and links based on configuring-playbook.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -876,7 +876,7 @@ Thanks to [Benjamin Kampmann](https://github.com/gnunicorn) for [getting it star
 
 The upcoming Element X clients ([Element X iOS](https://github.com/vector-im/element-x-ios) and [Element X Android](https://github.com/vector-im/element-x-android)) require the `sliding-sync` proxy to do their job. **These clients are still in beta** (especially Element X Android, which requires manual compilation to get it working with a non-`matrix.org` homeseserver). Playbook users can now easily give these clients a try and help test them thanks to us having `sliding-sync` support.
 
-To get started, see our [Setting up Sliding Sync proxy](docs/configuring-playbook-sliding-sync-proxy.md) documentation page.
+To get started, see our [Setting up the Sliding Sync proxy](docs/configuring-playbook-sliding-sync-proxy.md) documentation page.
 
 
 # 2023-03-02
@@ -1464,7 +1464,7 @@ With the new Synapse-customization feature in the playbook, we use the original 
 
 Thanks to [@TheOneWithTheBraid](https://github.com/TheOneWithTheBraid), we now support installing [matrix-ldap-registration-proxy](https://gitlab.com/activism.international/matrix_ldap_registration_proxy) - a proxy which handles Matrix registration requests and forwards them to LDAP.
 
-See our [Setting up the ldap-registration-proxy](docs/configuring-playbook-matrix-ldap-registration-proxy.md) documentation to get started.
+See our [Setting up matrix-ldap-registration-proxy](docs/configuring-playbook-matrix-ldap-registration-proxy.md) documentation to get started.
 
 
 # 2022-09-15
@@ -1564,7 +1564,7 @@ Below we'll discuss **potential backward incompatibilities**.
 
 Thanks to [Julian-Samuel Gebühr (@moan0s)](https://github.com/moan0s), the playbook can now set up [Cactus Comments](https://cactus.chat) - federated comment system for the web based on Matrix.
 
-See our [Setting up a Cactus Comments server](docs/configuring-playbook-cactus-comments.md) documentation to get started.
+See our [Setting up Cactus Comments](docs/configuring-playbook-cactus-comments.md) documentation to get started.
 
 
 # 2022-08-23
@@ -1708,7 +1708,7 @@ See our [Setting up the ntfy push notifications server](docs/configuring-playboo
 
 Thanks to [CyberShadow](https://github.com/CyberShadow), the playbook can now install the [go-skype-bridge](https://github.com/kelaresg/go-skype-bridge) bridge for bridging Matrix to [Skype](https://www.skype.com/).
 
-See our [Setting up Go Skype Bridge](docs/configuring-playbook-bridge-go-skype-bridge.md) documentation to get started.
+See our [Setting up Go Skype Bridge bridging](docs/configuring-playbook-bridge-go-skype-bridge.md) documentation to get started.
 
 The playbook has supported [mx-puppet-skype](https://github.com/Sorunome/mx-puppet-skype) bridging (see [Setting up MX Puppet Skype bridging](docs/configuring-playbook-bridge-mx-puppet-skype.md)) since [2020-04-09](#2020-04-09), but `mx-puppet-skype` is reportedly broken.
 
@@ -2038,7 +2038,7 @@ The playbook can now install the [Sygnal](https://github.com/matrix-org/sygnal) 
 
 This is only useful to people who develop/build their own Matrix client applications.
 
-Additional details are available in our [Setting up Sygnal](docs/configuring-playbook-sygnal.md) docs.
+Additional details are available in our [Setting up the Sygnal push gateway](docs/configuring-playbook-sygnal.md) docs.
 
 
 # 2021-03-16
@@ -2717,7 +2717,7 @@ It forces a [Postgres database upgrade](docs/maintenance-postgres.md#upgrading-p
 
 Thanks to a contribution from [Björn Marten](https://github.com/tripleawwy) from [netresearch](https://www.netresearch.de/), the playbook can now install and configure [matrix-appservice-webhooks](https://github.com/turt2live/matrix-appservice-webhooks) for you. This bridge provides support for Slack-compatible webhooks.
 
-Learn more in [Setting up Appservice Webhooks](docs/configuring-playbook-bridge-appservice-webhooks.md).
+Learn more in [Setting up Appservice Webhooks bridging](docs/configuring-playbook-bridge-appservice-webhooks.md).
 
 
 # 2020-01-12
@@ -3292,7 +3292,7 @@ When using:
 ## IRC bridging support
 
 [Devon Maloney (@Plailect)](https://github.com/Plailect) has done some great work bringing IRC bridging support via [matrix-appservice-irc](https://github.com/TeDomum/matrix-appservice-irc).
-To learn more, see the [Setting up Appservice IRC](docs/configuring-playbook-bridge-appservice-irc.md) documentation page.
+To learn more, see the [Setting up Appservice IRC bridging](docs/configuring-playbook-bridge-appservice-irc.md) documentation page.
 
 
 # 2019-01-29
@@ -3757,7 +3757,7 @@ The Client APIs run only on the http port (8008) now.
 ## mxisd Identity Server support
 
 The playbook now sets up an [mxisd](https://github.com/kamax-io/mxisd) Identity Server for you by default.
-Additional details are available in [Adjusting mxisd Identity Server configuration](docs/configuring-playbook-mxisd.md).
+Additional details are available in [Setting up ma1sd Identity Server](docs/configuring-playbook-mxisd.md).
 
 
 # 2018-08-14

--- a/docs/configuring-playbook-alertmanager-receiver.md
+++ b/docs/configuring-playbook-alertmanager-receiver.md
@@ -1,4 +1,4 @@
-# Setting up matrix-alertmanager-receiver (optional)
+# Setting up Prometheus Alertmanager integration via matrix-alertmanager-receiver (optional)
 
 The playbook can install and configure the [matrix-alertmanager-receiver](https://github.com/metio/matrix-alertmanager-receiver) service for you. It's a [client](https://prometheus.io/docs/alerting/latest/clients/) for Prometheus' [Alertmanager](https://prometheus.io/docs/alerting/latest/alertmanager/), allowing you to deliver alerts to Matrix rooms.
 

--- a/docs/configuring-playbook-base-domain-serving.md
+++ b/docs/configuring-playbook-base-domain-serving.md
@@ -1,4 +1,4 @@
-# Serving the base domain
+# Serving the base domain (optional)
 
 This playbook sets up services on your Matrix server (`matrix.example.com`). To have this server officially be responsible for Matrix services for the base domain (`example.com`), you need to set up [Server Delegation](howto-server-delegation.md). This is normally done by [configuring well-known](configuring-well-known.md) files on the base domain.
 

--- a/docs/configuring-playbook-bot-chatgpt.md
+++ b/docs/configuring-playbook-bot-chatgpt.md
@@ -1,4 +1,4 @@
-# Setting up ChatGPT (optional)
+# Setting up matrix-bot-chatgpt (optional)
 
 The playbook can install and configure [matrix-chatgpt-bot](https://github.com/matrixgpt/matrix-chatgpt-bot) for you.
 

--- a/docs/configuring-playbook-bot-postmoogle.md
+++ b/docs/configuring-playbook-bot-postmoogle.md
@@ -1,4 +1,4 @@
-# Setting up Postmoogle (optional)
+# Setting up Postmoogle email bridging (optional)
 
 **Note**: email bridging can also happen via the [email2matrix](configuring-playbook-email2matrix.md) bridge supported by the playbook.
 

--- a/docs/configuring-playbook-bridge-appservice-discord.md
+++ b/docs/configuring-playbook-bridge-appservice-discord.md
@@ -1,4 +1,4 @@
-# Setting up Appservice Discord (optional)
+# Setting up Appservice Discord bridging (optional)
 
 **Note**: bridging to [Discord](https://discordapp.com/) can also happen via the [mx-puppet-discord](configuring-playbook-bridge-mx-puppet-discord.md) and [mautrix-discord](configuring-playbook-bridge-mautrix-discord.md) bridges supported by the playbook.
 - For using as a Bot we are recommend the Appservice Discord bridge (the one being discussed here), because it supports plumbing.

--- a/docs/configuring-playbook-bridge-appservice-irc.md
+++ b/docs/configuring-playbook-bridge-appservice-irc.md
@@ -1,4 +1,4 @@
-# Setting up Appservice IRC (optional)
+# Setting up Appservice IRC bridging (optional)
 
 **Note**: bridging to [IRC](https://en.wikipedia.org/wiki/Internet_Relay_Chat) can also happen via the [Heisenbridge](configuring-playbook-bridge-heisenbridge.md) bridge supported by the playbook.
 

--- a/docs/configuring-playbook-bridge-appservice-kakaotalk.md
+++ b/docs/configuring-playbook-bridge-appservice-kakaotalk.md
@@ -1,4 +1,4 @@
-# Setting up Appservice Kakaotalk (optional)
+# Setting up Appservice Kakaotalk bridging (optional)
 
 The playbook can install and configure [matrix-appservice-kakaotalk](https://src.miscworks.net/fair/matrix-appservice-kakaotalk) for you. `matrix-appservice-kakaotalk` is a bridge to [Kakaotalk](https://www.kakaocorp.com/page/service/service/KakaoTalk?lang=ENG) based on [node-kakao](https://github.com/storycraft/node-kakao) (now unmaintained) and some [mautrix-facebook](https://github.com/mautrix/facebook) code.
 

--- a/docs/configuring-playbook-bridge-appservice-slack.md
+++ b/docs/configuring-playbook-bridge-appservice-slack.md
@@ -1,4 +1,4 @@
-# Setting up Appservice Slack (optional)
+# Setting up Appservice Slack bridging (optional)
 
 **Note**: bridging to [Slack](https://slack.com) can also happen via the [mx-puppet-slack](configuring-playbook-bridge-mx-puppet-slack.md) and [mautrix-slack](configuring-playbook-bridge-mautrix-slack.md) bridges supported by the playbook.
 

--- a/docs/configuring-playbook-bridge-appservice-webhooks.md
+++ b/docs/configuring-playbook-bridge-appservice-webhooks.md
@@ -1,4 +1,4 @@
-# Setting up Appservice Webhooks (optional)
+# Setting up Appservice Webhooks bridging (optional)
 
 The playbook can install and configure [matrix-appservice-webhooks](https://github.com/turt2live/matrix-appservice-webhooks) for you.
 

--- a/docs/configuring-playbook-bridge-beeper-linkedin.md
+++ b/docs/configuring-playbook-bridge-beeper-linkedin.md
@@ -1,4 +1,4 @@
-# Setting up Beeper Linkedin (optional)
+# Setting up Beeper Linkedin bridging (optional)
 
 The playbook can install and configure [beeper-linkedin](https://github.com/beeper/linkedin) for you, for bridging to [LinkedIn](https://www.linkedin.com/) Messaging. This bridge is based on the mautrix-python framework and can be configured in a similar way to the other mautrix bridges
 

--- a/docs/configuring-playbook-bridge-go-skype-bridge.md
+++ b/docs/configuring-playbook-bridge-go-skype-bridge.md
@@ -1,4 +1,4 @@
-# Setting up Go Skype Bridge (optional)
+# Setting up Go Skype Bridge bridging (optional)
 
 The playbook can install and configure [go-skype-bridge](https://github.com/kelaresg/go-skype-bridge) for you.
 

--- a/docs/configuring-playbook-bridge-heisenbridge.md
+++ b/docs/configuring-playbook-bridge-heisenbridge.md
@@ -1,4 +1,4 @@
-# Setting up Heisenbridge (optional)
+# Setting up Heisenbridge bouncer-style IRC bridging (optional)
 
 **Note**: bridging to [IRC](https://en.wikipedia.org/wiki/Internet_Relay_Chat) can also happen via the [matrix-appservice-irc](configuring-playbook-bridge-appservice-irc.md) bridge supported by the playbook.
 

--- a/docs/configuring-playbook-bridge-hookshot.md
+++ b/docs/configuring-playbook-bridge-hookshot.md
@@ -1,4 +1,4 @@
-# Setting up Hookshot (optional)
+# Setting up matrix-hookshot (optional)
 
 The playbook can install and configure [matrix-hookshot](https://github.com/matrix-org/matrix-hookshot) for you.
 

--- a/docs/configuring-playbook-bridge-matrix-bridge-sms.md
+++ b/docs/configuring-playbook-bridge-matrix-bridge-sms.md
@@ -1,4 +1,4 @@
-# Setting up matrix-sms-bridge (optional)
+# Setting up Matrix SMS bridging (optional)
 
 The playbook can install and configure [matrix-sms-bridge](https://github.com/benkuly/matrix-sms-bridge) for you.
 

--- a/docs/configuring-playbook-bridge-mautrix-discord.md
+++ b/docs/configuring-playbook-bridge-mautrix-discord.md
@@ -1,4 +1,4 @@
-# Setting up Mautrix Discord (optional)
+# Setting up Mautrix Discord bridging (optional)
 
 **Note**: bridging to [Discord](https://discordapp.com/) can also happen via the [mx-puppet-discord](configuring-playbook-bridge-mx-puppet-discord.md) and [matrix-appservice-discord](configuring-playbook-bridge-appservice-discord.md) bridges supported by the playbook.
 - For using as a Bot we recommend the [Appservice Discord](configuring-playbook-bridge-appservice-discord.md), because it supports plumbing.

--- a/docs/configuring-playbook-bridge-mautrix-facebook.md
+++ b/docs/configuring-playbook-bridge-mautrix-facebook.md
@@ -1,4 +1,4 @@
-# Setting up Mautrix Facebook (optional)
+# Setting up Mautrix Facebook bridging (optional)
 
 **Note**: bridging to Facebook [Messenger](https://messenger.com) via this bridge is being [superseded by a new bridge - mautrix-meta](https://github.com/mautrix/facebook/issues/332). For now, the mautrix-facebook bridge continues to work, but the new [mautrix-meta-messenger bridge](./configuring-playbook-bridge-mautrix-meta-messenger.md) is better and more supported. Consider using that bridge instead of this one.
 

--- a/docs/configuring-playbook-bridge-mautrix-gmessages.md
+++ b/docs/configuring-playbook-bridge-mautrix-gmessages.md
@@ -1,4 +1,4 @@
-# Setting up Mautrix gmessages (optional)
+# Setting up Mautrix Google Messages bridging (optional)
 
 The playbook can install and configure [mautrix-gmessages](https://github.com/mautrix/gmessages) for you, for bridging to [Google Messages](https://messages.google.com/).
 

--- a/docs/configuring-playbook-bridge-mautrix-googlechat.md
+++ b/docs/configuring-playbook-bridge-mautrix-googlechat.md
@@ -1,4 +1,4 @@
-# Setting up Mautrix Google Chat (optional)
+# Setting up Mautrix Google Chat bridging (optional)
 
 The playbook can install and configure [mautrix-googlechat](https://github.com/mautrix/googlechat) for you.
 

--- a/docs/configuring-playbook-bridge-mautrix-hangouts.md
+++ b/docs/configuring-playbook-bridge-mautrix-hangouts.md
@@ -1,6 +1,6 @@
 # The [Mautrix Hangouts Bridge](https://mau.dev/mautrix/hangouts) is no longer maintained.  It has changed to a [Google Chat Bridge](https://github.com/mautrix/googlechat). Setup instructions for the Google Chat Bridge can be [found here](configuring-playbook-bridge-mautrix-googlechat.md).
 
-# Setting up Mautrix Hangouts (optional)
+# Setting up Mautrix Hangouts bridging (optional)
 
 The playbook can install and configure [mautrix-hangouts](https://github.com/mautrix/hangouts) for you.
 

--- a/docs/configuring-playbook-bridge-mautrix-instagram.md
+++ b/docs/configuring-playbook-bridge-mautrix-instagram.md
@@ -1,4 +1,4 @@
-# Setting up Mautrix Instagram (optional)
+# Setting up Mautrix Instagram bridging (optional)
 
 **Note**: bridging to Facebook [Instagram](https://instagram.com) via this bridge is being [superseded by a new bridge - mautrix-meta](https://github.com/mautrix/facebook/issues/332). For now, the mautrix-instagram bridge continues to work, but the new [mautrix-meta-instagram bridge](./configuring-playbook-bridge-mautrix-meta-instagram.md) is better and more supported. Consider using that bridge instead of this one.
 

--- a/docs/configuring-playbook-bridge-mautrix-signal.md
+++ b/docs/configuring-playbook-bridge-mautrix-signal.md
@@ -1,4 +1,4 @@
-# Setting up Mautrix Signal (optional)
+# Setting up Mautrix Signal bridging (optional)
 
 The playbook can install and configure [mautrix-signal](https://github.com/mautrix/signal) for you.
 

--- a/docs/configuring-playbook-bridge-mautrix-slack.md
+++ b/docs/configuring-playbook-bridge-mautrix-slack.md
@@ -1,4 +1,4 @@
-# Setting up Mautrix Slack (optional)
+# Setting up Mautrix Slack bridging (optional)
 
 **Note**: bridging to [Slack](https://slack.com/) can also happen via the [mx-puppet-slack](configuring-playbook-bridge-mx-puppet-slack.md) and [matrix-appservice-slack](configuring-playbook-bridge-appservice-slack.md) bridges supported by the playbook.
 - For using as a Bot we recommend the [Appservice Slack](configuring-playbook-bridge-appservice-slack.md), because it supports plumbing.

--- a/docs/configuring-playbook-bridge-mautrix-telegram.md
+++ b/docs/configuring-playbook-bridge-mautrix-telegram.md
@@ -1,4 +1,4 @@
-# Setting up Mautrix Telegram (optional)
+# Setting up Mautrix Telegram bridging (optional)
 
 The playbook can install and configure [mautrix-telegram](https://github.com/mautrix/telegram) for you.
 

--- a/docs/configuring-playbook-bridge-mautrix-twitter.md
+++ b/docs/configuring-playbook-bridge-mautrix-twitter.md
@@ -1,4 +1,4 @@
-# Setting up Mautrix Twitter (optional)
+# Setting up Mautrix Twitter bridging (optional)
 
 **Note**: bridging to [Twitter](https://twitter.com/) can also happen via the [mx-puppet-twitter](configuring-playbook-bridge-mx-puppet-twitter.md) bridge supported by the playbook.
 

--- a/docs/configuring-playbook-bridge-mautrix-whatsapp.md
+++ b/docs/configuring-playbook-bridge-mautrix-whatsapp.md
@@ -1,4 +1,4 @@
-# Setting up Mautrix Whatsapp (optional)
+# Setting up Mautrix Whatsapp bridging (optional)
 
 The playbook can install and configure [mautrix-whatsapp](https://github.com/mautrix/whatsapp) for you.
 

--- a/docs/configuring-playbook-bridge-mautrix-wsproxy.md
+++ b/docs/configuring-playbook-bridge-mautrix-wsproxy.md
@@ -1,4 +1,4 @@
-# Setting up Mautrix wsproxy (optional)
+# Setting up Mautrix wsproxy for bridging Android SMS or Apple iMessage (optional)
 
 The playbook can install and configure [mautrix-wsproxy](https://github.com/mautrix/wsproxy) for you.
 

--- a/docs/configuring-playbook-bridge-mx-puppet-discord.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-discord.md
@@ -1,4 +1,4 @@
-# Setting up MX Puppet Discord (optional)
+# Setting up MX Puppet Discord bridging (optional)
 
 **Note**: bridging to [Discord](https://discordapp.com/) can also happen via the [matrix-appservice-discord](configuring-playbook-bridge-appservice-discord.md)and [mautrix-discord](configuring-playbook-bridge-mautrix-discord.md) bridges supported by the playbook.   
 - For using as a Bot we recommend the [Appservice Discord](configuring-playbook-bridge-appservice-discord.md), because it supports plumbing.  

--- a/docs/configuring-playbook-bridge-mx-puppet-groupme.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-groupme.md
@@ -1,4 +1,4 @@
-# Setting up MX Puppet GroupMe (optional)
+# Setting up MX Puppet GroupMe bridging (optional)
 
 The playbook can install and configure [mx-puppet-groupme](https://gitlab.com/xangelix-pub/matrix/mx-puppet-groupme) for you.
 

--- a/docs/configuring-playbook-bridge-mx-puppet-instagram.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-instagram.md
@@ -1,4 +1,4 @@
-# Setting up mx-puppet-instagram (optional)
+# Setting up MX Puppet Instagram bridging (optional)
 
 The playbook can install and configure [mx-puppet-instagram](https://github.com/Sorunome/mx-puppet-instagram) for you.
 

--- a/docs/configuring-playbook-bridge-mx-puppet-skype.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-skype.md
@@ -1,4 +1,4 @@
-# Setting up MX Puppet Skype (optional)
+# Setting up MX Puppet Skype bridging (optional)
 
 The playbook used to be able to install and configure [mx-puppet-skype](https://github.com/Sorunome/mx-puppet-skype), but no longer includes this component, because it has been broken and unmaintaned for a long time.
 

--- a/docs/configuring-playbook-bridge-mx-puppet-slack.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-slack.md
@@ -1,4 +1,4 @@
-# Setting up MX Puppet Slack (optional)
+# Setting up MX Puppet Slack bridging (optional)
 
 **Note**: bridging to [Slack](https://slack.com) can also happen via the
 [matrix-appservice-slack](configuring-playbook-bridge-appservice-slack.md) and [mautrix-slack](configuring-playbook-bridge-mautrix-slack.md) bridges supported by the playbook.

--- a/docs/configuring-playbook-bridge-mx-puppet-steam.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-steam.md
@@ -1,4 +1,4 @@
-# Setting up MX Puppet Steam (optional)
+# Setting up MX Puppet Steam bridging (optional)
 
 The playbook can install and configure [mx-puppet-steam](https://github.com/icewind1991/mx-puppet-steam) for you.
 

--- a/docs/configuring-playbook-bridge-mx-puppet-twitter.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-twitter.md
@@ -1,4 +1,4 @@
-# Setting up MX Puppet Twitter (optional)
+# Setting up MX Puppet Twitter bridging (optional)
 
 **Note**: bridging to [Twitter](https://twitter.com/) can also happen via the [mautrix-twitter](configuring-playbook-bridge-mautrix-twitter.md) bridge supported by the playbook.
 

--- a/docs/configuring-playbook-bridge-wechat.md
+++ b/docs/configuring-playbook-bridge-wechat.md
@@ -1,4 +1,4 @@
-# Setting up the WeChat Bridge (optional)
+# Setting up WeChat bridging (optional)
 
 The playbook can install and configure the [matrix-wechat](https://github.com/duo/matrix-wechat) bridge for you (for bridging to the [WeChat](https://www.wechat.com/) network).
 

--- a/docs/configuring-playbook-client-cinny.md
+++ b/docs/configuring-playbook-client-cinny.md
@@ -1,4 +1,4 @@
-# Configuring Cinny (optional)
+# Setting up Cinny (optional)
 
 This playbook can install the [cinny](https://github.com/ajbura/cinny) Matrix web client for you.
 

--- a/docs/configuring-playbook-client-hydrogen.md
+++ b/docs/configuring-playbook-client-hydrogen.md
@@ -1,4 +1,4 @@
-# Configuring Hydrogen (optional)
+# Setting up Hydrogen (optional)
 
 This playbook can install the [Hydrogen](https://github.com/element-hq/hydrogen-web) Matrix web client for you.
 

--- a/docs/configuring-playbook-client-schildichat.md
+++ b/docs/configuring-playbook-client-schildichat.md
@@ -1,4 +1,4 @@
-# Configuring SchildiChat (optional)
+# Setting up SchildiChat (optional)
 
 This playbook can install the [SchildiChat](https://github.com/SchildiChat/schildichat-desktop) Matrix web client for you.
 

--- a/docs/configuring-playbook-dimension.md
+++ b/docs/configuring-playbook-dimension.md
@@ -1,4 +1,4 @@
-# Setting up Dimension (optional)
+# Setting up Dimension integration manager (optional)
 
 **[Dimension](https://dimension.t2bot.io) can only be installed after Matrix services are installed and running.** If you're just installing Matrix services for the first time, please continue with the [Configuration](configuring-playbook.md) / [Installation](installing.md) flow and come back here later.
 

--- a/docs/configuring-playbook-dynamic-dns.md
+++ b/docs/configuring-playbook-dynamic-dns.md
@@ -1,4 +1,4 @@
-# Dynamic DNS
+# Setting up Dynamic DNS (optional)
 
 ## Setup
 

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -1,4 +1,4 @@
-# Jitsi
+# Setting up the Jitsi video-conferencing platform (optional)
 
 The playbook can install the [Jitsi](https://jitsi.org/) video-conferencing platform and integrate it with [Element](configuring-playbook-client-element.md).
 

--- a/docs/configuring-playbook-ma1sd.md
+++ b/docs/configuring-playbook-ma1sd.md
@@ -1,4 +1,4 @@
-# Adjusting ma1sd Identity Server configuration (optional)
+# Setting up ma1sd Identity Server (optional)
 
 The playbook can configure the [ma1sd](https://github.com/ma1uta/ma1sd) Identity Server for you.
 

--- a/docs/configuring-playbook-matrix-authentication-service.md
+++ b/docs/configuring-playbook-matrix-authentication-service.md
@@ -1,4 +1,4 @@
-# Matrix Authentication Service (MAS)
+# Setting up Matrix Authentication Service (optional)
 
 This playbook can install and configure [Matrix Authentication Service](https://github.com/element-hq/matrix-authentication-service/) (MAS) - a service operating alongside your existing [Synapse](./configuring-playbook-synapse.md) homeserver and providing [better authentication, session management and permissions in Matrix](https://matrix.org/blog/2023/09/better-auth/).
 

--- a/docs/configuring-playbook-matrix-media-repo.md
+++ b/docs/configuring-playbook-matrix-media-repo.md
@@ -1,4 +1,4 @@
-# Setting up matrix-media-repo (optional)
+# Storing Matrix media files using matrix-media-repo (optional)
 
 [matrix-media-repo](https://docs.t2bot.io/matrix-media-repo/) (often abbreviated "MMR") is a highly customizable multi-domain media repository for Matrix. Intended for medium to large environments consisting of several homeservers, this media repo de-duplicates media (including remote media) while being fully compliant with the specification.
 

--- a/docs/configuring-playbook-ntfy.md
+++ b/docs/configuring-playbook-ntfy.md
@@ -1,4 +1,4 @@
-# Setting up ntfy (optional)
+# Setting up the ntfy push notifications server (optional)
 
 The playbook can install and configure the [ntfy](https://ntfy.sh/) push notifications server for you.
 

--- a/docs/configuring-playbook-pantalaimon.md
+++ b/docs/configuring-playbook-pantalaimon.md
@@ -1,4 +1,4 @@
-# Setting up pantalaimon (optional)
+# Setting up Pantalaimon (E2EE aware proxy daemon) (optional)
 
 The playbook can install and configure the [pantalaimon](https://github.com/matrix-org/pantalaimon) E2EE aware proxy daemon for you.
 

--- a/docs/configuring-playbook-prometheus-grafana.md
+++ b/docs/configuring-playbook-prometheus-grafana.md
@@ -1,4 +1,4 @@
-# Enabling metrics and graphs for your Matrix server (optional)
+# Enabling metrics and graphs (Prometheus, Grafana) for your Matrix server (optional)
 
 The playbook can install [Grafana](https://grafana.com/) with [Prometheus](https://prometheus.io/) and configure performance metrics of your homeserver with graphs for you.
 

--- a/docs/configuring-playbook-rageshake.md
+++ b/docs/configuring-playbook-rageshake.md
@@ -1,4 +1,4 @@
-# Setting up rageshake (optional)
+# Setting up the rageshake bug report server (optional)
 
 The playbook can install and configure the [rageshake](https://github.com/matrix-org/rageshake) bug report server for you.
 

--- a/docs/configuring-playbook-sliding-sync-proxy.md
+++ b/docs/configuring-playbook-sliding-sync-proxy.md
@@ -1,4 +1,4 @@
-# Setting up Sliding Sync proxy (optional)
+# Setting up the Sliding Sync proxy (optional)
 
 The playbook can install and configure [sliding-sync](https://github.com/matrix-org/sliding-sync) proxy for you.
 

--- a/docs/configuring-playbook-sygnal.md
+++ b/docs/configuring-playbook-sygnal.md
@@ -1,4 +1,4 @@
-# Setting up Sygnal (optional)
+# Setting up the Sygnal push gateway (optional)
 
 The playbook can install and configure the [Sygnal](https://github.com/matrix-org/sygnal) push gateway for you.
 

--- a/docs/configuring-playbook-synapse-auto-compressor.md
+++ b/docs/configuring-playbook-synapse-auto-compressor.md
@@ -1,4 +1,4 @@
-# Setting up synapse_auto_compressor
+# Setting up synapse-auto-compressor (optional)
 
 The playbook can install and configure [synapse_auto_compressor](https://github.com/matrix-org/rust-synapse-compress-state/#automated-tool-synapse_auto_compressor) for you.
 

--- a/docs/configuring-playbook-synapse-usage-exporter.md
+++ b/docs/configuring-playbook-synapse-usage-exporter.md
@@ -1,4 +1,4 @@
-# Setting up synapse-usage-exporter (optional)
+# Enabling synapse-usage-exporter for Synapse usage statistics (optional)
 
 [synapse-usage-exporter](https://github.com/loelkes/synapse-usage-exporter) allows you to export the usage statistics of a Synapse homeserver to this container service and for the collected metrics to later be scraped by Prometheus.
 

--- a/docs/configuring-playbook-turn.md
+++ b/docs/configuring-playbook-turn.md
@@ -1,4 +1,4 @@
-# TURN server
+# Adjusting TURN server configuration (optional, advanced)
 
 The playbook installs a [Coturn](https://github.com/coturn/coturn) TURN server by default, so that clients can make audio/video calls even from [NAT](https://en.wikipedia.org/wiki/Network_address_translation)-ed networks.
 

--- a/docs/configuring-playbook.md
+++ b/docs/configuring-playbook.md
@@ -64,11 +64,11 @@ When you're done with all the configuration you'd like to do, continue with [Ins
 
 - [Adjusting SSL certificate retrieval](configuring-playbook-ssl-certificates.md) (optional, advanced)
 
-- [Serving your base domain using this playbook's nginx server](configuring-playbook-base-domain-serving.md) (optional)
+- [Serving the base domain](configuring-playbook-base-domain-serving.md) (optional)
 
 - [Configuring the Traefik reverse-proxy](configuring-playbook-traefik.md) (optional, advanced)
 
-- [Using your own webserver, instead of this playbook's default reverse-proxy](configuring-playbook-own-webserver.md) (optional, advanced)
+- [Using your own webserver, instead of this playbook's Traefik reverse-proxy](configuring-playbook-own-webserver.md) (optional, advanced)
 
 - [Adjusting TURN server configuration](configuring-playbook-turn.md) (optional, advanced)
 
@@ -94,7 +94,7 @@ When you're done with all the configuration you'd like to do, continue with [Ins
 
 - [Setting up Appservice Double Puppet](configuring-playbook-appservice-double-puppet.md) (optional)
 
-- [Setting up an ma1sd Identity Server](configuring-playbook-ma1sd.md) (optional)
+- [Setting up ma1sd Identity Server](configuring-playbook-ma1sd.md) (optional)
 
 - [Setting up Synapse Admin](configuring-playbook-synapse-admin.md) (optional)
 
@@ -104,9 +104,9 @@ When you're done with all the configuration you'd like to do, continue with [Ins
 
 - [Setting up the Shared Secret Auth password provider module](configuring-playbook-shared-secret-auth.md) (optional, advanced)
 
-- [Setting up the LDAP password provider module](configuring-playbook-ldap-auth.md) (optional, advanced)
+- [Setting up the LDAP authentication password provider module](configuring-playbook-ldap-auth.md) (optional, advanced)
 
-- [Setting up the ldap-registration-proxy](configuring-playbook-matrix-ldap-registration-proxy.md) (optional, advanced)
+- [Setting up matrix-ldap-registration-proxy](configuring-playbook-matrix-ldap-registration-proxy.md) (optional, advanced)
 
 - [Setting up Synapse Simple Antispam](configuring-playbook-synapse-simple-antispam.md) (optional, advanced)
 
@@ -208,7 +208,7 @@ When you're done with all the configuration you'd like to do, continue with [Ins
 
 - [Setting up Draupnir](configuring-playbook-bot-draupnir.md) - a moderation tool/bot, forked from Mjolnir and maintained by its former leader developer (optional)
 
-- [Setting up Draupnir for all](configuring-playbook-appservice-draupnir-for-all.md) - like the [Draupnir bot](configuring-playbook-bot-draupnir.md) mentioned above, but running in appservice mode and supporting multiple instances (optional)
+- [Setting up Draupnir for all/D4A](configuring-playbook-appservice-draupnir-for-all.md) - like the [Draupnir bot](configuring-playbook-bot-draupnir.md) mentioned above, but running in appservice mode and supporting multiple instances (optional)
 
 - [Setting up Buscarron](configuring-playbook-bot-buscarron.md) - a bot you can use to send any form (HTTP POST, HTML) to a (encrypted) Matrix room (optional)
 
@@ -230,7 +230,7 @@ When you're done with all the configuration you'd like to do, continue with [Ins
 
 - [Setting up the ntfy push notifications server](configuring-playbook-ntfy.md) (optional)
 
-- [Setting up a Cactus Comments server](configuring-playbook-cactus-comments.md) - a federated comment system built on Matrix (optional)
+- [Setting up Cactus Comments](configuring-playbook-cactus-comments.md) - a federated comment system built on Matrix (optional)
 
 - [Setting up the rageshake bug report server](configuring-playbook-rageshake.md) (optional)
 


### PR DESCRIPTION
Generally the titles on docs/configuring-playbook.md have been regarded as canonical.