### PR TITLE
Update .github/workflows/close-stale-issues.yml: include PRs

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,6 +1,8 @@
 ---
 name: 'Close stale issues and PRs'
 on:  # yamllint disable-line rule:truthy
+  # Use this to do a dry run from a pull request
+  # pull_request:
   schedule:
     - cron: '30 1 * * *'
 
@@ -19,6 +21,7 @@ jobs:
           # Issues/PRs
           ######################################################################
           exempt-assignees: 'spantaleev,aine-etke'
+          operations-per-run: 100
           # An allow-list of label(s) to only process the issues/PRs which contain one of these label(s).
           any-of-labels: 'needs-info'
           # Use this to do a dry run from a pull request

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -15,8 +15,13 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
+          ######################################################################
+          # Issues/PRs
+          ######################################################################
           # An allow-list of label(s) to only process the issues/PRs which contain one of these label(s).
           any-of-labels: 'needs-info'
+          # Use this to do a dry run from a pull request
+          # debug-only: true
           ######################################################################
           # Issues
           ######################################################################
@@ -41,5 +46,3 @@ jobs:
           any-of-pr-labels: 'needs-rebase'
           # Use this to ignore updates such as comments (only to keep the PR alive by bumping)
           # ignore-pr-updates: true
-          # Use this to do a dry run from a pull request
-          # debug-only: true

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -46,4 +46,4 @@ jobs:
           # An allow-list of label(s) to only process the PRs which contain one of these label(s).
           any-of-pr-labels: 'needs-rebase'
           # Use this to ignore updates such as comments (only to keep the PR alive by bumping)
-          # ignore-pr-updates: true
+          ignore-pr-updates: true

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -18,6 +18,7 @@ jobs:
           ######################################################################
           # Issues/PRs
           ######################################################################
+          exempt-assignees: 'spantaleev,aine-etke'
           # An allow-list of label(s) to only process the issues/PRs which contain one of these label(s).
           any-of-labels: 'needs-info'
           # Use this to do a dry run from a pull request

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,11 +1,12 @@
 ---
-name: 'Close stale issues'
+name: 'Close stale issues and PRs'
 on:  # yamllint disable-line rule:truthy
   schedule:
     - cron: '30 1 * * *'
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   stale:
@@ -14,14 +15,31 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          # Don't process pull requests at all
-          days-before-pr-stale: -1
+          # An allow-list of label(s) to only process the issues/PRs which contain one of these label(s).
+          any-of-labels: 'needs-info'
+          ######################################################################
+          # Issues
+          ######################################################################
           stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity. If this issue is still reproduced, feel free to provide the issue with up-to-date information.'
           stale-issue-label: 'stale'
           # Add this label to exempt the issue from being marked as stale due to inactivity
           exempt-issue-labels: 'confirmed'
           # An allow-list of label(s) to only process the issues which contain one of these label(s).
-          any-of-issue-labels: 'question,needs-info'
+          any-of-issue-labels: 'question'
+          ######################################################################
+          # PRs
+          ######################################################################
+          days-before-pr-stale: '365'
+          days-before-pr-close: '30'
+          stale-pr-message: 'This PR is stale because it has been open a year with no activity. Remove stale label or this will be closed in 30 days.'
+          close-pr-message: 'This PR was closed because it has been stalled for 30 days with no activity.'
+          stale-pr-label: 'stale'
+          # Add this label to exempt the PR from being marked as stale due to inactivity
+          exempt-pr-labels: 'confirmed'
+          # An allow-list of label(s) to only process the PRs which contain one of these label(s).
+          any-of-pr-labels: 'needs-rebase'
+          # Use this to ignore updates such as comments (only to keep the PR alive by bumping)
+          # ignore-pr-updates: true
           # Use this to do a dry run from a pull request
           # debug-only: true


### PR DESCRIPTION
Closes https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/3807

With this PR:
- Issues with `question` and/or `needs-info` label(s) will be labelled with `stale` after 60 days without activity and closed in 7 days after that. Stale counter to add `stale` label will restart whenever any update occurs or a comment is added to them.
- PRs with `needs-rebase` and/or `needs-info` label(s) will be labelled with `stale` after 1 year since creation without activity and closed in 30 days after that. Stale counter to add `stale` label will not restart.
- No issues or PRs assigned to @spantaleev and/or @aine-etke (not authored) will be closed.