### PR TITLE
Change "translated" → "translations"

### DIFF
--- a/i18n/.gitignore
+++ b/i18n/.gitignore
@@ -3,4 +3,4 @@ doctrees
 .doctrees/
 /**/*.mo
 
-/translated/*
+/translations/*

--- a/i18n/README.md
+++ b/i18n/README.md
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Internationalization
 
-Translated documentation files are published and maintained in [`translated/`](translated/) directory.
+Translated documentation files are published and maintained in [`translations/`](translations/) directory.
 
 Currently, we support translation of:
 
@@ -19,13 +19,13 @@ Currently, we support translation of:
 
 Organization of this `i18n` directory is as follows:
 
-- [PUBLISHED_LANGUAGES](PUBLISHED_LANGUAGES): a list of languages that we publish translations for (in the [translated/](translated/) directory)
-- [.gitignore](.gitignore): a list of files and directories to ignore in the `i18n` directory. We intentionaly ignore translated results (`translated/<language>` directories) for languages taht are still in progress. We only [publish translations in a new language](#publish-translations-in-a-new-language) when the translation progresses beyond a certain threshold.
+- [PUBLISHED_LANGUAGES](PUBLISHED_LANGUAGES): a list of languages that we publish translations for (in the [translations/](translations/) directory)
+- [.gitignore](.gitignore): a list of files and directories to ignore in the `i18n` directory. We intentionaly ignore translated results (`translations/<language>` directories) for languages taht are still in progress. We only [publish translations in a new language](#publish-translations-in-a-new-language) when the translation progresses beyond a certain threshold.
 - [justfile](justfile): a list of recipes for [just](https://github.com/casey/just) command runner
 - [requirements.txt](requirements.txt): a list of Python packages required to work with translations
 - [translation-templates/](translation-templates/): a list of English translation templates - strings extracted from Markdown files
 - [locales/](locales/): localization files for languages
-- [translated/](translated/): translated documents for published languages (see [PUBLISHED_LANGUAGES](PUBLISHED_LANGUAGES) and [publish translations in a new language](#publish-translations-in-a-new-language))
+- [translations/](translations/): translated documents for published languages (see [PUBLISHED_LANGUAGES](PUBLISHED_LANGUAGES) and [publish translations in a new language](#publish-translations-in-a-new-language))
 
 ## Guide for translators
 
@@ -55,7 +55,7 @@ Recommended flow when working on a new language (replace `<language>` with the l
 
 - Build translated documents: `just build-for-language <language>`
 
-- Preview the result in the `translated/<language>` directory
+- Preview the result in the `translations/<language>` directory
 
 - Commit your changes done to the `locales/<language>` directory
 
@@ -88,7 +88,7 @@ Recommended flow when working on a new language (replace `<language>` with the l
 
 - Build translated documents: `./bin/build-translated-result.sh <language>`
 
-- Preview the result in the `translated/<language>` directory
+- Preview the result in the `translations/<language>` directory
 
 - Commit your changes done to the `locales/<language>` directory
 
@@ -96,9 +96,9 @@ Recommended flow when working on a new language (replace `<language>` with the l
 
 ### Publish translations in a new language
 
-To publish prebuilt documents translated in a new language to the `translated/<language>` directory:
+To publish prebuilt documents translated in a new language to the `translations/<language>` directory:
 
 - add its language code to the [PUBLISHED_LANGUAGES](PUBLISHED_LANGUAGES) file
-- whitelist its `translated/<language>` directory by adding a `!translated/<language>` rule to the [.gitignore](.gitignore) file
+- whitelist its `translations/<language>` directory by adding a `!translations/<language>` rule to the [.gitignore](.gitignore) file
 
 💡 Leave a trailing new line at the end of the [PUBLISHED_LANGUAGES](PUBLISHED_LANGUAGES) file.

--- a/i18n/bin/build-translated-result.sh
+++ b/i18n/bin/build-translated-result.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 # SPDX-FileCopyrightText: 2024 Slavi Pantaleev <slavi@devture.com>
+# SPDX-FileCopyrightText: 2024 Suguru Hirahara <acioustick@noreply.codeberg.org>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-# This script builds the translated result (translated project) for a given language in the `translated/<language>/` directory.
+# This script builds the translated result (translated project) for a given language in the `translations/<language>/` directory.
 
 set -euxo pipefail
 
@@ -47,14 +48,14 @@ rm -rf ${base_path}/i18n/translated-result-build-${LANGUAGE}/.doctrees
 cp -r ${base_path}/docs/assets ${base_path}/i18n/translated-result-build-${LANGUAGE}/docs/assets/
 
 # Remove the old result directory for this language
-if [ -d ${base_path}/i18n/translated/${LANGUAGE} ]; then
-    rm -rf ${base_path}/i18n/translated/${LANGUAGE}
+if [ -d ${base_path}/i18n/translations/${LANGUAGE} ]; then
+    rm -rf ${base_path}/i18n/translations/${LANGUAGE}
 fi
 
-# Make sure the `translated/` directory exists
+# Make sure the `translations/` directory exists
 if [ ! -d ${base_path}/i18n/translated ]; then
     mkdir -p ${base_path}/i18n/translated
 fi
 
-# Relocate the built result to translated/<language>
-mv ${base_path}/i18n/translated-result-build-${LANGUAGE} ${base_path}/i18n/translated/${LANGUAGE}
+# Relocate the built result to translations/<language>
+mv ${base_path}/i18n/translated-result-build-${LANGUAGE} ${base_path}/i18n/translations/${LANGUAGE}

--- a/i18n/justfile
+++ b/i18n/justfile
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024 Slavi Pantaleev <slavi@devture.com>
+# SPDX-FileCopyrightText: 2024 Suguru Hirahara <acioustick@noreply.codeberg.org>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -34,18 +35,18 @@ sync-for-language language: extract-translation-templates (_sync-translation-tem
 _sync-translation-templates-to-locales-for-language language: _venv
     PATH={{ justfile_directory() }}/.venv/bin:$PATH {{ justfile_directory() }}/bin/sync-translation-templates-to-locales.sh {{ language }}
 
-# Builds the translated result for a given language into the `translated/{{ language }}` directory
+# Builds the translated result for a given language into the `translations/{{ language }}` directory
 build-for-language language: _venv
     PATH={{ justfile_directory() }}/.venv/bin:$PATH {{ justfile_directory() }}/bin/build-translated-result.sh {{ language }}
 
-# Builds the translated result for all published languages into the `translated/` directory
+# Builds the translated result for all published languages into the `translations/` directory
 build-for-all-published-languages:
     #!/bin/sh
     cat {{ justfile_directory() }}/PUBLISHED_LANGUAGES | while read language ; do
         {{ just_executable() }} build-for-language $language
     done
 
-# Builds the translated result for all known languages into the `translated/` directory
+# Builds the translated result for all known languages into the `translations/` directory
 build-for-all-known-languages:
     #!/bin/sh
     find {{ justfile_directory() }}/locales -mindepth 1 -maxdepth 1 -type d | while read path ; do

--- a/i18n/translation-templates/i18n/README.pot
+++ b/i18n/translation-templates/i18n/README.pot
@@ -21,7 +21,7 @@ msgid "Internationalization"
 msgstr ""
 
 #: ../../README.md:3
-msgid "Translated documentation files are published and maintained in [`translated/`](translated/) directory."
+msgid "Translated documentation files are published and maintained in [`translations/`](translations/) directory."
 msgstr ""
 
 #: ../../README.md:5
@@ -49,11 +49,11 @@ msgid "Organization of this `i18n` directory is as follows:"
 msgstr ""
 
 #: ../../README.md:15
-msgid "[PUBLISHED_LANGUAGES](PUBLISHED_LANGUAGES): a list of languages that we publish translations for (in the [translated/](translated/) directory)"
+msgid "[PUBLISHED_LANGUAGES](PUBLISHED_LANGUAGES): a list of languages that we publish translations for (in the [translations/](translations/) directory)"
 msgstr ""
 
 #: ../../README.md:16
-msgid "[.gitignore](.gitignore): a list of files and directories to ignore in the `i18n` directory. We intentionaly ignore translated results (`translated/<language>` directories) for languages taht are still in progress. We only [publish translations in a new language](#publish-translations-in-a-new-language) when the translation progresses beyond a certain threshold."
+msgid "[.gitignore](.gitignore): a list of files and directories to ignore in the `i18n` directory. We intentionaly ignore translated results (`translations/<language>` directories) for languages taht are still in progress. We only [publish translations in a new language](#publish-translations-in-a-new-language) when the translation progresses beyond a certain threshold."
 msgstr ""
 
 #: ../../README.md:17
@@ -73,7 +73,7 @@ msgid "[locales/](locales/): localization files for languages"
 msgstr ""
 
 #: ../../README.md:21
-msgid "[translated/](translated/): translated documents for published languages (see [PUBLISHED_LANGUAGES](PUBLISHED_LANGUAGES) and [publish translations in a new language](#publish-translations-in-a-new-language))"
+msgid "[translations/](translations/): translated documents for published languages (see [PUBLISHED_LANGUAGES](PUBLISHED_LANGUAGES) and [publish translations in a new language](#publish-translations-in-a-new-language))"
 msgstr ""
 
 #: ../../README.md:23
@@ -138,7 +138,7 @@ msgstr ""
 
 #: ../../README.md:51
 #: ../../README.md:84
-msgid "Preview the result in the `translated/<language>` directory"
+msgid "Preview the result in the `translations/<language>` directory"
 msgstr ""
 
 #: ../../README.md:53
@@ -200,7 +200,7 @@ msgid "Publish translations in a new language"
 msgstr ""
 
 #: ../../README.md:92
-msgid "To publish prebuilt documents translated in a new language to the `translated/<language>` directory:"
+msgid "To publish prebuilt documents translated in a new language to the `translations/<language>` directory:"
 msgstr ""
 
 #: ../../README.md:94
@@ -208,7 +208,7 @@ msgid "add its language code to the [PUBLISHED_LANGUAGES](PUBLISHED_LANGUAGES) f
 msgstr ""
 
 #: ../../README.md:95
-msgid "whitelist its `translated/<language>` directory by adding a `!translated/<language>` rule to the [.gitignore](.gitignore) file"
+msgid "whitelist its `translations/<language>` directory by adding a `!translations/<language>` rule to the [.gitignore](.gitignore) file"
 msgstr ""
 
 #: ../../README.md:97


### PR DESCRIPTION
I think it is better to use the word "translations" on this context.

Note: this commit does not include PO files as I thought we might as well to update them from POT files, per an expected workflow.