### PR TITLE
Edit descriptions about installation of components

### DIFF
--- a/docs/configuring-playbook-alertmanager-receiver.md
+++ b/docs/configuring-playbook-alertmanager-receiver.md
@@ -78,6 +78,7 @@ Steps 3 and 4 need to be done for each new room you'd like the bot to deliver al
 
 Now that you've [prepared the bot account and room](#account-and-room-preparation), [configured the playbook](#adjusting-the-playbook-configuration), and potentially [adjusted your DNS records](#adjusting-dns-records), you can run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-alertmanager-receiver.md
+++ b/docs/configuring-playbook-alertmanager-receiver.md
@@ -76,7 +76,7 @@ Steps 3 and 4 need to be done for each new room you'd like the bot to deliver al
 
 ## Installing
 
-Now that you've [prepared the bot account and room](#account-and-room-preparation), [configured the playbook](#adjusting-the-playbook-configuration), and potentially [adjusted your DNS records](#adjusting-dns-records), you can run the [installation](installing.md) command:
+Now that you've [prepared the bot account and room](#account-and-room-preparation), [configured the playbook](#adjusting-the-playbook-configuration), and potentially [adjusted your DNS records](#adjusting-dns-records), you can run the playbook with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-alertmanager-receiver.md
+++ b/docs/configuring-playbook-alertmanager-receiver.md
@@ -80,7 +80,7 @@ Now that you've [prepared the bot account and room](#account-and-room-preparatio
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-alertmanager-receiver.md
+++ b/docs/configuring-playbook-alertmanager-receiver.md
@@ -91,9 +91,6 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
   `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
-Then, you can proceed to [Usage](#usage).
-
-
 ## Usage
 
 Configure your Prometheus Alertmanager with configuration like this:

--- a/docs/configuring-playbook-alertmanager-receiver.md
+++ b/docs/configuring-playbook-alertmanager-receiver.md
@@ -83,9 +83,13 @@ Now that you've [prepared the bot account and room](#account-and-room-preparatio
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 Then, you can proceed to [Usage](#usage).
 

--- a/docs/configuring-playbook-alertmanager-receiver.md
+++ b/docs/configuring-playbook-alertmanager-receiver.md
@@ -83,6 +83,10 @@ Now that you've [prepared the bot account and room](#account-and-room-preparatio
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 Then, you can proceed to [Usage](#usage).
 
 

--- a/docs/configuring-playbook-alertmanager-receiver.md
+++ b/docs/configuring-playbook-alertmanager-receiver.md
@@ -76,7 +76,11 @@ Steps 3 and 4 need to be done for each new room you'd like the bot to deliver al
 
 ## Installing
 
-Now that you've [prepared the bot account and room](#account-and-room-preparation), [configured the playbook](#adjusting-the-playbook-configuration), and potentially [adjusted your DNS records](#adjusting-dns-records), you can run the [installation](installing.md) command: `just install-all`
+Now that you've [prepared the bot account and room](#account-and-room-preparation), [configured the playbook](#adjusting-the-playbook-configuration), and potentially [adjusted your DNS records](#adjusting-dns-records), you can run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 Then, you can proceed to [Usage](#usage).
 

--- a/docs/configuring-playbook-appservice-double-puppet.md
+++ b/docs/configuring-playbook-appservice-double-puppet.md
@@ -20,7 +20,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-appservice-double-puppet.md
+++ b/docs/configuring-playbook-appservice-double-puppet.md
@@ -16,7 +16,7 @@ matrix_appservice_double_puppet_enabled: true
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-appservice-double-puppet.md
+++ b/docs/configuring-playbook-appservice-double-puppet.md
@@ -16,7 +16,11 @@ matrix_appservice_double_puppet_enabled: true
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Usage
 

--- a/docs/configuring-playbook-appservice-double-puppet.md
+++ b/docs/configuring-playbook-appservice-double-puppet.md
@@ -23,6 +23,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 When enabled, double puppeting will automatically be enabled for all bridges that support double puppeting via the appservice method.

--- a/docs/configuring-playbook-appservice-double-puppet.md
+++ b/docs/configuring-playbook-appservice-double-puppet.md
@@ -18,6 +18,7 @@ matrix_appservice_double_puppet_enabled: true
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-appservice-double-puppet.md
+++ b/docs/configuring-playbook-appservice-double-puppet.md
@@ -23,9 +23,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-appservice-draupnir-for-all.md
+++ b/docs/configuring-playbook-appservice-draupnir-for-all.md
@@ -56,9 +56,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-appservice-draupnir-for-all.md
+++ b/docs/configuring-playbook-appservice-draupnir-for-all.md
@@ -49,7 +49,7 @@ matrix_appservice_draupnir_for_all_master_control_room_alias: "ALIAS_FROM_STEP_2
 
 ### 4. Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-appservice-draupnir-for-all.md
+++ b/docs/configuring-playbook-appservice-draupnir-for-all.md
@@ -56,6 +56,9 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-appservice-draupnir-for-all.md
+++ b/docs/configuring-playbook-appservice-draupnir-for-all.md
@@ -53,7 +53,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-appservice-draupnir-for-all.md
+++ b/docs/configuring-playbook-appservice-draupnir-for-all.md
@@ -51,6 +51,7 @@ matrix_appservice_draupnir_for_all_master_control_room_alias: "ALIAS_FROM_STEP_2
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-backup-borg.md
+++ b/docs/configuring-playbook-backup-borg.md
@@ -71,7 +71,7 @@ Check the [backup_borg role](https://github.com/mother-of-all-self-hosting/ansib
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-backup-borg.md
+++ b/docs/configuring-playbook-backup-borg.md
@@ -75,12 +75,12 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Manually start a backup
 

--- a/docs/configuring-playbook-backup-borg.md
+++ b/docs/configuring-playbook-backup-borg.md
@@ -78,7 +78,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
 `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 

--- a/docs/configuring-playbook-backup-borg.md
+++ b/docs/configuring-playbook-backup-borg.md
@@ -78,6 +78,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Manually start a backup
 
 For testing your setup it can be helpful to not wait until 4am. If you want to run the backup immediately, log onto the server and run `systemctl start matrix-backup-borg`. This will not return until the backup is done, so possibly a long time. Consider using [tmux](https://en.wikipedia.org/wiki/Tmux) if your SSH connection is unstable.

--- a/docs/configuring-playbook-backup-borg.md
+++ b/docs/configuring-playbook-backup-borg.md
@@ -73,6 +73,7 @@ Check the [backup_borg role](https://github.com/mother-of-all-self-hosting/ansib
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-backup-borg.md
+++ b/docs/configuring-playbook-backup-borg.md
@@ -75,7 +75,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bot-baibot.md
+++ b/docs/configuring-playbook-bot-baibot.md
@@ -376,7 +376,7 @@ matrix_bot_baibot_config_initial_global_config_handler_image_generation: null
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bot-baibot.md
+++ b/docs/configuring-playbook-bot-baibot.md
@@ -378,6 +378,7 @@ matrix_bot_baibot_config_initial_global_config_handler_image_generation: null
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```

--- a/docs/configuring-playbook-bot-baibot.md
+++ b/docs/configuring-playbook-bot-baibot.md
@@ -379,7 +379,7 @@ matrix_bot_baibot_config_initial_global_config_handler_image_generation: null
 After configuring the playbook, run the [installation](installing.md) command:
 
 ```sh
-just run-tags install-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 **Notes**:

--- a/docs/configuring-playbook-bot-baibot.md
+++ b/docs/configuring-playbook-bot-baibot.md
@@ -383,6 +383,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 **Notes**:
 
 - the `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account

--- a/docs/configuring-playbook-bot-baibot.md
+++ b/docs/configuring-playbook-bot-baibot.md
@@ -383,16 +383,15 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
-
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
-
 **Notes**:
 
-- the `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
 
-- if you change the bot password (`matrix_bot_baibot_config_user_password` in your `vars.yml` file) subsequently, the bot user's credentials on the homeserver won't be updated automatically. If you'd like to change the bot user's password, use a tool like [synapse-admin](configuring-playbook-synapse-admin.md) to change it, and then update `matrix_bot_baibot_config_user_password` to let the bot know its new password
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
 
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
+- If you change the bot password (`matrix_bot_baibot_config_user_password` in your `vars.yml` file) subsequently, the bot user's credentials on the homeserver won't be updated automatically. If you'd like to change the bot user's password, use a tool like [synapse-admin](configuring-playbook-synapse-admin.md) to change it, and then update `matrix_bot_baibot_config_user_password` to let the bot know its new password.
 
 ## Usage
 

--- a/docs/configuring-playbook-bot-buscarron.md
+++ b/docs/configuring-playbook-bot-buscarron.md
@@ -63,6 +63,10 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 **Notes**:
 
 - the `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account

--- a/docs/configuring-playbook-bot-buscarron.md
+++ b/docs/configuring-playbook-bot-buscarron.md
@@ -63,15 +63,15 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
-
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
-
 **Notes**:
 
-- the `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
 
-- if you change the bot password (`matrix_bot_buscarron_password` in your `vars.yml` file) subsequently, the bot user's credentials on the homeserver won't be updated automatically. If you'd like to change the bot user's password, use a tool like [synapse-admin](configuring-playbook-synapse-admin.md) to change it, and then update `matrix_bot_buscarron_password` to let the bot know its new password
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
+- If you change the bot password (`matrix_bot_buscarron_password` in your `vars.yml` file) subsequently, the bot user's credentials on the homeserver won't be updated automatically. If you'd like to change the bot user's password, use a tool like [synapse-admin](configuring-playbook-synapse-admin.md) to change it, and then update `matrix_bot_buscarron_password` to let the bot know its new password.
 
 
 ## Usage

--- a/docs/configuring-playbook-bot-buscarron.md
+++ b/docs/configuring-playbook-bot-buscarron.md
@@ -73,7 +73,6 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
 - If you change the bot password (`matrix_bot_buscarron_password` in your `vars.yml` file) subsequently, the bot user's credentials on the homeserver won't be updated automatically. If you'd like to change the bot user's password, use a tool like [synapse-admin](configuring-playbook-synapse-admin.md) to change it, and then update `matrix_bot_buscarron_password` to let the bot know its new password.
 
-
 ## Usage
 
 To use the bot, invite the `@bot.buscarron:example.com` to the room you specified in a config, after that any point your form to the form url, example for the `contact` form:

--- a/docs/configuring-playbook-bot-buscarron.md
+++ b/docs/configuring-playbook-bot-buscarron.md
@@ -56,7 +56,7 @@ If you've decided to reuse the `matrix.` domain, you won't need to do any extra 
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bot-buscarron.md
+++ b/docs/configuring-playbook-bot-buscarron.md
@@ -58,6 +58,7 @@ If you've decided to reuse the `matrix.` domain, you won't need to do any extra 
 
 After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```

--- a/docs/configuring-playbook-bot-chatgpt.md
+++ b/docs/configuring-playbook-bot-chatgpt.md
@@ -56,7 +56,7 @@ You will need to get tokens for ChatGPT.
 
 ## 4. Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bot-chatgpt.md
+++ b/docs/configuring-playbook-bot-chatgpt.md
@@ -60,7 +60,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bot-chatgpt.md
+++ b/docs/configuring-playbook-bot-chatgpt.md
@@ -63,6 +63,9 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bot-chatgpt.md
+++ b/docs/configuring-playbook-bot-chatgpt.md
@@ -59,7 +59,7 @@ You will need to get tokens for ChatGPT.
 After configuring the playbook, run the [installation](installing.md) command:
 
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=install-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
 

--- a/docs/configuring-playbook-bot-chatgpt.md
+++ b/docs/configuring-playbook-bot-chatgpt.md
@@ -58,6 +58,7 @@ You will need to get tokens for ChatGPT.
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bot-chatgpt.md
+++ b/docs/configuring-playbook-bot-chatgpt.md
@@ -63,9 +63,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bot-draupnir.md
+++ b/docs/configuring-playbook-bot-draupnir.md
@@ -117,6 +117,7 @@ That is all you need to do due to that Draupnir can complete migration on its ow
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bot-draupnir.md
+++ b/docs/configuring-playbook-bot-draupnir.md
@@ -122,6 +122,9 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bot-draupnir.md
+++ b/docs/configuring-playbook-bot-draupnir.md
@@ -119,7 +119,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bot-draupnir.md
+++ b/docs/configuring-playbook-bot-draupnir.md
@@ -115,7 +115,7 @@ That is all you need to do due to that Draupnir can complete migration on its ow
 
 ## 6. Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bot-draupnir.md
+++ b/docs/configuring-playbook-bot-draupnir.md
@@ -130,6 +130,8 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
   `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
+- If you change the Pantalaimon's password (`matrix_bot_draupnir_pantalaimon_password` in your `vars.yml` file) subsequently, its credentials on the homeserver won't be updated automatically. If you'd like to change the password, use a tool like [synapse-admin](configuring-playbook-synapse-admin.md) to change it, and then update `matrix_bot_draupnir_pantalaimon_password` to let Pantalaimon know its new password.
+
 ## Usage
 
 You can refer to the upstream [documentation](https://the-draupnir-project.github.io/draupnir-documentation/) for additional ways to use and configure Draupnir and for a more detailed usage guide.

--- a/docs/configuring-playbook-bot-draupnir.md
+++ b/docs/configuring-playbook-bot-draupnir.md
@@ -122,9 +122,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bot-go-neb.md
+++ b/docs/configuring-playbook-bot-go-neb.md
@@ -226,9 +226,13 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bot-go-neb.md
+++ b/docs/configuring-playbook-bot-go-neb.md
@@ -221,6 +221,7 @@ If you've decided to reuse the `matrix.` domain, you won't need to do any extra 
 
 After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bot-go-neb.md
+++ b/docs/configuring-playbook-bot-go-neb.md
@@ -223,7 +223,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bot-go-neb.md
+++ b/docs/configuring-playbook-bot-go-neb.md
@@ -226,6 +226,9 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bot-go-neb.md
+++ b/docs/configuring-playbook-bot-go-neb.md
@@ -219,7 +219,7 @@ If you've decided to reuse the `matrix.` domain, you won't need to do any extra 
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bot-honoroit.md
+++ b/docs/configuring-playbook-bot-honoroit.md
@@ -48,7 +48,7 @@ If you've decided to use the default hostname, you won't need to do any extra DN
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bot-honoroit.md
+++ b/docs/configuring-playbook-bot-honoroit.md
@@ -55,6 +55,10 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 **Notes**:
 
 - the `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account

--- a/docs/configuring-playbook-bot-honoroit.md
+++ b/docs/configuring-playbook-bot-honoroit.md
@@ -50,6 +50,7 @@ If you've decided to use the default hostname, you won't need to do any extra DN
 
 After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```

--- a/docs/configuring-playbook-bot-honoroit.md
+++ b/docs/configuring-playbook-bot-honoroit.md
@@ -55,15 +55,15 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
-
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
-
 **Notes**:
 
-- the `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
 
-- if you change the bot password (`matrix_bot_honoroit_password` in your `vars.yml` file) subsequently, the bot user's credentials on the homeserver won't be updated automatically. If you'd like to change the bot user's password, use a tool like [synapse-admin](configuring-playbook-synapse-admin.md) to change it, and then update `matrix_bot_honoroit_password` to let the bot know its new password
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
+- If you change the bot password (`matrix_bot_honoroit_password` in your `vars.yml` file) subsequently, the bot user's credentials on the homeserver won't be updated automatically. If you'd like to change the bot user's password, use a tool like [synapse-admin](configuring-playbook-synapse-admin.md) to change it, and then update `matrix_bot_honoroit_password` to let the bot know its new password.
 
 
 ## Usage

--- a/docs/configuring-playbook-bot-honoroit.md
+++ b/docs/configuring-playbook-bot-honoroit.md
@@ -65,7 +65,6 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
 - If you change the bot password (`matrix_bot_honoroit_password` in your `vars.yml` file) subsequently, the bot user's credentials on the homeserver won't be updated automatically. If you'd like to change the bot user's password, use a tool like [synapse-admin](configuring-playbook-synapse-admin.md) to change it, and then update `matrix_bot_honoroit_password` to let the bot know its new password.
 
-
 ## Usage
 
 To use the bot, invite the `@honoroit:example.com` to the room you specified in config, after that any Matrix user can send a message to the `@honoroit:example.com` to start a new thread in that room.

--- a/docs/configuring-playbook-bot-matrix-registration-bot.md
+++ b/docs/configuring-playbook-bot-matrix-registration-bot.md
@@ -47,6 +47,8 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
   `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
+- If you change the bot password (`matrix_bot_matrix_registration_bot_bot_password` in your `vars.yml` file) subsequently, the bot user's credentials on the homeserver won't be updated automatically. If you'd like to change the bot user's password, use a tool like [synapse-admin](configuring-playbook-synapse-admin.md) to change it, and then update `matrix_bot_matrix_registration_bot_bot_password` to let the bot know its new password.
+
 ## Usage
 
 To use the bot, start a chat with `@bot.matrix-registration-bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).

--- a/docs/configuring-playbook-bot-matrix-registration-bot.md
+++ b/docs/configuring-playbook-bot-matrix-registration-bot.md
@@ -32,7 +32,7 @@ The bot account will be created automatically.
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bot-matrix-registration-bot.md
+++ b/docs/configuring-playbook-bot-matrix-registration-bot.md
@@ -39,9 +39,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bot-matrix-registration-bot.md
+++ b/docs/configuring-playbook-bot-matrix-registration-bot.md
@@ -39,6 +39,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 To use the bot, start a chat with `@bot.matrix-registration-bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).

--- a/docs/configuring-playbook-bot-matrix-registration-bot.md
+++ b/docs/configuring-playbook-bot-matrix-registration-bot.md
@@ -34,6 +34,7 @@ The bot account will be created automatically.
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bot-matrix-registration-bot.md
+++ b/docs/configuring-playbook-bot-matrix-registration-bot.md
@@ -32,7 +32,11 @@ The bot account will be created automatically.
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Usage
 

--- a/docs/configuring-playbook-bot-matrix-registration-bot.md
+++ b/docs/configuring-playbook-bot-matrix-registration-bot.md
@@ -36,7 +36,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bot-matrix-reminder-bot.md
+++ b/docs/configuring-playbook-bot-matrix-reminder-bot.md
@@ -29,6 +29,7 @@ matrix_bot_matrix_reminder_bot_reminders_timezone: Europe/London
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```

--- a/docs/configuring-playbook-bot-matrix-reminder-bot.md
+++ b/docs/configuring-playbook-bot-matrix-reminder-bot.md
@@ -44,7 +44,6 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
 - If you change the bot password (`matrix_bot_matrix_reminder_bot_matrix_user_password` in your `vars.yml` file) subsequently, the bot user's credentials on the homeserver won't be updated automatically. If you'd like to change the bot user's password, use a tool like [synapse-admin](configuring-playbook-synapse-admin.md) to change it, and then update `matrix_bot_matrix_reminder_bot_matrix_user_password` to let the bot know its new password.
 
-
 ## Usage
 
 To use the bot, start a chat with `@bot.matrix-reminder-bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).

--- a/docs/configuring-playbook-bot-matrix-reminder-bot.md
+++ b/docs/configuring-playbook-bot-matrix-reminder-bot.md
@@ -34,6 +34,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 **Notes**:
 
 - the `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account

--- a/docs/configuring-playbook-bot-matrix-reminder-bot.md
+++ b/docs/configuring-playbook-bot-matrix-reminder-bot.md
@@ -34,15 +34,15 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
-
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
-
 **Notes**:
 
-- the `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
 
-- if you change the bot password (`matrix_bot_matrix_reminder_bot_matrix_user_password` in your `vars.yml` file) subsequently, the bot user's credentials on the homeserver won't be updated automatically. If you'd like to change the bot user's password, use a tool like [synapse-admin](configuring-playbook-synapse-admin.md) to change it, and then update `matrix_bot_matrix_reminder_bot_matrix_user_password` to let the bot know its new password
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
+- If you change the bot password (`matrix_bot_matrix_reminder_bot_matrix_user_password` in your `vars.yml` file) subsequently, the bot user's credentials on the homeserver won't be updated automatically. If you'd like to change the bot user's password, use a tool like [synapse-admin](configuring-playbook-synapse-admin.md) to change it, and then update `matrix_bot_matrix_reminder_bot_matrix_user_password` to let the bot know its new password.
 
 
 ## Usage

--- a/docs/configuring-playbook-bot-matrix-reminder-bot.md
+++ b/docs/configuring-playbook-bot-matrix-reminder-bot.md
@@ -27,7 +27,7 @@ matrix_bot_matrix_reminder_bot_reminders_timezone: Europe/London
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bot-maubot.md
+++ b/docs/configuring-playbook-bot-maubot.md
@@ -51,6 +51,7 @@ If you've decided to use the default hostname, you won't need to do any extra DN
 
 After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bot-maubot.md
+++ b/docs/configuring-playbook-bot-maubot.md
@@ -49,7 +49,11 @@ If you've decided to use the default hostname, you won't need to do any extra DN
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command: `just install-all`
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 **Notes**:
 

--- a/docs/configuring-playbook-bot-maubot.md
+++ b/docs/configuring-playbook-bot-maubot.md
@@ -49,7 +49,7 @@ If you've decided to use the default hostname, you won't need to do any extra DN
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bot-maubot.md
+++ b/docs/configuring-playbook-bot-maubot.md
@@ -56,13 +56,15 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
-
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
-
 **Notes**:
 
-- if you change the bot password (`matrix_bot_maubot_initial_password` in your `vars.yml` file) subsequently, the bot user's credentials on the homeserver won't be updated automatically. If you'd like to change the bot user's password, use a tool like [synapse-admin](configuring-playbook-synapse-admin.md) to change it, and then update `matrix_bot_maubot_initial_password` to let the bot know its new password
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
+- If you change the bot password (`matrix_bot_maubot_initial_password` in your `vars.yml` file) subsequently, the bot user's credentials on the homeserver won't be updated automatically. If you'd like to change the bot user's password, use a tool like [synapse-admin](configuring-playbook-synapse-admin.md) to change it, and then update `matrix_bot_maubot_initial_password` to let the bot know its new password.
 
 ## Usage
 

--- a/docs/configuring-playbook-bot-maubot.md
+++ b/docs/configuring-playbook-bot-maubot.md
@@ -53,7 +53,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bot-maubot.md
+++ b/docs/configuring-playbook-bot-maubot.md
@@ -56,6 +56,10 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 **Notes**:
 
 - if you change the bot password (`matrix_bot_maubot_initial_password` in your `vars.yml` file) subsequently, the bot user's credentials on the homeserver won't be updated automatically. If you'd like to change the bot user's password, use a tool like [synapse-admin](configuring-playbook-synapse-admin.md) to change it, and then update `matrix_bot_maubot_initial_password` to let the bot know its new password

--- a/docs/configuring-playbook-bot-mjolnir.md
+++ b/docs/configuring-playbook-bot-mjolnir.md
@@ -117,7 +117,7 @@ matrix_synapse_ext_spam_checker_mjolnir_antispam_config_ban_lists: []
 
 ## 7. Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bot-mjolnir.md
+++ b/docs/configuring-playbook-bot-mjolnir.md
@@ -132,6 +132,8 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
   `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
+- If you change the Pantalaimon's password (`matrix_bot_mjolnir_pantalaimon_password` in your `vars.yml` file) subsequently, its credentials on the homeserver won't be updated automatically. If you'd like to change the password, use a tool like [synapse-admin](configuring-playbook-synapse-admin.md) to change it, and then update `matrix_bot_mjolnir_pantalaimon_password` to let Pantalaimon know its new password.
+
 ## Usage
 
 You can refer to the upstream [documentation](https://github.com/matrix-org/mjolnir) for additional ways to use and configure Mjolnir. Check out their [quickstart guide](https://github.com/matrix-org/mjolnir#quickstart-guide) for some basic commands you can give to the bot.

--- a/docs/configuring-playbook-bot-mjolnir.md
+++ b/docs/configuring-playbook-bot-mjolnir.md
@@ -124,9 +124,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bot-mjolnir.md
+++ b/docs/configuring-playbook-bot-mjolnir.md
@@ -119,6 +119,7 @@ matrix_synapse_ext_spam_checker_mjolnir_antispam_config_ban_lists: []
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bot-mjolnir.md
+++ b/docs/configuring-playbook-bot-mjolnir.md
@@ -124,6 +124,9 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bot-mjolnir.md
+++ b/docs/configuring-playbook-bot-mjolnir.md
@@ -121,7 +121,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-appservice-discord.md
+++ b/docs/configuring-playbook-bridge-appservice-discord.md
@@ -32,6 +32,7 @@ matrix_appservice_discord_bot_token: "YOUR DISCORD APP BOT TOKEN"
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-appservice-discord.md
+++ b/docs/configuring-playbook-bridge-appservice-discord.md
@@ -34,7 +34,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-appservice-discord.md
+++ b/docs/configuring-playbook-bridge-appservice-discord.md
@@ -37,9 +37,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Self-Service Bridging (Manual)
 

--- a/docs/configuring-playbook-bridge-appservice-discord.md
+++ b/docs/configuring-playbook-bridge-appservice-discord.md
@@ -37,6 +37,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Self-Service Bridging (Manual)
 
 Self-service bridging allows you to bridge specific and existing Matrix rooms to specific Discord rooms. To enable it, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:

--- a/docs/configuring-playbook-bridge-appservice-discord.md
+++ b/docs/configuring-playbook-bridge-appservice-discord.md
@@ -30,7 +30,7 @@ matrix_appservice_discord_bot_token: "YOUR DISCORD APP BOT TOKEN"
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-appservice-irc.md
+++ b/docs/configuring-playbook-bridge-appservice-irc.md
@@ -69,9 +69,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-appservice-irc.md
+++ b/docs/configuring-playbook-bridge-appservice-irc.md
@@ -64,6 +64,7 @@ matrix_appservice_irc_ircService_servers:
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-appservice-irc.md
+++ b/docs/configuring-playbook-bridge-appservice-irc.md
@@ -62,7 +62,11 @@ matrix_appservice_irc_ircService_servers:
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-appservice-irc.md
+++ b/docs/configuring-playbook-bridge-appservice-irc.md
@@ -69,6 +69,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 You then need to start a chat with `@irc_bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).

--- a/docs/configuring-playbook-bridge-appservice-irc.md
+++ b/docs/configuring-playbook-bridge-appservice-irc.md
@@ -66,7 +66,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-appservice-irc.md
+++ b/docs/configuring-playbook-bridge-appservice-irc.md
@@ -62,7 +62,7 @@ matrix_appservice_irc_ircService_servers:
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-appservice-kakaotalk.md
+++ b/docs/configuring-playbook-bridge-appservice-kakaotalk.md
@@ -40,6 +40,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 Start a chat with `@kakaotalkbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).

--- a/docs/configuring-playbook-bridge-appservice-kakaotalk.md
+++ b/docs/configuring-playbook-bridge-appservice-kakaotalk.md
@@ -40,9 +40,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-appservice-kakaotalk.md
+++ b/docs/configuring-playbook-bridge-appservice-kakaotalk.md
@@ -37,7 +37,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-appservice-kakaotalk.md
+++ b/docs/configuring-playbook-bridge-appservice-kakaotalk.md
@@ -35,6 +35,7 @@ Take a look at:
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-appservice-kakaotalk.md
+++ b/docs/configuring-playbook-bridge-appservice-kakaotalk.md
@@ -33,7 +33,7 @@ Take a look at:
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-appservice-slack.md
+++ b/docs/configuring-playbook-bridge-appservice-slack.md
@@ -72,9 +72,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-appservice-slack.md
+++ b/docs/configuring-playbook-bridge-appservice-slack.md
@@ -69,7 +69,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-appservice-slack.md
+++ b/docs/configuring-playbook-bridge-appservice-slack.md
@@ -67,6 +67,7 @@ Other configuration options are available via the `matrix_appservice_slack_confi
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-appservice-slack.md
+++ b/docs/configuring-playbook-bridge-appservice-slack.md
@@ -72,6 +72,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 Send `/invite @slackbot:example.com` to invite the bridge bot user into the admin room.

--- a/docs/configuring-playbook-bridge-appservice-slack.md
+++ b/docs/configuring-playbook-bridge-appservice-slack.md
@@ -65,7 +65,7 @@ Other configuration options are available via the `matrix_appservice_slack_confi
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-appservice-webhooks.md
+++ b/docs/configuring-playbook-bridge-appservice-webhooks.md
@@ -28,6 +28,7 @@ matrix_appservice_webhooks_api_secret: '<your_secret>'
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-appservice-webhooks.md
+++ b/docs/configuring-playbook-bridge-appservice-webhooks.md
@@ -33,9 +33,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-appservice-webhooks.md
+++ b/docs/configuring-playbook-bridge-appservice-webhooks.md
@@ -30,7 +30,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-appservice-webhooks.md
+++ b/docs/configuring-playbook-bridge-appservice-webhooks.md
@@ -33,6 +33,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 Invite the bridge bot user to your room in either way.

--- a/docs/configuring-playbook-bridge-appservice-webhooks.md
+++ b/docs/configuring-playbook-bridge-appservice-webhooks.md
@@ -26,7 +26,7 @@ matrix_appservice_webhooks_api_secret: '<your_secret>'
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-beeper-linkedin.md
+++ b/docs/configuring-playbook-bridge-beeper-linkedin.md
@@ -37,6 +37,7 @@ You may wish to look at `roles/custom/matrix-bridge-beeper-linkedin/templates/co
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-beeper-linkedin.md
+++ b/docs/configuring-playbook-bridge-beeper-linkedin.md
@@ -35,7 +35,11 @@ You may wish to look at `roles/custom/matrix-bridge-beeper-linkedin/templates/co
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Set up Double Puppeting by enabling Appservice Double Puppet or Shared Secret Auth
 

--- a/docs/configuring-playbook-bridge-beeper-linkedin.md
+++ b/docs/configuring-playbook-bridge-beeper-linkedin.md
@@ -42,9 +42,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Set up Double Puppeting by enabling Appservice Double Puppet or Shared Secret Auth
 

--- a/docs/configuring-playbook-bridge-beeper-linkedin.md
+++ b/docs/configuring-playbook-bridge-beeper-linkedin.md
@@ -42,6 +42,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Set up Double Puppeting by enabling Appservice Double Puppet or Shared Secret Auth
 
 The bridge automatically performs Double Puppeting if [Appservice Double Puppet](configuring-playbook-appservice-double-puppet.md) or [Shared Secret Auth](configuring-playbook-shared-secret-auth.md) service is configured and enabled on the server for this playbook.

--- a/docs/configuring-playbook-bridge-beeper-linkedin.md
+++ b/docs/configuring-playbook-bridge-beeper-linkedin.md
@@ -35,7 +35,7 @@ You may wish to look at `roles/custom/matrix-bridge-beeper-linkedin/templates/co
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-beeper-linkedin.md
+++ b/docs/configuring-playbook-bridge-beeper-linkedin.md
@@ -39,7 +39,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-go-skype-bridge.md
+++ b/docs/configuring-playbook-bridge-go-skype-bridge.md
@@ -21,9 +21,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-go-skype-bridge.md
+++ b/docs/configuring-playbook-bridge-go-skype-bridge.md
@@ -14,7 +14,11 @@ matrix_go_skype_bridge_enabled: true
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-go-skype-bridge.md
+++ b/docs/configuring-playbook-bridge-go-skype-bridge.md
@@ -18,7 +18,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-go-skype-bridge.md
+++ b/docs/configuring-playbook-bridge-go-skype-bridge.md
@@ -16,6 +16,7 @@ matrix_go_skype_bridge_enabled: true
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-go-skype-bridge.md
+++ b/docs/configuring-playbook-bridge-go-skype-bridge.md
@@ -21,6 +21,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 Once the bot is enabled, you need to start a chat with `Skype bridge bot` with the handle `@skypebridgebot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).

--- a/docs/configuring-playbook-bridge-go-skype-bridge.md
+++ b/docs/configuring-playbook-bridge-go-skype-bridge.md
@@ -14,7 +14,7 @@ matrix_go_skype_bridge_enabled: true
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-heisenbridge.md
+++ b/docs/configuring-playbook-bridge-heisenbridge.md
@@ -51,6 +51,7 @@ If you've decided to use the default hostname, you won't need to do any extra DN
 
 After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-heisenbridge.md
+++ b/docs/configuring-playbook-bridge-heisenbridge.md
@@ -49,7 +49,11 @@ If you've decided to use the default hostname, you won't need to do any extra DN
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-heisenbridge.md
+++ b/docs/configuring-playbook-bridge-heisenbridge.md
@@ -56,9 +56,13 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-heisenbridge.md
+++ b/docs/configuring-playbook-bridge-heisenbridge.md
@@ -49,7 +49,7 @@ If you've decided to use the default hostname, you won't need to do any extra DN
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-heisenbridge.md
+++ b/docs/configuring-playbook-bridge-heisenbridge.md
@@ -56,6 +56,10 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 After the bridge is successfully running just DM `@heisenbridge:example.com` to start setting it up. If the bridge ignores you and a DM is not accepted then the owner setting may be wrong.

--- a/docs/configuring-playbook-bridge-heisenbridge.md
+++ b/docs/configuring-playbook-bridge-heisenbridge.md
@@ -53,7 +53,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-matrix-bridge-sms.md
+++ b/docs/configuring-playbook-bridge-matrix-bridge-sms.md
@@ -33,7 +33,7 @@ matrix_sms_bridge_provider_android_truststore_password: 123
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-matrix-bridge-sms.md
+++ b/docs/configuring-playbook-bridge-matrix-bridge-sms.md
@@ -33,7 +33,11 @@ matrix_sms_bridge_provider_android_truststore_password: 123
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-matrix-bridge-sms.md
+++ b/docs/configuring-playbook-bridge-matrix-bridge-sms.md
@@ -40,9 +40,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-matrix-bridge-sms.md
+++ b/docs/configuring-playbook-bridge-matrix-bridge-sms.md
@@ -37,7 +37,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-matrix-bridge-sms.md
+++ b/docs/configuring-playbook-bridge-matrix-bridge-sms.md
@@ -35,6 +35,7 @@ matrix_sms_bridge_provider_android_truststore_password: 123
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-matrix-bridge-sms.md
+++ b/docs/configuring-playbook-bridge-matrix-bridge-sms.md
@@ -40,6 +40,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 Read the [user guide](https://github.com/benkuly/matrix-sms-bridge/blob/master/README.md#user-guide) to see how this bridge works.

--- a/docs/configuring-playbook-bridge-mautrix-discord.md
+++ b/docs/configuring-playbook-bridge-mautrix-discord.md
@@ -49,9 +49,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mautrix-discord.md
+++ b/docs/configuring-playbook-bridge-mautrix-discord.md
@@ -46,7 +46,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-mautrix-discord.md
+++ b/docs/configuring-playbook-bridge-mautrix-discord.md
@@ -42,7 +42,7 @@ Take a look at:
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-mautrix-discord.md
+++ b/docs/configuring-playbook-bridge-mautrix-discord.md
@@ -49,6 +49,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 ### Logging in

--- a/docs/configuring-playbook-bridge-mautrix-discord.md
+++ b/docs/configuring-playbook-bridge-mautrix-discord.md
@@ -44,6 +44,7 @@ Take a look at:
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-mautrix-facebook.md
+++ b/docs/configuring-playbook-bridge-mautrix-facebook.md
@@ -55,7 +55,7 @@ You may wish to look at `roles/custom/matrix-bridge-mautrix-facebook/templates/c
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-mautrix-facebook.md
+++ b/docs/configuring-playbook-bridge-mautrix-facebook.md
@@ -62,9 +62,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mautrix-facebook.md
+++ b/docs/configuring-playbook-bridge-mautrix-facebook.md
@@ -55,7 +55,11 @@ You may wish to look at `roles/custom/matrix-bridge-mautrix-facebook/templates/c
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mautrix-facebook.md
+++ b/docs/configuring-playbook-bridge-mautrix-facebook.md
@@ -59,7 +59,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-mautrix-facebook.md
+++ b/docs/configuring-playbook-bridge-mautrix-facebook.md
@@ -57,6 +57,7 @@ You may wish to look at `roles/custom/matrix-bridge-mautrix-facebook/templates/c
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-mautrix-facebook.md
+++ b/docs/configuring-playbook-bridge-mautrix-facebook.md
@@ -62,6 +62,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 You then need to start a chat with `@facebookbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).

--- a/docs/configuring-playbook-bridge-mautrix-gmessages.md
+++ b/docs/configuring-playbook-bridge-mautrix-gmessages.md
@@ -22,6 +22,7 @@ matrix_mautrix_gmessages_enabled: true
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-mautrix-gmessages.md
+++ b/docs/configuring-playbook-bridge-mautrix-gmessages.md
@@ -27,9 +27,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mautrix-gmessages.md
+++ b/docs/configuring-playbook-bridge-mautrix-gmessages.md
@@ -20,7 +20,11 @@ matrix_mautrix_gmessages_enabled: true
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mautrix-gmessages.md
+++ b/docs/configuring-playbook-bridge-mautrix-gmessages.md
@@ -20,7 +20,7 @@ matrix_mautrix_gmessages_enabled: true
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-mautrix-gmessages.md
+++ b/docs/configuring-playbook-bridge-mautrix-gmessages.md
@@ -24,7 +24,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-mautrix-gmessages.md
+++ b/docs/configuring-playbook-bridge-mautrix-gmessages.md
@@ -27,6 +27,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 You then need to start a chat with `@gmessagesbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).

--- a/docs/configuring-playbook-bridge-mautrix-googlechat.md
+++ b/docs/configuring-playbook-bridge-mautrix-googlechat.md
@@ -27,9 +27,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mautrix-googlechat.md
+++ b/docs/configuring-playbook-bridge-mautrix-googlechat.md
@@ -20,7 +20,7 @@ matrix_mautrix_googlechat_enabled: true
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-mautrix-googlechat.md
+++ b/docs/configuring-playbook-bridge-mautrix-googlechat.md
@@ -24,7 +24,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-mautrix-googlechat.md
+++ b/docs/configuring-playbook-bridge-mautrix-googlechat.md
@@ -20,7 +20,11 @@ matrix_mautrix_googlechat_enabled: true
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mautrix-googlechat.md
+++ b/docs/configuring-playbook-bridge-mautrix-googlechat.md
@@ -27,6 +27,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 Once the bot is enabled you need to start a chat with `googlechat bridge bot` with handle `@googlechatbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).

--- a/docs/configuring-playbook-bridge-mautrix-googlechat.md
+++ b/docs/configuring-playbook-bridge-mautrix-googlechat.md
@@ -22,6 +22,7 @@ matrix_mautrix_googlechat_enabled: true
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-mautrix-hangouts.md
+++ b/docs/configuring-playbook-bridge-mautrix-hangouts.md
@@ -22,7 +22,11 @@ matrix_mautrix_hangouts_enabled: true
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mautrix-hangouts.md
+++ b/docs/configuring-playbook-bridge-mautrix-hangouts.md
@@ -24,6 +24,7 @@ matrix_mautrix_hangouts_enabled: true
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-mautrix-hangouts.md
+++ b/docs/configuring-playbook-bridge-mautrix-hangouts.md
@@ -29,6 +29,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 Once the bot is enabled you need to start a chat with `Hangouts bridge bot` with handle `@hangoutsbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).

--- a/docs/configuring-playbook-bridge-mautrix-hangouts.md
+++ b/docs/configuring-playbook-bridge-mautrix-hangouts.md
@@ -22,7 +22,7 @@ matrix_mautrix_hangouts_enabled: true
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-mautrix-hangouts.md
+++ b/docs/configuring-playbook-bridge-mautrix-hangouts.md
@@ -29,9 +29,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mautrix-hangouts.md
+++ b/docs/configuring-playbook-bridge-mautrix-hangouts.md
@@ -26,7 +26,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-mautrix-instagram.md
+++ b/docs/configuring-playbook-bridge-mautrix-instagram.md
@@ -49,9 +49,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mautrix-instagram.md
+++ b/docs/configuring-playbook-bridge-mautrix-instagram.md
@@ -42,7 +42,7 @@ You may wish to look at `roles/custom/matrix-bridge-mautrix-instagram/templates/
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-mautrix-instagram.md
+++ b/docs/configuring-playbook-bridge-mautrix-instagram.md
@@ -46,7 +46,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-mautrix-instagram.md
+++ b/docs/configuring-playbook-bridge-mautrix-instagram.md
@@ -49,6 +49,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 You then need to start a chat with `@instagrambot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).

--- a/docs/configuring-playbook-bridge-mautrix-instagram.md
+++ b/docs/configuring-playbook-bridge-mautrix-instagram.md
@@ -44,6 +44,7 @@ You may wish to look at `roles/custom/matrix-bridge-mautrix-instagram/templates/
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-mautrix-instagram.md
+++ b/docs/configuring-playbook-bridge-mautrix-instagram.md
@@ -42,7 +42,11 @@ You may wish to look at `roles/custom/matrix-bridge-mautrix-instagram/templates/
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mautrix-meta-instagram.md
+++ b/docs/configuring-playbook-bridge-mautrix-meta-instagram.md
@@ -70,6 +70,7 @@ You may wish to look at `roles/custom/matrix-bridge-mautrix-meta-instagram/templ
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-mautrix-meta-instagram.md
+++ b/docs/configuring-playbook-bridge-mautrix-meta-instagram.md
@@ -68,7 +68,11 @@ You may wish to look at `roles/custom/matrix-bridge-mautrix-meta-instagram/templ
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mautrix-meta-instagram.md
+++ b/docs/configuring-playbook-bridge-mautrix-meta-instagram.md
@@ -75,6 +75,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 You then need to start a chat with `@instagrambot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).

--- a/docs/configuring-playbook-bridge-mautrix-meta-instagram.md
+++ b/docs/configuring-playbook-bridge-mautrix-meta-instagram.md
@@ -72,7 +72,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-mautrix-meta-instagram.md
+++ b/docs/configuring-playbook-bridge-mautrix-meta-instagram.md
@@ -75,9 +75,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mautrix-meta-instagram.md
+++ b/docs/configuring-playbook-bridge-mautrix-meta-instagram.md
@@ -68,7 +68,7 @@ You may wish to look at `roles/custom/matrix-bridge-mautrix-meta-instagram/templ
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-mautrix-meta-messenger.md
+++ b/docs/configuring-playbook-bridge-mautrix-meta-messenger.md
@@ -84,6 +84,7 @@ You may wish to look at `roles/custom/matrix-bridge-mautrix-meta-messenger/templ
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-mautrix-meta-messenger.md
+++ b/docs/configuring-playbook-bridge-mautrix-meta-messenger.md
@@ -82,7 +82,11 @@ You may wish to look at `roles/custom/matrix-bridge-mautrix-meta-messenger/templ
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mautrix-meta-messenger.md
+++ b/docs/configuring-playbook-bridge-mautrix-meta-messenger.md
@@ -86,7 +86,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-mautrix-meta-messenger.md
+++ b/docs/configuring-playbook-bridge-mautrix-meta-messenger.md
@@ -89,9 +89,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mautrix-meta-messenger.md
+++ b/docs/configuring-playbook-bridge-mautrix-meta-messenger.md
@@ -82,7 +82,7 @@ You may wish to look at `roles/custom/matrix-bridge-mautrix-meta-messenger/templ
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-mautrix-meta-messenger.md
+++ b/docs/configuring-playbook-bridge-mautrix-meta-messenger.md
@@ -89,6 +89,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 You then need to start a chat with `@messengerbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain). Note that the user ID of the bridge's bot is not `@facebookbot:example.com`.

--- a/docs/configuring-playbook-bridge-mautrix-signal.md
+++ b/docs/configuring-playbook-bridge-mautrix-signal.md
@@ -75,6 +75,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 You then need to start a chat with `@signalbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).

--- a/docs/configuring-playbook-bridge-mautrix-signal.md
+++ b/docs/configuring-playbook-bridge-mautrix-signal.md
@@ -68,7 +68,11 @@ You may wish to look at `roles/custom/matrix-bridge-mautrix-signal/templates/con
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mautrix-signal.md
+++ b/docs/configuring-playbook-bridge-mautrix-signal.md
@@ -72,7 +72,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-mautrix-signal.md
+++ b/docs/configuring-playbook-bridge-mautrix-signal.md
@@ -75,9 +75,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mautrix-signal.md
+++ b/docs/configuring-playbook-bridge-mautrix-signal.md
@@ -68,7 +68,7 @@ You may wish to look at `roles/custom/matrix-bridge-mautrix-signal/templates/con
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-mautrix-signal.md
+++ b/docs/configuring-playbook-bridge-mautrix-signal.md
@@ -70,6 +70,7 @@ You may wish to look at `roles/custom/matrix-bridge-mautrix-signal/templates/con
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-mautrix-slack.md
+++ b/docs/configuring-playbook-bridge-mautrix-slack.md
@@ -48,7 +48,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-mautrix-slack.md
+++ b/docs/configuring-playbook-bridge-mautrix-slack.md
@@ -46,6 +46,7 @@ Take a look at:
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-mautrix-slack.md
+++ b/docs/configuring-playbook-bridge-mautrix-slack.md
@@ -44,7 +44,7 @@ Take a look at:
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-mautrix-slack.md
+++ b/docs/configuring-playbook-bridge-mautrix-slack.md
@@ -51,9 +51,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mautrix-slack.md
+++ b/docs/configuring-playbook-bridge-mautrix-slack.md
@@ -51,6 +51,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 1. Start a chat with `@slackbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).

--- a/docs/configuring-playbook-bridge-mautrix-telegram.md
+++ b/docs/configuring-playbook-bridge-mautrix-telegram.md
@@ -29,6 +29,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 You then need to start a chat with `@telegrambot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).

--- a/docs/configuring-playbook-bridge-mautrix-telegram.md
+++ b/docs/configuring-playbook-bridge-mautrix-telegram.md
@@ -22,7 +22,7 @@ matrix_mautrix_telegram_api_hash: YOUR_TELEGRAM_API_HASH
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-mautrix-telegram.md
+++ b/docs/configuring-playbook-bridge-mautrix-telegram.md
@@ -22,7 +22,11 @@ matrix_mautrix_telegram_api_hash: YOUR_TELEGRAM_API_HASH
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mautrix-telegram.md
+++ b/docs/configuring-playbook-bridge-mautrix-telegram.md
@@ -24,6 +24,7 @@ matrix_mautrix_telegram_api_hash: YOUR_TELEGRAM_API_HASH
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-mautrix-telegram.md
+++ b/docs/configuring-playbook-bridge-mautrix-telegram.md
@@ -29,9 +29,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mautrix-telegram.md
+++ b/docs/configuring-playbook-bridge-mautrix-telegram.md
@@ -26,7 +26,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-mautrix-twitter.md
+++ b/docs/configuring-playbook-bridge-mautrix-twitter.md
@@ -22,7 +22,7 @@ matrix_mautrix_twitter_enabled: true
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-mautrix-twitter.md
+++ b/docs/configuring-playbook-bridge-mautrix-twitter.md
@@ -24,6 +24,7 @@ matrix_mautrix_twitter_enabled: true
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-mautrix-twitter.md
+++ b/docs/configuring-playbook-bridge-mautrix-twitter.md
@@ -22,7 +22,11 @@ matrix_mautrix_twitter_enabled: true
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mautrix-twitter.md
+++ b/docs/configuring-playbook-bridge-mautrix-twitter.md
@@ -29,9 +29,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mautrix-twitter.md
+++ b/docs/configuring-playbook-bridge-mautrix-twitter.md
@@ -29,6 +29,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 1. You then need to start a chat with `@twitterbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).

--- a/docs/configuring-playbook-bridge-mautrix-twitter.md
+++ b/docs/configuring-playbook-bridge-mautrix-twitter.md
@@ -26,7 +26,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-mautrix-whatsapp.md
+++ b/docs/configuring-playbook-bridge-mautrix-whatsapp.md
@@ -43,6 +43,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 You then need to start a chat with `@whatsappbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).

--- a/docs/configuring-playbook-bridge-mautrix-whatsapp.md
+++ b/docs/configuring-playbook-bridge-mautrix-whatsapp.md
@@ -36,7 +36,11 @@ If you want to activate the relay bot in a room, send `!wa set-relay`. To deacti
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mautrix-whatsapp.md
+++ b/docs/configuring-playbook-bridge-mautrix-whatsapp.md
@@ -43,9 +43,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mautrix-whatsapp.md
+++ b/docs/configuring-playbook-bridge-mautrix-whatsapp.md
@@ -36,7 +36,7 @@ If you want to activate the relay bot in a room, send `!wa set-relay`. To deacti
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-mautrix-whatsapp.md
+++ b/docs/configuring-playbook-bridge-mautrix-whatsapp.md
@@ -40,7 +40,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-mautrix-whatsapp.md
+++ b/docs/configuring-playbook-bridge-mautrix-whatsapp.md
@@ -38,6 +38,7 @@ If you want to activate the relay bot in a room, send `!wa set-relay`. To deacti
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-mautrix-wsproxy.md
+++ b/docs/configuring-playbook-bridge-mautrix-wsproxy.md
@@ -41,7 +41,7 @@ By default, you will need to create a CNAME record for `wsproxy`. See [Configuri
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-mautrix-wsproxy.md
+++ b/docs/configuring-playbook-bridge-mautrix-wsproxy.md
@@ -41,7 +41,11 @@ By default, you will need to create a CNAME record for `wsproxy`. See [Configuri
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mautrix-wsproxy.md
+++ b/docs/configuring-playbook-bridge-mautrix-wsproxy.md
@@ -45,7 +45,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-mautrix-wsproxy.md
+++ b/docs/configuring-playbook-bridge-mautrix-wsproxy.md
@@ -43,6 +43,7 @@ By default, you will need to create a CNAME record for `wsproxy`. See [Configuri
 
 After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-mautrix-wsproxy.md
+++ b/docs/configuring-playbook-bridge-mautrix-wsproxy.md
@@ -48,6 +48,10 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 Follow the [matrix-imessage documenation](https://docs.mau.fi/bridges/go/imessage/index.html) for running `android-sms` and/or `matrix-imessage` on your device(s).

--- a/docs/configuring-playbook-bridge-mautrix-wsproxy.md
+++ b/docs/configuring-playbook-bridge-mautrix-wsproxy.md
@@ -48,9 +48,13 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mx-puppet-discord.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-discord.md
@@ -20,6 +20,7 @@ matrix_mx_puppet_discord_enabled: true
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-mx-puppet-discord.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-discord.md
@@ -18,7 +18,11 @@ matrix_mx_puppet_discord_enabled: true
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mx-puppet-discord.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-discord.md
@@ -25,9 +25,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mx-puppet-discord.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-discord.md
@@ -22,7 +22,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-mx-puppet-discord.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-discord.md
@@ -25,6 +25,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 Once the bot is enabled you need to start a chat with `Discord Puppet Bridge` with the handle `@_discordpuppet_bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).

--- a/docs/configuring-playbook-bridge-mx-puppet-discord.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-discord.md
@@ -18,7 +18,7 @@ matrix_mx_puppet_discord_enabled: true
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-mx-puppet-groupme.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-groupme.md
@@ -14,7 +14,11 @@ matrix_mx_puppet_groupme_enabled: true
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mx-puppet-groupme.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-groupme.md
@@ -21,9 +21,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mx-puppet-groupme.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-groupme.md
@@ -14,7 +14,7 @@ matrix_mx_puppet_groupme_enabled: true
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-mx-puppet-groupme.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-groupme.md
@@ -21,6 +21,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 Once the bot is enabled you need to start a chat with `GroupMe Puppet Bridge` with the handle `@_groupmepuppet_bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).

--- a/docs/configuring-playbook-bridge-mx-puppet-groupme.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-groupme.md
@@ -16,6 +16,7 @@ matrix_mx_puppet_groupme_enabled: true
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-mx-puppet-groupme.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-groupme.md
@@ -18,7 +18,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-mx-puppet-instagram.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-instagram.md
@@ -21,9 +21,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mx-puppet-instagram.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-instagram.md
@@ -21,6 +21,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 Once the bot is enabled, you need to start a chat with `Instagram Puppet Bridge` with the handle `@_instagrampuppet_bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).

--- a/docs/configuring-playbook-bridge-mx-puppet-instagram.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-instagram.md
@@ -18,7 +18,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-mx-puppet-instagram.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-instagram.md
@@ -14,7 +14,11 @@ matrix_mx_puppet_instagram_enabled: true
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mx-puppet-instagram.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-instagram.md
@@ -14,7 +14,7 @@ matrix_mx_puppet_instagram_enabled: true
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-mx-puppet-instagram.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-instagram.md
@@ -16,6 +16,7 @@ matrix_mx_puppet_instagram_enabled: true
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-mx-puppet-slack.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-slack.md
@@ -23,7 +23,7 @@ matrix_mx_puppet_slack_oauth_client_secret: "<SLACK_APP_CLIENT_SECRET>"
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-mx-puppet-slack.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-slack.md
@@ -27,7 +27,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-mx-puppet-slack.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-slack.md
@@ -25,6 +25,7 @@ matrix_mx_puppet_slack_oauth_client_secret: "<SLACK_APP_CLIENT_SECRET>"
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-mx-puppet-slack.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-slack.md
@@ -30,9 +30,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mx-puppet-slack.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-slack.md
@@ -30,6 +30,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 Once the bot is enabled you need to start a chat with `Slack Puppet Bridge` with the handle `@_slackpuppet_bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).

--- a/docs/configuring-playbook-bridge-mx-puppet-steam.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-steam.md
@@ -21,9 +21,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mx-puppet-steam.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-steam.md
@@ -16,6 +16,7 @@ matrix_mx_puppet_steam_enabled: true
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-mx-puppet-steam.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-steam.md
@@ -21,6 +21,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 Once the bot is enabled you need to start a chat with `Steam Puppet Bridge` with the handle `@_steampuppet_bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).

--- a/docs/configuring-playbook-bridge-mx-puppet-steam.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-steam.md
@@ -18,7 +18,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-mx-puppet-steam.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-steam.md
@@ -14,7 +14,11 @@ matrix_mx_puppet_steam_enabled: true
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mx-puppet-steam.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-steam.md
@@ -14,7 +14,7 @@ matrix_mx_puppet_steam_enabled: true
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-mx-puppet-twitter.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-twitter.md
@@ -32,9 +32,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-mx-puppet-twitter.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-twitter.md
@@ -25,7 +25,7 @@ matrix_mx_puppet_twitter_environment: ''
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-mx-puppet-twitter.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-twitter.md
@@ -29,7 +29,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-mx-puppet-twitter.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-twitter.md
@@ -32,6 +32,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 Once the bot is enabled you need to start a chat with `Twitter Puppet Bridge` with the handle `@_twitterpuppet_bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).

--- a/docs/configuring-playbook-bridge-mx-puppet-twitter.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-twitter.md
@@ -27,6 +27,7 @@ matrix_mx_puppet_twitter_environment: ''
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-mx-puppet-twitter.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-twitter.md
@@ -25,7 +25,11 @@ matrix_mx_puppet_twitter_environment: ''
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-postmoogle.md
+++ b/docs/configuring-playbook-bridge-postmoogle.md
@@ -51,6 +51,7 @@ You will also need to add several DNS records so that Postmoogle can send emails
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```

--- a/docs/configuring-playbook-bridge-postmoogle.md
+++ b/docs/configuring-playbook-bridge-postmoogle.md
@@ -56,16 +56,15 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
-
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
-
 **Notes**:
 
-- the `ensure-matrix-users-created` playbook tag makes the playbook automatically create a user account of the bridge's bot
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create a user account of the bridge's bot.
 
-- if you change the bridge's bot password (`matrix_postmoogle_password` in your `vars.yml` file) subsequently, the bot user's credentials on the homeserver won't be updated automatically. If you'd like to change the bot user's password, use a tool like [synapse-admin](configuring-playbook-synapse-admin.md) to change it, and then update `matrix_postmoogle_password` to let the bot know its new password
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
 
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
+- If you change the bridge's bot password (`matrix_postmoogle_password` in your `vars.yml` file) subsequently, the bot user's credentials on the homeserver won't be updated automatically. If you'd like to change the bot user's password, use a tool like [synapse-admin](configuring-playbook-synapse-admin.md) to change it, and then update `matrix_postmoogle_password` to let the bot know its new password.
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-postmoogle.md
+++ b/docs/configuring-playbook-bridge-postmoogle.md
@@ -49,7 +49,7 @@ You will also need to add several DNS records so that Postmoogle can send emails
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-bridge-postmoogle.md
+++ b/docs/configuring-playbook-bridge-postmoogle.md
@@ -56,6 +56,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 **Notes**:
 
 - the `ensure-matrix-users-created` playbook tag makes the playbook automatically create a user account of the bridge's bot

--- a/docs/configuring-playbook-bridge-wechat.md
+++ b/docs/configuring-playbook-bridge-wechat.md
@@ -14,7 +14,11 @@ matrix_wechat_enabled: true
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-wechat.md
+++ b/docs/configuring-playbook-bridge-wechat.md
@@ -21,9 +21,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-bridge-wechat.md
+++ b/docs/configuring-playbook-bridge-wechat.md
@@ -21,6 +21,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 Once the bridge is installed, start a chat with `@wechatbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).

--- a/docs/configuring-playbook-bridge-wechat.md
+++ b/docs/configuring-playbook-bridge-wechat.md
@@ -18,7 +18,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-bridge-wechat.md
+++ b/docs/configuring-playbook-bridge-wechat.md
@@ -16,6 +16,7 @@ matrix_wechat_enabled: true
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-bridge-wechat.md
+++ b/docs/configuring-playbook-bridge-wechat.md
@@ -14,7 +14,7 @@ matrix_wechat_enabled: true
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-cactus-comments.md
+++ b/docs/configuring-playbook-cactus-comments.md
@@ -65,6 +65,7 @@ If you've decided to use the default hostname, you won't need to do any extra DN
 
 After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-cactus-comments.md
+++ b/docs/configuring-playbook-cactus-comments.md
@@ -63,7 +63,7 @@ If you've decided to use the default hostname, you won't need to do any extra DN
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-cactus-comments.md
+++ b/docs/configuring-playbook-cactus-comments.md
@@ -67,7 +67,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-cactus-comments.md
+++ b/docs/configuring-playbook-cactus-comments.md
@@ -70,6 +70,10 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 Upon starting Cactus Comments, a `bot.cactusbot` user account is created automatically.

--- a/docs/configuring-playbook-cactus-comments.md
+++ b/docs/configuring-playbook-cactus-comments.md
@@ -70,9 +70,13 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-cactus-comments.md
+++ b/docs/configuring-playbook-cactus-comments.md
@@ -63,7 +63,11 @@ If you've decided to use the default hostname, you won't need to do any extra DN
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Usage
 

--- a/docs/configuring-playbook-client-cinny.md
+++ b/docs/configuring-playbook-client-cinny.md
@@ -42,4 +42,8 @@ If you've adjusted `matrix_client_cinny_hostname`, you will need to adjust your 
 
 ## Installing
 
-After configuring the playbook and [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook and [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```

--- a/docs/configuring-playbook-client-cinny.md
+++ b/docs/configuring-playbook-client-cinny.md
@@ -46,9 +46,9 @@ After configuring the playbook and [adjusting your DNS records](#adjusting-dns-r
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-client-cinny.md
+++ b/docs/configuring-playbook-client-cinny.md
@@ -42,7 +42,7 @@ If you've adjusted `matrix_client_cinny_hostname`, you will need to adjust your 
 
 ## Installing
 
-After configuring the playbook and [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+After configuring the playbook and [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-client-cinny.md
+++ b/docs/configuring-playbook-client-cinny.md
@@ -49,6 +49,6 @@ After configuring the playbook and [adjusting your DNS records](#adjusting-dns-r
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
 `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-client-cinny.md
+++ b/docs/configuring-playbook-client-cinny.md
@@ -46,7 +46,7 @@ After configuring the playbook and [adjusting your DNS records](#adjusting-dns-r
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-client-cinny.md
+++ b/docs/configuring-playbook-client-cinny.md
@@ -44,6 +44,7 @@ If you've adjusted `matrix_client_cinny_hostname`, you will need to adjust your 
 
 After configuring the playbook and [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-client-cinny.md
+++ b/docs/configuring-playbook-client-cinny.md
@@ -48,3 +48,7 @@ After configuring the playbook and [adjusting your DNS records](#adjusting-dns-r
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
+
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-client-element-web.md
+++ b/docs/configuring-playbook-client-element-web.md
@@ -73,6 +73,7 @@ If you've decided to reuse the `matrix.` domain, you won't need to do any extra 
 
 After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-client-element-web.md
+++ b/docs/configuring-playbook-client-element-web.md
@@ -71,7 +71,7 @@ If you've decided to reuse the `matrix.` domain, you won't need to do any extra 
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-client-element-web.md
+++ b/docs/configuring-playbook-client-element-web.md
@@ -75,7 +75,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-client-element-web.md
+++ b/docs/configuring-playbook-client-element-web.md
@@ -77,3 +77,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
+
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-client-element-web.md
+++ b/docs/configuring-playbook-client-element-web.md
@@ -71,4 +71,8 @@ If you've decided to reuse the `matrix.` domain, you won't need to do any extra 
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```

--- a/docs/configuring-playbook-client-element-web.md
+++ b/docs/configuring-playbook-client-element-web.md
@@ -75,9 +75,9 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-client-element-web.md
+++ b/docs/configuring-playbook-client-element-web.md
@@ -78,6 +78,6 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
 `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-client-hydrogen.md
+++ b/docs/configuring-playbook-client-hydrogen.md
@@ -43,7 +43,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-client-hydrogen.md
+++ b/docs/configuring-playbook-client-hydrogen.md
@@ -43,9 +43,9 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-client-hydrogen.md
+++ b/docs/configuring-playbook-client-hydrogen.md
@@ -39,7 +39,7 @@ If you've decided to reuse the `matrix.` domain, you won't need to do any extra 
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-client-hydrogen.md
+++ b/docs/configuring-playbook-client-hydrogen.md
@@ -39,4 +39,8 @@ If you've decided to reuse the `matrix.` domain, you won't need to do any extra 
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```

--- a/docs/configuring-playbook-client-hydrogen.md
+++ b/docs/configuring-playbook-client-hydrogen.md
@@ -45,3 +45,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
+
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-client-hydrogen.md
+++ b/docs/configuring-playbook-client-hydrogen.md
@@ -46,6 +46,6 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
 `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-client-hydrogen.md
+++ b/docs/configuring-playbook-client-hydrogen.md
@@ -41,6 +41,7 @@ If you've decided to reuse the `matrix.` domain, you won't need to do any extra 
 
 After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-client-schildichat-web.md
+++ b/docs/configuring-playbook-client-schildichat-web.md
@@ -73,7 +73,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-client-schildichat-web.md
+++ b/docs/configuring-playbook-client-schildichat-web.md
@@ -75,3 +75,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
+
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-client-schildichat-web.md
+++ b/docs/configuring-playbook-client-schildichat-web.md
@@ -71,6 +71,7 @@ If you've decided to reuse the `matrix.` domain, you won't need to do any extra 
 
 After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-client-schildichat-web.md
+++ b/docs/configuring-playbook-client-schildichat-web.md
@@ -69,7 +69,7 @@ If you've decided to reuse the `matrix.` domain, you won't need to do any extra 
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-client-schildichat-web.md
+++ b/docs/configuring-playbook-client-schildichat-web.md
@@ -69,4 +69,8 @@ If you've decided to reuse the `matrix.` domain, you won't need to do any extra 
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```

--- a/docs/configuring-playbook-client-schildichat-web.md
+++ b/docs/configuring-playbook-client-schildichat-web.md
@@ -73,9 +73,9 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-client-schildichat-web.md
+++ b/docs/configuring-playbook-client-schildichat-web.md
@@ -76,6 +76,6 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
 `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-dendrite.md
+++ b/docs/configuring-playbook-dendrite.md
@@ -38,9 +38,9 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-dendrite.md
+++ b/docs/configuring-playbook-dendrite.md
@@ -38,7 +38,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-dendrite.md
+++ b/docs/configuring-playbook-dendrite.md
@@ -40,3 +40,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
+
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-dendrite.md
+++ b/docs/configuring-playbook-dendrite.md
@@ -34,4 +34,8 @@ Alternatively, **if there is no pre-defined variable** for a Dendrite setting yo
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```

--- a/docs/configuring-playbook-dendrite.md
+++ b/docs/configuring-playbook-dendrite.md
@@ -34,7 +34,7 @@ Alternatively, **if there is no pre-defined variable** for a Dendrite setting yo
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-dendrite.md
+++ b/docs/configuring-playbook-dendrite.md
@@ -36,6 +36,7 @@ Alternatively, **if there is no pre-defined variable** for a Dendrite setting yo
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-dendrite.md
+++ b/docs/configuring-playbook-dendrite.md
@@ -41,6 +41,6 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
 `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-dimension.md
+++ b/docs/configuring-playbook-dimension.md
@@ -69,7 +69,7 @@ By default, you will need to create a CNAME record for `dimension`. See [Configu
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-dimension.md
+++ b/docs/configuring-playbook-dimension.md
@@ -73,7 +73,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-dimension.md
+++ b/docs/configuring-playbook-dimension.md
@@ -76,7 +76,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
 `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 

--- a/docs/configuring-playbook-dimension.md
+++ b/docs/configuring-playbook-dimension.md
@@ -73,12 +73,12 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 After Dimension has been installed you may need to log out and log back in for it to pick up the new integration manager. Then you can access integrations in Element Web by opening a room, clicking the Room info button (`i`) button in the top right corner of the screen, and then clicking Add widgets, bridges & bots.
 

--- a/docs/configuring-playbook-dimension.md
+++ b/docs/configuring-playbook-dimension.md
@@ -76,12 +76,13 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
+**Notes**:
 
-`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
-After Dimension has been installed you may need to log out and log back in for it to pick up the new integration manager. Then you can access integrations in Element Web by opening a room, clicking the Room info button (`i`) button in the top right corner of the screen, and then clicking Add widgets, bridges & bots.
+  `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
+- After Dimension has been installed you may need to log out and log back in for it to pick up the new integration manager. Then you can access integrations in Element Web by opening a room, clicking the Room info button (`i`) button in the top right corner of the screen, and then clicking Add widgets, bridges & bots.
 
 ## Jitsi domain
 

--- a/docs/configuring-playbook-dimension.md
+++ b/docs/configuring-playbook-dimension.md
@@ -71,6 +71,7 @@ By default, you will need to create a CNAME record for `dimension`. See [Configu
 
 After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-dimension.md
+++ b/docs/configuring-playbook-dimension.md
@@ -76,6 +76,10 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 After Dimension has been installed you may need to log out and log back in for it to pick up the new integration manager. Then you can access integrations in Element Web by opening a room, clicking the Room info button (`i`) button in the top right corner of the screen, and then clicking Add widgets, bridges & bots.
 
 

--- a/docs/configuring-playbook-dynamic-dns.md
+++ b/docs/configuring-playbook-dynamic-dns.md
@@ -27,6 +27,7 @@ matrix_dynamic_dns_domain_configurations:
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-dynamic-dns.md
+++ b/docs/configuring-playbook-dynamic-dns.md
@@ -25,7 +25,7 @@ matrix_dynamic_dns_domain_configurations:
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-dynamic-dns.md
+++ b/docs/configuring-playbook-dynamic-dns.md
@@ -29,7 +29,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-dynamic-dns.md
+++ b/docs/configuring-playbook-dynamic-dns.md
@@ -25,7 +25,11 @@ matrix_dynamic_dns_domain_configurations:
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Additional Reading
 

--- a/docs/configuring-playbook-dynamic-dns.md
+++ b/docs/configuring-playbook-dynamic-dns.md
@@ -32,6 +32,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Additional Reading
 
 Additional resources:

--- a/docs/configuring-playbook-dynamic-dns.md
+++ b/docs/configuring-playbook-dynamic-dns.md
@@ -32,7 +32,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
 `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 

--- a/docs/configuring-playbook-dynamic-dns.md
+++ b/docs/configuring-playbook-dynamic-dns.md
@@ -29,12 +29,12 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Additional Reading
 

--- a/docs/configuring-playbook-email2matrix.md
+++ b/docs/configuring-playbook-email2matrix.md
@@ -83,6 +83,16 @@ Refer to the official documentation [here](https://github.com/devture/email2matr
 
 ## Installing
 
-To enable Email2Matrix, run the [installation](installing.md) command (`--tags=setup-email2matrix,start`).
+To enable Email2Matrix, run the playbook with [playbook tags](playbook-tags.md) as below:
 
-After installation, you may wish to send a test email to the email address assigned to `mailbox1` (default: `mailbox1@matrix.example.com`) to make sure that Email2Matrix works as expected.
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-email2matrix,start
+```
+
+**Notes**:
+
+- The shortcut commands with `just` program are also available: `just run-tags setup-email2matrix,start` or `just run-tags setup-all,start`
+
+  `just run-tags setup-email2matrix,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
+- After installation, you may wish to send a test email to the email address assigned to `mailbox1` (default: `mailbox1@matrix.example.com`) to make sure that Email2Matrix works as expected.

--- a/docs/configuring-playbook-etherpad.md
+++ b/docs/configuring-playbook-etherpad.md
@@ -48,7 +48,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.

--- a/docs/configuring-playbook-etherpad.md
+++ b/docs/configuring-playbook-etherpad.md
@@ -46,6 +46,7 @@ If you've decided to reuse the `matrix.` domain, you won't need to do any extra 
 
 After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-etherpad.md
+++ b/docs/configuring-playbook-etherpad.md
@@ -51,6 +51,10 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 The Etherpad UI should be available at `https://etherpad.example.com`, while the admin UI (if enabled) should then be available at `https://etherpad.example.com/admin`.

--- a/docs/configuring-playbook-etherpad.md
+++ b/docs/configuring-playbook-etherpad.md
@@ -51,9 +51,13 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+**Notes**:
 
-`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the Etherpad admin user (`etherpad_admin_username`).
+
+- The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
+
+  `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-etherpad.md
+++ b/docs/configuring-playbook-etherpad.md
@@ -59,6 +59,8 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
   `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
+- If you change the Etherpad admin user's password (`etherpad_admin_password` in your `vars.yml` file) subsequently, the admin user's credentials on the homeserver won't be updated automatically. If you'd like to change the admin user's password, use a tool like [synapse-admin](configuring-playbook-synapse-admin.md) to change it, and then update `etherpad_admin_password` to let the admin user know its new password.
+
 ## Usage
 
 The Etherpad UI should be available at `https://etherpad.example.com`, while the admin UI (if enabled) should then be available at `https://etherpad.example.com/admin`.

--- a/docs/configuring-playbook-etherpad.md
+++ b/docs/configuring-playbook-etherpad.md
@@ -44,7 +44,11 @@ If you've decided to reuse the `matrix.` domain, you won't need to do any extra 
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Usage
 

--- a/docs/configuring-playbook-etherpad.md
+++ b/docs/configuring-playbook-etherpad.md
@@ -44,7 +44,7 @@ If you've decided to reuse the `matrix.` domain, you won't need to do any extra 
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-etherpad.md
+++ b/docs/configuring-playbook-etherpad.md
@@ -48,12 +48,12 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-etherpad.md
+++ b/docs/configuring-playbook-etherpad.md
@@ -48,7 +48,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -276,6 +276,10 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 You can use the self-hosted Jitsi server in multiple ways:

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -273,7 +273,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -273,12 +273,12 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -276,7 +276,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
 `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -271,6 +271,7 @@ jitsi_disable_gravatar: false
 
 After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -269,7 +269,7 @@ jitsi_disable_gravatar: false
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-ma1sd.md
+++ b/docs/configuring-playbook-ma1sd.md
@@ -138,7 +138,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
 `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 

--- a/docs/configuring-playbook-ma1sd.md
+++ b/docs/configuring-playbook-ma1sd.md
@@ -135,12 +135,12 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Troubleshooting
 

--- a/docs/configuring-playbook-ma1sd.md
+++ b/docs/configuring-playbook-ma1sd.md
@@ -131,7 +131,7 @@ matrix_ma1sd_configuration_extension_yaml: |
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-ma1sd.md
+++ b/docs/configuring-playbook-ma1sd.md
@@ -133,6 +133,7 @@ matrix_ma1sd_configuration_extension_yaml: |
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-ma1sd.md
+++ b/docs/configuring-playbook-ma1sd.md
@@ -138,6 +138,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Troubleshooting
 
 If email address validation emails sent by ma1sd are not reaching you, you should look into [Adjusting email-sending settings](configuring-playbook-email.md).

--- a/docs/configuring-playbook-ma1sd.md
+++ b/docs/configuring-playbook-ma1sd.md
@@ -131,7 +131,11 @@ matrix_ma1sd_configuration_extension_yaml: |
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Troubleshooting
 

--- a/docs/configuring-playbook-ma1sd.md
+++ b/docs/configuring-playbook-ma1sd.md
@@ -135,7 +135,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-matrix-authentication-service.md
+++ b/docs/configuring-playbook-matrix-authentication-service.md
@@ -288,7 +288,11 @@ If you've decided to use the default hostname, you won't need to do any extra DN
 
 ## Installing
 
-Now that you've [adjusted the playbook configuration](#adjusting-the-playbook-configuration) and [your DNS records](#adjusting-dns-records), you can run the [installation](installing.md) command: `just install-all`
+Now that you've [adjusted the playbook configuration](#adjusting-the-playbook-configuration) and [your DNS records](#adjusting-dns-records), you can run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 If you're in the process of migrating an existing Synapse homeserver to MAS, you should now follow the rest of the steps in the [Migrating an existing Synapse homeserver to Matrix Authentication Service](#migrating-an-existing-synapse-homeserver-to-matrix-authentication-service) guide.
 

--- a/docs/configuring-playbook-matrix-authentication-service.md
+++ b/docs/configuring-playbook-matrix-authentication-service.md
@@ -290,6 +290,7 @@ If you've decided to use the default hostname, you won't need to do any extra DN
 
 Now that you've [adjusted the playbook configuration](#adjusting-the-playbook-configuration) and [your DNS records](#adjusting-dns-records), you can run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-matrix-authentication-service.md
+++ b/docs/configuring-playbook-matrix-authentication-service.md
@@ -288,7 +288,7 @@ If you've decided to use the default hostname, you won't need to do any extra DN
 
 ## Installing
 
-Now that you've [adjusted the playbook configuration](#adjusting-the-playbook-configuration) and [your DNS records](#adjusting-dns-records), you can run the [installation](installing.md) command:
+Now that you've [adjusted the playbook configuration](#adjusting-the-playbook-configuration) and [your DNS records](#adjusting-dns-records), you can run the playbook with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-matrix-authentication-service.md
+++ b/docs/configuring-playbook-matrix-authentication-service.md
@@ -295,7 +295,7 @@ Now that you've [adjusted the playbook configuration](#adjusting-the-playbook-co
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
 `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 

--- a/docs/configuring-playbook-matrix-authentication-service.md
+++ b/docs/configuring-playbook-matrix-authentication-service.md
@@ -292,12 +292,12 @@ Now that you've [adjusted the playbook configuration](#adjusting-the-playbook-co
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 If you're in the process of migrating an existing Synapse homeserver to MAS, you should now follow the rest of the steps in the [Migrating an existing Synapse homeserver to Matrix Authentication Service](#migrating-an-existing-synapse-homeserver-to-matrix-authentication-service) guide.
 

--- a/docs/configuring-playbook-matrix-authentication-service.md
+++ b/docs/configuring-playbook-matrix-authentication-service.md
@@ -292,7 +292,7 @@ Now that you've [adjusted the playbook configuration](#adjusting-the-playbook-co
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-matrix-authentication-service.md
+++ b/docs/configuring-playbook-matrix-authentication-service.md
@@ -295,6 +295,10 @@ Now that you've [adjusted the playbook configuration](#adjusting-the-playbook-co
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 If you're in the process of migrating an existing Synapse homeserver to MAS, you should now follow the rest of the steps in the [Migrating an existing Synapse homeserver to Matrix Authentication Service](#migrating-an-existing-synapse-homeserver-to-matrix-authentication-service) guide.
 
 💡 After installation, you should [verify that Matrix Authentication Service is installed correctly](#verify-that-matrix-authentication-service-is-installed-correctly).

--- a/docs/configuring-playbook-matrix-authentication-service.md
+++ b/docs/configuring-playbook-matrix-authentication-service.md
@@ -295,11 +295,13 @@ Now that you've [adjusted the playbook configuration](#adjusting-the-playbook-co
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
+**Notes**:
 
-`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
-If you're in the process of migrating an existing Synapse homeserver to MAS, you should now follow the rest of the steps in the [Migrating an existing Synapse homeserver to Matrix Authentication Service](#migrating-an-existing-synapse-homeserver-to-matrix-authentication-service) guide.
+  `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
+- If you're in the process of migrating an existing Synapse homeserver to MAS, you should now follow the rest of the steps in the [Migrating an existing Synapse homeserver to Matrix Authentication Service](#migrating-an-existing-synapse-homeserver-to-matrix-authentication-service) guide.
 
 💡 After installation, you should [verify that Matrix Authentication Service is installed correctly](#verify-that-matrix-authentication-service-is-installed-correctly).
 

--- a/docs/configuring-playbook-matrix-corporal.md
+++ b/docs/configuring-playbook-matrix-corporal.md
@@ -116,8 +116,16 @@ To learn more about what the policy configuration, see the matrix-corporal docum
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command (`--tags=setup-all,start` or `--tags=setup-aux-files,setup-corporal,start`).
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
+
+The shortcut commands with `just` program are also available: `just run-tags setup-aux-files,setup-corporal,start` or `just run-tags setup-all,start`
+
+`just run-tags setup-aux-files,setup-corporal,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Matrix Corporal files
 

--- a/docs/configuring-playbook-matrix-ldap-registration-proxy.md
+++ b/docs/configuring-playbook-matrix-ldap-registration-proxy.md
@@ -38,9 +38,9 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-matrix-ldap-registration-proxy.md
+++ b/docs/configuring-playbook-matrix-ldap-registration-proxy.md
@@ -36,6 +36,7 @@ matrix_ldap_registration_proxy_systemd_wanted_services_list_custom:
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-matrix-ldap-registration-proxy.md
+++ b/docs/configuring-playbook-matrix-ldap-registration-proxy.md
@@ -34,7 +34,7 @@ matrix_ldap_registration_proxy_systemd_wanted_services_list_custom:
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-matrix-ldap-registration-proxy.md
+++ b/docs/configuring-playbook-matrix-ldap-registration-proxy.md
@@ -38,7 +38,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-matrix-ldap-registration-proxy.md
+++ b/docs/configuring-playbook-matrix-ldap-registration-proxy.md
@@ -40,3 +40,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
+
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-matrix-ldap-registration-proxy.md
+++ b/docs/configuring-playbook-matrix-ldap-registration-proxy.md
@@ -34,4 +34,8 @@ matrix_ldap_registration_proxy_systemd_wanted_services_list_custom:
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```

--- a/docs/configuring-playbook-matrix-ldap-registration-proxy.md
+++ b/docs/configuring-playbook-matrix-ldap-registration-proxy.md
@@ -41,6 +41,6 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
 `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-matrix-registration.md
+++ b/docs/configuring-playbook-matrix-registration.md
@@ -56,7 +56,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-matrix-registration.md
+++ b/docs/configuring-playbook-matrix-registration.md
@@ -59,7 +59,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
 `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
@@ -96,4 +96,4 @@ ansible-playbook -i inventory/hosts setup.yml \
 --tags=list-matrix-registration-tokens
 ```
 
-The shortcut command with `just` program is also available: `just run-tags list-matrix-registration-tokens`.
+The shortcut command with `just` program is also available: `just run-tags list-matrix-registration-tokens`

--- a/docs/configuring-playbook-matrix-registration.md
+++ b/docs/configuring-playbook-matrix-registration.md
@@ -52,7 +52,7 @@ If you've decided to use the default hostname, you won't need to do any extra DN
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-matrix-registration.md
+++ b/docs/configuring-playbook-matrix-registration.md
@@ -59,6 +59,9 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 
@@ -92,3 +95,5 @@ To **list the existing user registration tokens**, use this command:
 ansible-playbook -i inventory/hosts setup.yml \
 --tags=list-matrix-registration-tokens
 ```
+
+The shortcut command with `just` program is also available: `just run-tags list-matrix-registration-tokens`.

--- a/docs/configuring-playbook-matrix-registration.md
+++ b/docs/configuring-playbook-matrix-registration.md
@@ -54,6 +54,7 @@ If you've decided to use the default hostname, you won't need to do any extra DN
 
 After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-matrix-registration.md
+++ b/docs/configuring-playbook-matrix-registration.md
@@ -56,12 +56,12 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-mautrix-bridges.md
+++ b/docs/configuring-playbook-mautrix-bridges.md
@@ -100,9 +100,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+**Notes**:
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account.
+
+- The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`
+
+  `just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Set up Double Puppeting
 

--- a/docs/configuring-playbook-mautrix-bridges.md
+++ b/docs/configuring-playbook-mautrix-bridges.md
@@ -95,6 +95,7 @@ You may wish to look at `roles/custom/matrix-bridge-mautrix-SERVICENAME/template
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-mautrix-bridges.md
+++ b/docs/configuring-playbook-mautrix-bridges.md
@@ -93,7 +93,11 @@ You may wish to look at `roles/custom/matrix-bridge-mautrix-SERVICENAME/template
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Set up Double Puppeting
 

--- a/docs/configuring-playbook-mautrix-bridges.md
+++ b/docs/configuring-playbook-mautrix-bridges.md
@@ -97,7 +97,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-mautrix-bridges.md
+++ b/docs/configuring-playbook-mautrix-bridges.md
@@ -100,6 +100,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Set up Double Puppeting
 
 To set up [Double Puppeting](https://docs.mau.fi/bridges/general/double-puppeting.html) enable the [Appservice Double Puppet](configuring-playbook-appservice-double-puppet.md) service for this playbook.

--- a/docs/configuring-playbook-mautrix-bridges.md
+++ b/docs/configuring-playbook-mautrix-bridges.md
@@ -93,7 +93,7 @@ You may wish to look at `roles/custom/matrix-bridge-mautrix-SERVICENAME/template
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-ntfy.md
+++ b/docs/configuring-playbook-ntfy.md
@@ -54,12 +54,12 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-ntfy.md
+++ b/docs/configuring-playbook-ntfy.md
@@ -50,7 +50,7 @@ By default, you will need to create a CNAME record for `ntfy`. See [Configuring 
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-ntfy.md
+++ b/docs/configuring-playbook-ntfy.md
@@ -54,7 +54,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-ntfy.md
+++ b/docs/configuring-playbook-ntfy.md
@@ -52,6 +52,7 @@ By default, you will need to create a CNAME record for `ntfy`. See [Configuring 
 
 After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-ntfy.md
+++ b/docs/configuring-playbook-ntfy.md
@@ -57,6 +57,9 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-ntfy.md
+++ b/docs/configuring-playbook-ntfy.md
@@ -57,7 +57,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
 `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 

--- a/docs/configuring-playbook-pantalaimon.md
+++ b/docs/configuring-playbook-pantalaimon.md
@@ -18,7 +18,7 @@ The default configuration should suffice. For advanced configuration, you can ov
 
 ## 2. Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-pantalaimon.md
+++ b/docs/configuring-playbook-pantalaimon.md
@@ -22,7 +22,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-pantalaimon.md
+++ b/docs/configuring-playbook-pantalaimon.md
@@ -18,4 +18,8 @@ The default configuration should suffice. For advanced configuration, you can ov
 
 ## 2. Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```

--- a/docs/configuring-playbook-pantalaimon.md
+++ b/docs/configuring-playbook-pantalaimon.md
@@ -24,3 +24,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
+
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-pantalaimon.md
+++ b/docs/configuring-playbook-pantalaimon.md
@@ -25,6 +25,6 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
 `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-pantalaimon.md
+++ b/docs/configuring-playbook-pantalaimon.md
@@ -22,9 +22,9 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-pantalaimon.md
+++ b/docs/configuring-playbook-pantalaimon.md
@@ -20,6 +20,7 @@ The default configuration should suffice. For advanced configuration, you can ov
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-postgres-backup.md
+++ b/docs/configuring-playbook-postgres-backup.md
@@ -31,6 +31,7 @@ Refer to the table below for additional configuration variables and their defaul
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-postgres-backup.md
+++ b/docs/configuring-playbook-postgres-backup.md
@@ -35,3 +35,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
+
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-postgres-backup.md
+++ b/docs/configuring-playbook-postgres-backup.md
@@ -33,7 +33,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-postgres-backup.md
+++ b/docs/configuring-playbook-postgres-backup.md
@@ -29,7 +29,7 @@ Refer to the table below for additional configuration variables and their defaul
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-postgres-backup.md
+++ b/docs/configuring-playbook-postgres-backup.md
@@ -36,6 +36,6 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
 `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-postgres-backup.md
+++ b/docs/configuring-playbook-postgres-backup.md
@@ -33,9 +33,9 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-prometheus-grafana.md
+++ b/docs/configuring-playbook-prometheus-grafana.md
@@ -59,7 +59,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-prometheus-grafana.md
+++ b/docs/configuring-playbook-prometheus-grafana.md
@@ -62,6 +62,10 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## What does it do?
 
 Name | Description

--- a/docs/configuring-playbook-prometheus-grafana.md
+++ b/docs/configuring-playbook-prometheus-grafana.md
@@ -57,6 +57,7 @@ By default, you will need to create a CNAME record for `stats`. See [Configuring
 
 After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-prometheus-grafana.md
+++ b/docs/configuring-playbook-prometheus-grafana.md
@@ -55,7 +55,7 @@ By default, you will need to create a CNAME record for `stats`. See [Configuring
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-prometheus-grafana.md
+++ b/docs/configuring-playbook-prometheus-grafana.md
@@ -59,12 +59,12 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## What does it do?
 

--- a/docs/configuring-playbook-prometheus-grafana.md
+++ b/docs/configuring-playbook-prometheus-grafana.md
@@ -55,7 +55,11 @@ By default, you will need to create a CNAME record for `stats`. See [Configuring
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## What does it do?
 

--- a/docs/configuring-playbook-prometheus-grafana.md
+++ b/docs/configuring-playbook-prometheus-grafana.md
@@ -62,7 +62,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
 `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 

--- a/docs/configuring-playbook-prometheus-nginxlog.md
+++ b/docs/configuring-playbook-prometheus-nginxlog.md
@@ -22,7 +22,7 @@ matrix_prometheus_nginxlog_exporter_enabled: true
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-prometheus-nginxlog.md
+++ b/docs/configuring-playbook-prometheus-nginxlog.md
@@ -29,7 +29,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
 `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 

--- a/docs/configuring-playbook-prometheus-nginxlog.md
+++ b/docs/configuring-playbook-prometheus-nginxlog.md
@@ -26,12 +26,12 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Docker Image Compatibility
 

--- a/docs/configuring-playbook-prometheus-nginxlog.md
+++ b/docs/configuring-playbook-prometheus-nginxlog.md
@@ -24,6 +24,7 @@ matrix_prometheus_nginxlog_exporter_enabled: true
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-prometheus-nginxlog.md
+++ b/docs/configuring-playbook-prometheus-nginxlog.md
@@ -22,7 +22,11 @@ matrix_prometheus_nginxlog_exporter_enabled: true
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## Docker Image Compatibility
 

--- a/docs/configuring-playbook-prometheus-nginxlog.md
+++ b/docs/configuring-playbook-prometheus-nginxlog.md
@@ -26,7 +26,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-prometheus-nginxlog.md
+++ b/docs/configuring-playbook-prometheus-nginxlog.md
@@ -29,6 +29,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Docker Image Compatibility
 
 At the moment of writing only images for `amd64` and `arm64` architectures are available. The playbook currently does not support [self-building](./self-building.md) a container image on other architectures. You can however use a custom-build image by setting:

--- a/docs/configuring-playbook-prometheus-postgres.md
+++ b/docs/configuring-playbook-prometheus-postgres.md
@@ -12,7 +12,11 @@ prometheus_postgres_exporter_enabled: true
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ## What does it do?
 

--- a/docs/configuring-playbook-prometheus-postgres.md
+++ b/docs/configuring-playbook-prometheus-postgres.md
@@ -16,7 +16,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-prometheus-postgres.md
+++ b/docs/configuring-playbook-prometheus-postgres.md
@@ -19,7 +19,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
 `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 

--- a/docs/configuring-playbook-prometheus-postgres.md
+++ b/docs/configuring-playbook-prometheus-postgres.md
@@ -12,7 +12,7 @@ prometheus_postgres_exporter_enabled: true
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-prometheus-postgres.md
+++ b/docs/configuring-playbook-prometheus-postgres.md
@@ -16,12 +16,12 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## What does it do?
 

--- a/docs/configuring-playbook-prometheus-postgres.md
+++ b/docs/configuring-playbook-prometheus-postgres.md
@@ -19,6 +19,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## What does it do?
 
 Name | Description

--- a/docs/configuring-playbook-prometheus-postgres.md
+++ b/docs/configuring-playbook-prometheus-postgres.md
@@ -14,6 +14,7 @@ prometheus_postgres_exporter_enabled: true
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-rageshake.md
+++ b/docs/configuring-playbook-rageshake.md
@@ -51,7 +51,7 @@ If you've decided to reuse the `matrix.` domain, you won't need to do any extra 
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-rageshake.md
+++ b/docs/configuring-playbook-rageshake.md
@@ -55,7 +55,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-rageshake.md
+++ b/docs/configuring-playbook-rageshake.md
@@ -58,7 +58,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
 `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 

--- a/docs/configuring-playbook-rageshake.md
+++ b/docs/configuring-playbook-rageshake.md
@@ -55,12 +55,12 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-rageshake.md
+++ b/docs/configuring-playbook-rageshake.md
@@ -53,6 +53,7 @@ If you've decided to reuse the `matrix.` domain, you won't need to do any extra 
 
 After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-rageshake.md
+++ b/docs/configuring-playbook-rageshake.md
@@ -58,6 +58,9 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-rest-auth.md
+++ b/docs/configuring-playbook-rest-auth.md
@@ -32,3 +32,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
+
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-rest-auth.md
+++ b/docs/configuring-playbook-rest-auth.md
@@ -28,6 +28,7 @@ matrix_synapse_password_config_localdb_enabled: false
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-rest-auth.md
+++ b/docs/configuring-playbook-rest-auth.md
@@ -33,6 +33,6 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
 `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-rest-auth.md
+++ b/docs/configuring-playbook-rest-auth.md
@@ -26,4 +26,8 @@ matrix_synapse_password_config_localdb_enabled: false
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```

--- a/docs/configuring-playbook-rest-auth.md
+++ b/docs/configuring-playbook-rest-auth.md
@@ -30,7 +30,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-rest-auth.md
+++ b/docs/configuring-playbook-rest-auth.md
@@ -26,7 +26,7 @@ matrix_synapse_password_config_localdb_enabled: false
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-rest-auth.md
+++ b/docs/configuring-playbook-rest-auth.md
@@ -30,9 +30,9 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-riot-web.md
+++ b/docs/configuring-playbook-riot-web.md
@@ -30,7 +30,7 @@ There are a few options for handling this:
 
 ### Re-running the playbook
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-riot-web.md
+++ b/docs/configuring-playbook-riot-web.md
@@ -34,7 +34,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-riot-web.md
+++ b/docs/configuring-playbook-riot-web.md
@@ -32,6 +32,7 @@ There are a few options for handling this:
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-riot-web.md
+++ b/docs/configuring-playbook-riot-web.md
@@ -30,4 +30,8 @@ There are a few options for handling this:
 
 ### Re-running the playbook
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```

--- a/docs/configuring-playbook-riot-web.md
+++ b/docs/configuring-playbook-riot-web.md
@@ -37,6 +37,6 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
 `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-riot-web.md
+++ b/docs/configuring-playbook-riot-web.md
@@ -34,9 +34,9 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-riot-web.md
+++ b/docs/configuring-playbook-riot-web.md
@@ -36,3 +36,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
+
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-shared-secret-auth.md
+++ b/docs/configuring-playbook-shared-secret-auth.md
@@ -31,3 +31,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
+
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-shared-secret-auth.md
+++ b/docs/configuring-playbook-shared-secret-auth.md
@@ -29,7 +29,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-shared-secret-auth.md
+++ b/docs/configuring-playbook-shared-secret-auth.md
@@ -29,9 +29,9 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-shared-secret-auth.md
+++ b/docs/configuring-playbook-shared-secret-auth.md
@@ -25,4 +25,8 @@ matrix_synapse_password_config_localdb_enabled: false
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```

--- a/docs/configuring-playbook-shared-secret-auth.md
+++ b/docs/configuring-playbook-shared-secret-auth.md
@@ -27,6 +27,7 @@ matrix_synapse_password_config_localdb_enabled: false
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-shared-secret-auth.md
+++ b/docs/configuring-playbook-shared-secret-auth.md
@@ -32,6 +32,6 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
 `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-shared-secret-auth.md
+++ b/docs/configuring-playbook-shared-secret-auth.md
@@ -25,7 +25,7 @@ matrix_synapse_password_config_localdb_enabled: false
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-sliding-sync-proxy.md
+++ b/docs/configuring-playbook-sliding-sync-proxy.md
@@ -39,7 +39,11 @@ If you've decided to use the default hostname, you won't need to do any extra DN
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command: `just install-all`.
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 ### External databases
 

--- a/docs/configuring-playbook-sliding-sync-proxy.md
+++ b/docs/configuring-playbook-sliding-sync-proxy.md
@@ -43,7 +43,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-sliding-sync-proxy.md
+++ b/docs/configuring-playbook-sliding-sync-proxy.md
@@ -43,12 +43,12 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ### External databases
 

--- a/docs/configuring-playbook-sliding-sync-proxy.md
+++ b/docs/configuring-playbook-sliding-sync-proxy.md
@@ -46,6 +46,10 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ### External databases
 
 Please note that, if your setup utilizes an external database, you must also establish configuration for the sliding sync proxy. Alter the defaults below to suit your configuration:

--- a/docs/configuring-playbook-sliding-sync-proxy.md
+++ b/docs/configuring-playbook-sliding-sync-proxy.md
@@ -46,7 +46,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
 `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 

--- a/docs/configuring-playbook-sliding-sync-proxy.md
+++ b/docs/configuring-playbook-sliding-sync-proxy.md
@@ -39,7 +39,7 @@ If you've decided to use the default hostname, you won't need to do any extra DN
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-sliding-sync-proxy.md
+++ b/docs/configuring-playbook-sliding-sync-proxy.md
@@ -41,6 +41,7 @@ If you've decided to use the default hostname, you won't need to do any extra DN
 
 After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-sygnal.md
+++ b/docs/configuring-playbook-sygnal.md
@@ -77,7 +77,7 @@ If you've decided to reuse the `matrix.` domain, you won't need to do any extra 
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-sygnal.md
+++ b/docs/configuring-playbook-sygnal.md
@@ -81,7 +81,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-sygnal.md
+++ b/docs/configuring-playbook-sygnal.md
@@ -84,6 +84,9 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-sygnal.md
+++ b/docs/configuring-playbook-sygnal.md
@@ -81,12 +81,12 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-sygnal.md
+++ b/docs/configuring-playbook-sygnal.md
@@ -79,6 +79,7 @@ If you've decided to reuse the `matrix.` domain, you won't need to do any extra 
 
 After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-sygnal.md
+++ b/docs/configuring-playbook-sygnal.md
@@ -84,7 +84,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
 `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 

--- a/docs/configuring-playbook-synapse-admin.md
+++ b/docs/configuring-playbook-synapse-admin.md
@@ -50,6 +50,15 @@ If you've decided to use the default hostname, you won't need to do any extra DN
 
 After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
+
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
+
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Usage
 
 After installation, Synapse Admin will be accessible at: `https://matrix.example.com/synapse-admin/`

--- a/docs/configuring-playbook-synapse-admin.md
+++ b/docs/configuring-playbook-synapse-admin.md
@@ -48,7 +48,7 @@ If you've decided to use the default hostname, you won't need to do any extra DN
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:
 
 ## Usage
 

--- a/docs/configuring-playbook-synapse-auto-compressor.md
+++ b/docs/configuring-playbook-synapse-auto-compressor.md
@@ -25,7 +25,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
 `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 

--- a/docs/configuring-playbook-synapse-auto-compressor.md
+++ b/docs/configuring-playbook-synapse-auto-compressor.md
@@ -22,7 +22,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-synapse-auto-compressor.md
+++ b/docs/configuring-playbook-synapse-auto-compressor.md
@@ -22,12 +22,12 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-synapse-auto-compressor.md
+++ b/docs/configuring-playbook-synapse-auto-compressor.md
@@ -18,7 +18,7 @@ matrix_synapse_auto_compressor_enabled: true
 
 ## Installing
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-synapse-auto-compressor.md
+++ b/docs/configuring-playbook-synapse-auto-compressor.md
@@ -25,6 +25,9 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 ## Usage
 

--- a/docs/configuring-playbook-synapse-auto-compressor.md
+++ b/docs/configuring-playbook-synapse-auto-compressor.md
@@ -20,6 +20,7 @@ matrix_synapse_auto_compressor_enabled: true
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-synapse-usage-exporter.md
+++ b/docs/configuring-playbook-synapse-usage-exporter.md
@@ -57,6 +57,6 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
 `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-synapse-usage-exporter.md
+++ b/docs/configuring-playbook-synapse-usage-exporter.md
@@ -54,9 +54,9 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-synapse-usage-exporter.md
+++ b/docs/configuring-playbook-synapse-usage-exporter.md
@@ -50,4 +50,8 @@ If you've decided to use the default hostname, you won't need to do any extra DN
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```

--- a/docs/configuring-playbook-synapse-usage-exporter.md
+++ b/docs/configuring-playbook-synapse-usage-exporter.md
@@ -50,7 +50,7 @@ If you've decided to use the default hostname, you won't need to do any extra DN
 
 ## Installing
 
-After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
+After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/configuring-playbook-synapse-usage-exporter.md
+++ b/docs/configuring-playbook-synapse-usage-exporter.md
@@ -52,6 +52,7 @@ If you've decided to use the default hostname, you won't need to do any extra DN
 
 After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/configuring-playbook-synapse-usage-exporter.md
+++ b/docs/configuring-playbook-synapse-usage-exporter.md
@@ -54,7 +54,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/configuring-playbook-synapse-usage-exporter.md
+++ b/docs/configuring-playbook-synapse-usage-exporter.md
@@ -56,3 +56,7 @@ After configuring the playbook and potentially [adjusting your DNS records](#adj
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
+
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)

--- a/docs/configuring-playbook-user-verification-service.md
+++ b/docs/configuring-playbook-user-verification-service.md
@@ -90,7 +90,7 @@ This will instruct UVS to verify the OpenID token against any domain given in a 
 
 ## Installing
 
-After these variables have been set, run the [installation](installing.md) command to restart UVS:
+After these variables have been set, run the playbook with [playbook tags](playbook-tags.md) as below to restart UVS:
 
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-matrix-user-verification-service,start

--- a/docs/configuring-playbook-user-verification-service.md
+++ b/docs/configuring-playbook-user-verification-service.md
@@ -96,7 +96,7 @@ After these variables have been set, run the [installation](installing.md) comma
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-matrix-user-verification-service,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags setup-matrix-user-verification-service,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags setup-matrix-user-verification-service,start` or `just run-tags setup-all,start`
 
 `just run-tags setup-matrix-user-verification-service,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 

--- a/docs/configuring-playbook-user-verification-service.md
+++ b/docs/configuring-playbook-user-verification-service.md
@@ -96,6 +96,10 @@ After these variables have been set, run the [installation](installing.md) comma
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-matrix-user-verification-service,start
 ```
 
+The shortcut commands with `just` program are also available: `just run-tags setup-matrix-user-verification-service,start` or `just run-tags setup-all,start`.
+
+`just run-tags setup-matrix-user-verification-service,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 ## Logging
 
 The configuration variable `UVS_LOG_LEVEL` can be set to:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -269,7 +269,7 @@ matrix_server_fqn_element: "element.example.com"
 matrix_server_fqn_etherpad: "etherpad.example.com"
 ```
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -271,6 +271,7 @@ matrix_server_fqn_etherpad: "etherpad.example.com"
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -276,11 +276,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
+**Notes**:
 
-`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
-**Note**: without setting up [server delegation](howto-server-delegation.md) to `matrix.example.com`, your user identifiers will be like `@user:matrix.example.com`. This is equivalent to having an email address like `bob@mail.company.com`, instead of just `bob@company.com`.
+  `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
+- Without setting up [server delegation](howto-server-delegation.md) to `matrix.example.com`, your user identifiers will be like `@user:matrix.example.com`. This is equivalent to having an email address like `bob@mail.company.com`, instead of just `bob@company.com`.
 
 ### I don't use the base domain for anything. How am I supposed to set up Server Delegation for Matrix services?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -273,12 +273,12 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 **Note**: without setting up [server delegation](howto-server-delegation.md) to `matrix.example.com`, your user identifiers will be like `@user:matrix.example.com`. This is equivalent to having an email address like `bob@mail.company.com`, instead of just `bob@company.com`.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -273,7 +273,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -276,6 +276,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 **Note**: without setting up [server delegation](howto-server-delegation.md) to `matrix.example.com`, your user identifiers will be like `@user:matrix.example.com`. This is equivalent to having an email address like `bob@mail.company.com`, instead of just `bob@company.com`.
 
 ### I don't use the base domain for anything. How am I supposed to set up Server Delegation for Matrix services?

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -276,7 +276,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
 `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 

--- a/docs/importing-synapse-media-store.md
+++ b/docs/importing-synapse-media-store.md
@@ -18,6 +18,8 @@ As an alternative, you can perform a manual restore using the [AWS CLI tool](htt
 
 Run this command (make sure to replace `<server-path-to-media_store>` with a path on your server):
 
-	ansible-playbook -i inventory/hosts setup.yml --extra-vars='server_path_media_store=<server-path-to-media_store>' --tags=import-synapse-media-store
+```sh
+ansible-playbook -i inventory/hosts setup.yml --extra-vars='server_path_media_store=<server-path-to-media_store>' --tags=import-synapse-media-store
+```
 
 **Note**: `<server-path-to-media_store>` must be a file path to a `media_store` directory on the server (not on your local machine!).

--- a/docs/maintenance-and-troubleshooting.md
+++ b/docs/maintenance-and-troubleshooting.md
@@ -46,7 +46,7 @@ You can free some disk space from Docker, see [docker system prune](https://docs
 ansible-playbook -i inventory/hosts setup.yml --tags=run-docker-prune
 ```
 
-The shortcut command with `just` program is also available: `just run-tags run-docker-prune`.
+The shortcut command with `just` program is also available: `just run-tags run-docker-prune`
 
 ## Postgres
 

--- a/docs/maintenance-and-troubleshooting.md
+++ b/docs/maintenance-and-troubleshooting.md
@@ -41,9 +41,12 @@ Re-run the playbook after making these configuration changes.
 ## Remove unused Docker data
 
 You can free some disk space from Docker, see [docker system prune](https://docs.docker.com/engine/reference/commandline/system_prune/) for more information.
+
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=run-docker-prune
 ```
+
+The shortcut command with `just` program is also available: `just run-tags run-docker-prune`.
 
 ## Postgres
 

--- a/docs/maintenance-checking-services.md
+++ b/docs/maintenance-checking-services.md
@@ -8,7 +8,7 @@ To perform the check, run:
 ansible-playbook -i inventory/hosts setup.yml --tags=self-check
 ```
 
-The shortcut command with `just` program is also available: `just run-tags self-check`.
+The shortcut command with `just` program is also available: `just run-tags self-check`
 
 If it's all green, everything is probably running correctly.
 

--- a/docs/maintenance-checking-services.md
+++ b/docs/maintenance-checking-services.md
@@ -8,6 +8,8 @@ To perform the check, run:
 ansible-playbook -i inventory/hosts setup.yml --tags=self-check
 ```
 
+The shortcut command with `just` program is also available: `just run-tags self-check`.
+
 If it's all green, everything is probably running correctly.
 
 Besides this self-check, you can also check whether your server federates with the Matrix network by using the [Federation Tester](https://federationtester.matrix.org/) against your base domain (`example.com`), not the `matrix.example.com` subdomain.

--- a/docs/maintenance-migrating.md
+++ b/docs/maintenance-migrating.md
@@ -46,7 +46,7 @@ Then, run the command below on your local computer to create the `matrix` user a
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-system-user
 ```
 
-The shortcut command with `just` program is also available: `just run-tags setup-system-user`.
+The shortcut command with `just` program is also available: `just run-tags setup-system-user`
 
 **Note**: because the `matrix` user and group are created dynamically on each server, the user/group ID may differ between the old and new server. We suggest that you adjust ownership of `/matrix` files. To adjust the ownership, log in to the new server and run the command:
 
@@ -62,7 +62,7 @@ Finally, run the command below on your local computer to finish the installation
 ansible-playbook -i inventory/hosts setup.yml --tags=install-all,start
 ```
 
-The shortcut command with `just` program is also available: `just run-tags install-all,start`.
+The shortcut command with `just` program is also available: `just run-tags install-all,start`
 
 ### Check if services work
 

--- a/docs/maintenance-migrating.md
+++ b/docs/maintenance-migrating.md
@@ -46,6 +46,8 @@ Then, run the command below on your local computer to create the `matrix` user a
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-system-user
 ```
 
+The shortcut command with `just` program is also available: `just run-tags setup-system-user`.
+
 **Note**: because the `matrix` user and group are created dynamically on each server, the user/group ID may differ between the old and new server. We suggest that you adjust ownership of `/matrix` files. To adjust the ownership, log in to the new server and run the command:
 
 ```sh
@@ -59,6 +61,8 @@ Finally, run the command below on your local computer to finish the installation
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=install-all,start
 ```
+
+The shortcut command with `just` program is also available: `just run-tags install-all,start`.
 
 ### Check if services work
 

--- a/docs/maintenance-synapse.md
+++ b/docs/maintenance-synapse.md
@@ -39,7 +39,7 @@ To ask the playbook to run rust-synapse-compress-state, execute:
 ansible-playbook -i inventory/hosts setup.yml --tags=rust-synapse-compress-state
 ```
 
-The shortcut command with `just` program is also available: `just run-tags rust-synapse-compress-state`.
+The shortcut command with `just` program is also available: `just run-tags rust-synapse-compress-state`
 
 By default, all rooms with more than `100000` state group rows will be compressed. If you need to adjust this, pass: `--extra-vars='matrix_synapse_rust_synapse_compress_state_min_state_groups_required=SOME_NUMBER_HERE'` to the command above.
 

--- a/docs/maintenance-synapse.md
+++ b/docs/maintenance-synapse.md
@@ -39,6 +39,8 @@ To ask the playbook to run rust-synapse-compress-state, execute:
 ansible-playbook -i inventory/hosts setup.yml --tags=rust-synapse-compress-state
 ```
 
+The shortcut command with `just` program is also available: `just run-tags rust-synapse-compress-state`.
+
 By default, all rooms with more than `100000` state group rows will be compressed. If you need to adjust this, pass: `--extra-vars='matrix_synapse_rust_synapse_compress_state_min_state_groups_required=SOME_NUMBER_HERE'` to the command above.
 
 After state compression, you may wish to run a [`FULL` Postgres `VACUUM`](./maintenance-postgres.md#vacuuming-postgresql).

--- a/docs/registering-users.md
+++ b/docs/registering-users.md
@@ -112,7 +112,7 @@ For Dendrite:
 matrix_dendrite_client_api_registration_disabled: false
 ```
 
-After configuring the playbook, run the [installation](installing.md) command:
+After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh

--- a/docs/registering-users.md
+++ b/docs/registering-users.md
@@ -112,7 +112,11 @@ For Dendrite:
 matrix_dendrite_client_api_registration_disabled: false
 ```
 
-After configuring the playbook, run the [installation](installing.md) command: `just install-all` or `just setup-all`
+After configuring the playbook, run the [installation](installing.md) command:
+
+```sh
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+```
 
 If you're opening up registrations publicly like this, you might also wish to [configure CAPTCHA protection](configuring-captcha.md).
 

--- a/docs/registering-users.md
+++ b/docs/registering-users.md
@@ -119,6 +119,10 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
+The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+
+`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+
 If you're opening up registrations publicly like this, you might also wish to [configure CAPTCHA protection](configuring-captcha.md).
 
 

--- a/docs/registering-users.md
+++ b/docs/registering-users.md
@@ -119,12 +119,13 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
+**Notes**:
 
-`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+- The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
-If you're opening up registrations publicly like this, you might also wish to [configure CAPTCHA protection](configuring-captcha.md).
+  `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
+- If you're opening up registrations publicly like this, you might also wish to [configure CAPTCHA protection](configuring-captcha.md).
 
 ## Adding/Removing Administrator privileges to an existing user
 

--- a/docs/registering-users.md
+++ b/docs/registering-users.md
@@ -116,7 +116,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
 ```
 
 The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.

--- a/docs/registering-users.md
+++ b/docs/registering-users.md
@@ -119,7 +119,7 @@ After configuring the playbook, run the [installation](installing.md) command:
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`
 
 `just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 

--- a/docs/registering-users.md
+++ b/docs/registering-users.md
@@ -116,12 +116,12 @@ After configuring the playbook, run the [installation](installing.md) command:
 
 <!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
-ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-users-created,start
+ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```
 
-The shortcut commands with `just` program are also available: `just install-all` or `just setup-all`.
+The shortcut commands with `just` program are also available: `just run-tags install-all,start` or `just run-tags setup-all,start`.
 
-`just install-all` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
+`just run-tags install-all,start` is useful for maintaining your setup quickly when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just run-tags setup-all,start`, or these components will still remain installed. For more information about `just` shortcuts, take a look at this page: [Running `just` commands](just.md)
 
 If you're opening up registrations publicly like this, you might also wish to [configure CAPTCHA protection](configuring-captcha.md).
 

--- a/docs/registering-users.md
+++ b/docs/registering-users.md
@@ -114,6 +114,7 @@ matrix_dendrite_client_api_registration_disabled: false
 
 After configuring the playbook, run the [installation](installing.md) command:
 
+<!-- NOTE: let this conservative command run (instead of install-all) to make it clear that failure of the command means something is clearly broken. -->
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 ```


### PR DESCRIPTION
The main aims here are:

- Add both `ansible-playbook` commands and shortcuts (mostly `just install-all` and `just setup-all`) for quick installation
    - Add `just run-tags install-all,start` or `just run-tags setup-all,start` instead, if the raw ansible-playbook commands do not require `ensure-matrix-users-created`
- Add/remove `ensure-matrix-users-created` according to components
- Update capitalization and punctuation of list items, according to https://www.purchase.edu/editorial-style-guide/general-style-preferences/punctuation/bulleted-and-numbered-lists/

Though these changes do seem to be really repetitive, it will not matter to readers as they read documentation selectively, when they want/need to.

--

I chose the raw ansible-playbook commands as main ones since they are basic and conservative, but the `just` shortcut commands could be displayed as main and the raw ansible-playbook commands could be displayed as hint in notes conversely, if this is better.