### PR TITLE
Add links to matrix-user-verification-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Extend and modify how users are authenticated on your homeserver.
 | [matrix-synapse-ldap3](https://github.com/matrix-org/matrix-synapse-ldap3) (advanced) | x | LDAP Auth password provider module | [Link](docs/configuring-playbook-ldap-auth.md) |
 | [matrix-ldap-registration-proxy](https://gitlab.com/activism.international/matrix_ldap_registration_proxy) (advanced) | x | A proxy that handles Matrix registration requests and forwards them to LDAP. | [Link](docs/configuring-playbook-matrix-ldap-registration-proxy.md) |
 | [matrix-registration](https://github.com/ZerataX/matrix-registration) | x | A simple python application to have a token based Matrix registration | [Link](docs/configuring-playbook-matrix-registration.md) |
-| [Matrix User Verification Service](https://github.com/matrix-org/matrix-user-verification-service) (UVS) | x | Service to verify details of a user based on a Open ID token | [Link](docs/configuring-playbook-user-verification-service.md) |
+| [Matrix User Verification Service](https://github.com/matrix-org/matrix-user-verification-service) (UVS) | x | Service to verify details of a user based on an Open ID token | [Link](docs/configuring-playbook-user-verification-service.md) |
 
 
 ### File Storage

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Extend and modify how users are authenticated on your homeserver.
 | [matrix-synapse-ldap3](https://github.com/matrix-org/matrix-synapse-ldap3) (advanced) | x | LDAP Auth password provider module | [Link](docs/configuring-playbook-ldap-auth.md) |
 | [matrix-ldap-registration-proxy](https://gitlab.com/activism.international/matrix_ldap_registration_proxy) (advanced) | x | A proxy that handles Matrix registration requests and forwards them to LDAP. | [Link](docs/configuring-playbook-matrix-ldap-registration-proxy.md) |
 | [matrix-registration](https://github.com/ZerataX/matrix-registration) | x | A simple python application to have a token based Matrix registration | [Link](docs/configuring-playbook-matrix-registration.md) |
+| [Matrix User Verification Service](https://github.com/matrix-org/matrix-user-verification-service) (UVS) | x | Service to verify details of a user based on a Open ID token | [Link](docs/configuring-playbook-user-verification-service.md) |
 
 
 ### File Storage

--- a/docs/container-images.md
+++ b/docs/container-images.md
@@ -44,7 +44,7 @@ These services are not part of our default installation, but can be enabled by [
 
 - [zeratax/matrix-registration](https://hub.docker.com/r/devture/zeratax-matrix-registration/) - [matrix-registration](https://github.com/ZerataX/matrix-registration): a simple python application to have a token based Matrix registration (optional)
 
-- [matrixdotorg/matrix-user-verification-service](https://hub.docker.com/r/matrixdotorg/matrix-user-verification-service) - [Matrix User Verification Service](https://github.com/matrix-org/matrix-user-verification-service) for verifying details of a user based on a Open ID token (optional)
+- [matrixdotorg/matrix-user-verification-service](https://hub.docker.com/r/matrixdotorg/matrix-user-verification-service) - [Matrix User Verification Service](https://github.com/matrix-org/matrix-user-verification-service) for verifying details of a user based on an Open ID token (optional)
 
 - [mautrix/telegram](https://mau.dev/mautrix/telegram/container_registry) - the [mautrix-telegram](https://github.com/mautrix/telegram) bridge to [Telegram](https://telegram.org/) (optional)
 

--- a/docs/container-images.md
+++ b/docs/container-images.md
@@ -44,6 +44,8 @@ These services are not part of our default installation, but can be enabled by [
 
 - [zeratax/matrix-registration](https://hub.docker.com/r/devture/zeratax-matrix-registration/) - [matrix-registration](https://github.com/ZerataX/matrix-registration): a simple python application to have a token based Matrix registration (optional)
 
+- [matrixdotorg/matrix-user-verification-service](https://hub.docker.com/r/matrixdotorg/matrix-user-verification-service) - [Matrix User Verification Service](https://github.com/matrix-org/matrix-user-verification-service) for verifying details of a user based on a Open ID token (optional)
+
 - [mautrix/telegram](https://mau.dev/mautrix/telegram/container_registry) - the [mautrix-telegram](https://github.com/mautrix/telegram) bridge to [Telegram](https://telegram.org/) (optional)
 
 - [mautrix/gmessages](https://mau.dev/mautrix/gmessages/container_registry) - the [mautrix-gmessages](https://github.com/mautrix/gmessages) bridge to [Google Messages](https://messages.google.com/) (optional)

--- a/roles/custom/matrix-user-verification-service/defaults/main.yml
+++ b/roles/custom/matrix-user-verification-service/defaults/main.yml
@@ -1,4 +1,8 @@
 ---
+
+# matrix-user-verification-service - Service to verify details of a user based on a Open ID token
+# Project source code URL: https://github.com/matrix-org/matrix-user-verification-service
+
 # Set this to the display name for ansible used in Output e.g. fail_msg
 matrix_user_verification_service_ansible_name: "Matrix User Verification Service"
 

--- a/roles/custom/matrix-user-verification-service/defaults/main.yml
+++ b/roles/custom/matrix-user-verification-service/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-# matrix-user-verification-service - Service to verify details of a user based on a Open ID token
+# matrix-user-verification-service - Service to verify details of a user based on an Open ID token
 # Project source code URL: https://github.com/matrix-org/matrix-user-verification-service
 
 # Set this to the display name for ansible used in Output e.g. fail_msg


### PR DESCRIPTION
Matrix User Authentication Service itself has been available for Jitsi since 42e4e50f5be654b812939732114f0724865cdc78.