### PR TITLE
Use common expressions for user IDs, bridge usage, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This [Ansible](https://www.ansible.com/) playbook is meant to help you run your own [Matrix](http://matrix.org/) homeserver, along with the [various services](#supported-services) related to that.
 
-That is, it lets you join the Matrix network using your own user identifier like `@alice:example.com`, all hosted on your own server (see [prerequisites](docs/prerequisites.md)).
+That is, it lets you join the Matrix network using your own user ID like `@alice:example.com`, all hosted on your own server (see [prerequisites](docs/prerequisites.md)).
 
 We run all [supported services](#-supported-services) in [Docker](https://www.docker.com/) containers (see [the container images we use](docs/container-images.md)), which lets us have a predictable and up-to-date setup, across multiple supported distros (see [prerequisites](docs/prerequisites.md)) and [architectures](docs/alternative-architectures.md) (x86/amd64 being recommended).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This [Ansible](https://www.ansible.com/) playbook is meant to help you run your own [Matrix](http://matrix.org/) homeserver, along with the [various services](#supported-services) related to that.
 
-That is, it lets you join the Matrix network using your own `@<username>:example.com` identifier, all hosted on your own server (see [prerequisites](docs/prerequisites.md)).
+That is, it lets you join the Matrix network using your own `@alice:example.com` identifier, all hosted on your own server (see [prerequisites](docs/prerequisites.md)).
 
 We run all [supported services](#-supported-services) in [Docker](https://www.docker.com/) containers (see [the container images we use](docs/container-images.md)), which lets us have a predictable and up-to-date setup, across multiple supported distros (see [prerequisites](docs/prerequisites.md)) and [architectures](docs/alternative-architectures.md) (x86/amd64 being recommended).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This [Ansible](https://www.ansible.com/) playbook is meant to help you run your own [Matrix](http://matrix.org/) homeserver, along with the [various services](#supported-services) related to that.
 
-That is, it lets you join the Matrix network using your own `@alice:example.com` identifier, all hosted on your own server (see [prerequisites](docs/prerequisites.md)).
+That is, it lets you join the Matrix network using your own user identifier like `@alice:example.com`, all hosted on your own server (see [prerequisites](docs/prerequisites.md)).
 
 We run all [supported services](#-supported-services) in [Docker](https://www.docker.com/) containers (see [the container images we use](docs/container-images.md)), which lets us have a predictable and up-to-date setup, across multiple supported distros (see [prerequisites](docs/prerequisites.md)) and [architectures](docs/alternative-architectures.md) (x86/amd64 being recommended).
 

--- a/docs/configuring-dns.md
+++ b/docs/configuring-dns.md
@@ -6,7 +6,7 @@ To set up Matrix on your domain, you'd need to do some DNS configuration.
 
 ## DNS setting for server delegation (optional)
 
-In the sample `vars.yml` ([`examples/vars.yml`](../examples/vars.yml)), we recommend to use a short user identifier like `@<username>:example.com`.
+In the sample `vars.yml` ([`examples/vars.yml`](../examples/vars.yml)), we recommend to use a short user identifier like `@alice:example.com`.
 
 To use such an identifier, you don't need to install anything on the actual `example.com` server. Instead, you need to instruct the Matrix network that Matrix services for `example.com` are redirected over to `matrix.example.com`. This redirection is also known as "delegation".
 

--- a/docs/configuring-dns.md
+++ b/docs/configuring-dns.md
@@ -6,7 +6,7 @@ To set up Matrix on your domain, you'd need to do some DNS configuration.
 
 ## DNS setting for server delegation (optional)
 
-In the sample `vars.yml` ([`examples/vars.yml`](../examples/vars.yml)), we recommend to use a short user ID like `@alice:example.com`.
+In the sample `vars.yml` ([`examples/vars.yml`](../examples/vars.yml)), we recommend to use a short user ID like `@alice:example.com` instead of `@alice:matrix.example.com`.
 
 To use such an ID, you don't need to install anything on the actual `example.com` server. Instead, you need to instruct the Matrix network that Matrix services for `example.com` are redirected over to `matrix.example.com`. This redirection is also known as "delegation".
 

--- a/docs/configuring-dns.md
+++ b/docs/configuring-dns.md
@@ -6,9 +6,9 @@ To set up Matrix on your domain, you'd need to do some DNS configuration.
 
 ## DNS setting for server delegation (optional)
 
-In the sample `vars.yml` ([`examples/vars.yml`](../examples/vars.yml)), we recommend to use a short user identifier like `@alice:example.com`.
+In the sample `vars.yml` ([`examples/vars.yml`](../examples/vars.yml)), we recommend to use a short user ID like `@alice:example.com`.
 
-To use such an identifier, you don't need to install anything on the actual `example.com` server. Instead, you need to instruct the Matrix network that Matrix services for `example.com` are redirected over to `matrix.example.com`. This redirection is also known as "delegation".
+To use such an ID, you don't need to install anything on the actual `example.com` server. Instead, you need to instruct the Matrix network that Matrix services for `example.com` are redirected over to `matrix.example.com`. This redirection is also known as "delegation".
 
 As we discuss in [Server Delegation](howto-server-delegation.md), server delegation can be configured in either of these ways:
 

--- a/docs/configuring-playbook-bot-draupnir.md
+++ b/docs/configuring-playbook-bot-draupnir.md
@@ -34,7 +34,7 @@ You will need to prevent Synapse from rate limiting the bot's account. This is n
 
 If your Synapse Admin API is exposed to the internet for some reason like running the Synapse Admin Role [Link](configuring-playbook-synapse-admin.md) or running `matrix_synapse_container_labels_public_client_synapse_admin_api_enabled: true` in your playbook config. If your API is not externally exposed you should still be able to on the local host for your synapse run these commands.
 
-The following command works on semi up to date Windows 10 installs and All Windows 11 installations and other systems that ship curl. `curl --header "Authorization: Bearer <access_token>" -X POST https://matrix.example.com/_synapse/admin/v1/users/@alice:example.com/override_ratelimit` Replace `@alice:example.com` with the MXID of your Draupnir and example.com with your homeserver domain. You can easily obtain an access token for a homeserver admin account the same way you can obtain an access token for Draupnir itself. If you made Draupnir Admin you can just use the Draupnir token.
+The following command works on semi up to date Windows 10 installs and All Windows 11 installations and other systems that ship curl. `curl --header "Authorization: Bearer <access_token>" -X POST https://matrix.example.com/_synapse/admin/v1/users/@bot.draupnir:example.com/override_ratelimit` Replace `@bot.draupnir:example.com` with the MXID of your Draupnir and example.com with your homeserver domain. You can easily obtain an access token for a homeserver admin account the same way you can obtain an access token for Draupnir itself. If you made Draupnir Admin you can just use the Draupnir token.
 
 ## Create a management room
 

--- a/docs/configuring-playbook-bot-draupnir.md
+++ b/docs/configuring-playbook-bot-draupnir.md
@@ -34,7 +34,7 @@ You will need to prevent Synapse from rate limiting the bot's account. This is n
 
 If your Synapse Admin API is exposed to the internet for some reason like running the Synapse Admin Role [Link](configuring-playbook-synapse-admin.md) or running `matrix_synapse_container_labels_public_client_synapse_admin_api_enabled: true` in your playbook config. If your API is not externally exposed you should still be able to on the local host for your synapse run these commands.
 
-The following command works on semi up to date Windows 10 installs and All Windows 11 installations and other systems that ship curl. `curl --header "Authorization: Bearer <access_token>" -X POST https://matrix.example.com/_synapse/admin/v1/users/@example:example.com/override_ratelimit` Replace `@example:example.com` with the MXID of your Draupnir and example.com with your homeserver domain. You can easily obtain an access token for a homeserver admin account the same way you can obtain an access token for Draupnir itself. If you made Draupnir Admin you can just use the Draupnir token.
+The following command works on semi up to date Windows 10 installs and All Windows 11 installations and other systems that ship curl. `curl --header "Authorization: Bearer <access_token>" -X POST https://matrix.example.com/_synapse/admin/v1/users/@alice:example.com/override_ratelimit` Replace `@alice:example.com` with the MXID of your Draupnir and example.com with your homeserver domain. You can easily obtain an access token for a homeserver admin account the same way you can obtain an access token for Draupnir itself. If you made Draupnir Admin you can just use the Draupnir token.
 
 ## Create a management room
 
@@ -170,7 +170,7 @@ The simplest and most useful entity to target is `user`. Below are a few example
 
 To create rules, you run commands in the Management Room (**not** in the policy list room).
 
-- (ban a single user on a given homeserver): `!draupnir ban @someone:example.com my-bans Rude to others`
+- (ban a single user on a given homeserver): `!draupnir ban @alice:example.com my-bans Rude to others`
 - (ban all users on a given homeserver by using a [wildcard](https://the-draupnir-project.github.io/draupnir-documentation/moderator/managing-users#wildcards)): `!draupnir ban @*:example.org my-bans Spam server - all users are fake`
 
 As a result of running these commands, you may observe:

--- a/docs/configuring-playbook-bot-draupnir.md
+++ b/docs/configuring-playbook-bot-draupnir.md
@@ -170,7 +170,7 @@ The simplest and most useful entity to target is `user`. Below are a few example
 
 To create rules, you run commands in the Management Room (**not** in the policy list room).
 
-- (ban a single user on a given homeserver): `!draupnir ban @alice:example.com my-bans Rude to others`
+- (ban a single user on a given homeserver): `!draupnir ban @charles:example.com my-bans Rude to others`
 - (ban all users on a given homeserver by using a [wildcard](https://the-draupnir-project.github.io/draupnir-documentation/moderator/managing-users#wildcards)): `!draupnir ban @*:example.org my-bans Spam server - all users are fake`
 
 As a result of running these commands, you may observe:

--- a/docs/configuring-playbook-bot-go-neb.md
+++ b/docs/configuring-playbook-bot-go-neb.md
@@ -8,7 +8,7 @@ Go-NEB is a Matrix bot written in Go. It is the successor to Matrix-NEB, the ori
 
 See the project's [documentation](https://github.com/matrix-org/go-neb) to learn what it does and why it might be useful to you.
 
-## Registering the bot user
+## Registering the bot account
 
 The playbook does not automatically create users for you. The bot requires at least 1 access token to be able to connect to your homeserver.
 

--- a/docs/configuring-playbook-bot-go-neb.md
+++ b/docs/configuring-playbook-bot-go-neb.md
@@ -62,7 +62,7 @@ matrix_bot_go_neb_realms:
 matrix_bot_go_neb_sessions:
   - SessionID: "your_github_session"
     RealmID: "github_realm"
-    UserID: "@YOUR_USER_ID:{{ matrix_domain }}" # This needs to be the username of the person that's allowed to use the !github commands
+    UserID: "@alice:{{ matrix_domain }}" # This needs to be the username of the person that's allowed to use the !github commands
     Config:
       # Populate these fields by generating a "Personal Access Token" on github.com
       AccessToken: "YOUR_GITHUB_ACCESS_TOKEN"
@@ -149,7 +149,7 @@ matrix_bot_go_neb_services:
     UserID: "@another_goneb:{{ matrix_domain }}"
     Config:
       RealmID: "github_realm"
-      ClientUserID: "@YOUR_USER_ID:{{ matrix_domain }}" # needs to be an authenticated user so Go-NEB can create webhooks. Check the UserID field in the github_realm in matrix_bot_go_neb_sessions.
+      ClientUserID: "@alice:{{ matrix_domain }}" # needs to be an authenticated user so Go-NEB can create webhooks. Check the UserID field in the github_realm in matrix_bot_go_neb_sessions.
       Rooms:
         "!qporfwt:example.com":
           Repos:
@@ -234,7 +234,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
 ## Usage
 
-To use the bot, invite it to any existing Matrix room (`/invite @whatever_you_chose:example.com` where `example.com` is your base domain, not the `matrix.` domain, make sure you have permission from the room owner if that's not you).
+To use the bot, invite it to any existing Matrix room (`/invite @alice:example.com` where `example.com` is your base domain, not the `matrix.` domain, make sure you have permission from the room owner if that's not you).
 
 Basic usage is like this: `!echo hi` or `!imgur puppies` or `!giphy matrix`
 

--- a/docs/configuring-playbook-bot-go-neb.md
+++ b/docs/configuring-playbook-bot-go-neb.md
@@ -234,7 +234,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
 ## Usage
 
-To use the bot, invite it to any existing Matrix room (`/invite @alice:example.com` where `example.com` is your base domain, not the `matrix.` domain, make sure you have permission from the room owner if that's not you).
+To use the bot, invite it to any existing Matrix room (`/invite @bot.go-neb:example.com` where `example.com` is your base domain, not the `matrix.` domain). Make sure you are granted with the sufficient permission if you are not the room owner.
 
 Basic usage is like this: `!echo hi` or `!imgur puppies` or `!giphy matrix`
 

--- a/docs/configuring-playbook-bot-mjolnir.md
+++ b/docs/configuring-playbook-bot-mjolnir.md
@@ -30,7 +30,7 @@ You will need to prevent Synapse from rate limiting the bot's account. This is n
 
 If your Synapse Admin API is exposed to the internet for some reason like running the Synapse Admin Role [Link](configuring-playbook-synapse-admin.md) or running `matrix_synapse_container_labels_public_client_synapse_admin_api_enabled: true` in your playbook config. If your API is not externally exposed you should still be able to on the local host for your synapse run these commands.
 
-The following command works on semi up to date Windows 10 installs and All Windows 11 installations and other systems that ship curl. `curl --header "Authorization: Bearer <access_token>" -X POST https://matrix.example.com/_synapse/admin/v1/users/@example:example.com/override_ratelimit` Replace `@example:example.com` with the MXID of your Mjolnir and example.com with your homeserver domain. You can easily obtain an access token for a homeserver admin account the same way you can obtain an access token for Mjolnir itself. If you made Mjolnir Admin you can just use the Mjolnir token.
+The following command works on semi up to date Windows 10 installs and All Windows 11 installations and other systems that ship curl. `curl --header "Authorization: Bearer <access_token>" -X POST https://matrix.example.com/_synapse/admin/v1/users/@alice:example.com/override_ratelimit` Replace `@alice:example.com` with the MXID of your Mjolnir and example.com with your homeserver domain. You can easily obtain an access token for a homeserver admin account the same way you can obtain an access token for Mjolnir itself. If you made Mjolnir Admin you can just use the Mjolnir token.
 
 ## Create a management room
 

--- a/docs/configuring-playbook-bot-mjolnir.md
+++ b/docs/configuring-playbook-bot-mjolnir.md
@@ -30,7 +30,7 @@ You will need to prevent Synapse from rate limiting the bot's account. This is n
 
 If your Synapse Admin API is exposed to the internet for some reason like running the Synapse Admin Role [Link](configuring-playbook-synapse-admin.md) or running `matrix_synapse_container_labels_public_client_synapse_admin_api_enabled: true` in your playbook config. If your API is not externally exposed you should still be able to on the local host for your synapse run these commands.
 
-The following command works on semi up to date Windows 10 installs and All Windows 11 installations and other systems that ship curl. `curl --header "Authorization: Bearer <access_token>" -X POST https://matrix.example.com/_synapse/admin/v1/users/@alice:example.com/override_ratelimit` Replace `@alice:example.com` with the MXID of your Mjolnir and example.com with your homeserver domain. You can easily obtain an access token for a homeserver admin account the same way you can obtain an access token for Mjolnir itself. If you made Mjolnir Admin you can just use the Mjolnir token.
+The following command works on semi up to date Windows 10 installs and All Windows 11 installations and other systems that ship curl. `curl --header "Authorization: Bearer <access_token>" -X POST https://matrix.example.com/_synapse/admin/v1/users/@bot.mjolnir:example.com/override_ratelimit` Replace `@bot.mjolnir:example.com` with the MXID of your Mjolnir and example.com with your homeserver domain. You can easily obtain an access token for a homeserver admin account the same way you can obtain an access token for Mjolnir itself. If you made Mjolnir Admin you can just use the Mjolnir token.
 
 ## Create a management room
 

--- a/docs/configuring-playbook-bridge-appservice-discord.md
+++ b/docs/configuring-playbook-bridge-appservice-discord.md
@@ -97,5 +97,5 @@ There's the Discord bridge's guide for [setting privileges on bridge managed roo
 
 ```sh
 docker exec -it matrix-appservice-discord \
-/bin/sh -c 'cp /cfg/registration.yaml /tmp/discord-registration.yaml && cd /tmp && node /build/tools/adminme.js -c /cfg/config.yaml -m "!qporfwt:example.com" -u "@USER:example.com" -p 100'
+/bin/sh -c 'cp /cfg/registration.yaml /tmp/discord-registration.yaml && cd /tmp && node /build/tools/adminme.js -c /cfg/config.yaml -m "!qporfwt:example.com" -u "@alice:example.com" -p 100'
 ```

--- a/docs/configuring-playbook-bridge-appservice-irc.md
+++ b/docs/configuring-playbook-bridge-appservice-irc.md
@@ -79,4 +79,4 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
 ## Usage
 
-You then need to start a chat with `@irc_bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
+To use the bridge, you need to start a chat with `@irc_bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).

--- a/docs/configuring-playbook-bridge-appservice-kakaotalk.md
+++ b/docs/configuring-playbook-bridge-appservice-kakaotalk.md
@@ -50,7 +50,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
 ## Usage
 
-Start a chat with `@kakaotalkbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
+To use the bridge, you need to start a chat with `@kakaotalkbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
 
 Send `login --save EMAIL_OR_PHONE_NUMBER` to the bridge bot to enable bridging for your Kakaotalk account. The `--save` flag may be omitted, if you'd rather not save your password.
 

--- a/docs/configuring-playbook-bridge-appservice-slack.md
+++ b/docs/configuring-playbook-bridge-appservice-slack.md
@@ -82,7 +82,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
 ## Usage
 
-Send `/invite @slackbot:example.com` to invite the bridge bot user into the admin room.
+To use the bridge, you need to send `/invite @slackbot:example.com` to invite the bridge bot user into the admin room.
 
 If Team Sync is not enabled, for each channel you would like to bridge, perform the following steps:
 

--- a/docs/configuring-playbook-bridge-appservice-webhooks.md
+++ b/docs/configuring-playbook-bridge-appservice-webhooks.md
@@ -43,7 +43,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
 ## Usage
 
-Invite the bridge bot user to your room in either way.
+To use the bridge, you need to invite the bridge bot user to your room in either way.
 
 - Send `/invite @_webhook:example.com` (**Note**: Make sure you have administration permissions in your room)
 - Add the bridge bot to a private channel (personal channels imply you being an administrator)

--- a/docs/configuring-playbook-bridge-beeper-linkedin.md
+++ b/docs/configuring-playbook-bridge-beeper-linkedin.md
@@ -59,7 +59,7 @@ Enabling double puppeting by enabling the [Shared Secret Auth](configuring-playb
 
 ## Usage
 
-You then need to start a chat with `@linkedinbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
+To use the bridge, you need to start a chat with `@linkedinbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
 
 Send `login YOUR_LINKEDIN_EMAIL_ADDRESS` to the bridge bot to enable bridging for your LinkedIn account.
 

--- a/docs/configuring-playbook-bridge-beeper-linkedin.md
+++ b/docs/configuring-playbook-bridge-beeper-linkedin.md
@@ -27,7 +27,7 @@ If you would like to be able to administrate the bridge from your account it can
 matrix_beeper_linkedin_configuration_extension_yaml: |
   bridge:
     permissions:
-      '@alice:example.com': admin
+      '@alice:{{ matrix_domain }}': admin
 ```
 
 You may wish to look at `roles/custom/matrix-bridge-beeper-linkedin/templates/config.yaml.j2` to find other things you would like to configure.

--- a/docs/configuring-playbook-bridge-beeper-linkedin.md
+++ b/docs/configuring-playbook-bridge-beeper-linkedin.md
@@ -27,7 +27,7 @@ If you would like to be able to administrate the bridge from your account it can
 matrix_beeper_linkedin_configuration_extension_yaml: |
   bridge:
     permissions:
-      '@YOUR_USERNAME:example.com': admin
+      '@alice:example.com': admin
 ```
 
 You may wish to look at `roles/custom/matrix-bridge-beeper-linkedin/templates/config.yaml.j2` to find other things you would like to configure.

--- a/docs/configuring-playbook-bridge-go-skype-bridge.md
+++ b/docs/configuring-playbook-bridge-go-skype-bridge.md
@@ -31,6 +31,6 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
 ## Usage
 
-Once the bot is enabled, you need to start a chat with `Skype bridge bot` with the handle `@skypebridgebot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
+To use the bridge, you need to start a chat with `Skype bridge bot` with the handle `@skypebridgebot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
 
 Send `help` to the bot to see the commands available.

--- a/docs/configuring-playbook-bridge-heisenbridge.md
+++ b/docs/configuring-playbook-bridge-heisenbridge.md
@@ -15,7 +15,7 @@ matrix_heisenbridge_enabled: true
 
 # Setting the owner is optional as the first local user to DM `@heisenbridge:example.com` will be made the owner.
 # If you are not using a local user you must set it as otherwise you can't DM it at all.
-matrix_heisenbridge_owner: "@alice:example.com"
+matrix_heisenbridge_owner: "@alice:{{ matrix_domain }}"
 
 # Uncomment to enable identd on host port 113/TCP (optional)
 # matrix_heisenbridge_identd_enabled: true

--- a/docs/configuring-playbook-bridge-heisenbridge.md
+++ b/docs/configuring-playbook-bridge-heisenbridge.md
@@ -66,7 +66,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
 ## Usage
 
-After the bridge is successfully running just DM `@heisenbridge:example.com` to start setting it up. If the bridge ignores you and a DM is not accepted then the owner setting may be wrong.
+To use the bridge, you need to start a chat with `@heisenbridge:example.com` (where `example.com` is your base domain, not the `matrix.` domain). If the bridge ignores you and a DM is not accepted then the owner setting may be wrong.
 
 Help is available for all commands with the `-h` switch.
 

--- a/docs/configuring-playbook-bridge-heisenbridge.md
+++ b/docs/configuring-playbook-bridge-heisenbridge.md
@@ -15,7 +15,7 @@ matrix_heisenbridge_enabled: true
 
 # Setting the owner is optional as the first local user to DM `@heisenbridge:example.com` will be made the owner.
 # If you are not using a local user you must set it as otherwise you can't DM it at all.
-matrix_heisenbridge_owner: "@you:example.com"
+matrix_heisenbridge_owner: "@alice:example.com"
 
 # Uncomment to enable identd on host port 113/TCP (optional)
 # matrix_heisenbridge_identd_enabled: true

--- a/docs/configuring-playbook-bridge-hookshot.md
+++ b/docs/configuring-playbook-bridge-hookshot.md
@@ -30,7 +30,7 @@ Should the crypto store be corrupted, you can reset it by executing this Ansible
 
 ## Usage
 
-Create a room and invite the Hookshot bot (`@hookshot:example.com`) to it.
+To use the bridge, you need to create a room and invite the Hookshot bot (`@hookshot:example.com`) to it.
 
 Make sure the bot is able to send state events (usually the Moderator power level in clients).
 

--- a/docs/configuring-playbook-bridge-mautrix-facebook.md
+++ b/docs/configuring-playbook-bridge-mautrix-facebook.md
@@ -74,7 +74,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
 ## Usage
 
-You then need to start a chat with `@facebookbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
+To use the bridge, you need to start a chat with `@facebookbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
 
 Send `login YOUR_FACEBOOK_EMAIL_ADDRESS` to the bridge bot to enable bridging for your Facebook Messenger account. You can learn more here about authentication from the bridge's [official documentation on Authentication](https://docs.mau.fi/bridges/python/facebook/authentication.html).
 

--- a/docs/configuring-playbook-bridge-mautrix-facebook.md
+++ b/docs/configuring-playbook-bridge-mautrix-facebook.md
@@ -38,7 +38,7 @@ If you would like to be able to administrate the bridge from your account it can
 matrix_mautrix_facebook_configuration_extension_yaml: |
   bridge:
     permissions:
-      '@YOUR_USERNAME:{{ matrix_domain }}': admin
+      '@alice:{{ matrix_domain }}': admin
 ```
 
 Using both would look like
@@ -47,7 +47,7 @@ Using both would look like
 matrix_mautrix_facebook_configuration_extension_yaml: |
   bridge:
     permissions:
-      '@YOUR_USERNAME:{{ matrix_domain }}': admin
+      '@alice:{{ matrix_domain }}': admin
     encryption:
       allow: true
       default: true

--- a/docs/configuring-playbook-bridge-mautrix-gmessages.md
+++ b/docs/configuring-playbook-bridge-mautrix-gmessages.md
@@ -37,7 +37,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
 ## Usage
 
-You then need to start a chat with `@gmessagesbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
+To use the bridge, you need to start a chat with `@gmessagesbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
 
 ### 💡 Set up Double Puppeting
 

--- a/docs/configuring-playbook-bridge-mautrix-googlechat.md
+++ b/docs/configuring-playbook-bridge-mautrix-googlechat.md
@@ -37,7 +37,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
 ## Usage
 
-Once the bot is enabled you need to start a chat with `googlechat bridge bot` with handle `@googlechatbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
+To use the bridge, you need to start a chat with `googlechat bridge bot` with handle `@googlechatbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
 
 Send `login` to the bridge bot to receive a link to the portal from which you can enable the bridging. Open the link sent by the bot and follow the instructions.
 

--- a/docs/configuring-playbook-bridge-mautrix-hangouts.md
+++ b/docs/configuring-playbook-bridge-mautrix-hangouts.md
@@ -39,7 +39,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
 ## Usage
 
-Once the bot is enabled you need to start a chat with `Hangouts bridge bot` with handle `@hangoutsbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
+To use the bridge, you need to start a chat with `Hangouts bridge bot` with handle `@hangoutsbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
 
 Send `login` to the bridge bot to receive a link to the portal from which you can enable the bridging. Open the link sent by the bot and follow the instructions.
 

--- a/docs/configuring-playbook-bridge-mautrix-instagram.md
+++ b/docs/configuring-playbook-bridge-mautrix-instagram.md
@@ -37,7 +37,7 @@ matrix_admin: "@alice:{{ matrix_domain }}"
 matrix_mautrix_instagram_configuration_extension_yaml: |
   bridge:
     permissions:
-      '@alice:example.com': admin
+      '@alice:{{ matrix_domain }}': admin
 ```
 
 You may wish to look at `roles/custom/matrix-bridge-mautrix-instagram/templates/config.yaml.j2` and `roles/custom/matrix-bridge-mautrix-instagram/defaults/main.yml` to find other things you would like to configure.

--- a/docs/configuring-playbook-bridge-mautrix-instagram.md
+++ b/docs/configuring-playbook-bridge-mautrix-instagram.md
@@ -30,14 +30,14 @@ If you would like to be able to administrate the bridge from your account it can
 
 ```yaml
 # The easy way. The specified Matrix user ID will be made an admin of all bridges
-matrix_admin: "@YOUR_USERNAME:{{ matrix_domain }}"
+matrix_admin: "@alice:{{ matrix_domain }}"
 
 # OR:
 # The more verbose way. Applies to this bridge only. You may define multiple Matrix users as admins.
 matrix_mautrix_instagram_configuration_extension_yaml: |
   bridge:
     permissions:
-      '@YOUR_USERNAME:example.com': admin
+      '@alice:example.com': admin
 ```
 
 You may wish to look at `roles/custom/matrix-bridge-mautrix-instagram/templates/config.yaml.j2` and `roles/custom/matrix-bridge-mautrix-instagram/defaults/main.yml` to find other things you would like to configure.

--- a/docs/configuring-playbook-bridge-mautrix-instagram.md
+++ b/docs/configuring-playbook-bridge-mautrix-instagram.md
@@ -61,7 +61,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
 ## Usage
 
-You then need to start a chat with `@instagrambot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
+To use the bridge, you need to start a chat with `@instagrambot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
 
 Send `login YOUR_INSTAGRAM_EMAIL_ADDRESS YOUR_INSTAGRAM_PASSWORD` to the bridge bot to enable bridging for your instagram/Messenger account.
 

--- a/docs/configuring-playbook-bridge-mautrix-meta-instagram.md
+++ b/docs/configuring-playbook-bridge-mautrix-meta-instagram.md
@@ -86,7 +86,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
 ## Usage
 
-You then need to start a chat with `@instagrambot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
+To use the bridge, you need to start a chat with `@instagrambot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
 
 ### 💡 Set up Double Puppeting
 

--- a/docs/configuring-playbook-bridge-mautrix-meta-instagram.md
+++ b/docs/configuring-playbook-bridge-mautrix-meta-instagram.md
@@ -62,7 +62,7 @@ You may redefine `matrix_mautrix_meta_instagram_bridge_permissions_default` any 
 
 ```yaml
 matrix_mautrix_meta_instagram_bridge_permissions_custom:
-  '@alice:example.com': admin
+  '@alice:{{ matrix_domain }}': admin
 ```
 
 You may wish to look at `roles/custom/matrix-bridge-mautrix-meta-instagram/templates/config.yaml.j2` to find more information on the permissions settings and other options you would like to configure.

--- a/docs/configuring-playbook-bridge-mautrix-meta-instagram.md
+++ b/docs/configuring-playbook-bridge-mautrix-meta-instagram.md
@@ -56,7 +56,7 @@ matrix_mautrix_meta_instagram_bridge_permissions_default:
   '{{ matrix_admin }}': admin
 ```
 
-If you don't define the `matrix_admin` in your configuration (e.g. `matrix_admin: @user:example.com`), then there's no admin by default.
+If you don't define the `matrix_admin` in your configuration (e.g. `matrix_admin: @alice:example.com`), then there's no admin by default.
 
 You may redefine `matrix_mautrix_meta_instagram_bridge_permissions_default` any way you see fit, or add extra permissions using `matrix_mautrix_meta_instagram_bridge_permissions_custom` like this:
 

--- a/docs/configuring-playbook-bridge-mautrix-meta-instagram.md
+++ b/docs/configuring-playbook-bridge-mautrix-meta-instagram.md
@@ -62,7 +62,7 @@ You may redefine `matrix_mautrix_meta_instagram_bridge_permissions_default` any 
 
 ```yaml
 matrix_mautrix_meta_instagram_bridge_permissions_custom:
-  '@YOUR_USERNAME:example.com': admin
+  '@alice:example.com': admin
 ```
 
 You may wish to look at `roles/custom/matrix-bridge-mautrix-meta-instagram/templates/config.yaml.j2` to find more information on the permissions settings and other options you would like to configure.

--- a/docs/configuring-playbook-bridge-mautrix-meta-messenger.md
+++ b/docs/configuring-playbook-bridge-mautrix-meta-messenger.md
@@ -75,7 +75,7 @@ You may redefine `matrix_mautrix_meta_messenger_bridge_permissions_default` any 
 
 ```yaml
 matrix_mautrix_meta_messenger_bridge_permissions_custom:
-  '@YOUR_USERNAME:example.com': admin
+  '@alice:example.com': admin
 ```
 
 You may wish to look at `roles/custom/matrix-bridge-mautrix-meta-messenger/templates/config.yaml.j2` to find more information on the permissions settings and other options you would like to configure.

--- a/docs/configuring-playbook-bridge-mautrix-meta-messenger.md
+++ b/docs/configuring-playbook-bridge-mautrix-meta-messenger.md
@@ -69,7 +69,7 @@ matrix_mautrix_meta_messenger_bridge_permissions_default:
   '{{ matrix_admin }}': admin
 ```
 
-If you don't define the `matrix_admin` in your configuration (e.g. `matrix_admin: @user:example.com`), then there's no admin by default.
+If you don't define the `matrix_admin` in your configuration (e.g. `matrix_admin: @alice:example.com`), then there's no admin by default.
 
 You may redefine `matrix_mautrix_meta_messenger_bridge_permissions_default` any way you see fit, or add extra permissions using `matrix_mautrix_meta_messenger_bridge_permissions_custom` like this:
 

--- a/docs/configuring-playbook-bridge-mautrix-meta-messenger.md
+++ b/docs/configuring-playbook-bridge-mautrix-meta-messenger.md
@@ -99,7 +99,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
 ## Usage
 
-You then need to start a chat with `@messengerbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain). Note that the user ID of the bridge's bot is not `@facebookbot:example.com`.
+To use the bridge, you need to start a chat with `@messengerbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain). Note that the user ID of the bridge's bot is not `@facebookbot:example.com`.
 
 You then need to send a `login` command and follow the bridge bot's instructions.
 

--- a/docs/configuring-playbook-bridge-mautrix-meta-messenger.md
+++ b/docs/configuring-playbook-bridge-mautrix-meta-messenger.md
@@ -75,7 +75,7 @@ You may redefine `matrix_mautrix_meta_messenger_bridge_permissions_default` any 
 
 ```yaml
 matrix_mautrix_meta_messenger_bridge_permissions_custom:
-  '@alice:example.com': admin
+  '@alice:{{ matrix_domain }}': admin
 ```
 
 You may wish to look at `roles/custom/matrix-bridge-mautrix-meta-messenger/templates/config.yaml.j2` to find more information on the permissions settings and other options you would like to configure.

--- a/docs/configuring-playbook-bridge-mautrix-signal.md
+++ b/docs/configuring-playbook-bridge-mautrix-signal.md
@@ -54,7 +54,7 @@ If you want to augment the preset permissions, you might want to set the additio
 matrix_mautrix_signal_configuration_extension_yaml: |
   bridge:
     permissions:
-      '@alice:example.com': admin
+      '@alice:{{ matrix_domain }}': admin
 ```
 
 This will add the admin permission to the specific user, while keeping the default permissions.
@@ -63,8 +63,8 @@ In case you want to replace the default permissions settings **completely**, pop
 
 ```yaml
 matrix_mautrix_signal_bridge_permissions:
-  '@alice:example.com': admin
-  '@bob:example.com' : user
+  '@alice:{{ matrix_domain }}': admin
+  '@bob:{{ matrix_domain }}' : user
 ```
 
 You may wish to look at `roles/custom/matrix-bridge-mautrix-signal/templates/config.yaml.j2` to find more information on the permissions settings and other options you would like to configure.

--- a/docs/configuring-playbook-bridge-mautrix-signal.md
+++ b/docs/configuring-playbook-bridge-mautrix-signal.md
@@ -88,7 +88,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
 ## Usage
 
-You then need to start a chat with `@signalbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
+To use the bridge, you need to start a chat with `@signalbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
 
 ### 💡 Set up Double Puppeting
 

--- a/docs/configuring-playbook-bridge-mautrix-signal.md
+++ b/docs/configuring-playbook-bridge-mautrix-signal.md
@@ -54,7 +54,7 @@ If you want to augment the preset permissions, you might want to set the additio
 matrix_mautrix_signal_configuration_extension_yaml: |
   bridge:
     permissions:
-      '@YOUR_USERNAME:example.com': admin
+      '@alice:example.com': admin
 ```
 
 This will add the admin permission to the specific user, while keeping the default permissions.

--- a/docs/configuring-playbook-bridge-mautrix-signal.md
+++ b/docs/configuring-playbook-bridge-mautrix-signal.md
@@ -63,8 +63,8 @@ In case you want to replace the default permissions settings **completely**, pop
 
 ```yaml
 matrix_mautrix_signal_bridge_permissions:
-  '@ADMIN:example.com': admin
-  '@USER:example.com' : user
+  '@alice:example.com': admin
+  '@bob:example.com' : user
 ```
 
 You may wish to look at `roles/custom/matrix-bridge-mautrix-signal/templates/config.yaml.j2` to find more information on the permissions settings and other options you would like to configure.

--- a/docs/configuring-playbook-bridge-mautrix-telegram.md
+++ b/docs/configuring-playbook-bridge-mautrix-telegram.md
@@ -57,7 +57,7 @@ You might also want to give permissions to administrate the bot:
 matrix_mautrix_telegram_configuration_extension_yaml: |
   bridge:
     permissions:
-      '@alice:example.com': admin
+      '@alice:{{ matrix_domain }}': admin
 ```
 
 More details about permissions in this example: https://github.com/mautrix/telegram/blob/master/mautrix_telegram/example-config.yaml#L410

--- a/docs/configuring-playbook-bridge-mautrix-telegram.md
+++ b/docs/configuring-playbook-bridge-mautrix-telegram.md
@@ -57,7 +57,7 @@ You might also want to give permissions to administrate the bot:
 matrix_mautrix_telegram_configuration_extension_yaml: |
   bridge:
     permissions:
-      '@user:example.com': admin
+      '@alice:example.com': admin
 ```
 
 More details about permissions in this example: https://github.com/mautrix/telegram/blob/master/mautrix_telegram/example-config.yaml#L410

--- a/docs/configuring-playbook-bridge-mautrix-telegram.md
+++ b/docs/configuring-playbook-bridge-mautrix-telegram.md
@@ -39,7 +39,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
 ## Usage
 
-You then need to start a chat with `@telegrambot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
+To use the bridge, you need to start a chat with `@telegrambot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
 
 If you want to use the relay-bot feature ([relay bot documentation](https://docs.mau.fi/bridges/python/telegram/relay-bot.html)), which allows anonymous user to chat with telegram users, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:
 

--- a/docs/configuring-playbook-bridge-mautrix-whatsapp.md
+++ b/docs/configuring-playbook-bridge-mautrix-whatsapp.md
@@ -53,7 +53,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
 ## Usage
 
-You then need to start a chat with `@whatsappbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
+To use the bridge, you need to start a chat with `@whatsappbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
 
 ### 💡 Set up Double Puppeting
 

--- a/docs/configuring-playbook-bridge-mx-puppet-discord.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-discord.md
@@ -35,7 +35,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
 ## Usage
 
-Once the bot is enabled you need to start a chat with `Discord Puppet Bridge` with the handle `@_discordpuppet_bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
+To use the bridge, you need to start a chat with `Discord Puppet Bridge` with the handle `@_discordpuppet_bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
 
 Three authentication methods are available, Legacy Token, OAuth and xoxc token. See mx-puppet-discord [documentation](https://gitlab.com/mx-puppet/discord/mx-puppet-discord) for more information about how to configure the bridge.
 

--- a/docs/configuring-playbook-bridge-mx-puppet-groupme.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-groupme.md
@@ -31,7 +31,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
 ## Usage
 
-Once the bot is enabled you need to start a chat with `GroupMe Puppet Bridge` with the handle `@_groupmepuppet_bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
+To use the bridge, you need to start a chat with `GroupMe Puppet Bridge` with the handle `@_groupmepuppet_bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
 
 One authentication method is available.
 

--- a/docs/configuring-playbook-bridge-mx-puppet-instagram.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-instagram.md
@@ -31,7 +31,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
 ## Usage
 
-Once the bot is enabled, you need to start a chat with `Instagram Puppet Bridge` with the handle `@_instagrampuppet_bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
+To use the bridge, you need to start a chat with `Instagram Puppet Bridge` with the handle `@_instagrampuppet_bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
 
 Send `link <username> <password>` to the bridge bot to link your instagram account.
 

--- a/docs/configuring-playbook-bridge-mx-puppet-slack.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-slack.md
@@ -40,7 +40,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
 ## Usage
 
-Once the bot is enabled you need to start a chat with `Slack Puppet Bridge` with the handle `@_slackpuppet_bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
+To use the bridge, you need to start a chat with `Slack Puppet Bridge` with the handle `@_slackpuppet_bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
 
 Three authentication methods are available, Legacy Token, OAuth and xoxc token. See mx-puppet-slack [documentation](https://gitlab.com/mx-puppet/slack/mx-puppet-slack) for more information about how to configure the bridge.
 

--- a/docs/configuring-playbook-bridge-mx-puppet-steam.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-steam.md
@@ -31,7 +31,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
 ## Usage
 
-Once the bot is enabled you need to start a chat with `Steam Puppet Bridge` with the handle `@_steampuppet_bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
+To use the bridge, you need to start a chat with `Steam Puppet Bridge` with the handle `@_steampuppet_bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
 
 Three authentication methods are available, Legacy Token, OAuth and xoxc token. See mx-puppet-steam [documentation](https://github.com/icewind1991/mx-puppet-steam) for more information about how to configure the bridge.
 

--- a/docs/configuring-playbook-bridge-mx-puppet-twitter.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-twitter.md
@@ -42,7 +42,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,ensure-matrix-use
 
 ## Usage
 
-Once the bot is enabled you need to start a chat with `Twitter Puppet Bridge` with the handle `@_twitterpuppet_bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
+To use the bridge, you need to start a chat with `Twitter Puppet Bridge` with the handle `@_twitterpuppet_bot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
 
 To log in, use `link` and click the link.
 

--- a/docs/configuring-playbook-email2matrix.md
+++ b/docs/configuring-playbook-email2matrix.md
@@ -24,11 +24,13 @@ For details about using Email2Matrix alongside [Postfix](http://www.postfix.org/
 
 ### Creating a user
 
-Before enabling Email2Matrix, you'd most likely wish to create a dedicated user (or more) that would be sending messages on the Matrix side. Refer to [Registering users](registering-users.md) for ways to do that. A regular (non-admin) user works best.
+Before enabling Email2Matrix, you'd most likely wish to create a dedicated user (or more) that would be sending messages on the Matrix side. Take note of the user's ID as it needs to be specified as `MatrixUserId` on your `inventory/host_vars/matrix.example.com/vars.yml` file later.
+
+Refer to [Registering users](registering-users.md) for ways to create a user. A regular (non-admin) user works best.
 
 ### Creating a shared room
 
-After creating a sender user, you should create one or more Matrix rooms that you share with that user. It doesn't matter who creates and owns the rooms and who joins later (you or the sender user).
+After creating the sender user, you should create one or more Matrix rooms that you share with that user. It doesn't matter who creates and owns the rooms and who joins later (you or the sender user).
 
 What matters is that both you and the sender user are part of the same room and that the sender user has enough privileges in the room to be able to send messages there.
 
@@ -51,7 +53,7 @@ matrix_email2matrix_matrix_mappings:
   - MailboxName: "mailbox1"
     MatrixRoomId: "!qporfwt:{{ matrix_domain }}"
     MatrixHomeserverUrl: "{{ matrix_homeserver_url }}"
-    MatrixUserId: "@alice:{{ matrix_domain }}"
+    MatrixUserId: "@email2matrix1:{{ matrix_domain }}"
     MatrixAccessToken: "MATRIX_ACCESS_TOKEN_HERE"
     IgnoreSubject: false
     IgnoreBody: false
@@ -60,7 +62,7 @@ matrix_email2matrix_matrix_mappings:
   - MailboxName: "mailbox2"
     MatrixRoomId: "!aaabaa:{{ matrix_domain }}"
     MatrixHomeserverUrl: "{{ matrix_homeserver_url }}"
-    MatrixUserId: "@bob:{{ matrix_domain }}"
+    MatrixUserId: "@email2matrix2:{{ matrix_domain }}"
     MatrixAccessToken: "MATRIX_ACCESS_TOKEN_HERE"
     IgnoreSubject: true
     IgnoreBody: false
@@ -72,7 +74,7 @@ where:
 * MailboxName - local-part of the email address, through which emails are bridged to the room whose ID is defined with MatrixRoomId
 * MatrixRoomId - internal ID of the room, to which received emails are sent as Matrix message
 * MatrixHomeserverUrl - URL of your Matrix homeserver, through which to send Matrix messages. You can also set `MatrixHomeserverUrl` to the container URL where your homeserver's Client-Server API lives by using the `{{ matrix_addons_homeserver_client_api_url }}` variable
-* MatrixUserId - the full ID of the sender user which sends bridged messages to the room. On this configuration it is `@alice:example.com` and `@bob:example.com` (where `example.com` is your base domain, not the `matrix.` domain)
+* MatrixUserId - the full ID of the sender user which sends bridged messages to the room. On this configuration it is `@email2matrix1:example.com` and `@email2matrix2:example.com` (where `example.com` is your base domain, not the `matrix.` domain)
 * MatrixAccessToken - sender user's access token
 * IgnoreSubject - if set to "true", the subject is not bridged to Matrix
 * IgnoreBody - if set to "true", the message body is not bridged to Matrix

--- a/docs/configuring-playbook-email2matrix.md
+++ b/docs/configuring-playbook-email2matrix.md
@@ -51,7 +51,7 @@ matrix_email2matrix_matrix_mappings:
   - MailboxName: "mailbox1"
     MatrixRoomId: "!qporfwt:{{ matrix_domain }}"
     MatrixHomeserverUrl: "{{ matrix_homeserver_url }}"
-    MatrixUserId: "@email2matrix:{{ matrix_domain }}"
+    MatrixUserId: "@alice:{{ matrix_domain }}"
     MatrixAccessToken: "MATRIX_ACCESS_TOKEN_HERE"
     IgnoreSubject: false
     IgnoreBody: false
@@ -60,7 +60,7 @@ matrix_email2matrix_matrix_mappings:
   - MailboxName: "mailbox2"
     MatrixRoomId: "!aaabaa:{{ matrix_domain }}"
     MatrixHomeserverUrl: "{{ matrix_homeserver_url }}"
-    MatrixUserId: "@email2matrix:{{ matrix_domain }}"
+    MatrixUserId: "@bob:{{ matrix_domain }}"
     MatrixAccessToken: "MATRIX_ACCESS_TOKEN_HERE"
     IgnoreSubject: true
     IgnoreBody: false
@@ -72,7 +72,7 @@ where:
 * MailboxName - local-part of the email address, through which emails are bridged to the room whose ID is defined with MatrixRoomId
 * MatrixRoomId - internal ID of the room, to which received emails are sent as Matrix message
 * MatrixHomeserverUrl - URL of your Matrix homeserver, through which to send Matrix messages. You can also set `MatrixHomeserverUrl` to the container URL where your homeserver's Client-Server API lives by using the `{{ matrix_addons_homeserver_client_api_url }}` variable
-* MatrixUserId - the full ID of the sender user which sends bridged messages to the room
+* MatrixUserId - the full ID of the sender user which sends bridged messages to the room. On this configuration it is `@alice:example.com` and `@bob:example.com` (where `example.com` is your base domain, not the `matrix.` domain)
 * MatrixAccessToken - sender user's access token
 * IgnoreSubject - if set to "true", the subject is not bridged to Matrix
 * IgnoreBody - if set to "true", the message body is not bridged to Matrix

--- a/docs/configuring-playbook-federation.md
+++ b/docs/configuring-playbook-federation.md
@@ -2,7 +2,7 @@
 
 By default, your server federates with the whole Matrix network. That is, people on your server can communicate with people on any other Matrix server.
 
-**Note**: in the sample `vars.yml` ([`examples/vars.yml`](../examples/vars.yml)), we recommend to use a short user identifier like `@<username>:example.com` and set up [server delegation](howto-server-delegation.md) / redirection. Without a proper configuration, your server will effectively not be part of the Matrix network. If you find your server is not federated, make sure to [check whether services work](maintenance-checking-services.md) and your server is properly delegated.
+**Note**: in the sample `vars.yml` ([`examples/vars.yml`](../examples/vars.yml)), we recommend to use a short user identifier like `@alice:example.com` and set up [server delegation](howto-server-delegation.md) / redirection. Without a proper configuration, your server will effectively not be part of the Matrix network. If you find your server is not federated, make sure to [check whether services work](maintenance-checking-services.md) and your server is properly delegated.
 
 ## Federating only with select servers
 

--- a/docs/configuring-playbook-federation.md
+++ b/docs/configuring-playbook-federation.md
@@ -2,7 +2,7 @@
 
 By default, your server federates with the whole Matrix network. That is, people on your server can communicate with people on any other Matrix server.
 
-**Note**: in the sample `vars.yml` ([`examples/vars.yml`](../examples/vars.yml)), we recommend to use a short user identifier like `@alice:example.com` and set up [server delegation](howto-server-delegation.md) / redirection. Without a proper configuration, your server will effectively not be part of the Matrix network. If you find your server is not federated, make sure to [check whether services work](maintenance-checking-services.md) and your server is properly delegated.
+**Note**: in the sample `vars.yml` ([`examples/vars.yml`](../examples/vars.yml)), we recommend to use a short user ID like `@alice:example.com` and set up [server delegation](howto-server-delegation.md) / redirection. Without a proper configuration, your server will effectively not be part of the Matrix network. If you find your server is not federated, make sure to [check whether services work](maintenance-checking-services.md) and your server is properly delegated.
 
 ## Federating only with select servers
 

--- a/docs/configuring-playbook-federation.md
+++ b/docs/configuring-playbook-federation.md
@@ -2,7 +2,7 @@
 
 By default, your server federates with the whole Matrix network. That is, people on your server can communicate with people on any other Matrix server.
 
-**Note**: in the sample `vars.yml` ([`examples/vars.yml`](../examples/vars.yml)), we recommend to use a short user ID like `@alice:example.com` and set up [server delegation](howto-server-delegation.md) / redirection. Without a proper configuration, your server will effectively not be part of the Matrix network. If you find your server is not federated, make sure to [check whether services work](maintenance-checking-services.md) and your server is properly delegated.
+**Note**: in the sample `vars.yml` ([`examples/vars.yml`](../examples/vars.yml)), we recommend to use a short user ID like `@alice:example.com` instead of `@alice:matrix.example.com` and set up [server delegation](howto-server-delegation.md) / redirection. Without a proper configuration, your server will effectively not be part of the Matrix network. If you find your server is not federated, make sure to [check whether services work](maintenance-checking-services.md) and your server is properly delegated.
 
 ## Federating only with select servers
 

--- a/docs/configuring-playbook-matrix-authentication-service.md
+++ b/docs/configuring-playbook-matrix-authentication-service.md
@@ -353,7 +353,7 @@ If you have existing OIDC users in your Synapse user database (which will be the
 
 If you don't do this, `syn2mas` would report errors like this one:
 
-> [FATAL] migrate - [Failed to import external id 4264b0f0-4f11-4ddd-aedb-b500e4d07c25 with oidc-keycloak for user @user:example.com: Error: Unknown upstream provider oidc-keycloak]
+> [FATAL] migrate - [Failed to import external id 4264b0f0-4f11-4ddd-aedb-b500e4d07c25 with oidc-keycloak for user @alice:example.com: Error: Unknown upstream provider oidc-keycloak]
 
 Below is an example situation and a guide for how to solve it.
 

--- a/docs/configuring-playbook-matrix-media-repo.md
+++ b/docs/configuring-playbook-matrix-media-repo.md
@@ -47,7 +47,7 @@ matrix_media_repo_database_max_idle_connections: 5
 # See docs/admin.md for information on what these people can do. They must belong to one of the
 # configured homeservers above.
 # matrix_media_repo_admins: [
-#   "@your_username:example.org"
+#   "@alice:example.org"
 # ]
 
 matrix_media_repo_admins: []

--- a/docs/configuring-playbook-mautrix-bridges.md
+++ b/docs/configuring-playbook-mautrix-bridges.md
@@ -132,7 +132,7 @@ If you have issues with a service, and are requesting support, the higher levels
 
 ## Usage
 
-You then need to start a chat with `@SERVICENAMEbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
+To use the bridge, you need to start a chat with `@SERVICENAMEbot:example.com` (where `example.com` is your base domain, not the `matrix.` domain).
 
 Send `login` to the bridge bot to get started. You can learn more here about authentication from the bridge's official documentation on Authentication: https://docs.mau.fi/bridges/python/SERVICENAME/authentication.html
 

--- a/docs/configuring-playbook-mautrix-bridges.md
+++ b/docs/configuring-playbook-mautrix-bridges.md
@@ -18,7 +18,7 @@ There are some additional things you may wish to configure about the bridge befo
 To **configure a user as an administrator for all bridges**, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:
 
 ```yaml
-matrix_admin: "@YOUR_USERNAME:{{ matrix_domain }}"
+matrix_admin: "@alice:{{ matrix_domain }}"
 ```
 
 **Alternatively** (more verbose, but allows multiple admins to be configured), you can do the same on a per-bridge basis with:
@@ -27,7 +27,7 @@ matrix_admin: "@YOUR_USERNAME:{{ matrix_domain }}"
 matrix_mautrix_SERVICENAME_configuration_extension_yaml: |
   bridge:
     permissions:
-      '@YOUR_USERNAME:{{ matrix_domain }}': admin
+      '@alice:{{ matrix_domain }}': admin
 ```
 
 ## encryption
@@ -73,7 +73,7 @@ You can only have one `matrix_mautrix_SERVICENAME_configuration_extension_yaml` 
 matrix_mautrix_SERVICENAME_configuration_extension_yaml: |
   bridge:
     permissions:
-      '@YOUR_USERNAME:{{ matrix_domain }}': admin
+      '@alice:{{ matrix_domain }}': admin
     encryption:
       allow: true
       default: true

--- a/docs/configuring-well-known.md
+++ b/docs/configuring-well-known.md
@@ -16,7 +16,7 @@ There are 3 types of well-known service discovery mechanism that Matrix makes us
 
 All services created by this playbook are meant to be installed on their own server (such as `matrix.example.com`), instead of the base domain (`example.com`).
 
-As [per the Server-Server specification](https://matrix.org/docs/spec/server_server/r0.1.0.html#server-discovery), to use a short Matrix user identifier like `@user:example.com` while hosting services on a subdomain such as `matrix.example.com`, the Matrix network needs to be instructed of [server delegation](howto-server-delegation.md) / redirection.
+As [per the Server-Server specification](https://matrix.org/docs/spec/server_server/r0.1.0.html#server-discovery), to use a short Matrix user identifier like `@alice:example.com` while hosting services on a subdomain such as `matrix.example.com`, the Matrix network needs to be instructed of [server delegation](howto-server-delegation.md) / redirection.
 
 For simplicity reasons, this playbook recommends you to set up server delegation via a `/.well-known/matrix/server` file.
 
@@ -24,7 +24,7 @@ If you set up the DNS SRV record for server delegation instead, take a look at t
 
 ### Client Server Discovery
 
-Client Server Service discovery lets various client programs which support it, to receive a full user ID (e.g. `@username:example.com`) and determine where the Matrix server is automatically (e.g. `https://matrix.example.com`).
+Client Server Service discovery lets various client programs which support it, to receive a full user ID (e.g. `@alice:example.com`) and determine where the Matrix server is automatically (e.g. `https://matrix.example.com`).
 
 This lets you (and your users) easily connect to your Matrix server without having to customize connection URLs. When using client programs that support it, you won't need to point them to `https://matrix.example.com` in Custom Server options manually anymore. The connection URL would be discovered automatically from your full username.
 

--- a/docs/configuring-well-known.md
+++ b/docs/configuring-well-known.md
@@ -16,7 +16,7 @@ There are 3 types of well-known service discovery mechanism that Matrix makes us
 
 All services created by this playbook are meant to be installed on their own server (such as `matrix.example.com`), instead of the base domain (`example.com`).
 
-As [per the Server-Server specification](https://matrix.org/docs/spec/server_server/r0.1.0.html#server-discovery), to use a short Matrix user ID like `@alice:example.com` while hosting services on a subdomain such as `matrix.example.com`, the Matrix network needs to be instructed of [server delegation](howto-server-delegation.md) / redirection.
+As [per the Server-Server specification](https://matrix.org/docs/spec/server_server/r0.1.0.html#server-discovery), in order to use a short Matrix user ID like `@alice:example.com` instead of `@alice:matrix.example.com` while hosting services on a subdomain such as `matrix.example.com`, the Matrix network needs to be instructed of [server delegation](howto-server-delegation.md) / redirection.
 
 For simplicity reasons, this playbook recommends you to set up server delegation via a `/.well-known/matrix/server` file.
 

--- a/docs/configuring-well-known.md
+++ b/docs/configuring-well-known.md
@@ -16,7 +16,7 @@ There are 3 types of well-known service discovery mechanism that Matrix makes us
 
 All services created by this playbook are meant to be installed on their own server (such as `matrix.example.com`), instead of the base domain (`example.com`).
 
-As [per the Server-Server specification](https://matrix.org/docs/spec/server_server/r0.1.0.html#server-discovery), to use a short Matrix user identifier like `@alice:example.com` while hosting services on a subdomain such as `matrix.example.com`, the Matrix network needs to be instructed of [server delegation](howto-server-delegation.md) / redirection.
+As [per the Server-Server specification](https://matrix.org/docs/spec/server_server/r0.1.0.html#server-discovery), to use a short Matrix user ID like `@alice:example.com` while hosting services on a subdomain such as `matrix.example.com`, the Matrix network needs to be instructed of [server delegation](howto-server-delegation.md) / redirection.
 
 For simplicity reasons, this playbook recommends you to set up server delegation via a `/.well-known/matrix/server` file.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -56,7 +56,7 @@ There are 3 ways to get into Matrix, depending on your technical ability and nee
 
 - **using some other server** - instead of using the largest public server (`matrix.org`), you can use another public one. Here's a [list of public Matrix servers](https://joinmatrix.org/servers/) to choose from. Go to [Element Web](https://app.element.io) or download [some other client](https://matrix.org/clients/) of your choosing and adjust the homeserver URL during login.
 
-- **using your own server** - running your own server puts you in ultimate control of your data. It also lets you have your own user identifiers (e.g. `@bob:example.com`). See [How do I set up my own Matrix server](#how-do-i-set-up-my-own-matrix-server).
+- **using your own server** - running your own server puts you in ultimate control of your data. It also lets you have your own user IDs (e.g. `@bob:example.com`). See [How do I set up my own Matrix server](#how-do-i-set-up-my-own-matrix-server).
 
 ### How do I set up my own Matrix server?
 
@@ -281,7 +281,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 
   `just install-all` is useful for maintaining your setup quickly ([2x-5x faster](../CHANGELOG.md#2x-5x-performance-improvements-in-playbook-runtime) than `just setup-all`) when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. Note these shortcuts run the `ensure-matrix-users-created` tag too.
 
-- Without setting up [server delegation](howto-server-delegation.md) to `matrix.example.com`, your user identifiers will be like `@alice:matrix.example.com`. This is equivalent to having an email address like `bob@mail.company.com`, instead of just `bob@company.com`.
+- Without setting up [server delegation](howto-server-delegation.md) to `matrix.example.com`, your user IDs will be like `@alice:matrix.example.com`. This is equivalent to having an email address like `bob@mail.company.com`, instead of just `bob@company.com`.
 
 ### I don't use the base domain for anything. How am I supposed to set up Server Delegation for Matrix services?
 
@@ -391,7 +391,7 @@ Yes, you can.
 
 You generally need to do a playbook installation. It's recommended to follow the full installation guide (starting at the [Prerequisites](prerequisites.md) page), not the [Quick start](quick-start.md) guide. The full installation guide will tell you when it's time to import your existing data into the newly-prepared server.
 
-This Ansible playbook guides you into installing a server for `example.com` (user identifiers are like this: `@alice:example.com`), while the server is at `matrix.example.com`. If your existing setup has a server name (`server_name` configuration setting in Synapse's `homeserver.yaml` file) other than the base `example.com`, you may need to tweak some additional variables. This FAQ entry may be of use if you're dealing with a more complicated setup - [How do I install on matrix.example.com without involving the base domain?](#how-do-i-install-on-matrixexamplecom-without-involving-the-base-domain)
+This Ansible playbook guides you into installing a server for `example.com` (user IDs are like this: `@alice:example.com`), while the server is at `matrix.example.com`. If your existing setup has a server name (`server_name` configuration setting in Synapse's `homeserver.yaml` file) other than the base `example.com`, you may need to tweak some additional variables. This FAQ entry may be of use if you're dealing with a more complicated setup - [How do I install on matrix.example.com without involving the base domain?](#how-do-i-install-on-matrixexamplecom-without-involving-the-base-domain)
 
 After configuring the playbook and installing and **before starting** services (done with `ansible-playbook … --tags=start`) you'd import [your SQLite](importing-synapse-sqlite.md) (or [Postgres](importing-postgres.md)) database and also [import your media store](importing-synapse-media-store.md).
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -26,7 +26,7 @@ In the world of the Matrix chat protocol, there are various client programs. The
 
 Matrix is also like email due to the fact that there are many servers around the world which can all talk to each other (you can send email from `@gmail.com` addresses to `@yahoo.com` and `@hotmail.com` addresses). It's the same with Matrix (`@bob:example.com` can talk to `@alice:example.org`).
 
-If someone else is hosting your Matrix server (you being `@example:matrix.org` or some other public server like this), all you need is a Matrix client program, like Element Web or Element X Android.
+If someone else is hosting your Matrix server (you being `@alice:matrix.org` or some other public server like this), all you need is a Matrix client program, like Element Web or Element X Android.
 
 If you'd like to host your own server (you being `@alice:example.com`), you'd need to set up a Matrix server program, like Synapse.
 
@@ -281,7 +281,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 
   `just install-all` is useful for maintaining your setup quickly ([2x-5x faster](../CHANGELOG.md#2x-5x-performance-improvements-in-playbook-runtime) than `just setup-all`) when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. Note these shortcuts run the `ensure-matrix-users-created` tag too.
 
-- Without setting up [server delegation](howto-server-delegation.md) to `matrix.example.com`, your user identifiers will be like `@example:matrix.example.com`. This is equivalent to having an email address like `bob@mail.company.com`, instead of just `bob@company.com`.
+- Without setting up [server delegation](howto-server-delegation.md) to `matrix.example.com`, your user identifiers will be like `@alice:matrix.example.com`. This is equivalent to having an email address like `bob@mail.company.com`, instead of just `bob@company.com`.
 
 ### I don't use the base domain for anything. How am I supposed to set up Server Delegation for Matrix services?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -26,9 +26,9 @@ In the world of the Matrix chat protocol, there are various client programs. The
 
 Matrix is also like email due to the fact that there are many servers around the world which can all talk to each other (you can send email from `@gmail.com` addresses to `@yahoo.com` and `@hotmail.com` addresses). It's the same with Matrix (`@bob:example.com` can talk to `@alice:example.org`).
 
-If someone else is hosting your Matrix server (you being `@user:matrix.org` or some other public server like this), all you need is a Matrix client program, like Element Web or Element X Android.
+If someone else is hosting your Matrix server (you being `@example:matrix.org` or some other public server like this), all you need is a Matrix client program, like Element Web or Element X Android.
 
-If you'd like to host your own server (you being `@user:example.com`), you'd need to set up a Matrix server program, like Synapse.
+If you'd like to host your own server (you being `@alice:example.com`), you'd need to set up a Matrix server program, like Synapse.
 
 In short:
 
@@ -281,7 +281,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 
   `just install-all` is useful for maintaining your setup quickly ([2x-5x faster](../CHANGELOG.md#2x-5x-performance-improvements-in-playbook-runtime) than `just setup-all`) when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. Note these shortcuts run the `ensure-matrix-users-created` tag too.
 
-- Without setting up [server delegation](howto-server-delegation.md) to `matrix.example.com`, your user identifiers will be like `@user:matrix.example.com`. This is equivalent to having an email address like `bob@mail.company.com`, instead of just `bob@company.com`.
+- Without setting up [server delegation](howto-server-delegation.md) to `matrix.example.com`, your user identifiers will be like `@example:matrix.example.com`. This is equivalent to having an email address like `bob@mail.company.com`, instead of just `bob@company.com`.
 
 ### I don't use the base domain for anything. How am I supposed to set up Server Delegation for Matrix services?
 
@@ -391,7 +391,7 @@ Yes, you can.
 
 You generally need to do a playbook installation. It's recommended to follow the full installation guide (starting at the [Prerequisites](prerequisites.md) page), not the [Quick start](quick-start.md) guide. The full installation guide will tell you when it's time to import your existing data into the newly-prepared server.
 
-This Ansible playbook guides you into installing a server for `example.com` (user identifiers are like this: `@user:example.com`), while the server is at `matrix.example.com`. If your existing setup has a server name (`server_name` configuration setting in Synapse's `homeserver.yaml` file) other than the base `example.com`, you may need to tweak some additional variables. This FAQ entry may be of use if you're dealing with a more complicated setup - [How do I install on matrix.example.com without involving the base domain?](#how-do-i-install-on-matrixexamplecom-without-involving-the-base-domain)
+This Ansible playbook guides you into installing a server for `example.com` (user identifiers are like this: `@alice:example.com`), while the server is at `matrix.example.com`. If your existing setup has a server name (`server_name` configuration setting in Synapse's `homeserver.yaml` file) other than the base `example.com`, you may need to tweak some additional variables. This FAQ entry may be of use if you're dealing with a more complicated setup - [How do I install on matrix.example.com without involving the base domain?](#how-do-i-install-on-matrixexamplecom-without-involving-the-base-domain)
 
 After configuring the playbook and installing and **before starting** services (done with `ansible-playbook … --tags=start`) you'd import [your SQLite](importing-synapse-sqlite.md) (or [Postgres](importing-postgres.md)) database and also [import your media store](importing-synapse-media-store.md).
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -104,7 +104,7 @@ This is required for federation to work! Without a proper configuration, your se
 
 To configure the delegation, you have these two options. Choose one of them according to your situation.
 
-- If you can afford to point the base domain at the Matrix server, follow the instructions below which guide you into [serving the base domain](configuring-playbook-base-domain-serving.md) from the integrated web server. It will enable you to use a Matrix user identifier like `@<username>:example.com` while hosting services on a subdomain like `matrix.example.com`.
+- If you can afford to point the base domain at the Matrix server, follow the instructions below which guide you into [serving the base domain](configuring-playbook-base-domain-serving.md) from the integrated web server. It will enable you to use a Matrix user identifier like `@alice:example.com` while hosting services on a subdomain like `matrix.example.com`.
 - Alternatively, if you're using the base domain for other purposes and cannot point it to the Matrix server (and thus cannot "serve the base domain" from it), you most likely need to [manually install well-known files on the base domain's server](configuring-well-known.md#manually-installing-well-known-files-on-the-base-domains-server), but feel free to familiarize yourself with all [server delegation (redirection) options](howto-server-delegation.md).
 
 To have the base domain served from the integrated web server, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -104,7 +104,7 @@ This is required for federation to work! Without a proper configuration, your se
 
 To configure the delegation, you have these two options. Choose one of them according to your situation.
 
-- If you can afford to point the base domain at the Matrix server, follow the instructions below which guide you into [serving the base domain](configuring-playbook-base-domain-serving.md) from the integrated web server. It will enable you to use a Matrix user identifier like `@alice:example.com` while hosting services on a subdomain like `matrix.example.com`.
+- If you can afford to point the base domain at the Matrix server, follow the instructions below which guide you into [serving the base domain](configuring-playbook-base-domain-serving.md) from the integrated web server. It will enable you to use a Matrix user ID like `@alice:example.com` while hosting services on a subdomain like `matrix.example.com`.
 - Alternatively, if you're using the base domain for other purposes and cannot point it to the Matrix server (and thus cannot "serve the base domain" from it), you most likely need to [manually install well-known files on the base domain's server](configuring-well-known.md#manually-installing-well-known-files-on-the-base-domains-server), but feel free to familiarize yourself with all [server delegation (redirection) options](howto-server-delegation.md).
 
 To have the base domain served from the integrated web server, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -83,7 +83,7 @@ To create your user account (as an administrator of the server) via this Ansible
 
 **Notes**:
 - Make sure to adjust `YOUR_USERNAME_HERE` and `YOUR_PASSWORD_HERE`
-- For `YOUR_USERNAME_HERE`, use a plain username like `alice`, not your full identifier (`@alice:example.com`)
+- For `YOUR_USERNAME_HERE`, use a plain username like `alice`, not your full ID (`@alice:example.com`)
 - Use `admin=yes` to make your user account an administrator of the Matrix server
 
 ```sh

--- a/docs/obtaining-access-tokens.md
+++ b/docs/obtaining-access-tokens.md
@@ -26,7 +26,7 @@ You can use the following command to get an access token for your user directly 
 
 ```sh
 curl -XPOST -d '{
-    "identifier": { "type": "m.id.user", "user": "USERNAME" },
+    "identifier": { "type": "m.id.user", "user": "alice" },
     "password": "PASSWORD",
     "type": "m.login.password",
     "device_id": "YOURDEVICEID"
@@ -40,7 +40,7 @@ Your response will look like this (prettified):
 
 ```
 {
-    "user_id":"@USERNAME:example.com",
+    "user_id":"@alice:example.com",
     "access_token":">>>YOUR_ACCESS_TOKEN_IS_HERE<<<",
     "home_server":"example.com",
     "device_id":"YOURDEVICEID"

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -136,7 +136,7 @@ To create your user account (as an administrator of the server) via this Ansible
 
 **💡 Notes**:
 - Make sure to adjust `YOUR_USERNAME_HERE` and `YOUR_PASSWORD_HERE`
-- For `YOUR_USERNAME_HERE`, use a plain username like `alice`, not your full identifier (`@alice:example.com`)
+- For `YOUR_USERNAME_HERE`, use a plain username like `alice`, not your full ID (`@alice:example.com`)
 
 ```sh
 ansible-playbook -i inventory/hosts setup.yml --extra-vars='username=YOUR_USERNAME_HERE password=YOUR_PASSWORD_HERE admin=yes' --tags=register-user

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -13,7 +13,7 @@ We will be using `example.com` as the "base domain" in the following instruction
 By following the instruction on this page, you will set up:
 
 - **your own Matrix server** on a `matrix.example.com` server, which is configured to present itself as `example.com`
-- **your user account** like `@user:example.com` on the server
+- **your user account** like `@alice:example.com` on the server
 - a **self-hosted Matrix client**, [Element Web](configuring-playbook-client-element-web.md) with the default subdomain at `element.example.com`
 - Matrix delegation, so that your `matrix.example.com` server (presenting itself as `example.com`) can join the Matrix Federation and communicate with any other server in the Matrix network
 

--- a/docs/registering-users.md
+++ b/docs/registering-users.md
@@ -130,7 +130,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 To change the admin privileges for a user in Synapse's local database, you need to run an SQL query like this against the `synapse` database:
 
 ```sql
-UPDATE users SET admin=ADMIN_VALUE WHERE name = '@USER:example.com';
+UPDATE users SET admin=ADMIN_VALUE WHERE name = '@alice:example.com';
 ```
 
 where:

--- a/docs/registering-users.md
+++ b/docs/registering-users.md
@@ -15,7 +15,7 @@ Table of contents:
 
 **Notes**:
 - Make sure to adjust `USERNAME_HERE` and `PASSWORD_HERE`
-- For `USERNAME_HERE`, use a plain username like `alice`, not a full identifier (`@alice:example.com`)
+- For `USERNAME_HERE`, use a plain username like `alice`, not a full ID (`@alice:example.com`)
 - Use `admin=yes` or `admin=no` depending on whether you wish to make the user an administrator of the Matrix server
 
 After registering a user (using one of the methods below), **you can log in with that user** via the [Element Web](configuring-playbook-client-element-web.md) service that this playbook has installed for you at a URL like this: `https://element.example.com/`.

--- a/docs/updating-users-passwords.md
+++ b/docs/updating-users-passwords.md
@@ -25,7 +25,7 @@ docker exec -it matrix-synapse /usr/local/bin/hash_password -c /data/homeserver.
 and then connecting to the postgres server and executing:
 
 ```sql
-UPDATE users SET password_hash = '<password-hash>' WHERE name = '@someone:example.com';
+UPDATE users SET password_hash = '<password-hash>' WHERE name = '@alice:example.com';
 ```
 
 where `<password-hash>` is the hash returned by the docker command above.
@@ -40,8 +40,8 @@ If you didn't make your account a server admin when you created it, you can lear
 
 ### Example:
 
-To set @user:example.com's password to `correct_horse_battery_staple` you could use this curl command:
+To set @alice:example.com's password to `correct_horse_battery_staple` you could use this curl command:
 
 ```sh
-curl -XPOST -d '{ "new_password": "correct_horse_battery_staple" }' "https://matrix.example.com/_matrix/client/r0/admin/reset_password/@user:example.com?access_token=MDA...this_is_my_access_token
+curl -XPOST -d '{ "new_password": "correct_horse_battery_staple" }' "https://matrix.example.com/_matrix/client/r0/admin/reset_password/@alice:example.com?access_token=MDA...this_is_my_access_token
 ```

--- a/docs/updating-users-passwords.md
+++ b/docs/updating-users-passwords.md
@@ -4,7 +4,7 @@
 
 **Notes**:
 - Make sure to adjust `USERNAME_HERE` and `PASSWORD_HERE`
-- For `USERNAME_HERE`, use a plain username like `alice`, not a full identifier (`@alice:example.com`)
+- For `USERNAME_HERE`, use a plain username like `alice`, not a full ID (`@alice:example.com`)
 
 You can reset a user's password via the Ansible playbook:
 

--- a/examples/vars.yml
+++ b/examples/vars.yml
@@ -1,6 +1,6 @@
 ---
 # The bare domain name which represents your Matrix identity.
-# Matrix user IDs for your server will be of the form (`@user:example.com`).
+# Matrix user IDs for your server will be of the form (`@alice:example.com`).
 #
 # Note: this playbook does not touch the server referenced here.
 # Installation happens on another server ("matrix.example.com", see `matrix_server_fqn_matrix`).

--- a/roles/custom/matrix-base/defaults/main.yml
+++ b/roles/custom/matrix-base/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 # The bare domain name which represents your Matrix identity.
-# Matrix user IDs for your server will be of the form (`@user:example.com`).
+# Matrix user IDs for your server will be of the form (`@alice:example.com`).
 #
 # Note: this playbook does not touch the server referenced here.
 # Installation happens on another server ("matrix.example.com", see `matrix_server_fqn_matrix`).
@@ -10,7 +10,7 @@
 matrix_domain: ~
 
 # The optional Matrix admin MXID, used in bridges' configs to set bridge admin user
-# Example value: "@someone:{{ matrix_domain }}"
+# Example value: "@alice:{{ matrix_domain }}"
 matrix_admin: ''
 
 # Global var to enable/disable encryption across all bridges with encryption support

--- a/roles/custom/matrix-bot-chatgpt/defaults/main.yml
+++ b/roles/custom/matrix-bot-chatgpt/defaults/main.yml
@@ -57,7 +57,7 @@ matrix_bot_chatgpt_keyv_bot_storage: true
 # Matrix Static Settings (required, see notes)
 # Defaults to "https://matrix.org"
 matrix_bot_chatgpt_matrix_homeserver_url: ""  # MATRIX_HOMESERVER_URL=
-# With the @ and :example.com, ie @alice:example.com, needs to be set, created manually beforehand.
+# With the @ and :example.com, ie @bot.chatgpt:example.com, needs to be set, created manually beforehand.
 matrix_bot_chatgpt_matrix_bot_username_localpart: 'bot.chatgpt'
 matrix_bot_chatgpt_matrix_bot_username: "@{{ matrix_bot_chatgpt_matrix_bot_username_localpart }}:{{ matrix_domain }}"  # MATRIX_BOT_USERNAME=
 # Set `MATRIX_BOT_PASSWORD` the bot will print an `MATRIX_ACCESS_TOKEN` to the terminal

--- a/roles/custom/matrix-bot-chatgpt/defaults/main.yml
+++ b/roles/custom/matrix-bot-chatgpt/defaults/main.yml
@@ -57,7 +57,7 @@ matrix_bot_chatgpt_keyv_bot_storage: true
 # Matrix Static Settings (required, see notes)
 # Defaults to "https://matrix.org"
 matrix_bot_chatgpt_matrix_homeserver_url: ""  # MATRIX_HOMESERVER_URL=
-# With the @ and :example.com, ie @SOMETHING:example.com, needs to be set, created manually beforehand.
+# With the @ and :example.com, ie @alice:example.com, needs to be set, created manually beforehand.
 matrix_bot_chatgpt_matrix_bot_username_localpart: 'bot.chatgpt'
 matrix_bot_chatgpt_matrix_bot_username: "@{{ matrix_bot_chatgpt_matrix_bot_username_localpart }}:{{ matrix_domain }}"  # MATRIX_BOT_USERNAME=
 # Set `MATRIX_BOT_PASSWORD` the bot will print an `MATRIX_ACCESS_TOKEN` to the terminal
@@ -87,8 +87,8 @@ matrix_bot_chatgpt_matrix_rich_text: true  # MATRIX_RICH_TEXT=true
 # A list of admins
 # Example set of rules:
 # matrix_bot_chatgpt_admins:
-# - @someone:example.com
-# - @another:example.com
+# - @alice:example.com
+# - @bob:example.com
 # - @bot.*:example.com
 # - @*:example.net
 # matrix_bot_chatgpt_admins: "{{ [matrix_admin] if matrix_admin else [] }}"

--- a/roles/custom/matrix-bot-chatgpt/templates/env.j2
+++ b/roles/custom/matrix-bot-chatgpt/templates/env.j2
@@ -10,7 +10,7 @@ KEYV_URL={{ matrix_bot_chatgpt_keyv_url }}
 KEYV_BOT_ENCRYPTION={{ matrix_bot_chatgpt_keyv_bot_encryption|lower }}
 KEYV_BOT_STORAGE={{ matrix_bot_chatgpt_keyv_bot_storage|lower }}
 
-# With the @ and :example.com, ie @alice:example.com
+# With the @ and :example.com, ie @bot.chatgpt:example.com
 MATRIX_BOT_USERNAME={{ matrix_bot_chatgpt_matrix_bot_username }}
 MATRIX_BOT_PASSWORD={{ matrix_bot_chatgpt_matrix_bot_password }}
 

--- a/roles/custom/matrix-bot-chatgpt/templates/env.j2
+++ b/roles/custom/matrix-bot-chatgpt/templates/env.j2
@@ -10,7 +10,7 @@ KEYV_URL={{ matrix_bot_chatgpt_keyv_url }}
 KEYV_BOT_ENCRYPTION={{ matrix_bot_chatgpt_keyv_bot_encryption|lower }}
 KEYV_BOT_STORAGE={{ matrix_bot_chatgpt_keyv_bot_storage|lower }}
 
-# With the @ and :example.com, ie @SOMETHING:example.com
+# With the @ and :example.com, ie @alice:example.com
 MATRIX_BOT_USERNAME={{ matrix_bot_chatgpt_matrix_bot_username }}
 MATRIX_BOT_PASSWORD={{ matrix_bot_chatgpt_matrix_bot_password }}
 

--- a/roles/custom/matrix-bot-go-neb/defaults/main.yml
+++ b/roles/custom/matrix-bot-go-neb/defaults/main.yml
@@ -200,7 +200,7 @@ matrix_bot_go_neb_realms: []
 matrix_bot_go_neb_sessions: []
 #  - SessionID: "your_github_session"
 #    RealmID: "github_realm"
-#    UserID: "@YOUR_USER_ID:{{ matrix_domain }}" # This needs to be the username of the person that's allowed to use the !github commands
+#    UserID: "@alice:{{ matrix_domain }}" # This needs to be the username of the person that's allowed to use the !github commands
 #    Config:
 #      # Populate these fields by generating a "Personal Access Token" on github.com
 #      AccessToken: "YOUR_GITHUB_ACCESS_TOKEN"
@@ -286,7 +286,7 @@ matrix_bot_go_neb_services: []
 #    UserID: "@another_goneb:{{ matrix_domain }}"
 #    Config:
 #      RealmID: "github_realm"
-#      ClientUserID: "@YOUR_USER_ID:{{ matrix_domain }}" # needs to be an authenticated user so Go-NEB can create webhooks. Check the UserID field in the github_realm in matrix_bot_go_neb_sessions.
+#      ClientUserID: "@alice:{{ matrix_domain }}" # needs to be an authenticated user so Go-NEB can create webhooks. Check the UserID field in the github_realm in matrix_bot_go_neb_sessions.
 #      Rooms:
 #        "!qporfwt:example.com":
 #          Repos:

--- a/roles/custom/matrix-bot-honoroit/defaults/main.yml
+++ b/roles/custom/matrix-bot-honoroit/defaults/main.yml
@@ -165,8 +165,8 @@ matrix_bot_honoroit_redmine_done_status_id: ''  # done status ID (e.g. 3)
 # If not defined, everyone is allowed.
 # Example set of rules:
 # matrix_bot_honoroit_allowedusers:
-# - @someone:example.com
-# - @another:example.com
+# - @alice:example.com
+# - @bob:example.com
 # - @bot.*:example.com
 # - @*:example.net
 matrix_bot_honoroit_allowedusers:

--- a/roles/custom/matrix-bridge-appservice-kakaotalk/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-appservice-kakaotalk/templates/config.yaml.j2
@@ -225,8 +225,8 @@ bridge:
         #
         # Available variables:
         #   $sender_displayname - The display name of the sender (e.g. Example User)
-        #   $sender_username    - The username (Matrix ID localpart) of the sender (e.g. exampleuser)
-        #   $sender_mxid        - The Matrix ID of the sender (e.g. @exampleuser:example.com)
+        #   $sender_username    - The username (Matrix ID localpart) of the sender (e.g. alice)
+        #   $sender_mxid        - The Matrix ID of the sender (e.g. @alice:example.com)
         #   $message            - The message content
         message_formats:
             m.text: '<b>$sender_displayname</b>: $message'

--- a/roles/custom/matrix-bridge-mautrix-facebook/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mautrix-facebook/templates/config.yaml.j2
@@ -211,8 +211,8 @@ bridge:
         #
         # Available variables:
         #   $sender_displayname - The display name of the sender (e.g. Example User)
-        #   $sender_username    - The username (Matrix ID localpart) of the sender (e.g. exampleuser)
-        #   $sender_mxid        - The Matrix ID of the sender (e.g. @exampleuser:example.com)
+        #   $sender_username    - The username (Matrix ID localpart) of the sender (e.g. alice)
+        #   $sender_mxid        - The Matrix ID of the sender (e.g. @alice:example.com)
         #   $message            - The message content
         message_formats:
             m.text: '<b>$sender_displayname</b>: $message'

--- a/roles/custom/matrix-bridge-mautrix-instagram/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mautrix-instagram/templates/config.yaml.j2
@@ -204,8 +204,8 @@ bridge:
     #
     # Available variables:
     #   $sender_displayname - The display name of the sender (e.g. Example User)
-    #   $sender_username    - The username (Matrix ID localpart) of the sender (e.g. exampleuser)
-    #   $sender_mxid        - The Matrix ID of the sender (e.g. @exampleuser:example.com)
+    #   $sender_username    - The username (Matrix ID localpart) of the sender (e.g. alice)
+    #   $sender_mxid        - The Matrix ID of the sender (e.g. @alice:example.com)
     #   $message            - The message content
     #
     # Note that Instagram doesn't support captions for images, so images won't include any indication of being relayed.

--- a/roles/custom/matrix-bridge-mautrix-telegram/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mautrix-telegram/templates/config.yaml.j2
@@ -122,7 +122,7 @@ bridge:
     # Default: {displayname} (Telegram)
     displayname_template: {{ matrix_mautrix_telegram_displayname_template|to_json }}
 
-    # Set the preferred order of user identifiers which to use in the Matrix puppet display name.
+    # Set the preferred order of user IDs which to use in the Matrix puppet display name.
     # In the (hopefully unlikely) scenario that none of the given keys are found, the numeric user
     # ID is used.
     #

--- a/roles/custom/matrix-bridge-mautrix-telegram/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mautrix-telegram/templates/config.yaml.j2
@@ -450,8 +450,8 @@ bridge:
     #
     # Available variables:
     #   $sender_displayname - The display name of the sender (e.g. Example User)
-    #   $sender_username    - The username (Matrix ID localpart) of the sender (e.g. exampleuser)
-    #   $sender_mxid        - The Matrix ID of the sender (e.g. @exampleuser:example.com)
+    #   $sender_username    - The username (Matrix ID localpart) of the sender (e.g. alice)
+    #   $sender_mxid        - The Matrix ID of the sender (e.g. @alice:example.com)
     #   $distinguisher      - A random string from the options in the relay_user_distinguishers array.
     #   $message            - The message content
     message_formats:

--- a/roles/custom/matrix-bridge-mx-puppet-discord/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-discord/defaults/main.yml
@@ -33,14 +33,14 @@ matrix_mx_puppet_discord_appservice_address: 'http://matrix-mx-puppet-discord:{{
 
 matrix_mx_puppet_discord_bridge_mediaUrl: "{{ matrix_homeserver_url }}"  # noqa var-naming
 
-# "@user:example.com" to allow a specific user
+# "@alice:example.com" to allow a specific user
 # "@.*:example.com" to allow users on a specific homeserver
 # "@.*" to allow anyone
 matrix_mx_puppet_discord_provisioning_whitelist:
   - "@.*:{{ matrix_domain | regex_escape }}"
 
 # Leave empty to disable blacklist
-# "@user:example.com" to disallow a specific user
+# "@bob:example.com" to disallow a specific user
 # "@.*:example.com" to disallow users on a specific homeserver
 matrix_mx_puppet_discord_provisioning_blacklist: []
 

--- a/roles/custom/matrix-bridge-mx-puppet-discord/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mx-puppet-discord/templates/config.yaml.j2
@@ -31,7 +31,7 @@ provisioning:
   # Regex of Matrix IDs allowed to use the puppet bridge
   whitelist: {{ matrix_mx_puppet_discord_provisioning_whitelist|to_json }}
     # Allow a specific user
-    #- "@user:example\\.com"
+    #- "@alice:example\\.com"
     # Allow users on a specific homeserver
     #- "@.*:example\\.com"
     # Allow anyone
@@ -39,7 +39,7 @@ provisioning:
   # Regex of Matrix IDs forbidden from using the puppet bridge
   #blacklist:
     # Disallow a specific user
-    #- "@user:example\\.com"
+    #- "@bob:example\\.com"
     # Disallow users on a specific homeserver
     #- "@.*:example\\.com"
   blacklist: {{ matrix_mx_puppet_discord_provisioning_blacklist|to_json }}

--- a/roles/custom/matrix-bridge-mx-puppet-groupme/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-groupme/defaults/main.yml
@@ -29,14 +29,14 @@ matrix_mx_puppet_groupme_homeserver_address: ""
 matrix_mx_puppet_groupme_homeserver_domain: '{{ matrix_domain }}'
 matrix_mx_puppet_groupme_appservice_address: 'http://matrix-mx-puppet-groupme:{{ matrix_mx_puppet_groupme_appservice_port }}'
 
-# "@user:example.com" to allow a specific user
+# "@alice:example.com" to allow a specific user
 # "@.*:example.com" to allow users on a specific homeserver
 # "@.*" to allow anyone
 matrix_mx_puppet_groupme_provisioning_whitelist:
   - "@.*:{{ matrix_domain | regex_escape }}"
 
 # Leave empty to disable blacklist
-# "@user:example.com" to disallow a specific user
+# "@bob:example.com" to disallow a specific user
 # "@.*:example.com" to disallow users on a specific homeserver
 matrix_mx_puppet_groupme_provisioning_blacklist: []
 

--- a/roles/custom/matrix-bridge-mx-puppet-groupme/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mx-puppet-groupme/templates/config.yaml.j2
@@ -31,7 +31,7 @@ provisioning:
   # Regex of Matrix IDs allowed to use the puppet bridge
   whitelist: {{ matrix_mx_puppet_groupme_provisioning_whitelist|to_json }}
     # Allow a specific user
-    #- "@user:example\\.com"
+    #- "@alice:example\\.com"
     # Allow users on a specific homeserver
     #- "@.*:example\\.com"
     # Allow anyone
@@ -39,7 +39,7 @@ provisioning:
   # Regex of Matrix IDs forbidden from using the puppet bridge
   #blacklist:
     # Disallow a specific user
-    #- "@user:example\\.com"
+    #- "@bob:example\\.com"
     # Disallow users on a specific homeserver
     #- "@.*:example\\.com"
   blacklist: {{ matrix_mx_puppet_groupme_provisioning_blacklist|to_json }}

--- a/roles/custom/matrix-bridge-mx-puppet-instagram/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-instagram/defaults/main.yml
@@ -24,14 +24,14 @@ matrix_mx_puppet_instagram_homeserver_address: ""
 matrix_mx_puppet_instagram_homeserver_domain: '{{ matrix_domain }}'
 matrix_mx_puppet_instagram_appservice_address: 'http://matrix-mx-puppet-instagram:{{ matrix_mx_puppet_instagram_appservice_port }}'
 
-# "@user:example.com" to allow a specific user
+# "@alice:example.com" to allow a specific user
 # "@.*:example.com" to allow users on a specific homeserver
 # "@.*" to allow anyone
 matrix_mx_puppet_instagram_provisioning_whitelist:
   - "@.*:{{ matrix_domain | regex_escape }}"
 
 # Leave empty to disable blacklist
-# "@user:example.com" to disallow a specific user
+# "@bob:example.com" to disallow a specific user
 # "@.*:example.com" to disallow users on a specific homeserver
 matrix_mx_puppet_instagram_provisioning_blacklist: []
 

--- a/roles/custom/matrix-bridge-mx-puppet-instagram/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mx-puppet-instagram/templates/config.yaml.j2
@@ -24,7 +24,7 @@ provisioning:
   # Regex of Matrix IDs allowed to use the puppet bridge
   whitelist: {{ matrix_mx_puppet_instagram_provisioning_whitelist|to_json }}
     # Allow a specific user
-    #- "@user:example\\.com"
+    #- "@alice:example\\.com"
     # Allow users on a specific homeserver
     #- "@.*:example\\.com"
     # Allow anyone
@@ -32,7 +32,7 @@ provisioning:
   # Regex of Matrix IDs forbidden from using the puppet bridge
   #blacklist:
     # Disallow a specific user
-    #- "@user:example\\.com"
+    #- "@bob:example\\.com"
     # Disallow users on a specific homeserver
     #- "@.*:example\\.com"
   blacklist: {{ matrix_mx_puppet_instagram_provisioning_blacklist|to_json }}

--- a/roles/custom/matrix-bridge-mx-puppet-slack/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-slack/defaults/main.yml
@@ -42,14 +42,14 @@ matrix_mx_puppet_slack_oauth_enabled: true
 matrix_mx_puppet_slack_oauth_redirect_path: "{{ matrix_mx_puppet_slack_path_prefix }}"
 matrix_mx_puppet_slack_oauth_redirect_uri: '{{ matrix_mx_puppet_slack_scheme }}://{{ matrix_mx_puppet_slack_hostname }}{{ matrix_mx_puppet_slack_oauth_redirect_path }}'
 
-# "@user:example.com" to allow a specific user
+# "@alice:example.com" to allow a specific user
 # "@.*:example.com" to allow users on a specific homeserver
 # "@.*" to allow anyone
 matrix_mx_puppet_slack_provisioning_whitelist:
   - "@.*:{{ matrix_domain | regex_escape }}"
 
 # Leave empty to disable blacklist
-# "@user:example.com" to disallow a specific user
+# "@bob:example.com" to disallow a specific user
 # "@.*:example.com" to disallow users on a specific homeserver
 matrix_mx_puppet_slack_provisioning_blacklist: []
 

--- a/roles/custom/matrix-bridge-mx-puppet-slack/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mx-puppet-slack/templates/config.yaml.j2
@@ -38,7 +38,7 @@ provisioning:
   # Regex of Matrix IDs allowed to use the puppet bridge
   whitelist: {{ matrix_mx_puppet_slack_provisioning_whitelist|to_json }}
     # Allow a specific user
-    #- "@user:example\\.com"
+    #- "@alice:example\\.com"
     # Allow users on a specific homeserver
     #- "@.*:example\\.com"
     # Allow anyone
@@ -46,7 +46,7 @@ provisioning:
   # Regex of Matrix IDs forbidden from using the puppet bridge
   #blacklist:
     # Disallow a specific user
-    #- "@user:example\\.com"
+    #- "@bob:example\\.com"
     # Disallow users on a specific homeserver
     #- "@.*:example\\.com"
   blacklist: {{ matrix_mx_puppet_slack_provisioning_blacklist|to_json }}

--- a/roles/custom/matrix-bridge-mx-puppet-steam/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-steam/defaults/main.yml
@@ -30,14 +30,14 @@ matrix_mx_puppet_steam_homeserver_address: ""
 matrix_mx_puppet_steam_homeserver_domain: '{{ matrix_domain }}'
 matrix_mx_puppet_steam_appservice_address: 'http://matrix-mx-puppet-steam:{{ matrix_mx_puppet_steam_appservice_port }}'
 
-# "@user:example.com" to allow a specific user
+# "@alice:example.com" to allow a specific user
 # "@.*:example.com" to allow users on a specific homeserver
 # "@.*" to allow anyone
 matrix_mx_puppet_steam_provisioning_whitelist:
   - "@.*:{{ matrix_domain | regex_escape }}"
 
 # Leave empty to disable blacklist
-# "@user:example.com" to disallow a specific user
+# "@bob:example.com" to disallow a specific user
 # "@.*:example.com" to disallow users on a specific homeserver
 matrix_mx_puppet_steam_provisioning_blacklist: []
 

--- a/roles/custom/matrix-bridge-mx-puppet-steam/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mx-puppet-steam/templates/config.yaml.j2
@@ -31,7 +31,7 @@ provisioning:
   # Regex of Matrix IDs allowed to use the puppet bridge
   whitelist: {{ matrix_mx_puppet_steam_provisioning_whitelist|to_json }}
     # Allow a specific user
-    #- "@user:example\\.com"
+    #- "@alice:example\\.com"
     # Allow users on a specific homeserver
     #- "@.*:example\\.com"
     # Allow anyone
@@ -39,7 +39,7 @@ provisioning:
   # Regex of Matrix IDs forbidden from using the puppet bridge
   #blacklist:
     # Disallow a specific user
-    #- "@user:example\\.com"
+    #- "@bob:example\\.com"
     # Disallow users on a specific homeserver
     #- "@.*:example\\.com"
   blacklist: {{ matrix_mx_puppet_steam_provisioning_blacklist|to_json }}

--- a/roles/custom/matrix-bridge-mx-puppet-twitter/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-twitter/defaults/main.yml
@@ -42,14 +42,14 @@ matrix_mx_puppet_twitter_environment: ''
 matrix_mx_puppet_twitter_server_path: "{{ matrix_mx_puppet_twitter_path_prefix }}"
 matrix_mx_puppet_twitter_server_url: '{{ matrix_homeserver_url }}{{ matrix_mx_puppet_twitter_server_path }}'
 
-# "@user:example.com" to allow a specific user
+# "@alice:example.com" to allow a specific user
 # "@.*:example.com" to allow users on a specific homeserver
 # "@.*" to allow anyone
 matrix_mx_puppet_twitter_provisioning_whitelist:
   - "@.*:{{ matrix_domain | regex_escape }}"
 
 # Leave empty to disable blacklist
-# "@user:example.com" to disallow a specific user
+# "@bob:example.com" to disallow a specific user
 # "@.*:example.com" to disallow users on a specific homeserver
 matrix_mx_puppet_twitter_provisioning_blacklist: []
 

--- a/roles/custom/matrix-bridge-mx-puppet-twitter/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mx-puppet-twitter/templates/config.yaml.j2
@@ -34,7 +34,7 @@ provisioning:
   # Regex of Matrix IDs allowed to use the puppet bridge
   whitelist: {{ matrix_mx_puppet_twitter_provisioning_whitelist|to_json }}
     # Allow a specific user
-    #- "@user:example\\.com"
+    #- "@alice:example\\.com"
     # Allow users on a specific homeserver
     #- "@.*:example\\.com"
     # Allow anyone
@@ -42,7 +42,7 @@ provisioning:
   # Regex of Matrix IDs forbidden from using the puppet bridge
   #blacklist:
     # Disallow a specific user
-    #- "@user:example\\.com"
+    #- "@bob:example\\.com"
     # Disallow users on a specific homeserver
     #- "@.*:example\\.com"
   blacklist: {{ matrix_mx_puppet_twitter_provisioning_blacklist|to_json }}

--- a/roles/custom/matrix-bridge-postmoogle/defaults/main.yml
+++ b/roles/custom/matrix-bridge-postmoogle/defaults/main.yml
@@ -100,8 +100,8 @@ matrix_postmoogle_relay_password: ''
 # A list of admins
 # Example set of rules:
 # matrix_postmoogle_admins:
-# - '@someone:example.com'
-# - '@another:example.com'
+# - '@alice:example.com'
+# - '@bob:example.com'
 # - '@bot.*:example.com'
 # - '@*:example.net'
 matrix_postmoogle_admins: "{{ [matrix_admin] if matrix_admin else [] }}"

--- a/roles/custom/matrix-dendrite/templates/dendrite.yaml.j2
+++ b/roles/custom/matrix-dendrite/templates/dendrite.yaml.j2
@@ -213,7 +213,7 @@ client_api:
     threshold: {{ matrix_dendrite_client_api_rate_limiting_threshold | to_json }}
     cooloff_ms: {{ matrix_dendrite_client_api_rate_limiting_cooloff_ms | to_json }}
     exempt_user_ids:
-    #  - "@user:{{ matrix_domain }}"
+    #  - "@alice:{{ matrix_domain }}"
 
 # Configuration for the Federation API.
 federation_api:

--- a/roles/custom/matrix-email2matrix/defaults/main.yml
+++ b/roles/custom/matrix-email2matrix/defaults/main.yml
@@ -48,7 +48,7 @@ matrix_email2matrix_smtp_hostname: "{{ matrix_server_fqn_matrix }}"
 #  - MailboxName: "mailbox1"
 #    MatrixRoomId: "!qporfwt:{{ matrix_domain }}"
 #    MatrixHomeserverUrl: "{{ matrix_homeserver_url }}"
-#    MatrixUserId: "@alice:{{ matrix_domain }}"
+#    MatrixUserId: "@email2matrix1:{{ matrix_domain }}"
 #    MatrixAccessToken: "MATRIX_ACCESS_TOKEN_HERE"
 #    IgnoreSubject: false
 #    IgnoreBody: false
@@ -57,7 +57,7 @@ matrix_email2matrix_smtp_hostname: "{{ matrix_server_fqn_matrix }}"
 #  - MailboxName: "mailbox2"
 #    MatrixRoomId: "!aaabaa:{{ matrix_domain }}"
 #    MatrixHomeserverUrl: "{{ matrix_homeserver_url }}"
-#    MatrixUserId: "@bob:{{ matrix_domain }}"
+#    MatrixUserId: "@email2matrix2:{{ matrix_domain }}"
 #    MatrixAccessToken: "MATRIX_ACCESS_TOKEN_HERE"
 #    IgnoreSubject: true
 #    IgnoreBody: false

--- a/roles/custom/matrix-email2matrix/defaults/main.yml
+++ b/roles/custom/matrix-email2matrix/defaults/main.yml
@@ -48,7 +48,7 @@ matrix_email2matrix_smtp_hostname: "{{ matrix_server_fqn_matrix }}"
 #  - MailboxName: "mailbox1"
 #    MatrixRoomId: "!qporfwt:{{ matrix_domain }}"
 #    MatrixHomeserverUrl: "{{ matrix_homeserver_url }}"
-#    MatrixUserId: "@email2matrix:{{ matrix_domain }}"
+#    MatrixUserId: "@alice:{{ matrix_domain }}"
 #    MatrixAccessToken: "MATRIX_ACCESS_TOKEN_HERE"
 #    IgnoreSubject: false
 #    IgnoreBody: false
@@ -57,7 +57,7 @@ matrix_email2matrix_smtp_hostname: "{{ matrix_server_fqn_matrix }}"
 #  - MailboxName: "mailbox2"
 #    MatrixRoomId: "!aaabaa:{{ matrix_domain }}"
 #    MatrixHomeserverUrl: "{{ matrix_homeserver_url }}"
-#    MatrixUserId: "@email2matrix:{{ matrix_domain }}"
+#    MatrixUserId: "@bob:{{ matrix_domain }}"
 #    MatrixAccessToken: "MATRIX_ACCESS_TOKEN_HERE"
 #    IgnoreSubject: true
 #    IgnoreBody: false

--- a/roles/custom/matrix-media-repo/defaults/main.yml
+++ b/roles/custom/matrix-media-repo/defaults/main.yml
@@ -384,7 +384,7 @@ matrix_media_repo_access_tokens_appservices: []
 # See docs/admin.md for information on what these people can do. They must belong to one of the
 # configured homeservers above.
 # matrix_media_repo_admins: [
-#   "@your_username:example.org"
+#   "@alice:example.org"
 # ]
 
 matrix_media_repo_admins: []

--- a/roles/custom/matrix-media-repo/templates/media-repo/media-repo.yaml.j2
+++ b/roles/custom/matrix-media-repo/templates/media-repo/media-repo.yaml.j2
@@ -172,7 +172,7 @@ admins:
   | to_nice_yaml(indent=2, width=999999, sort_keys=false) | indent(width=2, first=true) }}
 {% else %}
 #admins:
-#  - "@your_username:example.org"
+#  - "@alice:example.org"
 {% endif %}
 
 # Shared secret auth is useful for applications building on top of the media repository, such

--- a/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -30,7 +30,7 @@ modules: {{ matrix_synapse_modules|to_json }}
 #
 # The server_name name will appear at the end of usernames and room addresses
 # created on this server. For example if the server_name was example.com,
-# usernames on this server would be in the format @user:example.com
+# usernames on this server would be in the format @alice:example.com
 #
 # In most cases you should avoid using a Matrix specific subdomain such as
 # matrix.example.com or synapse.example.com as the server_name for the same


### PR DESCRIPTION
This PR intends to adopt common expressions for user IDs, bridge usage, etc., to make it easier to manage documentation in bulk, fixing other stuff like incorrect examples.