### PR TITLE
Update docs/configuring-playbook-bridge-appservice-webhooks.md

### DIFF
--- a/docs/configuring-playbook-bridge-appservice-webhooks.md
+++ b/docs/configuring-playbook-bridge-appservice-webhooks.md
@@ -8,7 +8,7 @@ Setup Instructions:
 
 loosely based on [this](https://github.com/turt2live/matrix-appservice-webhooks/blob/master/README.md)
 
-1. All you basically need is to adjust your `inventory/host_vars/matrix.example.com/vars.yml`:
+1. Add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:
 
     ```yaml
     matrix_appservice_webhooks_enabled: true


### PR DESCRIPTION
Use a common expression for adjusting configuration. As the component has been deprecated, this is purely for future use as a template.