### PR TITLE
Correct issuer URL in OIDC example section

### DIFF
--- a/docs/configuring-playbook-synapse.md
+++ b/docs/configuring-playbook-synapse.md
@@ -104,7 +104,7 @@ matrix_synapse_oidc_enabled: true
 matrix_synapse_oidc_providers:
   - idp_id: keycloak
     idp_name: "My KeyCloak server"
-    issuer: "https://url.ix/auth/realms/{realm_name}"
+    issuer: "https://url.ix/realms/{realm_name}"
     client_id: "matrix"
     client_secret: "{{ vault_synapse_keycloak }}"
     scopes: ["openid", "profile"]


### PR DESCRIPTION
Keycloak exposes the issuer information on /realms/whatever, not /auth/realms/whatever.