### PR TITLE
Replace existing links to matrix-org/synapse which should be replaced

### DIFF
--- a/docs/configuring-playbook-synapse.md
+++ b/docs/configuring-playbook-synapse.md
@@ -78,7 +78,7 @@ When Synapse workers are enabled, the integrated [Postgres database is tuned](ma
 
 A separate Ansible role (`matrix-synapse-reverse-proxy-companion`) and component handles load-balancing for workers. This role/component is automatically enabled when you enable workers. Make sure to use the `setup-all` tag (not `install-all`!) during the playbook's [installation](./installing.md) process, especially if you're disabling workers, so that components may be installed/uninstalled correctly.
 
-In case any problems occur, make sure to have a look at the [list of synapse issues about workers](https://github.com/matrix-org/synapse/issues?q=workers+in%3Atitle) and your `journalctl --unit 'matrix-*'`.
+In case any problems occur, make sure to have a look at the [list of synapse issues about workers](https://github.com/element-hq/synapse/issues?q=workers+in%3Atitle) and your `journalctl --unit 'matrix-*'`.
 
 
 ## Synapse Admin

--- a/docs/maintenance-and-troubleshooting.md
+++ b/docs/maintenance-and-troubleshooting.md
@@ -26,7 +26,7 @@ sudo journalctl -fu matrix-synapse
 
 Because the [Synapse](https://github.com/element-hq/synapse) Matrix server is originally very chatty when it comes to logging, we intentionally reduce its [logging level](https://docs.python.org/3/library/logging.html#logging-levels) from `INFO` to `WARNING`.
 
-If you'd like to debug an issue or [report a Synapse bug](https://github.com/matrix-org/synapse/issues/new/choose) to the developers, it'd be better if you temporarily increasing the logging level to `INFO`.
+If you'd like to debug an issue or [report a Synapse bug](https://github.com/element-hq/synapse/issues/new/choose) to the developers, it'd be better if you temporarily increasing the logging level to `INFO`.
 
 Example configuration (`inventory/host_vars/matrix.example.com/vars.yml`):
 


### PR DESCRIPTION
There are other links to the original repository such as `https://github.com/matrix-org/synapse/issues/3939` but an issue with the same number on the forked repository `https://github.com/element-hq/synapse/issues/3939` is used as a placeholder.