### PR TITLE
Add .github/workflows/close-stale-issues.yml: close stale issues automatically

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,0 +1,27 @@
+---
+name: 'Close stale issues'
+on:  # yamllint disable-line rule:truthy
+  schedule:
+    - cron: '30 1 * * *'
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    if: github.repository == 'spantaleev/matrix-docker-ansible-deploy'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Don't process pull requests at all
+          days-before-pr-stale: -1
+          stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity. If this issue is still reproduced, feel free to provide the issue with up-to-date information.'
+          stale-issue-label: 'stale'
+          # Add this label to exempt the issue from being marked as stale due to inactivity
+          exempt-issue-labels: 'confirmed'
+          # An allow-list of label(s) to only process the issues which contain one of these label(s).
+          any-of-issue-labels: 'question,needs-info'
+          # Use this to do a dry run from a pull request
+          # debug-only: true


### PR DESCRIPTION
The workflow itself should be fine. Perhaps `debug-only: true` should be enabled for testing, though I am not really sure how it works.