### PR TITLE
Add GitHub Action "Update translations"

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2024 Suguru Hirahara
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+---
+name: Update translations
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - master
+    paths:  # See include_patterns on conf.py
+      - 'docs/*.md'
+      - 'i18n/README.md'
+      - '*.md'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    if: github.repository == 'spantaleev/matrix-docker-ansible-deploy'
+    name: Update translations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      # Setting up recommended prerequisites
+      # See: i18n/README.md
+      - uses: astral-sh/setup-uv@v5.1.0
+      - uses: extractions/setup-just@v2
+
+      # TODO: optimize when we start publishing translations and integrate a Weblate instance
+      - name: Update translation catalog templates (POT) files
+        run: just --justfile i18n/justfile extract-translation-templates
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7.0.5
+        with:
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>  # Same as committer
+          body: This is an automatic pull request to update translation files.
+          branch: create-pull-request/i18n
+          commit-message: Automatic translations update
+          delete-branch: true
+          labels: docs
+          sign-commits: true
+          title: Automatic translations update


### PR DESCRIPTION
For https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/3841

This commit implements a GitHub Action to update translation files with the PR automatically created on behalf of "github-actions[bot]".

Used actions:
- https://github.com/marketplace/actions/checkout
- https://github.com/marketplace/actions/setup-python
- https://github.com/marketplace/actions/astral-sh-setup-uv
- https://github.com/marketplace/actions/setup-just
- https://github.com/marketplace/actions/create-pull-request

Please see:
- test run: https://github.com/luixxiul/matrix-docker-ansible-deploy/actions/runs/12494211847
- test PR: https://github.com/luixxiul/matrix-docker-ansible-deploy/pull/5
