### PR TITLE
Edit the note about "matrix_homeserver_implementation" variable

### DIFF
--- a/examples/vars.yml
+++ b/examples/vars.yml
@@ -13,6 +13,10 @@ matrix_domain: example.com
 # See:
 #  - `roles/custom/matrix-base/defaults/main.yml` for valid options
 # - the `docs/configuring-playbook-IMPLEMENTATION_NAME.md` documentation page, if one is available for your implementation choice
+#
+# By default, we use Synapse, because it's the only full-featured Matrix server at the moment.
+#
+# Note that the homeserver implementation of a server will not be able to be changed without data loss.
 matrix_homeserver_implementation: synapse
 
 # A secret used as a base, for generating various other secrets.

--- a/roles/custom/matrix-base/defaults/main.yml
+++ b/roles/custom/matrix-base/defaults/main.yml
@@ -54,7 +54,7 @@ matrix_homeserver_enabled: true
 # By default, we use Synapse, because it's the only full-featured Matrix server at the moment.
 #
 # This value automatically influences other variables (`matrix_synapse_enabled`, `matrix_dendrite_enabled`, etc.).
-# The homeserver implementation of an existing server cannot be changed without data loss.
+# Note that the homeserver implementation of a server will not be able to be changed without data loss.
 matrix_homeserver_implementation: synapse
 
 # This contains a secret, which is used for generating various other secrets later on.


### PR DESCRIPTION
Since a casual user might want to try another homeserver than Synapse without thinking about its consequence, it is important to clarify that it is not possible to switch homeservers once specified.