### PR TITLE
Update .github/workflows/close-stale-issues.yml: increase operations-per-run from 100 to 500

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -21,7 +21,7 @@ jobs:
           # Issues/PRs
           ######################################################################
           exempt-assignees: 'spantaleev,aine-etke'
-          operations-per-run: 100
+          operations-per-run: 500
           # Use this to do a dry run from a pull request
           # debug-only: true
           ######################################################################


### PR DESCRIPTION
Apparently checking issues or PRs which have been labelled with "stale" consumes more operations than checking ones without labelled, and the current amount (100) is not enough. See an example: https://github.com/spantaleev/matrix-docker-ansible-deploy/actions/runs/12566424393/job/35031806537#step:2:4083

Since the total amount of GitHub API rate is 5000, reserving 10 per cent for this action should not be an issue for now. Let's increase again if it is still too low.