### PR TITLE
Fixup variable name thats install nginx grafana dashboard

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -5421,7 +5421,7 @@ grafana_dashboard_download_urls: |
     (matrix_synapse_usage_exporter_dashboard_urls if matrix_synapse_usage_exporter_enabled else [])
   }}
 
-grafana_provisioning_dashboard_template_files: |
+grafana_dashboard_files: |
   {{
     ([{
         'path': 'roles/custom/matrix-prometheus-nginxlog-exporter/templates/grafana/nginx-proxy.json',


### PR DESCRIPTION
As for now nginx grafana dashboard is installed in provisioning config directory, not in dashboards one.
To fix this [new configuration option was introduced](https://github.com/mother-of-all-self-hosting/ansible-role-grafana/pull/2) in grafana role.