### PR TITLE
Fix docker networking when no reverse-proxy is used

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -32,7 +32,7 @@ matrix_playbook_docker_installation_daemon_options_custom: {}
 # yet still use Traefik installed in another way.
 matrix_playbook_traefik_labels_enabled: "{{ matrix_playbook_reverse_proxy_type in ['playbook-managed-traefik', 'other-traefik-container'] }}"
 
-matrix_playbook_reverse_proxy_container_network: "{{ traefik_container_network if traefik_enabled else 'traefik' }}"
+matrix_playbook_reverse_proxy_container_network: "{{ traefik_container_network if traefik_enabled else 'traefik' if matrix_playbook_reverse_proxy_type in ['playbook-managed-traefik', 'other-traefik-container'] else '' }}"
 matrix_playbook_reverse_proxy_hostname: "{{ traefik_identifier if traefik_enabled else 'traefik' }}"
 
 matrix_playbook_reverse_proxy_traefik_middleware_compression_enabled: "{{ traefik_config_http_middlewares_compression_enabled if (traefik_enabled and traefik_config_http_middlewares_compression_enabled) else false }}"

--- a/roles/custom/matrix-base/defaults/main.yml
+++ b/roles/custom/matrix-base/defaults/main.yml
@@ -234,7 +234,7 @@ matrix_metrics_exposure_http_basic_auth_users: ''
 matrix_playbook_reverse_proxy_type: ''
 
 # Specifies the network that the reverse-proxy is operating at
-matrix_playbook_reverse_proxy_container_network: 'traefik'
+matrix_playbook_reverse_proxy_container_network: "{{ 'traefik' if matrix_playbook_reverse_proxy_type in ['playbook-managed-traefik', 'other-traefik-container'] else '' }}"
 
 # Specifies the hostname that the reverse-proxy is available at
 matrix_playbook_reverse_proxy_hostname: 'matrix-traefik'


### PR DESCRIPTION
I’m one of those crazy people who use this playbook with `matrix_playbook_reverse_proxy_type: none` set. Everything works perfectly, except for `synapse-admin`.

`synapse-admin` connects to additional docker networks here: https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/c0559870b50ad9e3848533c10066f985ff4b3ae0/roles/custom/matrix-synapse-admin/templates/systemd/matrix-synapse-admin.service.j2#L39-L41

This defaults to `'traefik'` through `matrix_playbook_reverse_proxy_container_network`, which should not happen when `matrix_playbook_reverse_proxy_type` is set to `none`.