### PR TITLE
Export Traefik metrics to Prometheus and add Grafana dashboard for them

### DIFF
--- a/docs/configuring-playbook-prometheus-grafana.md
+++ b/docs/configuring-playbook-prometheus-grafana.md
@@ -16,7 +16,7 @@ prometheus_node_exporter_enabled: true
 prometheus_postgres_exporter_enabled: true
 
 # You can remove this, if unnecessary.
-matrix_prometheus_nginxlog_exporter_enabled: true
+matrix_prometheus_traefik_exporter_enabled: true
 
 grafana_enabled: true
 
@@ -64,7 +64,7 @@ Name | Description
 `prometheus_enabled`|[Prometheus](https://prometheus.io) is a time series database. It holds all the data we're going to talk about.
 `prometheus_node_exporter_enabled`|[Node Exporter](https://prometheus.io/docs/guides/node-exporter/) is an addon of sorts to Prometheus that collects generic system information such as CPU, memory, filesystem, and even system temperatures
 `prometheus_postgres_exporter_enabled`|[Postgres Exporter](configuring-playbook-prometheus-postgres.md) is an addon of sorts to expose Postgres database metrics to Prometheus.
-`matrix_prometheus_nginxlog_exporter_enabled`|[NGINX Log Exporter](configuring-playbook-prometheus-nginxlog.md) is an addon of sorts to expose NGINX logs to Prometheus.
+`matrix_prometheus_traefik_exporter_enabled`|Export [Traefik metrics](https://doc.traefik.io/traefik/observability/metrics/prometheus) to Prometheus and add Grafana dashboard for them.
 `grafana_enabled`|[Grafana](https://grafana.com/) is the visual component. It shows (on the `stats.example.com` subdomain) the dashboards with the graphs that we're interested in
 `grafana_anonymous_access`|By default you need to log in to see graphs. If you want to publicly share your graphs (e.g. when asking for help in [`#synapse:matrix.org`](https://matrix.to/#/#synapse:matrix.org?via=matrix.org&via=privacytools.io&via=mozilla.org)) you'll want to enable this option.
 `grafana_default_admin_user`<br>`grafana_default_admin_password`|By default Grafana creates a user with `admin` as the username and password. If you feel this is insecure and you want to change it beforehand, you can do that here
@@ -100,6 +100,7 @@ Name | Description
 `prometheus_node_exporter_container_labels_traefik_enabled`|Set this to `true` to expose the node (general system stats) metrics on `https://matrix.example.com/metrics/node-exporter`. To password-protect the metrics, see `matrix_metrics_exposure_http_basic_auth_users` above.
 `prometheus_postgres_exporter_enabled`|Set this to `true` to enable the [Postgres exporter](configuring-playbook-prometheus-postgres.md) (locally, on the container network)
 `prometheus_postgres_exporter_container_labels_traefik_enabled`|Set this to `true` to expose the [Postgres exporter](configuring-playbook-prometheus-postgres.md) metrics on `https://matrix.example.com/metrics/postgres-exporter`. To password-protect the metrics, see `matrix_metrics_exposure_http_basic_auth_users` above.
+`matrix_prometheus_traefik_exporter_enabled`|Set this to `true` to export [Traefik metrics](https://doc.traefik.io/traefik/observability/metrics/prometheus) (locally, on the container network) and add Grafana dashboard for them.
 `matrix_prometheus_nginxlog_exporter_enabled`|Set this to `true` to enable the [NGINX Log exporter](configuring-playbook-prometheus-nginxlog.md) (locally, on the container network)
 `matrix_sliding_sync_metrics_enabled`|Set this to `true` to make [Sliding Sync](configuring-playbook-sliding-sync-proxy.md) expose metrics (locally, on the container network)
 `matrix_sliding_sync_metrics_proxying_enabled`|Set this to `true` to expose the [Sliding Sync](configuring-playbook-sliding-sync-proxy.md) metrics on `https://matrix.example.com/metrics/sliding-sync`. To password-protect the metrics, see `matrix_metrics_exposure_http_basic_auth_users` above.

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -5310,6 +5310,8 @@ prometheus_config_scrape_configs_auto: |
     (matrix_prometheus_services_connect_scraper_media_repo_scrape_configs if matrix_prometheus_services_connect_scraper_media_repo_enabled else [])
     +
     (matrix_prometheus_services_connect_scraper_synapse_usage_exporter_scrape_configs if matrix_prometheus_services_connect_scraper_synapse_usage_exporter_enabled else [])
+    +
+    (matrix_prometheus_services_connect_scraper_traefik_scrape_configs if matrix_prometheus_services_connect_scraper_traefik_enabled else [])
   }}
 
 ######################################################################
@@ -5344,6 +5346,9 @@ matrix_prometheus_services_connect_scraper_hookshot_static_configs_target: "{{ m
 
 matrix_prometheus_services_connect_scraper_nginxlog_enabled: "{{ matrix_prometheus_nginxlog_exporter_enabled }}"
 matrix_prometheus_services_connect_scraper_nginxlog_static_configs_target: "{{ matrix_prometheus_nginxlog_exporter_identifier }}:{{ matrix_prometheus_nginxlog_exporter_container_metrics_port | string }}"
+
+matrix_prometheus_services_connect_scraper_traefik_enabled: "{{ matrix_prometheus_traefik_exporter_enabled }}"
+matrix_prometheus_services_connect_scraper_traefik_static_configs_target: "{{ traefik_identifier }}:{{ traefik_config_entrypoint_metrics_port | string }}"
 
 matrix_prometheus_services_connect_scraper_media_repo_enabled: "{{ matrix_media_repo_enabled and matrix_media_repo_metrics_enabled }}"
 matrix_prometheus_services_connect_scraper_media_repo_static_configs_target: "{{ matrix_media_repo_identifier }}:{{ matrix_media_repo_metrics_port }}"
@@ -5419,6 +5424,8 @@ grafana_dashboard_download_urls: |
     (matrix_media_repo_dashboard_urls if matrix_media_repo_metrics_enabled else [])
     +
     (matrix_synapse_usage_exporter_dashboard_urls if matrix_synapse_usage_exporter_enabled else [])
+    +
+    (matrix_traefik_dashboard_download_urls if matrix_traefik_dashboard_download_enabled else [])
   }}
 
 grafana_provisioning_dashboard_template_files: |
@@ -5932,6 +5939,9 @@ devture_container_socket_proxy_api_containers_enabled: true
 
 traefik_enabled: "{{ matrix_playbook_reverse_proxy_type == 'playbook-managed-traefik' }}"
 
+# Controls whether Traefik prometheus exporter integration should be done
+matrix_prometheus_traefik_exporter_enabled: false
+
 traefik_identifier: matrix-traefik
 
 traefik_base_path: "{{ matrix_base_data_path }}/traefik"
@@ -5951,6 +5961,8 @@ traefik_config_providers_docker_endpoint: "{{ devture_container_socket_proxy_end
 traefik_container_additional_networks_auto: |
   {{
     ([devture_container_socket_proxy_container_network] if devture_container_socket_proxy_enabled else [])
+    +
+    ([matrix_monitoring_container_network] if matrix_prometheus_traefik_exporter_enabled else [])
   }}
 
 traefik_systemd_required_services_list: |
@@ -5959,6 +5971,14 @@ traefik_systemd_required_services_list: |
     +
     ([devture_container_socket_proxy_identifier + '.service'] if devture_container_socket_proxy_enabled else [])
   }}
+
+traefik_config_metrics_prometheus_enabled: "{{ matrix_prometheus_traefik_exporter_enabled }}"
+traefik_container_metrics_host_bind_port: "{{ '' if matrix_prometheus_traefik_exporter_enabled else (traefik_config_entrypoint_metrics_port if traefik_config_entrypoint_metrics_enabled else '') }}"
+
+# Controls whether the Traefik grafana dashboard shall be downloaded
+matrix_traefik_dashboard_download_enabled: "{{ matrix_prometheus_traefik_exporter_enabled }}"
+matrix_traefik_dashboard_download_download_tag: master
+matrix_traefik_dashboard_download_urls: ["https://raw.githubusercontent.com/traefik/traefik/refs/heads/{{ matrix_traefik_dashboard_download_download_tag }}/contrib/grafana/traefik.json"]
 
 ########################################################################
 #                                                                      #

--- a/roles/custom/matrix-prometheus-services-connect/defaults/main.yml
+++ b/roles/custom/matrix-prometheus-services-connect/defaults/main.yml
@@ -143,6 +143,26 @@ matrix_prometheus_services_connect_scraper_nginxlog_scrape_configs: |
     }]
   }}
 
+# Controls whether Traefik shall be scraped
+matrix_prometheus_services_connect_scraper_traefik_enabled: false
+matrix_prometheus_services_connect_scraper_traefik_job_name: traefik
+matrix_prometheus_services_connect_scraper_traefik_metrics_path: /metrics
+matrix_prometheus_services_connect_scraper_traefik_scrape_interval: 15s
+matrix_prometheus_services_connect_scraper_traefik_scrape_timeout: 10s
+matrix_prometheus_services_connect_scraper_traefik_static_configs: "{{ [{'targets': [matrix_prometheus_services_connect_scraper_traefik_static_configs_target]}] }}"
+matrix_prometheus_services_connect_scraper_traefik_static_configs_target: ''
+# The final scrape config for the Traefik scraper
+matrix_prometheus_services_connect_scraper_traefik_scrape_configs: |
+  {{
+    [{
+      'job_name': matrix_prometheus_services_connect_scraper_traefik_job_name,
+      'metrics_path': matrix_prometheus_services_connect_scraper_traefik_metrics_path,
+      'scrape_interval': matrix_prometheus_services_connect_scraper_traefik_scrape_interval,
+      'scrape_timeout': matrix_prometheus_services_connect_scraper_traefik_scrape_timeout,
+      'static_configs': matrix_prometheus_services_connect_scraper_traefik_static_configs,
+    }]
+  }}
+
 # Controls whether media-repo shall be scraped
 matrix_prometheus_services_connect_scraper_media_repo_enabled: false
 matrix_prometheus_services_connect_scraper_media_repo_job_name: media-repo


### PR DESCRIPTION
Introduce __matrix_prometheus_traefik_exporter_enabled__ variable. Setting it to `true` enables export [Traefik metrics](https://doc.traefik.io/traefik/observability/metrics/prometheus) to Prometheus and adds Grafana dashboard for them.