### PR TITLE
hookshot: Allow the localpart of the hookshot-bot to be defined

### DIFF
--- a/roles/custom/matrix-bridge-hookshot/defaults/main.yml
+++ b/roles/custom/matrix-bridge-hookshot/defaults/main.yml
@@ -4,7 +4,7 @@
 # Project source code URL: https://github.com/matrix-org/matrix-hookshot
 
 matrix_hookshot_enabled: true
-
+matrix_hookshot_bot_localpart: "hookshot"
 matrix_hookshot_identifier: matrix-hookshot
 
 matrix_hookshot_container_image_self_build: false

--- a/roles/custom/matrix-bridge-hookshot/defaults/main.yml
+++ b/roles/custom/matrix-bridge-hookshot/defaults/main.yml
@@ -4,7 +4,6 @@
 # Project source code URL: https://github.com/matrix-org/matrix-hookshot
 
 matrix_hookshot_enabled: true
-matrix_hookshot_bot_localpart: "hookshot"
 matrix_hookshot_identifier: matrix-hookshot
 
 matrix_hookshot_container_image_self_build: false
@@ -29,6 +28,8 @@ matrix_hookshot_docker_src_files_path: "{{ matrix_hookshot_base_path }}/docker-s
 
 matrix_hookshot_homeserver_address: ""
 matrix_hookshot_container_url: 'matrix-hookshot'
+# Sets the localpart of the matrixID for the hookshot bot
+matrix_hookshot_bot_localpart: "hookshot"
 
 matrix_hookshot_public_scheme: https
 matrix_hookshot_public_hostname: "{{ matrix_server_fqn_matrix }}"

--- a/roles/custom/matrix-bridge-hookshot/defaults/main.yml
+++ b/roles/custom/matrix-bridge-hookshot/defaults/main.yml
@@ -4,6 +4,7 @@
 # Project source code URL: https://github.com/matrix-org/matrix-hookshot
 
 matrix_hookshot_enabled: true
+
 matrix_hookshot_identifier: matrix-hookshot
 
 matrix_hookshot_container_image_self_build: false
@@ -28,7 +29,8 @@ matrix_hookshot_docker_src_files_path: "{{ matrix_hookshot_base_path }}/docker-s
 
 matrix_hookshot_homeserver_address: ""
 matrix_hookshot_container_url: 'matrix-hookshot'
-# Sets the localpart of the matrixID for the hookshot bot
+
+# Sets the localpart of the Matrix ID for the hookshot bot
 matrix_hookshot_bot_localpart: "hookshot"
 
 matrix_hookshot_public_scheme: https

--- a/roles/custom/matrix-bridge-hookshot/templates/registration.yml.j2
+++ b/roles/custom/matrix-bridge-hookshot/templates/registration.yml.j2
@@ -25,7 +25,7 @@ namespaces:
     - regex: "#github_.+:{{ matrix_domain }}"
       exclusive: true
 
-sender_localpart: hookshot
+sender_localpart: {{ matrix_hookshot_bot_localpart }}
 url: "http://{{ matrix_hookshot_container_url }}:{{ matrix_hookshot_appservice_port }}" # This should match the bridge.port in your config file
 rate_limited: false
 

--- a/roles/custom/matrix-bridge-hookshot/templates/registration.yml.j2
+++ b/roles/custom/matrix-bridge-hookshot/templates/registration.yml.j2
@@ -25,7 +25,7 @@ namespaces:
     - regex: "#github_.+:{{ matrix_domain }}"
       exclusive: true
 
-sender_localpart: {{ matrix_hookshot_bot_localpart }}
+sender_localpart: {{ matrix_hookshot_bot_localpart | to_json }}
 url: "http://{{ matrix_hookshot_container_url }}:{{ matrix_hookshot_appservice_port }}" # This should match the bridge.port in your config file
 rate_limited: false
 


### PR DESCRIPTION
Usecase: I need to have a prefix for every non-person matrix account, so they dont mess  up my metrics, stats, scripts etc.


According to https://matrix-org.github.io/matrix-hookshot/latest/advanced/service_bots.html, you can define the localpart of the hookshot matrixID. I only renamed the hookshot bot localpart so this change should be easy, at least I couldnt see any problems with my change and it worked on my dev environment.

I set the default name to "hookshot", just as before, but with this, you can change it if you want/need to