### PR TITLE
Update .github/workflows/close-stale-issues.yml: edit stale messages and fix any-of-labels

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -39,7 +39,7 @@ jobs:
           ######################################################################
           days-before-pr-stale: '365'
           days-before-pr-close: '30'
-          stale-pr-message: 'This PR is stale because it has been open a year with no activity. Remove stale label or this will be closed in 30 days. To exempt the PR from being marked as stale again due to inactivity, add "confirmed" label.'
+          stale-pr-message: 'This PR is stale because it has not been provided with required information or its conflicts have not been fixed over a year. Remove stale label or this will be closed in 30 days. To exempt the PR from being marked as stale again due to inactivity, add "confirmed" label.'
           close-pr-message: 'This PR was closed because it has been stalled for 30 days with no activity.'
           stale-pr-label: 'stale'
           # Add this label to exempt the PR from being marked as stale due to inactivity

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -22,31 +22,29 @@ jobs:
           ######################################################################
           exempt-assignees: 'spantaleev,aine-etke'
           operations-per-run: 100
-          # An allow-list of label(s) to only process the issues/PRs which contain one of these label(s).
-          any-of-labels: 'needs-info'
           # Use this to do a dry run from a pull request
           # debug-only: true
           ######################################################################
           # Issues
           ######################################################################
-          stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days. To exempt the issue from being marked as stale again due to inactivity, add "confirmed" label.'
           close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity. If this issue is still reproduced, feel free to provide the issue with up-to-date information.'
           stale-issue-label: 'stale'
           # Add this label to exempt the issue from being marked as stale due to inactivity
           exempt-issue-labels: 'confirmed'
           # An allow-list of label(s) to only process the issues which contain one of these label(s).
-          any-of-issue-labels: 'question'
+          any-of-issue-labels: 'needs-info,question'
           ######################################################################
           # PRs
           ######################################################################
           days-before-pr-stale: '365'
           days-before-pr-close: '30'
-          stale-pr-message: 'This PR is stale because it has been open a year with no activity. Remove stale label or this will be closed in 30 days.'
+          stale-pr-message: 'This PR is stale because it has been open a year with no activity. Remove stale label or this will be closed in 30 days. To exempt the PR from being marked as stale again due to inactivity, add "confirmed" label.'
           close-pr-message: 'This PR was closed because it has been stalled for 30 days with no activity.'
           stale-pr-label: 'stale'
           # Add this label to exempt the PR from being marked as stale due to inactivity
           exempt-pr-labels: 'confirmed'
           # An allow-list of label(s) to only process the PRs which contain one of these label(s).
-          any-of-pr-labels: 'needs-rebase'
+          any-of-pr-labels: 'needs-info,needs-rebase'
           # Use this to ignore updates such as comments (only to keep the PR alive by bumping)
           ignore-pr-updates: true


### PR DESCRIPTION
This should fix the issue that https://github.com/spantaleev/matrix-docker-ansible-deploy/pull/2192 (labelled with `needs-info` but not with `needs-rebase`) was not marked as stale.