### PR TITLE
Update Mjolnir from 1.9.0 to 1.9.1

### DIFF
--- a/roles/custom/matrix-bot-mjolnir/defaults/main.yml
+++ b/roles/custom/matrix-bot-mjolnir/defaults/main.yml
@@ -5,7 +5,7 @@
 matrix_bot_mjolnir_enabled: true
 
 # renovate: datasource=docker depName=matrixdotorg/mjolnir
-matrix_bot_mjolnir_version: "v1.9.0"
+matrix_bot_mjolnir_version: "v1.9.1"
 
 matrix_bot_mjolnir_container_image_self_build: false
 matrix_bot_mjolnir_container_image_self_build_repo: "https://github.com/matrix-org/mjolnir.git"


### PR DESCRIPTION
This PR bumps mjolnir to https://github.com/matrix-org/mjolnir/releases/tag/v1.9.1

This release is listed as a security release.