### PR TITLE
Edit docs for bots: adopt the common format

### DIFF
--- a/docs/configuring-playbook-alertmanager-receiver.md
+++ b/docs/configuring-playbook-alertmanager-receiver.md
@@ -22,7 +22,7 @@ You can use the playbook to [register a new user](registering-users.md):
 ansible-playbook -i inventory/hosts setup.yml --extra-vars='username=bot.alertmanager.receiver password=PASSWORD_FOR_THE_BOT admin=no' --tags=register-user
 ```
 
-### Get an access token
+### Obtain an access token
 
 The bot requires an access token to be able to connect to your homeserver. Refer to the documentation on [how to obtain an access token](obtaining-access-tokens.md).
 
@@ -36,7 +36,7 @@ Then, log in as the bot using any Matrix client of your choosing, accept the roo
 
 ## Adjusting the playbook configuration
 
-Add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file. Make sure to replace `ACCESS_TOKEN_HERE` with the one created [above](#get-an-access-token).
+Add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file. Make sure to replace `ACCESS_TOKEN_HERE` with the one created [above](#obtain-an-access-token).
 
 ```yaml
 matrix_alertmanager_receiver_enabled: true
@@ -44,7 +44,6 @@ matrix_alertmanager_receiver_enabled: true
 # Uncomment and adjust this part if you'd like to use a username different than the default
 # matrix_alertmanager_receiver_config_matrix_user_id_localpart: "bot.alertmanager.receiver"
 
-# Specify the bot user's access token here.
 matrix_alertmanager_receiver_config_matrix_access_token: "ACCESS_TOKEN_HERE"
 
 # Optionally, configure some mappings (URL-friendly room name -> actual Matrix room ID).

--- a/docs/configuring-playbook-bot-baibot.md
+++ b/docs/configuring-playbook-bot-baibot.md
@@ -30,7 +30,7 @@ Depending on your current `vars.yml` file and desired configuration, **you may r
 
 ### Base configuration
 
-Add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:
+To enable the bot, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:
 
 ```yaml
 matrix_bot_baibot_enabled: true

--- a/docs/configuring-playbook-bot-buscarron.md
+++ b/docs/configuring-playbook-bot-buscarron.md
@@ -6,7 +6,7 @@ Buscarron is bot that receives HTTP POST submissions of web forms and forwards t
 
 ## Adjusting the playbook configuration
 
-To enable Buscarron, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:
+To enable the bot, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:
 
 ```yaml
 matrix_bot_buscarron_enabled: true

--- a/docs/configuring-playbook-bot-chatgpt.md
+++ b/docs/configuring-playbook-bot-chatgpt.md
@@ -6,11 +6,15 @@ The playbook can install and configure [matrix-chatgpt-bot](https://github.com/m
 
 Talk to [ChatGPT](https://openai.com/blog/chatgpt/) via your favourite Matrix client!
 
-## Register the bot account
+## Prerequisites
 
-The playbook does not automatically create users for you. The bot requires an access token to be able to connect to your homeserver.
+### Obtain an OpenAI API key
 
-You **need to register the bot user manually** before setting up the bot.
+To use the bot, you'd need to obtain an API key from [https://platform.openai.com/account/api-keys](https://platform.openai.com/account/api-keys).
+
+### Register the bot account
+
+The playbook does not automatically create users for you. You **need to register the bot user manually** before setting up the bot.
 
 Generate a strong password for the bot. You can create one with a command like `pwgen -s 64 1`.
 
@@ -20,36 +24,30 @@ You can use the playbook to [register a new user](registering-users.md):
 ansible-playbook -i inventory/hosts setup.yml --extra-vars='username=bot.chatgpt password=PASSWORD_FOR_THE_BOT admin=no' --tags=register-user
 ```
 
-## Get an access token and create encryption keys
+### Obtain an access token and create encryption keys
 
-Refer to the documentation on [how to obtain an access token](obtaining-access-tokens.md).
+The bot requires an access token to be able to connect to your homeserver. Refer to the documentation on [how to obtain an access token](obtaining-access-tokens.md).
 
 To make sure the bot can read encrypted messages, it will need an encryption key, just like any other new user. While obtaining the access token, follow the prompts to setup a backup key. More information can be found in the [Element documentation](https://element.io/help#encryption6).
 
 ## Adjusting the playbook configuration
 
-Add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file (adapt to your needs):
+To enable the bot, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file. Make sure to replace `API_KEY_HERE` with the API key retrieved [here](#obtain-an-openai-api-key) and `ACCESS_TOKEN_HERE` with the access token created [here](#obtain-an-access-token-and-create-encryption-keys), respectively.
 
 ```yaml
 matrix_bot_chatgpt_enabled: true
 
-# Obtain a new API key from https://platform.openai.com/account/api-keys
-matrix_bot_chatgpt_openai_api_key: ''
+matrix_bot_chatgpt_openai_api_key: 'API_KEY_HERE'
 
-# This is the default username
+# Uncomment and adjust this part if you'd like to use a username different than the default
 # matrix_bot_chatgpt_matrix_bot_username_localpart: 'bot.chatgpt'
 
-# Matrix access token (from bot user above)
-# see: https://webapps.stackexchange.com/questions/131056/how-to-get-an-access-token-for-element-riot-matrix
-matrix_bot_chatgpt_matrix_access_token: ''
+matrix_bot_chatgpt_matrix_access_token: 'ACCESS_TOKEN_HERE'
 
 # Configuring the system promt used, needed if the bot is used for special tasks.
 # More information: https://github.com/mustvlad/ChatGPT-System-Prompts
 matrix_bot_chatgpt_matrix_bot_prompt_prefix: 'Instructions:\nYou are ChatGPT, a large language model trained by OpenAI.'
-
 ```
-
-You will need to get tokens for ChatGPT.
 
 ## Installing
 

--- a/docs/configuring-playbook-bot-draupnir.md
+++ b/docs/configuring-playbook-bot-draupnir.md
@@ -24,7 +24,7 @@ ansible-playbook -i inventory/hosts setup.yml --extra-vars='username=bot.draupni
 
 If you would like Draupnir to be able to deactivate users, move aliases, shutdown rooms, show abuse reports (see [below](#abuse-reports)), etc then it must be a server admin so you need to change `admin=no` to `admin=yes` in the command above.
 
-### Get an access token
+### Obtain an access token
 
 The bot requires an access token to be able to connect to your homeserver. Refer to the documentation on [how to obtain an access token](obtaining-access-tokens.md).
 
@@ -64,7 +64,7 @@ Finally invite the `@bot.draupnir:example.com` account you created earlier into 
 
 ## Adjusting the playbook configuration
 
-Add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file. Make sure to replace `MANAGEMENT_ROOM_ID_HERE`.
+To enable the bot, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file. Make sure to replace `MANAGEMENT_ROOM_ID_HERE`.
 
 ```yaml
 # Enable Draupnir
@@ -113,7 +113,7 @@ matrix_bot_draupnir_raw_homeserver_url: "{{ matrix_addons_homeserver_client_api_
 
 When NOT using Pantalaimon, Draupnir does not log in by itself and you must give it an access token for its bot account.
 
-Add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file. Make sure to replace `ACCESS_TOKEN_HERE` with the one created [above](#get-an-access-token).
+Add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file. Make sure to replace `ACCESS_TOKEN_HERE` with the one created [above](#obtain-an-access-token).
 
 ```yaml
 matrix_bot_draupnir_access_token: "ACCESS_TOKEN_HERE"

--- a/docs/configuring-playbook-bot-go-neb.md
+++ b/docs/configuring-playbook-bot-go-neb.md
@@ -8,11 +8,11 @@ Go-NEB is a Matrix bot written in Go. It is the successor to Matrix-NEB, the ori
 
 See the project's [documentation](https://github.com/matrix-org/go-neb/blob/master/README.md) to learn what it does and why it might be useful to you.
 
-## Registering the bot account
+## Prerequisites
 
-The playbook does not automatically create users for you. The bot requires at least 1 access token to be able to connect to your homeserver.
+### Register the bot account
 
-You **need to register the bot user manually** before setting up the bot.
+The playbook does not automatically create users for you. You **need to register the bot user manually** before setting up the bot.
 
 Generate a strong password for the bot. You can create one with a command like `pwgen -s 64 1`.
 
@@ -22,11 +22,13 @@ You can use the playbook to [register a new user](registering-users.md):
 ansible-playbook -i inventory/hosts setup.yml --extra-vars='username=bot.go-neb password=PASSWORD_FOR_THE_BOT admin=no' --tags=register-user
 ```
 
-Once the user is created you can [obtain an access token](obtaining-access-tokens.md).
+### Obtain an access token
+
+The bot requires an access token to be able to connect to your homeserver. Refer to the documentation on [how to obtain an access token](obtaining-access-tokens.md).
 
 ## Adjusting the playbook configuration
 
-To enable Go-NEB, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:
+To enable the bot, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file. Make sure to replace `ACCESS_TOKEN_FOR_GONEB_HERE` and `ACCESS_TOKEN_FOR_ANOTHER_GONEB_HERE` with the ones created [above](#obtain-an-access-token).
 
 ```yaml
 matrix_bot_go_neb_enabled: true
@@ -35,7 +37,7 @@ matrix_bot_go_neb_enabled: true
 # Use the access token you obtained in the step above.
 matrix_bot_go_neb_clients:
   - UserID: "@goneb:{{ matrix_domain }}"
-    AccessToken: "MDASDASJDIASDJASDAFGFRGER"
+    AccessToken: "ACCESS_TOKEN_FOR_GONEB_HERE"
     DeviceID: "DEVICE1"
     HomeserverURL: "{{ matrix_addons_homeserver_client_api_url }}"
     Sync: true
@@ -44,7 +46,7 @@ matrix_bot_go_neb_clients:
     AcceptVerificationFromUsers: [":{{ matrix_domain }}"]
 
   - UserID: "@another_goneb:{{ matrix_domain }}"
-    AccessToken: "MDASDASJDIASDJASDAFGFRGER"
+    AccessToken: "ACCESS_TOKEN_FOR_ANOTHER_GONEB_HERE"
     DeviceID: "DEVICE2"
     HomeserverURL: "{{ matrix_addons_homeserver_client_api_url }}"
     Sync: false
@@ -105,7 +107,7 @@ matrix_bot_go_neb_services:
       api_key: "AIzaSyA4FD39m9"
       cx: "AIASDFWSRRtrtr"
 
-# Get a key via https://api.imgur.com/oauth2/addclient
+# Obtain a key via https://api.imgur.com/oauth2/addclient
 # Select "oauth2 without callback url"
   - ID: "imgur_service"
     Type: "imgur"

--- a/docs/configuring-playbook-bot-honoroit.md
+++ b/docs/configuring-playbook-bot-honoroit.md
@@ -8,7 +8,7 @@ See the project's [documentation](https://github.com/etkecc/honoroit/blob/main/R
 
 ## Adjusting the playbook configuration
 
-To enable Honoroit, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:
+To enable the bot, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:
 
 ```yaml
 matrix_bot_honoroit_enabled: true

--- a/docs/configuring-playbook-bot-matrix-registration-bot.md
+++ b/docs/configuring-playbook-bot-matrix-registration-bot.md
@@ -6,7 +6,7 @@ The bot allows you to easily **create and manage registration tokens** aka. invi
 
 See the project's [documentation](https://github.com/moan0s/matrix-registration-bot/blob/master/README.md) to learn what it does and why it might be useful to you.
 
-## Configuration
+## Adjusting the playbook configuration
 
 To enable the bot, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:
 

--- a/docs/configuring-playbook-bot-matrix-reminder-bot.md
+++ b/docs/configuring-playbook-bot-matrix-reminder-bot.md
@@ -8,7 +8,7 @@ See the project's [documentation](https://github.com/anoadragon453/matrix-remind
 
 ## Adjusting the playbook configuration
 
-Add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:
+To enable the bot, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:
 
 ```yaml
 matrix_bot_matrix_reminder_bot_enabled: true

--- a/docs/configuring-playbook-bot-maubot.md
+++ b/docs/configuring-playbook-bot-maubot.md
@@ -8,7 +8,7 @@ See the project's [documentation](https://docs.mau.fi/maubot/usage/basic.html) t
 
 ## Adjusting the playbook configuration
 
-To enable maubot, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:
+To enable the bot, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:
 
 ```yaml
 matrix_bot_maubot_enabled: true
@@ -75,7 +75,7 @@ You should start in the following order
 2. **Upload some Plugins**: Plugins can be obtained from [here](https://github.com/maubot/maubot#plugins) or any other source.
 3. **Create an instance**: An instance is the actual bot. You have to specify a client which the bot instance will use and the plugin (how the bot will behave)
 
-## Obtaining an access token
+## Obtain an access token
 
 This can be done via `mbc login` then `mbc auth` (see the [maubot documentation](https://docs.mau.fi/maubot/usage/cli/auth.html)). To run these commands, you'll first need to `exec` into the maubot container with `docker exec -it matrix-bot-maubot sh`.
 

--- a/docs/configuring-playbook-bot-mjolnir.md
+++ b/docs/configuring-playbook-bot-mjolnir.md
@@ -20,7 +20,7 @@ ansible-playbook -i inventory/hosts setup.yml --extra-vars='username=bot.mjolnir
 
 If you would like Mjolnir to be able to deactivate users, move aliases, shutdown rooms, etc then it must be a server admin so you need to change `admin=no` to `admin=yes` in the command above.
 
-### Get an access token
+### Obtain an access token
 
 The bot requires an access token to be able to connect to your homeserver. Refer to the documentation on [how to obtain an access token](obtaining-access-tokens.md).
 
@@ -60,7 +60,7 @@ Finally invite the `@bot.mjolnir:example.com` account you created earlier into t
 
 ## Adjusting the playbook configuration
 
-Add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file. Make sure to replace `MANAGEMENT_ROOM_ID_HERE`.
+To enable the bot, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file. Make sure to replace `MANAGEMENT_ROOM_ID_HERE`.
 
 ```yaml
 # Enable Mjolnir
@@ -109,7 +109,7 @@ matrix_bot_mjolnir_raw_homeserver_url: "{{ matrix_addons_homeserver_client_api_u
 
 When NOT using Pantalaimon, Mjolnir does not log in by itself and you must give it an access token for its bot account.
 
-Add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file. Make sure to replace `ACCESS_TOKEN_HERE` with the one created [above](#get-an-access-token).
+Add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file. Make sure to replace `ACCESS_TOKEN_HERE` with the one created [above](#obtain-an-access-token).
 
 ```yaml
 matrix_bot_mjolnir_access_token: "ACCESS_TOKEN_HERE"

--- a/docs/configuring-playbook-email2matrix.md
+++ b/docs/configuring-playbook-email2matrix.md
@@ -38,7 +38,7 @@ Inviting additional people to the room is okay too.
 
 Take note of each room's room ID (different clients show the room ID in a different place). You'll need the room ID when [configuring the playbook](#adjusting-the-playbook-configuration) below.
 
-### Obtaining an access token for the sender user
+### Obtain an access token for the sender user
 
 In order for the sender user created above to be able to send messages to the room, we'll need to obtain an access token for it. Refer to the documentation on [how to obtain an access token](obtaining-access-tokens.md).
 

--- a/docs/howto-server-delegation.md
+++ b/docs/howto-server-delegation.md
@@ -51,7 +51,7 @@ To use DNS SRV record validation, you need to:
 
 For more details on how to configure the playbook to work with SRV delegation, take a look at this documentation: [Server Delegation via a DNS SRV record (advanced)](howto-srv-server-delegation.md)
 
-### Obtaining certificates
+### Obtain certificates
 
 How you can obtain a valid certificate for `example.com` on the `matrix.example.com` server is up to you.
 

--- a/i18n/translation-templates/docs/configuring-playbook-alertmanager-receiver.pot
+++ b/i18n/translation-templates/docs/configuring-playbook-alertmanager-receiver.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: matrix-docker-ansible-deploy \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 17:53+0900\n"
+"POT-Creation-Date: 2024-12-23 13:09+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -57,7 +57,7 @@ msgid "You can use the playbook to [register a new user](registering-users.md):"
 msgstr ""
 
 #: ../../../docs/configuring-playbook-alertmanager-receiver.md:25
-msgid "Get an access token"
+msgid "Obtain an access token"
 msgstr ""
 
 #: ../../../docs/configuring-playbook-alertmanager-receiver.md:27
@@ -85,77 +85,77 @@ msgid "Adjusting the playbook configuration"
 msgstr ""
 
 #: ../../../docs/configuring-playbook-alertmanager-receiver.md:39
-msgid "Add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file. Make sure to replace `ACCESS_TOKEN_HERE` with the one created [above](#get-an-access-token)."
+msgid "Add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file. Make sure to replace `ACCESS_TOKEN_HERE` with the one created [above](#obtain-an-access-token)."
 msgstr ""
 
-#: ../../../docs/configuring-playbook-alertmanager-receiver.md:61
+#: ../../../docs/configuring-playbook-alertmanager-receiver.md:60
 msgid "See `roles/custom/matrix-alertmanager-receiver/defaults/main.yml` for additional configuration variables."
 msgstr ""
 
-#: ../../../docs/configuring-playbook-alertmanager-receiver.md:63
+#: ../../../docs/configuring-playbook-alertmanager-receiver.md:62
 msgid "Adjusting the matrix-alertmanager-receiver URL"
 msgstr ""
 
-#: ../../../docs/configuring-playbook-alertmanager-receiver.md:65
+#: ../../../docs/configuring-playbook-alertmanager-receiver.md:64
 msgid "By default, this playbook installs matrix-alertmanager-receiver on the `matrix.` subdomain, at the `/matrix-alertmanager-receiver` path (https://matrix.example.com/matrix-alertmanager-receiver). This makes it easy to install it, because it **doesn't require additional DNS records to be set up**. If that's okay, you can skip this section."
 msgstr ""
 
-#: ../../../docs/configuring-playbook-alertmanager-receiver.md:67
+#: ../../../docs/configuring-playbook-alertmanager-receiver.md:66
 msgid "By tweaking the `matrix_alertmanager_receiver_hostname` and `matrix_alertmanager_receiver_path_prefix` variables, you can easily make the service available at a **different hostname and/or path** than the default one."
 msgstr ""
 
-#: ../../../docs/configuring-playbook-alertmanager-receiver.md:69
+#: ../../../docs/configuring-playbook-alertmanager-receiver.md:68
 msgid "Example additional configuration for your `inventory/host_vars/matrix.example.com/vars.yml` file:"
 msgstr ""
 
-#: ../../../docs/configuring-playbook-alertmanager-receiver.md:77
+#: ../../../docs/configuring-playbook-alertmanager-receiver.md:76
 msgid "Adjusting DNS records"
 msgstr ""
 
-#: ../../../docs/configuring-playbook-alertmanager-receiver.md:79
+#: ../../../docs/configuring-playbook-alertmanager-receiver.md:78
 msgid "If you've changed the default hostname, **you may need to adjust your DNS** records to point the matrix-alertmanager-receiver domain to the Matrix server."
 msgstr ""
 
-#: ../../../docs/configuring-playbook-alertmanager-receiver.md:81
+#: ../../../docs/configuring-playbook-alertmanager-receiver.md:80
 msgid "See [Configuring DNS](configuring-dns.md) for details about DNS changes."
 msgstr ""
 
-#: ../../../docs/configuring-playbook-alertmanager-receiver.md:83
+#: ../../../docs/configuring-playbook-alertmanager-receiver.md:82
 msgid "If you've decided to use the default hostname, you won't need to do any extra DNS configuration."
 msgstr ""
 
-#: ../../../docs/configuring-playbook-alertmanager-receiver.md:85
+#: ../../../docs/configuring-playbook-alertmanager-receiver.md:84
 msgid "Installing"
 msgstr ""
 
-#: ../../../docs/configuring-playbook-alertmanager-receiver.md:87
+#: ../../../docs/configuring-playbook-alertmanager-receiver.md:86
 msgid "After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:"
 msgstr ""
 
-#: ../../../docs/configuring-playbook-alertmanager-receiver.md:94
+#: ../../../docs/configuring-playbook-alertmanager-receiver.md:93
 msgid "**Notes**:"
 msgstr ""
 
-#: ../../../docs/configuring-playbook-alertmanager-receiver.md:96
+#: ../../../docs/configuring-playbook-alertmanager-receiver.md:95
 msgid "The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account."
 msgstr ""
 
-#: ../../../docs/configuring-playbook-alertmanager-receiver.md:98
+#: ../../../docs/configuring-playbook-alertmanager-receiver.md:97
 msgid "The shortcut commands with the [`just` program](just.md) are also available: `just install-all` or `just setup-all`"
 msgstr ""
 
-#: ../../../docs/configuring-playbook-alertmanager-receiver.md:100
+#: ../../../docs/configuring-playbook-alertmanager-receiver.md:99
 msgid "`just install-all` is useful for maintaining your setup quickly ([2x-5x faster](../CHANGELOG.md#2x-5x-performance-improvements-in-playbook-runtime) than `just setup-all`) when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed."
 msgstr ""
 
-#: ../../../docs/configuring-playbook-alertmanager-receiver.md:102
+#: ../../../docs/configuring-playbook-alertmanager-receiver.md:101
 msgid "Usage"
 msgstr ""
 
-#: ../../../docs/configuring-playbook-alertmanager-receiver.md:104
+#: ../../../docs/configuring-playbook-alertmanager-receiver.md:103
 msgid "Configure your Prometheus Alertmanager with configuration like this:"
 msgstr ""
 
-#: ../../../docs/configuring-playbook-alertmanager-receiver.md:123
+#: ../../../docs/configuring-playbook-alertmanager-receiver.md:122
 msgid "where `URL_HERE` looks like `https://matrix.example.com/matrix-alertmanager-receiver-RANDOM_VALUE_HERE/alert/some-room-name` or `https://matrix.example.com/matrix-alertmanager-receiver-RANDOM_VALUE_HERE/alert/!qporfwt:example.com`."
 msgstr ""

--- a/i18n/translation-templates/docs/configuring-playbook-bot-baibot.pot
+++ b/i18n/translation-templates/docs/configuring-playbook-bot-baibot.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: matrix-docker-ansible-deploy \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 11:54+0900\n"
+"POT-Creation-Date: 2024-12-23 13:09+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -77,7 +77,7 @@ msgid "Base configuration"
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-baibot.md:33
-msgid "Add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:"
+msgid "To enable the bot, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:"
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-baibot.md:71

--- a/i18n/translation-templates/docs/configuring-playbook-bot-buscarron.pot
+++ b/i18n/translation-templates/docs/configuring-playbook-bot-buscarron.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: matrix-docker-ansible-deploy \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 11:54+0900\n"
+"POT-Creation-Date: 2024-12-23 13:09+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -33,7 +33,7 @@ msgid "Adjusting the playbook configuration"
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-buscarron.md:9
-msgid "To enable Buscarron, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:"
+msgid "To enable the bot, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:"
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-buscarron.md:32

--- a/i18n/translation-templates/docs/configuring-playbook-bot-chatgpt.pot
+++ b/i18n/translation-templates/docs/configuring-playbook-bot-chatgpt.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: matrix-docker-ansible-deploy \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 17:53+0900\n"
+"POT-Creation-Date: 2024-12-23 13:09+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -33,85 +33,89 @@ msgid "Talk to [ChatGPT](https://openai.com/blog/chatgpt/) via your favourite Ma
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-chatgpt.md:9
-msgid "Register the bot account"
+msgid "Prerequisites"
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-chatgpt.md:11
-msgid "The playbook does not automatically create users for you. The bot requires an access token to be able to connect to your homeserver."
+msgid "Obtain an OpenAI API key"
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-chatgpt.md:13
-msgid "You **need to register the bot user manually** before setting up the bot."
+msgid "To use the bot, you'd need to obtain an API key from [https://platform.openai.com/account/api-keys](https://platform.openai.com/account/api-keys)."
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-chatgpt.md:15
-msgid "Generate a strong password for the bot. You can create one with a command like `pwgen -s 64 1`."
+msgid "Register the bot account"
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-chatgpt.md:17
+msgid "The playbook does not automatically create users for you. You **need to register the bot user manually** before setting up the bot."
+msgstr ""
+
+#: ../../../docs/configuring-playbook-bot-chatgpt.md:19
+msgid "Generate a strong password for the bot. You can create one with a command like `pwgen -s 64 1`."
+msgstr ""
+
+#: ../../../docs/configuring-playbook-bot-chatgpt.md:21
 msgid "You can use the playbook to [register a new user](registering-users.md):"
 msgstr ""
 
-#: ../../../docs/configuring-playbook-bot-chatgpt.md:23
-msgid "Get an access token and create encryption keys"
-msgstr ""
-
-#: ../../../docs/configuring-playbook-bot-chatgpt.md:25
-msgid "Refer to the documentation on [how to obtain an access token](obtaining-access-tokens.md)."
-msgstr ""
-
 #: ../../../docs/configuring-playbook-bot-chatgpt.md:27
-msgid "To make sure the bot can read encrypted messages, it will need an encryption key, just like any other new user. While obtaining the access token, follow the prompts to setup a backup key. More information can be found in the [Element documentation](https://element.io/help#encryption6)."
+msgid "Obtain an access token and create encryption keys"
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-chatgpt.md:29
-msgid "Adjusting the playbook configuration"
+msgid "The bot requires an access token to be able to connect to your homeserver. Refer to the documentation on [how to obtain an access token](obtaining-access-tokens.md)."
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-chatgpt.md:31
-msgid "Add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file (adapt to your needs):"
+msgid "To make sure the bot can read encrypted messages, it will need an encryption key, just like any other new user. While obtaining the access token, follow the prompts to setup a backup key. More information can be found in the [Element documentation](https://element.io/help#encryption6)."
+msgstr ""
+
+#: ../../../docs/configuring-playbook-bot-chatgpt.md:33
+msgid "Adjusting the playbook configuration"
+msgstr ""
+
+#: ../../../docs/configuring-playbook-bot-chatgpt.md:35
+msgid "To enable the bot, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file. Make sure to replace `API_KEY_HERE` with the API key retrieved [here](#obtain-an-openai-api-key) and `ACCESS_TOKEN_HERE` with the access token created [here](#obtain-an-access-token-and-create-encryption-keys), respectively."
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-chatgpt.md:52
-msgid "You will need to get tokens for ChatGPT."
-msgstr ""
-
-#: ../../../docs/configuring-playbook-bot-chatgpt.md:54
 msgid "Installing"
 msgstr ""
 
-#: ../../../docs/configuring-playbook-bot-chatgpt.md:56
+#: ../../../docs/configuring-playbook-bot-chatgpt.md:54
 msgid "After configuring the playbook, run it with [playbook tags](playbook-tags.md) as below:"
 msgstr ""
 
-#: ../../../docs/configuring-playbook-bot-chatgpt.md:63
+#: ../../../docs/configuring-playbook-bot-chatgpt.md:61
 msgid "**Notes**:"
 msgstr ""
 
-#: ../../../docs/configuring-playbook-bot-chatgpt.md:65
+#: ../../../docs/configuring-playbook-bot-chatgpt.md:63
 msgid "The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account."
 msgstr ""
 
-#: ../../../docs/configuring-playbook-bot-chatgpt.md:67
+#: ../../../docs/configuring-playbook-bot-chatgpt.md:65
 msgid "The shortcut commands with the [`just` program](just.md) are also available: `just install-all` or `just setup-all`"
 msgstr ""
 
-#: ../../../docs/configuring-playbook-bot-chatgpt.md:69
+#: ../../../docs/configuring-playbook-bot-chatgpt.md:67
 msgid "`just install-all` is useful for maintaining your setup quickly ([2x-5x faster](../CHANGELOG.md#2x-5x-performance-improvements-in-playbook-runtime) than `just setup-all`) when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed."
 msgstr ""
 
-#: ../../../docs/configuring-playbook-bot-chatgpt.md:71
+#: ../../../docs/configuring-playbook-bot-chatgpt.md:69
 msgid "Usage"
 msgstr ""
 
-#: ../../../docs/configuring-playbook-bot-chatgpt.md:73
+#: ../../../docs/configuring-playbook-bot-chatgpt.md:71
 msgid "To use the bot, invite it to the room you specified on your `vars.yml` file (`/invite @bot.chatgpt:example.com` where `example.com` is your base domain, not the `matrix.` domain)."
 msgstr ""
 
-#: ../../../docs/configuring-playbook-bot-chatgpt.md:75
+#: ../../../docs/configuring-playbook-bot-chatgpt.md:73
 msgid "After the bot joins the room, you can send a message to it. When you do so, use the prefix if you configured it or mention the bot."
 msgstr ""
 
-#: ../../../docs/configuring-playbook-bot-chatgpt.md:77
+#: ../../../docs/configuring-playbook-bot-chatgpt.md:75
 msgid "You can also refer to the upstream [documentation](https://github.com/matrixgpt/matrix-chatgpt-bot)."
 msgstr ""

--- a/i18n/translation-templates/docs/configuring-playbook-bot-draupnir.pot
+++ b/i18n/translation-templates/docs/configuring-playbook-bot-draupnir.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: matrix-docker-ansible-deploy \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 17:53+0900\n"
+"POT-Creation-Date: 2024-12-23 13:09+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -61,7 +61,7 @@ msgid "If you would like Draupnir to be able to deactivate users, move aliases, 
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-draupnir.md:27
-msgid "Get an access token"
+msgid "Obtain an access token"
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-draupnir.md:29
@@ -125,7 +125,7 @@ msgid "Adjusting the playbook configuration"
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-draupnir.md:67
-msgid "Add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file. Make sure to replace `MANAGEMENT_ROOM_ID_HERE`."
+msgid "To enable the bot, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file. Make sure to replace `MANAGEMENT_ROOM_ID_HERE`."
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-draupnir.md:76
@@ -165,7 +165,7 @@ msgid "When NOT using Pantalaimon, Draupnir does not log in by itself and you mu
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-draupnir.md:116
-msgid "Add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file. Make sure to replace `ACCESS_TOKEN_HERE` with the one created [above](#get-an-access-token)."
+msgid "Add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file. Make sure to replace `ACCESS_TOKEN_HERE` with the one created [above](#obtain-an-access-token)."
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-draupnir.md:122

--- a/i18n/translation-templates/docs/configuring-playbook-bot-go-neb.pot
+++ b/i18n/translation-templates/docs/configuring-playbook-bot-go-neb.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: matrix-docker-ansible-deploy \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 17:53+0900\n"
+"POT-Creation-Date: 2024-12-23 13:09+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -37,15 +37,15 @@ msgid "See the project's [documentation](https://github.com/matrix-org/go-neb/bl
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-go-neb.md:11
-msgid "Registering the bot account"
+msgid "Prerequisites"
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-go-neb.md:13
-msgid "The playbook does not automatically create users for you. The bot requires at least 1 access token to be able to connect to your homeserver."
+msgid "Register the bot account"
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-go-neb.md:15
-msgid "You **need to register the bot user manually** before setting up the bot."
+msgid "The playbook does not automatically create users for you. You **need to register the bot user manually** before setting up the bot."
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-go-neb.md:17
@@ -57,89 +57,93 @@ msgid "You can use the playbook to [register a new user](registering-users.md):"
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-go-neb.md:25
-msgid "Once the user is created you can [obtain an access token](obtaining-access-tokens.md)."
+msgid "Obtain an access token"
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-go-neb.md:27
-msgid "Adjusting the playbook configuration"
+msgid "The bot requires an access token to be able to connect to your homeserver. Refer to the documentation on [how to obtain an access token](obtaining-access-tokens.md)."
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-go-neb.md:29
-msgid "To enable Go-NEB, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:"
+msgid "Adjusting the playbook configuration"
 msgstr ""
 
-#: ../../../docs/configuring-playbook-bot-go-neb.md:193
-msgid "Adjusting the Go-NEB URL"
+#: ../../../docs/configuring-playbook-bot-go-neb.md:31
+msgid "To enable the bot, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file. Make sure to replace `ACCESS_TOKEN_FOR_GONEB_HERE` and `ACCESS_TOKEN_FOR_ANOTHER_GONEB_HERE` with the ones created [above](#obtain-an-access-token)."
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-go-neb.md:195
-msgid "By default, this playbook installs Go-NEB on the `goneb.` subdomain (`goneb.example.com`) and requires you to [adjust your DNS records](#adjusting-dns-records)."
+msgid "Adjusting the Go-NEB URL"
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-go-neb.md:197
-msgid "By tweaking the `matrix_bot_go_neb_hostname` and `matrix_bot_go_neb_path_prefix` variables, you can easily make the service available at a **different hostname and/or path** than the default one."
+msgid "By default, this playbook installs Go-NEB on the `goneb.` subdomain (`goneb.example.com`) and requires you to [adjust your DNS records](#adjusting-dns-records)."
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-go-neb.md:199
+msgid "By tweaking the `matrix_bot_go_neb_hostname` and `matrix_bot_go_neb_path_prefix` variables, you can easily make the service available at a **different hostname and/or path** than the default one."
+msgstr ""
+
+#: ../../../docs/configuring-playbook-bot-go-neb.md:201
 msgid "Example additional configuration for your `inventory/host_vars/matrix.example.com/vars.yml` file:"
 msgstr ""
 
-#: ../../../docs/configuring-playbook-bot-go-neb.md:210
+#: ../../../docs/configuring-playbook-bot-go-neb.md:212
 msgid "Adjusting DNS records"
 msgstr ""
 
-#: ../../../docs/configuring-playbook-bot-go-neb.md:212
+#: ../../../docs/configuring-playbook-bot-go-neb.md:214
 msgid "Once you've decided on the domain and path, **you may need to adjust your DNS** records to point the Go-NEB domain to the Matrix server."
 msgstr ""
 
-#: ../../../docs/configuring-playbook-bot-go-neb.md:214
+#: ../../../docs/configuring-playbook-bot-go-neb.md:216
 msgid "By default, you will need to create a CNAME record for `goneb`. See [Configuring DNS](configuring-dns.md) for details about DNS changes."
 msgstr ""
 
-#: ../../../docs/configuring-playbook-bot-go-neb.md:216
+#: ../../../docs/configuring-playbook-bot-go-neb.md:218
 msgid "If you've decided to reuse the `matrix.` domain, you won't need to do any extra DNS configuration."
 msgstr ""
 
-#: ../../../docs/configuring-playbook-bot-go-neb.md:218
+#: ../../../docs/configuring-playbook-bot-go-neb.md:220
 msgid "Installing"
 msgstr ""
 
-#: ../../../docs/configuring-playbook-bot-go-neb.md:220
+#: ../../../docs/configuring-playbook-bot-go-neb.md:222
 msgid "After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:"
 msgstr ""
 
-#: ../../../docs/configuring-playbook-bot-go-neb.md:227
+#: ../../../docs/configuring-playbook-bot-go-neb.md:229
 msgid "**Notes**:"
 msgstr ""
 
-#: ../../../docs/configuring-playbook-bot-go-neb.md:229
+#: ../../../docs/configuring-playbook-bot-go-neb.md:231
 msgid "The `ensure-matrix-users-created` playbook tag makes the playbook automatically create the bot's user account."
 msgstr ""
 
-#: ../../../docs/configuring-playbook-bot-go-neb.md:231
+#: ../../../docs/configuring-playbook-bot-go-neb.md:233
 msgid "The shortcut commands with the [`just` program](just.md) are also available: `just install-all` or `just setup-all`"
 msgstr ""
 
-#: ../../../docs/configuring-playbook-bot-go-neb.md:233
+#: ../../../docs/configuring-playbook-bot-go-neb.md:235
 msgid "`just install-all` is useful for maintaining your setup quickly ([2x-5x faster](../CHANGELOG.md#2x-5x-performance-improvements-in-playbook-runtime) than `just setup-all`) when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed."
 msgstr ""
 
-#: ../../../docs/configuring-playbook-bot-go-neb.md:235
+#: ../../../docs/configuring-playbook-bot-go-neb.md:237
 msgid "Usage"
 msgstr ""
 
-#: ../../../docs/configuring-playbook-bot-go-neb.md:237
+#: ../../../docs/configuring-playbook-bot-go-neb.md:239
 msgid "To use the bot, invite it to any existing Matrix room (`/invite @bot.go-neb:example.com` where `example.com` is your base domain, not the `matrix.` domain). Make sure you are granted with the sufficient permission if you are not the room owner."
 msgstr ""
 
-#: ../../../docs/configuring-playbook-bot-go-neb.md:239
+#: ../../../docs/configuring-playbook-bot-go-neb.md:241
 msgid "Basic usage is like this: `!echo hi` or `!imgur puppies` or `!giphy matrix`"
 msgstr ""
 
-#: ../../../docs/configuring-playbook-bot-go-neb.md:241
+#: ../../../docs/configuring-playbook-bot-go-neb.md:243
 msgid "If you enabled the github_cmd service, send `!github help` to the bot in the room to see the available commands."
 msgstr ""
 
-#: ../../../docs/configuring-playbook-bot-go-neb.md:243
+#: ../../../docs/configuring-playbook-bot-go-neb.md:245
 msgid "You can also refer to the upstream [Documentation](https://github.com/matrix-org/go-neb)."
 msgstr ""

--- a/i18n/translation-templates/docs/configuring-playbook-bot-honoroit.pot
+++ b/i18n/translation-templates/docs/configuring-playbook-bot-honoroit.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: matrix-docker-ansible-deploy \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 11:54+0900\n"
+"POT-Creation-Date: 2024-12-23 13:09+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -37,7 +37,7 @@ msgid "Adjusting the playbook configuration"
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-honoroit.md:11
-msgid "To enable Honoroit, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:"
+msgid "To enable the bot, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:"
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-honoroit.md:26

--- a/i18n/translation-templates/docs/configuring-playbook-bot-matrix-registration-bot.pot
+++ b/i18n/translation-templates/docs/configuring-playbook-bot-matrix-registration-bot.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: matrix-docker-ansible-deploy \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-20 23:17+0900\n"
+"POT-Creation-Date: 2024-12-23 13:09+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -33,7 +33,7 @@ msgid "See the project's [documentation](https://github.com/moan0s/matrix-regist
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-matrix-registration-bot.md:9
-msgid "Configuration"
+msgid "Adjusting the playbook configuration"
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-matrix-registration-bot.md:11

--- a/i18n/translation-templates/docs/configuring-playbook-bot-matrix-reminder-bot.pot
+++ b/i18n/translation-templates/docs/configuring-playbook-bot-matrix-reminder-bot.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: matrix-docker-ansible-deploy \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-20 09:53+0200\n"
+"POT-Creation-Date: 2024-12-23 13:09+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -37,7 +37,7 @@ msgid "Adjusting the playbook configuration"
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-matrix-reminder-bot.md:11
-msgid "Add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:"
+msgid "To enable the bot, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:"
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-matrix-reminder-bot.md:26

--- a/i18n/translation-templates/docs/configuring-playbook-bot-maubot.pot
+++ b/i18n/translation-templates/docs/configuring-playbook-bot-maubot.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: matrix-docker-ansible-deploy \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-20 07:23+0200\n"
+"POT-Creation-Date: 2024-12-23 13:09+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -37,7 +37,7 @@ msgid "Adjusting the playbook configuration"
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-maubot.md:11
-msgid "To enable maubot, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:"
+msgid "To enable the bot, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:"
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-maubot.md:26
@@ -129,7 +129,7 @@ msgid "**Create an instance**: An instance is the actual bot. You have to specif
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-maubot.md:78
-msgid "Obtaining an access token"
+msgid "Obtain an access token"
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-maubot.md:80

--- a/i18n/translation-templates/docs/configuring-playbook-bot-mjolnir.pot
+++ b/i18n/translation-templates/docs/configuring-playbook-bot-mjolnir.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: matrix-docker-ansible-deploy \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-22 17:53+0900\n"
+"POT-Creation-Date: 2024-12-23 13:09+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -53,7 +53,7 @@ msgid "If you would like Mjolnir to be able to deactivate users, move aliases, s
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-mjolnir.md:23
-msgid "Get an access token"
+msgid "Obtain an access token"
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-mjolnir.md:25
@@ -117,7 +117,7 @@ msgid "Adjusting the playbook configuration"
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-mjolnir.md:63
-msgid "Add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file. Make sure to replace `MANAGEMENT_ROOM_ID_HERE`."
+msgid "To enable the bot, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file. Make sure to replace `MANAGEMENT_ROOM_ID_HERE`."
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-mjolnir.md:72
@@ -157,7 +157,7 @@ msgid "When NOT using Pantalaimon, Mjolnir does not log in by itself and you mus
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-mjolnir.md:112
-msgid "Add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file. Make sure to replace `ACCESS_TOKEN_HERE` with the one created [above](#get-an-access-token)."
+msgid "Add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file. Make sure to replace `ACCESS_TOKEN_HERE` with the one created [above](#obtain-an-access-token)."
 msgstr ""
 
 #: ../../../docs/configuring-playbook-bot-mjolnir.md:118

--- a/i18n/translation-templates/docs/configuring-playbook-email2matrix.pot
+++ b/i18n/translation-templates/docs/configuring-playbook-email2matrix.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: matrix-docker-ansible-deploy \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-20 09:53+0200\n"
+"POT-Creation-Date: 2024-12-23 13:09+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -97,7 +97,7 @@ msgid "Take note of each room's room ID (different clients show the room ID in a
 msgstr ""
 
 #: ../../../docs/configuring-playbook-email2matrix.md:41
-msgid "Obtaining an access token for the sender user"
+msgid "Obtain an access token for the sender user"
 msgstr ""
 
 #: ../../../docs/configuring-playbook-email2matrix.md:43

--- a/i18n/translation-templates/docs/howto-server-delegation.pot
+++ b/i18n/translation-templates/docs/howto-server-delegation.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: matrix-docker-ansible-deploy \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-20 07:23+0200\n"
+"POT-Creation-Date: 2024-12-23 13:09+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -125,7 +125,7 @@ msgid "For more details on how to configure the playbook to work with SRV delega
 msgstr ""
 
 #: ../../../docs/howto-server-delegation.md:54
-msgid "Obtaining certificates"
+msgid "Obtain certificates"
 msgstr ""
 
 #: ../../../docs/howto-server-delegation.md:56


### PR DESCRIPTION
- Add "To use the bot" if it is not: follow the docs for bridges
- Add "Prerequisites" section if a certain API key or user account is required
- Use the common instruction for getting an access token
- Replace placeholders for access tokens on docs/configuring-playbook-bot-go.neb.md