### PR TITLE
Tidy up docs/configuring-playbook-jitsi.md and another related file

### DIFF
--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -46,13 +46,13 @@ By default the Jitsi instance does not require for anyone to log in, and is open
 
 Currently, there are three supported authentication methods: `internal` (default), `matrix` and `ldap`.
 
+With authentication enabled, all meetings have to be started by a registered user. After the meeting is started by that user, then guests are free to join. If the registered user is not yet present, the guests are put on hold in individual waiting rooms.
+
 **Note**: authentication is not tested by the playbook's self-checks. We therefore recommend that you would make sure by yourself that authentication is configured properly. To test it, start a meeting at `jitsi.example.com` on your browser.
 
 #### Authenticate using Jitsi accounts: Auth-Type `internal` (recommended)
 
 The default authentication mechanism is `internal` auth, which requires a Jitsi account to have been configured. This is a recommended method, as it also works in federated rooms.
-
-With authentication enabled, all meetings have to be started by a registered user. After the meeting is started by that user, then guests are free to join. If the registered user is not yet present, the guests are put on hold in individual waiting rooms.
 
 To enable authentication with a Jitsi account, add the following configuration to your `vars.yml` file. Make sure to replace `USERNAME_…` and `PASSWORD_…` with your own values.
 
@@ -73,6 +73,7 @@ jitsi_prosody_auth_internal_accounts:
 ⚠️ **Warning**: this breaks the Jitsi instance on federated rooms probably and does not allow sharing conference links with guests.
 
 This authentication method requires [Matrix User Verification Service](https://github.com/matrix-org/matrix-user-verification-service), which can be installed using this [playbook](configuring-playbook-user-verification-service.md). By default, the playbook creates and configures a user-verification-service so that it runs locally.
+
 
 To enable authentication with Matrix OpenID, add the following configuration to your `vars.yml` file:
 

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -341,14 +341,13 @@ In this case, you should consider to rebuild your Jitsi installation.
 
 ### Rebuilding your Jitsi installation
 
-**If you ever run into any trouble** or **if you change configuration (`jitsi_*` variables) too much**, we urge you to rebuild your Jitsi setup.
+**If you ever run into any trouble** or **if you change configuration (`jitsi_*` variables) too much**, we recommend you to rebuild your Jitsi setup.
 
-We normally don't require such manual intervention for other services, but Jitsi services generate a lot of configuration files on their own.
+We normally don't recommend manual intervention, but Jitsi services tend to generate a lot of configuration files, and it is often wise to start afresh setting the services up, rather than messing with the existing configuration files. Since not all of those files are managed by Ansible (at least not yet), you may sometimes need to delete them by yourself manually.
 
-These files are not all managed by Ansible (at least not yet), so you may sometimes need to delete them all and start fresh.
+To rebuild your Jitsi configuration, follow the procedure below:
 
-To rebuild your Jitsi configuration:
-
-- ask Ansible to stop all Jitsi services: `just run-tags stop-group --extra-vars=group=jitsi`
-- SSH into the server and do this and remove all Jitsi configuration & data (`rm -rf /matrix/jitsi`)
-- ask Ansible to set up Jitsi anew and restart services (`just install-service jitsi`)
+- run this command locally to stop all Jitsi services: `just run-tags stop-group --extra-vars=group=jitsi`
+- log in the server with SSH
+- run this command remotely to remove all Jitsi configuration & data: `rm -rf /matrix/jitsi`
+- run this command locally to set up Jitsi anew and restart services: `just install-service jitsi`

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -217,8 +217,6 @@ You can use the self-hosted Jitsi server in multiple ways:
 
 - **by adding a widget to a room via Element Web** (the one configured by the playbook at `https://element.example.com`). Just start a voice or a video call in a room containing more than 2 members and that would create a Jitsi widget which utilizes your self-hosted Jitsi server.
 
-- **by adding a widget to a room via the Dimension integration manager**. You'll have to point the widget to your own Jitsi server manually. See our [Dimension integration manager](./configuring-playbook-dimension.md) documentation page for more details. Naturally, Dimension would need to be installed first (the playbook doesn't install it by default).
-
 - **directly (without any Matrix integration)**. Just go to `https://jitsi.example.com`
 
 ### Set up Additional JVBs (optional)

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -290,8 +290,6 @@ You can use the self-hosted Jitsi server in multiple ways:
 
 - **directly (without any Matrix integration)**. Just go to `https://jitsi.example.com`
 
-**Note**: Element apps on mobile devices currently [don't support joining meetings on a self-hosted Jitsi server](https://github.com/element-hq/riot-web/blob/601816862f7d84ac47547891bd53effa73d32957/docs/jitsi.md#mobile-app-support).
-
 ## Troubleshooting
 
 ### Rebuilding your Jitsi installation

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -13,7 +13,7 @@ See the project's [documentation](https://jitsi.github.io/handbook/) to learn wh
 You may need to open the following ports to your server:
 
 - `4443/tcp` - RTP media fallback over TCP
-- `10000/udp` - RTP media over UDP. Depending on your firewall/NAT setup, incoming RTP packets on port `10000` may have the external IP of your firewall as destination address, due to the usage of STUN in JVB (see [`jitsi_jvb_stun_servers`](https://github.com/mother-of-all-self-hosting/ansible-role-jitsi/blob/main/defaults/main.yml)).
+- `10000/udp` - RTP media over UDP. Depending on your firewall/NAT configuration, incoming RTP packets on port `10000` may have the external IP of your firewall as destination address, due to the usage of STUN in JVB (see [`jitsi_jvb_stun_servers`](https://github.com/mother-of-all-self-hosting/ansible-role-jitsi/blob/main/defaults/main.yml)).
 
 ## Adjusting DNS records
 
@@ -48,9 +48,9 @@ Currently, there are three supported authentication methods: `internal` (default
 
 **Note**: authentication is not tested by the playbook's self-checks. We therefore recommend that you would make sure by yourself that authentication is configured properly. To test it, start a meeting at `jitsi.example.com` on your browser.
 
-#### Authenticate using Jitsi accounts (Auth-Type `internal`)
+#### Authenticate using Jitsi accounts: Auth-Type `internal` (recommended)
 
-The default authentication mechanism is `internal` auth, which requires a Jitsi account to have been configured. This is the recommended method, as it also works in federated rooms.
+The default authentication mechanism is `internal` auth, which requires a Jitsi account to have been configured. This is a recommended method, as it also works in federated rooms.
 
 With authentication enabled, all meetings have to be started by a registered user. After the meeting is started by that user, then guests are free to join. If the registered user is not yet present, the guests are put on hold in individual waiting rooms.
 
@@ -68,9 +68,9 @@ jitsi_prosody_auth_internal_accounts:
 
 **Note**: as Jitsi account removal function is not integrated into the playbook, these accounts will not be able to be removed from the Prosody server automatically, even if they are removed from your `vars.yml` file subsequently.
 
-#### Authenticate using Matrix OpenID (Auth-Type `matrix`)
+#### Authenticate using Matrix OpenID: Auth-Type `matrix`
 
-⚠️ **Warning**: probably this breaks the Jitsi instance in federated rooms and does not allow sharing conference links with guests.
+⚠️ **Warning**: this breaks the Jitsi instance on federated rooms probably and does not allow sharing conference links with guests.
 
 This authentication method requires [Matrix User Verification Service](https://github.com/matrix-org/matrix-user-verification-service), which can be installed using this [playbook](configuring-playbook-user-verification-service.md). By default, the playbook creates and configures a user-verification-service so that it runs locally.
 
@@ -84,7 +84,7 @@ matrix_user_verification_service_enabled: true
 
 For more information see also [https://github.com/matrix-org/prosody-mod-auth-matrix-user-verification](https://github.com/matrix-org/prosody-mod-auth-matrix-user-verification).
 
-#### Authenticate using LDAP (Auth-Type `ldap`)
+#### Authenticate using LDAP: Auth-Type `ldap`
 
 To enable authentication with LDAP, add the following configuration to your `vars.yml` file (adapt to your needs):
 
@@ -108,7 +108,7 @@ jitsi_ldap_start_tls: false
 
 For more information refer to the [docker-jitsi-meet](https://github.com/jitsi/docker-jitsi-meet#authentication-using-ldap) and the [saslauthd `LDAP_SASLAUTHD`](https://github.com/winlibs/cyrus-sasl/blob/master/saslauthd/LDAP_SASLAUTHD) documentation.
 
-### Running behind NAT or on a LAN environment (optional)
+### Configure `JVB_ADVERTISE_IPS` for running behind NAT or on a LAN environment (optional)
 
 When running Jitsi in a LAN environment, or on the public Internet via NAT, the `JVB_ADVERTISE_IPS` enviornment variable should be set.
 
@@ -125,11 +125,11 @@ jitsi_jvb_container_extra_arguments:
 
 Check [the official documentation](https://jitsi.github.io/handbook/docs/devops-guide/devops-guide-docker/#running-behind-nat-or-on-a-lan-environment) for more details about it.
 
-### Specify a Max number of participants on a Jitsi conference (optional)
+### Set a maximum number of participants on a Jitsi conference (optional)
 
-The playbook allows a user to set a max number of participants allowed to join a Jitsi conference. By default the number is not limited.
+You can set a maximum number of participants allowed to join a Jitsi conference. By default the number is not specified.
 
-To set the max number of participants, add the following configuration to your `vars.yml` file (adapt to your needs):
+To set it, add the following configuration to your `vars.yml` file (adapt to your needs):
 
 ```yaml
 jitsi_prosody_max_participants: 4 # example value
@@ -139,7 +139,7 @@ jitsi_prosody_max_participants: 4 # example value
 
 In the default Jisti Meet configuration, `gravatar.com` is enabled as an avatar service.
 
-Since Element clients (Element Web, Element X Android, etc.) send the URL of configured Matrix avatars to the Jitsi instance, our default configuration has disabled the Gravatar service.
+Since the Element clients send the URL of configured Matrix avatars to the Jitsi instance, our default configuration has disabled the Gravatar service.
 
 To enable the Gravatar service, add the following configuration to your `vars.yml` file:
 
@@ -147,7 +147,7 @@ To enable the Gravatar service, add the following configuration to your `vars.ym
 jitsi_disable_gravatar: false
 ```
 
-⚠️ **Warning**: This will result in third party request leaking data to the Gravatar Service (`gravatar.com`, unless configured otherwise). Besides metadata, the Matrix user_id and possibly the room ID (via `referrer` header) will be also sent to the third party.
+⚠️ **Warning**: this will result in third party request leaking data to the Gravatar Service (`gravatar.com`, unless configured otherwise). Besides metadata, the Matrix user_id and possibly the room ID (via `referrer` header) will be also sent to the third party.
 
 ### Fine tune Jitsi (optional)
 
@@ -176,6 +176,7 @@ These configurations:
 Here is an example set of configurations for running a Jitsi instance with:
 
 - authentication using a Jitsi account (username: `US3RNAME`, password: `passw0rd`)
+- guests: allowed
 - maximum participants: 6 people
 - fine tuning with the configurations presented above
 - other miscellaneous options (see the official Jitsi documentation [here](https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-configuration) and [here](https://jitsi.github.io/handbook/docs/user-guide/user-guide-advanced))
@@ -219,7 +220,7 @@ You can use the self-hosted Jitsi server in multiple ways:
 
 - **directly (without any Matrix integration)**. Just go to `https://jitsi.example.com`
 
-### Set up Additional JVBs (optional)
+### Set up additional JVBs for more video-conferences (optional)
 
 By default, a single JVB ([Jitsi VideoBridge](https://github.com/jitsi/jitsi-videobridge)) is deployed on the same host as the Matrix server. To allow more video-conferences to happen at the same time, you'd need to provision additional JVB services on other hosts.
 
@@ -244,7 +245,7 @@ Each JVB requires a server ID to be set, so that it will be uniquely identified.
 
 The server ID can be set with the variable `jitsi_jvb_server_id`. It will end up as the `JVB_WS_SERVER_ID` environment variables in the JVB docker container.
 
-To set the server ID to `jvb-2`, add the following configuration to either `vars.yml` or `hosts` file (adapt to your needs). If you set the value on the `hosts` file, add `jitsi_jvb_server_id=jvb-2` after your JVB's external IP addresses as below.
+To set the server ID to `jvb-2`, add the following configuration to either `vars.yml` or `hosts` file (adapt to your needs). If you'd specify the server ID on the `hosts` file, add `jitsi_jvb_server_id=jvb-2` after your JVB's external IP addresses as below.
 
 - On `vars.yml`:
 
@@ -348,7 +349,7 @@ traefik_provider_configuration_extension_yaml: |
 
 #### Run the playbook
 
-After configuring `vars.yml` and `hosts` files, run the playbook with [playbook tags](playbook-tags.md) as below:
+After configuring `hosts` and `vars.yml` files, run the playbook with [playbook tags](playbook-tags.md) as below:
 
 ```sh
 ansible-playbook -i inventory/hosts --limit jitsi_jvb_servers jitsi_jvb.yml --tags=common,setup-additional-jitsi-jvb,start
@@ -364,7 +365,7 @@ In this case, you should consider to rebuild your Jitsi installation.
 
 ### Rebuilding your Jitsi installation
 
-**If you ever run into any trouble** or **if you change configuration (`jitsi_*` variables) too much**, we recommend you to rebuild your Jitsi setup.
+If you ever run into any trouble or if you have changed configuration (`jitsi_*` variables) too much, you can rebuild your Jitsi installation.
 
 We normally don't recommend manual intervention, but Jitsi services tend to generate a lot of configuration files, and it is often wise to start afresh setting the services up, rather than messing with the existing configuration files. Since not all of those files are managed by Ansible (at least not yet), you may sometimes need to delete them by yourself manually.
 

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -142,13 +142,12 @@ jitsi_web_config_resolution_width_ideal_and_max: 480
 jitsi_web_config_resolution_height_ideal_and_max: 240
 ```
 
-You may want to **suspend unused video layers** until they are requested again, to save up resources on both server and clients. Read more on this feature [here](https://jitsi.org/blog/new-off-stage-layer-suppression-feature/)
+These configurations:
 
-You may wish to **disable audio levels** to avoid excessive refresh of the client-side page and decrease the CPU consumption involved.
-
-You may want to **limit the number of video feeds forwarded to each client**, to save up resources on both server and clients. As clients’ bandwidth and CPU may not bear the load, use this setting to avoid lag and crashes. This feature is found by default in other webconference applications such as Office 365 Teams (limit is set to 4). Read how it works [here](https://github.com/jitsi/jitsi-videobridge/blob/master/doc/last-n.md) and performance evaluation on this [study](https://jitsi.org/wp-content/uploads/2016/12/nossdav2015lastn.pdf).
-
-You may want to **limit the maximum video resolution**, to save up resources on both server and clients.
+- **suspend unused video layers** until they are requested again, to save up resources on both server and clients. Read more on this feature [here](https://jitsi.org/blog/new-off-stage-layer-suppression-feature/).
+- **disable audio levels** to avoid excessive refresh of the client-side page and decrease the CPU consumption involved
+- **limit the number of video feeds forwarded to each client**, to save up resources on both server and clients. As clients’ bandwidth and CPU may not bear the load, use this setting to avoid lag and crashes. This feature is available by default on other webconference applications such as Office 365 Teams (the number is limited to 4). Read how it works [here](https://github.com/jitsi/jitsi-videobridge/blob/master/doc/last-n.md) and performance evaluation on this [study](https://jitsi.org/wp-content/uploads/2016/12/nossdav2015lastn.pdf).
+- **limit the maximum video resolution**, to save up resources on both server and clients
 
 ## Specify a Max number of participants on a Jitsi conference (optional)
 

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -169,7 +169,7 @@ These configurations:
 - **limit the maximum video resolution**, to save up resources on both server and clients
 - **suspend unused video layers** until they are requested again, to save up resources on both server and clients. Read more on this feature [here](https://jitsi.org/blog/new-off-stage-layer-suppression-feature/).
 - **disable audio levels** to avoid excessive refresh of the client-side page and decrease the CPU consumption involved
-- **limit the number of video feeds forwarded to each client**, to save up resources on both server and clients. As clients’ bandwidth and CPU may not bear the load, use this setting to avoid lag and crashes. This feature is available by default on other webconference applications such as Office 365 Teams (the number is limited to 4). Read how it works [here](https://github.com/jitsi/jitsi-videobridge/blob/master/doc/last-n.md) and performance evaluation on this [study](https://jitsi.org/wp-content/uploads/2016/12/nossdav2015lastn.pdf).
+- **limit the number of video feeds forwarded to each client**, to save up resources on both server and clients. As clients’ bandwidth and CPU may not bear the load, use this setting to avoid lag and crashes. This feature is available by default on other webconference applications such as Office 365 Teams (the number is limited to 4). Read how it works [here](https://github.com/jitsi/jitsi-videobridge/blob/5ff195985edf46c9399dcf263cb07167f0a2c724/doc/allocation.md).
 
 ### Example configurations
 

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -159,7 +159,6 @@ jitsi_web_custom_config_extension: |
 
   config.disableAudioLevels = true;
 
-  // Limit the number of video feeds forwarded to each client
   config.channelLastN = 4;
 ```
 

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -13,6 +13,10 @@ You may need to open the following ports to your server:
 - `4443/tcp` - RTP media fallback over TCP
 - `10000/udp` - RTP media over UDP. Depending on your firewall/NAT setup, incoming RTP packets on port `10000` may have the external IP of your firewall as destination address, due to the usage of STUN in JVB (see [`jitsi_jvb_stun_servers`](https://github.com/mother-of-all-self-hosting/ansible-role-jitsi/blob/main/defaults/main.yml)).
 
+## Adjusting DNS records
+
+By default, this playbook installs Jitsi on the `jitsi.` subdomain (`jitsi.example.com`) and requires you to create a CNAME record for `jitsi`. See [Configuring DNS](configuring-dns.md) for details about DNS changes.
+
 ## Adjusting the playbook configuration
 
 To enable Jitsi, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:
@@ -23,8 +27,6 @@ jitsi_enabled: true
 
 ### Adjusting the Jitsi URL
 
-By default, this playbook installs Jitsi on the `jitsi.` subdomain (`jitsi.example.com`) and requires you to [adjust your DNS records](#adjusting-dns-records).
-
 By tweaking the `jitsi_hostname` variable, you can easily make the service available at a **different hostname** than the default one.
 
 Example additional configuration for your `vars.yml` file:
@@ -34,11 +36,7 @@ Example additional configuration for your `vars.yml` file:
 jitsi_hostname: call.example.com
 ```
 
-#### Adjusting DNS records
-
-Once you've decided on the domain and path, **you may need to adjust your DNS** records to point the Jitsi domain to the Matrix server.
-
-By default, you will need to create a CNAME record for `jitsi`. See [Configuring DNS](configuring-dns.md) for details about DNS changes.
+After changing the domain, **you may need to adjust your DNS** records to point the Jitsi domain to the Matrix server.
 
 ### Configure Jitsi authentication and guests mode (optional)
 

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -74,7 +74,7 @@ jitsi_prosody_auth_internal_accounts:
 
 ### Authenticate using Matrix OpenID (Auth-Type 'matrix')
 
-**Attention: Probably breaks Jitsi in federated rooms and does not allow sharing conference links with guests.**
+⚠️ **Warning**: probably this breaks the Jitsi instance in federated rooms and does not allow sharing conference links with guests.
 
 Using this authentication type require a [Matrix User Verification Service](https://github.com/matrix-org/matrix-user-verification-service). By default, this playbook creates and configures a user-verification-service to run locally, see [configuring-user-verification-service](configuring-playbook-user-verification-service.md).
 
@@ -152,9 +152,9 @@ You may want to **limit the maximum video resolution**, to save up resources on 
 
 ## Specify a Max number of participants on a Jitsi conference (optional)
 
-The playbook allows a user to set a max number of participants allowed to join a Jitsi conference. By default there is no limit.
+The playbook allows a user to set a max number of participants allowed to join a Jitsi conference. By default the number is not limited.
 
-In order to set the max number of participants use the following **additional** configuration:
+To set the max number of participants, add the following configuration to your `vars.yml` file (adapt to your needs):
 
 ```yaml
 jitsi_prosody_max_participants: 4 # example value
@@ -164,7 +164,11 @@ jitsi_prosody_max_participants: 4 # example value
 
 By default, a single JVB ([Jitsi VideoBridge](https://github.com/jitsi/jitsi-videobridge)) is deployed on the same host as the Matrix server. To allow more video-conferences to happen at the same time, you may need to provision additional JVB services on other hosts.
 
-There is an ansible playbook that can be run with the following tag: `ansible-playbook -i inventory/hosts --limit jitsi_jvb_servers jitsi_jvb.yml --tags=common,setup-additional-jitsi-jvb,start`
+To do so, run the playbook with [playbook tags](playbook-tags.md) as below:
+
+```sh
+ansible-playbook -i inventory/hosts --limit jitsi_jvb_servers jitsi_jvb.yml --tags=common,setup-additional-jitsi-jvb,start
+```
 
 For this role to work you will need an additional section in the ansible hosts file with the details of the JVB hosts, for example:
 
@@ -255,7 +259,7 @@ traefik_provider_configuration_extension_yaml: |
 
 In the default Jisti Meet configuration, gravatar.com is enabled as an avatar service. This results in third party request leaking data to gravatar. Since Element clients already send the url of configured Matrix avatars to Jitsi, we disabled gravatar.
 
-To enable Gravatar set:
+To enable Gravatar, add the following configuration to your `vars.yml` file:
 
 ```yaml
 jitsi_disable_gravatar: false

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -108,18 +108,22 @@ jitsi_ldap_start_tls: false
 
 For more information refer to the [docker-jitsi-meet](https://github.com/jitsi/docker-jitsi-meet#authentication-using-ldap) and the [saslauthd `LDAP_SASLAUTHD`](https://github.com/winlibs/cyrus-sasl/blob/master/saslauthd/LDAP_SASLAUTHD) documentation.
 
-### Making your Jitsi server work on a LAN (optional)
+### Running behind NAT or on a LAN environment (optional)
 
-By default the Jitsi Meet instance does not work with a client in LAN (Local Area Network), even if others are connected from WAN. There are no video and audio. In the case of WAN to WAN everything is ok.
+When running Jitsi in a LAN environment, or on the public Internet via NAT, the `JVB_ADVERTISE_IPS` enviornment variable should be set.
 
-The reason is the Jitsi VideoBridge git to LAN client the IP address of the docker image instead of the host. The [documentation](https://jitsi.github.io/handbook/docs/devops-guide/devops-guide-docker/#running-behind-nat-or-on-a-lan-environment) of Jitsi in docker suggest to add `JVB_ADVERTISE_IPS` in enviornment variable to make it work.
+This variable allows to control which IP addresses the JVB will advertise for WebRTC media traffic. It is necessary to set it regardless of the use of a reverse proxy, since it's the IP address that will receive the media (audio / video) and not HTTP traffic, hence it's oblivious to the reverse proxy.
 
-To enable it, add the following configuration to your `vars.yml` file:
+If your users are coming in over the Internet (and not over LAN), this will likely be your public IP address. If this is not set up correctly, calls will crash when more than two users join a meeting.
+
+To set the variable, add the following configuration to your `vars.yml` file. Make sure to replace `LOCAL_IP_ADDRESS_OF_THE_HOST_HERE` with a proper value.
 
 ```yaml
 jitsi_jvb_container_extra_arguments:
-  - '--env "JVB_ADVERTISE_IPS=<Local IP address of the host>"'
+  - '--env "JVB_ADVERTISE_IPS=LOCAL_IP_ADDRESS_OF_THE_HOST_HERE"'
 ```
+
+Check [the official documentation](https://jitsi.github.io/handbook/docs/devops-guide/devops-guide-docker/#running-behind-nat-or-on-a-lan-environment) for more details about it.
 
 ### Specify a Max number of participants on a Jitsi conference (optional)
 

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -1,6 +1,8 @@
 # Setting up the Jitsi video-conferencing platform (optional)
 
-The playbook can install the [Jitsi](https://jitsi.org/) video-conferencing platform and integrate it with Element clients ([Element Web](configuring-playbook-client-element-web.md)/Desktop, Android and iOS).
+The playbook can install and configure the [Jitsi](https://jitsi.org/) video-conferencing platform for you.
+
+Jitsi can not only be integrated with Element clients ([Element Web](configuring-playbook-client-element-web.md)/Desktop, Android and iOS) as a widget, but also be used as standalone web app.
 
 See the project's [documentation](https://jitsi.github.io/handbook/) to learn what it does and why it might be useful to you.
 

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -42,43 +42,41 @@ By default, you will need to create a CNAME record for `jitsi`. See [Configuring
 
 ### Configure Jitsi authentication and guests mode (optional)
 
-By default the Jitsi Meet instance does not require any kind of login and is open to use for anyone without registration.
+By default the Jitsi instance does not require for anyone to log in, and is open to use without an account. To control who is allowed to start meetings on your Jitsi instance, you'd need to enable Jitsi's authentication and optionally guests mode.
 
-If you're fine with such an open Jitsi instance, please skip to [Installing](#installing).
+Currently, there are three supported authentication methods: `internal` (default), `matrix` and `ldap`.
 
-If you would like to control who is allowed to open meetings on your new Jitsi instance, then please follow the following steps to enable Jitsi's authentication and optionally guests mode.
+**Note**: authentication is not tested by the playbook's self-checks. We therefore recommend that you would make sure by yourself that authentication is configured properly. To test it, start a meeting at `jitsi.example.com` on your browser.
 
-Currently, there are three supported authentication modes: 'internal' (default), 'matrix' and 'ldap'.
+#### Authenticate using Jitsi accounts (Auth-Type `internal`)
 
-**Note**: Authentication is not tested via the playbook's self-checks. We therefore recommend that you manually verify if authentication is required by jitsi. For this, try to manually create a conference on jitsi.example.com in your browser.
+The default authentication mechanism is `internal` auth, which requires a Jitsi account to have been configured. This is the recommended method, as it also works in federated rooms.
 
-#### Authenticate using Jitsi accounts (Auth-Type 'internal')
+With authentication enabled, all meetings have to be started by a registered user. After the meeting is started by that user, then guests are free to join. If the registered user is not yet present, the guests are put on hold in individual waiting rooms.
 
-The default authentication mechanism is 'internal' auth, which requires jitsi-accounts to be setup and is the recommended setup, as it also works in federated rooms. With authentication enabled, all meeting rooms have to be opened by a registered user, after which guests are free to join. If a registered host is not yet present, guests are put on hold in individual waiting rooms.
-
-Add the following configuration to your `vars.yml` file:
+To enable authentication with a Jitsi account, add the following configuration to your `vars.yml` file. Make sure to replace `USERNAME_…` and `PASSWORD_…` with your own values.
 
 ```yaml
 jitsi_enable_auth: true
 jitsi_enable_guests: true
 jitsi_prosody_auth_internal_accounts:
-  - username: "jitsi-moderator"
-    password: "secret-password"
-  - username: "another-user"
-    password: "another-password"
+  - username: "USERNAME_FOR_THE_FIRST_USER_HERE"
+    password: "PASSWORD_FOR_THE_FIRST_USER_HERE"
+  - username: "USERNAME_FOR_THE_SECOND_USER_HERE"
+    password: "PASSWORD_FOR_THE_SECOND_USER_HERE"
 ```
 
-⚠️ **Warning**: Accounts added here and subsequently removed will not be automatically removed from the Prosody server until user account cleaning is integrated into the playbook.
+**Note**: as Jitsi account removal function is not integrated into the playbook, these accounts will not be able to be removed from the Prosody server automatically, even if they are removed from your `vars.yml` file subsequently.
 
-**If you get an error** like this: "Error: Account creation/modification not supported.", it's likely that you had previously installed Jitsi without auth/guest support. In such a case, you should look into [Rebuilding your Jitsi installation](#rebuilding-your-jitsi-installation).
+**Note**: if you get an error like `Error: Account creation/modification not supported.`, it's likely that you had previously installed Jitsi without auth/guest support. In such a case, you should look into [Rebuilding your Jitsi installation](#rebuilding-your-jitsi-installation).
 
-#### Authenticate using Matrix OpenID (Auth-Type 'matrix')
+#### Authenticate using Matrix OpenID (Auth-Type `matrix`)
 
 ⚠️ **Warning**: probably this breaks the Jitsi instance in federated rooms and does not allow sharing conference links with guests.
 
-Using this authentication type require a [Matrix User Verification Service](https://github.com/matrix-org/matrix-user-verification-service). By default, this playbook creates and configures a user-verification-service to run locally, see [configuring-user-verification-service](configuring-playbook-user-verification-service.md).
+This authentication method requires [Matrix User Verification Service](https://github.com/matrix-org/matrix-user-verification-service), which can be installed using this [playbook](configuring-playbook-user-verification-service.md). By default, the playbook creates and configures a user-verification-service so that it runs locally.
 
-To enable set this configuration at host level:
+To enable authentication with Matrix OpenID, add the following configuration to your `vars.yml` file:
 
 ```yaml
 jitsi_enable_auth: true
@@ -88,9 +86,9 @@ matrix_user_verification_service_enabled: true
 
 For more information see also [https://github.com/matrix-org/prosody-mod-auth-matrix-user-verification](https://github.com/matrix-org/prosody-mod-auth-matrix-user-verification).
 
-#### Authenticate using LDAP (Auth-Type 'ldap')
+#### Authenticate using LDAP (Auth-Type `ldap`)
 
-An example LDAP configuration could be:
+To enable authentication with LDAP, add the following configuration to your `vars.yml` file (adapt to your needs):
 
 ```yaml
 jitsi_enable_auth: true

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -2,9 +2,9 @@
 
 The playbook can install the [Jitsi](https://jitsi.org/) video-conferencing platform and integrate it with Element clients ([Element Web](configuring-playbook-client-element-web.md)/Desktop, Android and iOS).
 
-Jitsi installation is **not enabled by default**, because it's not a core component of Matrix services.
+See the project's [documentation](https://jitsi.github.io/handbook/) to learn what it does and why it might be useful to you.
 
-The setup done by the playbook is very similar to [docker-jitsi-meet](https://github.com/jitsi/docker-jitsi-meet). You can refer to the documentation there for many of the options here.
+**Note**: the configuration by the playbook is similar to the one by [docker-jitsi-meet](https://github.com/jitsi/docker-jitsi-meet). You can refer to the official documentation for Docker deployment [here](https://jitsi.github.io/handbook/docs/devops-guide/devops-guide-docker/).
 
 ## Prerequisites
 

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -125,30 +125,6 @@ jitsi_jvb_container_extra_arguments:
   - '--env "JVB_ADVERTISE_IPS=<Local IP address of the host>"'
 ```
 
-## Fine tune Jitsi (optional)
-
-If you'd like to have Jitsi save up resources, add the following configuration to your `vars.yml` file (adapt to your needs):
-
-```yaml
-jitsi_web_custom_config_extension: |
-  config.enableLayerSuspension = true;
-
-  config.disableAudioLevels = true;
-
-  // Limit the number of video feeds forwarded to each client
-  config.channelLastN = 4;
-
-jitsi_web_config_resolution_width_ideal_and_max: 480
-jitsi_web_config_resolution_height_ideal_and_max: 240
-```
-
-These configurations:
-
-- **suspend unused video layers** until they are requested again, to save up resources on both server and clients. Read more on this feature [here](https://jitsi.org/blog/new-off-stage-layer-suppression-feature/).
-- **disable audio levels** to avoid excessive refresh of the client-side page and decrease the CPU consumption involved
-- **limit the number of video feeds forwarded to each client**, to save up resources on both server and clients. As clients’ bandwidth and CPU may not bear the load, use this setting to avoid lag and crashes. This feature is available by default on other webconference applications such as Office 365 Teams (the number is limited to 4). Read how it works [here](https://github.com/jitsi/jitsi-videobridge/blob/master/doc/last-n.md) and performance evaluation on this [study](https://jitsi.org/wp-content/uploads/2016/12/nossdav2015lastn.pdf).
-- **limit the maximum video resolution**, to save up resources on both server and clients
-
 ## Specify a Max number of participants on a Jitsi conference (optional)
 
 The playbook allows a user to set a max number of participants allowed to join a Jitsi conference. By default the number is not limited.
@@ -305,6 +281,30 @@ jitsi_disable_gravatar: false
 ```
 
 ⚠️ **Warning**: This leaks information to a third party, namely the Gravatar-Service (unless configured otherwise: gravatar.com). Besides metadata, this includes the Matrix user_id and possibly the room identifier (via `referrer` header).
+
+## Fine tune Jitsi (optional)
+
+If you'd like to have Jitsi save up resources, add the following configuration to your `vars.yml` file (adapt to your needs):
+
+```yaml
+jitsi_web_custom_config_extension: |
+  config.enableLayerSuspension = true;
+
+  config.disableAudioLevels = true;
+
+  // Limit the number of video feeds forwarded to each client
+  config.channelLastN = 4;
+
+jitsi_web_config_resolution_width_ideal_and_max: 480
+jitsi_web_config_resolution_height_ideal_and_max: 240
+```
+
+These configurations:
+
+- **suspend unused video layers** until they are requested again, to save up resources on both server and clients. Read more on this feature [here](https://jitsi.org/blog/new-off-stage-layer-suppression-feature/).
+- **disable audio levels** to avoid excessive refresh of the client-side page and decrease the CPU consumption involved
+- **limit the number of video feeds forwarded to each client**, to save up resources on both server and clients. As clients’ bandwidth and CPU may not bear the load, use this setting to avoid lag and crashes. This feature is available by default on other webconference applications such as Office 365 Teams (the number is limited to 4). Read how it works [here](https://github.com/jitsi/jitsi-videobridge/blob/master/doc/last-n.md) and performance evaluation on this [study](https://jitsi.org/wp-content/uploads/2016/12/nossdav2015lastn.pdf).
+- **limit the maximum video resolution**, to save up resources on both server and clients
 
 ## Installing
 

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -170,6 +170,33 @@ These configurations:
 - **disable audio levels** to avoid excessive refresh of the client-side page and decrease the CPU consumption involved
 - **limit the number of video feeds forwarded to each client**, to save up resources on both server and clients. As clients’ bandwidth and CPU may not bear the load, use this setting to avoid lag and crashes. This feature is available by default on other webconference applications such as Office 365 Teams (the number is limited to 4). Read how it works [here](https://github.com/jitsi/jitsi-videobridge/blob/master/doc/last-n.md) and performance evaluation on this [study](https://jitsi.org/wp-content/uploads/2016/12/nossdav2015lastn.pdf).
 
+### Example configurations
+
+Here is an example set of configurations for running a Jitsi instance with:
+
+- authentication using a Jitsi account (username: `US3RNAME`, password: `passw0rd`)
+- maximum participants: 6 people
+- fine tuning with the configurations presented above
+- other miscellaneous options (see the official Jitsi documentation [here](https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-configuration) and [here](https://jitsi.github.io/handbook/docs/user-guide/user-guide-advanced))
+
+```yaml
+jitsi_enabled: true
+jitsi_enable_auth: true
+jitsi_enable_guests: true
+jitsi_prosody_auth_internal_accounts:
+  - username: "US3RNAME"
+    password: "passw0rd"
+jitsi_prosody_max_participants: 6
+jitsi_web_config_resolution_width_ideal_and_max: 480
+jitsi_web_config_resolution_height_ideal_and_max: 240
+jitsi_web_custom_config_extension: |
+  config.enableLayerSuspension = true;
+  config.disableAudioLevels = true;
+  config.channelLastN = 4;
+  config.requireDisplayName = true; // force users to set a display name
+  config.startAudioOnly = true; // start the conference in audio only mode (no video is being received nor sent)
+```
+
 ## Installing
 
 After configuring the playbook and potentially [adjusting your DNS records](#adjusting-dns-records), run the playbook with [playbook tags](playbook-tags.md) as below:

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -34,13 +34,13 @@ Example additional configuration for your `vars.yml` file:
 jitsi_hostname: call.example.com
 ```
 
-## Adjusting DNS records
+#### Adjusting DNS records
 
 Once you've decided on the domain and path, **you may need to adjust your DNS** records to point the Jitsi domain to the Matrix server.
 
 By default, you will need to create a CNAME record for `jitsi`. See [Configuring DNS](configuring-dns.md) for details about DNS changes.
 
-## Configure Jitsi authentication and guests mode (optional)
+### Configure Jitsi authentication and guests mode (optional)
 
 By default the Jitsi Meet instance does not require any kind of login and is open to use for anyone without registration.
 
@@ -52,7 +52,7 @@ Currently, there are three supported authentication modes: 'internal' (default),
 
 **Note**: Authentication is not tested via the playbook's self-checks. We therefore recommend that you manually verify if authentication is required by jitsi. For this, try to manually create a conference on jitsi.example.com in your browser.
 
-### Authenticate using Jitsi accounts (Auth-Type 'internal')
+#### Authenticate using Jitsi accounts (Auth-Type 'internal')
 
 The default authentication mechanism is 'internal' auth, which requires jitsi-accounts to be setup and is the recommended setup, as it also works in federated rooms. With authentication enabled, all meeting rooms have to be opened by a registered user, after which guests are free to join. If a registered host is not yet present, guests are put on hold in individual waiting rooms.
 
@@ -72,7 +72,7 @@ jitsi_prosody_auth_internal_accounts:
 
 **If you get an error** like this: "Error: Account creation/modification not supported.", it's likely that you had previously installed Jitsi without auth/guest support. In such a case, you should look into [Rebuilding your Jitsi installation](#rebuilding-your-jitsi-installation).
 
-### Authenticate using Matrix OpenID (Auth-Type 'matrix')
+#### Authenticate using Matrix OpenID (Auth-Type 'matrix')
 
 ⚠️ **Warning**: probably this breaks the Jitsi instance in federated rooms and does not allow sharing conference links with guests.
 
@@ -88,7 +88,7 @@ matrix_user_verification_service_enabled: true
 
 For more information see also [https://github.com/matrix-org/prosody-mod-auth-matrix-user-verification](https://github.com/matrix-org/prosody-mod-auth-matrix-user-verification).
 
-### Authenticate using LDAP (Auth-Type 'ldap')
+#### Authenticate using LDAP (Auth-Type 'ldap')
 
 An example LDAP configuration could be:
 
@@ -112,7 +112,7 @@ jitsi_ldap_start_tls: false
 
 For more information refer to the [docker-jitsi-meet](https://github.com/jitsi/docker-jitsi-meet#authentication-using-ldap) and the [saslauthd `LDAP_SASLAUTHD`](https://github.com/winlibs/cyrus-sasl/blob/master/saslauthd/LDAP_SASLAUTHD) documentation.
 
-## Making your Jitsi server work on a LAN (optional)
+### Making your Jitsi server work on a LAN (optional)
 
 By default the Jitsi Meet instance does not work with a client in LAN (Local Area Network), even if others are connected from WAN. There are no video and audio. In the case of WAN to WAN everything is ok.
 
@@ -125,7 +125,7 @@ jitsi_jvb_container_extra_arguments:
   - '--env "JVB_ADVERTISE_IPS=<Local IP address of the host>"'
 ```
 
-## Specify a Max number of participants on a Jitsi conference (optional)
+### Specify a Max number of participants on a Jitsi conference (optional)
 
 The playbook allows a user to set a max number of participants allowed to join a Jitsi conference. By default the number is not limited.
 
@@ -135,13 +135,13 @@ To set the max number of participants, add the following configuration to your `
 jitsi_prosody_max_participants: 4 # example value
 ```
 
-## Set up Additional JVBs (optional)
+### Set up Additional JVBs (optional)
 
 By default, a single JVB ([Jitsi VideoBridge](https://github.com/jitsi/jitsi-videobridge)) is deployed on the same host as the Matrix server. To allow more video-conferences to happen at the same time, you'd need to provision additional JVB services on other hosts.
 
 These settings below will allow you to provision those extra JVB instances. The instances will register themselves with the Prosody service, and be available for Jicofo to route conferences too.
 
-### Add the `jitsi_jvb_servers` section on `hosts` file
+#### Add the `jitsi_jvb_servers` section on `hosts` file
 
 For additional JVBs, you'd need to add the section titled `jitsi_jvb_servers` on the ansible `hosts` file with the details of the JVB hosts as below:
 
@@ -154,7 +154,7 @@ Make sure to replace `jvb-2.example.com` with your hostname for the JVB and `192
 
 You could add JVB hosts as many as you would like. When doing so, add lines with the details of them.
 
-### Set the server ID to each JVB
+#### Set the server ID to each JVB
 
 Each JVB requires a server ID to be set, so that it will be uniquely identified. The server ID allows Jitsi to keep track of which conferences are on which JVB.
 
@@ -180,7 +180,7 @@ Alternatively, you can specify the variable as a parameter to [the ansible comma
 
 **Note**: the server ID `jvb-1` is reserved for the JVB instance running on the Matrix host, therefore should not be used as the ID of an additional JVB host.
 
-### Set colibri WebSocket port
+#### Set colibri WebSocket port
 
 The additional JVBs will need to expose the colibri WebSocket port.
 
@@ -190,13 +190,13 @@ To expose the port, add the following configuration to your `vars.yml` file:
 jitsi_jvb_container_colibri_ws_host_bind_port: 9090
 ```
 
-### Set Prosody XMPP server
+#### Set Prosody XMPP server
 
 The JVB will also need to know the location of the Prosody XMPP server.
 
 Similar to the server ID (`jitsi_jvb_server_id`), this can be set with the variable for the JVB by using the variable `jitsi_xmpp_server`.
 
-#### Set the Matrix domain
+##### Set the Matrix domain
 
 The Jitsi Prosody container is deployed on the Matrix server by default, so the value can be set to the Matrix domain. To set the value, add the following configuration to your `vars.yml` file:
 
@@ -204,7 +204,7 @@ The Jitsi Prosody container is deployed on the Matrix server by default, so the 
 jitsi_xmpp_server: "{{ matrix_domain }}"
 ```
 
-#### Set an IP address of the Matrix server
+##### Set an IP address of the Matrix server
 
 Alternatively, the IP address of the Matrix server can be set. This can be useful if you would like to use a private IP address.
 
@@ -214,7 +214,7 @@ To set the IP address of the Matrix server, add the following configuration to y
 jitsi_xmpp_server: "192.168.0.1"
 ```
 
-#### Expose XMPP port
+##### Expose XMPP port
 
 By default, the Matrix server does not expose the XMPP port (`5222`); only the XMPP container exposes it internally inside the host. This means that the first JVB (which runs on the Matrix server) can reach it but the additional JVBs cannot. Therefore, the XMPP server needs to expose the port, so that the additional JVBs can connect to it.
 
@@ -224,7 +224,7 @@ To expose the port and have Docker forward the port, add the following configura
 jitsi_prosody_container_jvb_host_bind_port: 5222
 ```
 
-### Reverse-proxy with Traefik
+#### Reverse-proxy with Traefik
 
 To make Traefik reverse-proxy to these additional JVBs (living on other hosts), add the following configuration to your `vars.yml` file:
 
@@ -262,7 +262,7 @@ traefik_provider_configuration_extension_yaml: |
      {% endfor %}
 ```
 
-### Run the playbook
+#### Run the playbook
 
 After configuring `vars.yml` and `hosts` files, run the playbook with [playbook tags](playbook-tags.md) as below:
 
@@ -270,7 +270,7 @@ After configuring `vars.yml` and `hosts` files, run the playbook with [playbook 
 ansible-playbook -i inventory/hosts --limit jitsi_jvb_servers jitsi_jvb.yml --tags=common,setup-additional-jitsi-jvb,start
 ```
 
-## Enable Gravatar (optional)
+### Enable Gravatar (optional)
 
 In the default Jisti Meet configuration, gravatar.com is enabled as an avatar service. This results in third party request leaking data to gravatar. Since Element clients already send the url of configured Matrix avatars to Jitsi, we disabled gravatar.
 
@@ -282,7 +282,7 @@ jitsi_disable_gravatar: false
 
 ⚠️ **Warning**: This leaks information to a third party, namely the Gravatar-Service (unless configured otherwise: gravatar.com). Besides metadata, this includes the Matrix user_id and possibly the room identifier (via `referrer` header).
 
-## Fine tune Jitsi (optional)
+### Fine tune Jitsi (optional)
 
 If you'd like to have Jitsi save up resources, add the following configuration to your `vars.yml` file (adapt to your needs):
 

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -133,15 +133,17 @@ jitsi_prosody_max_participants: 4 # example value
 
 ### Enable Gravatar (optional)
 
-In the default Jisti Meet configuration, gravatar.com is enabled as an avatar service. This results in third party request leaking data to gravatar. Since Element clients already send the url of configured Matrix avatars to Jitsi, we disabled gravatar.
+In the default Jisti Meet configuration, `gravatar.com` is enabled as an avatar service.
 
-To enable Gravatar, add the following configuration to your `vars.yml` file:
+Since Element clients (Element Web, Element X Android, etc.) send the URL of configured Matrix avatars to the Jitsi instance, our default configuration has disabled the Gravatar service.
+
+To enable the Gravatar service, add the following configuration to your `vars.yml` file:
 
 ```yaml
 jitsi_disable_gravatar: false
 ```
 
-⚠️ **Warning**: This leaks information to a third party, namely the Gravatar-Service (unless configured otherwise: gravatar.com). Besides metadata, this includes the Matrix user_id and possibly the room identifier (via `referrer` header).
+⚠️ **Warning**: This will result in third party request leaking data to the Gravatar Service (`gravatar.com`, unless configured otherwise). Besides metadata, the Matrix user_id and possibly the room ID (via `referrer` header) will be also sent to the third party.
 
 ### Fine tune Jitsi (optional)
 

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -44,7 +44,7 @@ After changing the domain, **you may need to adjust your DNS** records to point 
 
 By default the Jitsi instance does not require for anyone to log in, and is open to use without an account. To control who is allowed to start meetings on your Jitsi instance, you'd need to enable Jitsi's authentication and optionally guests mode.
 
-Currently, there are three supported authentication methods: `internal` (default), `matrix` and `ldap`.
+Authentication type must be one of them: `internal` (default), `jwt`, `matrix` or `ldap`. Currently, only `internal`, `matrix` and `ldap` mechanisms are supported by the [Jitsi role](https://github.com/mother-of-all-self-hosting/ansible-role-jitsi).
 
 With authentication enabled, all meetings have to be started by a registered user. After the meeting is started by that user, then guests are free to join. If the registered user is not yet present, the guests are put on hold in individual waiting rooms.
 
@@ -72,8 +72,7 @@ jitsi_prosody_auth_internal_accounts:
 
 ⚠️ **Warning**: this breaks the Jitsi instance on federated rooms probably and does not allow sharing conference links with guests.
 
-This authentication method requires [Matrix User Verification Service](https://github.com/matrix-org/matrix-user-verification-service), which can be installed using this [playbook](configuring-playbook-user-verification-service.md). By default, the playbook creates and configures a user-verification-service so that it runs locally.
-
+This authentication method requires [Matrix User Verification Service](https://github.com/matrix-org/matrix-user-verification-service), which can be installed using this [playbook](configuring-playbook-user-verification-service.md). It verifies against Matrix openID, and requires a user-verification-service to run.
 
 To enable authentication with Matrix OpenID, add the following configuration to your `vars.yml` file:
 

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -152,6 +152,8 @@ jitsi_disable_gravatar: false
 If you'd like to have Jitsi save up resources, add the following configuration to your `vars.yml` file (adapt to your needs):
 
 ```yaml
+jitsi_web_config_resolution_width_ideal_and_max: 480
+jitsi_web_config_resolution_height_ideal_and_max: 240
 jitsi_web_custom_config_extension: |
   config.enableLayerSuspension = true;
 
@@ -159,17 +161,14 @@ jitsi_web_custom_config_extension: |
 
   // Limit the number of video feeds forwarded to each client
   config.channelLastN = 4;
-
-jitsi_web_config_resolution_width_ideal_and_max: 480
-jitsi_web_config_resolution_height_ideal_and_max: 240
 ```
 
 These configurations:
 
+- **limit the maximum video resolution**, to save up resources on both server and clients
 - **suspend unused video layers** until they are requested again, to save up resources on both server and clients. Read more on this feature [here](https://jitsi.org/blog/new-off-stage-layer-suppression-feature/).
 - **disable audio levels** to avoid excessive refresh of the client-side page and decrease the CPU consumption involved
 - **limit the number of video feeds forwarded to each client**, to save up resources on both server and clients. As clients’ bandwidth and CPU may not bear the load, use this setting to avoid lag and crashes. This feature is available by default on other webconference applications such as Office 365 Teams (the number is limited to 4). Read how it works [here](https://github.com/jitsi/jitsi-videobridge/blob/master/doc/last-n.md) and performance evaluation on this [study](https://jitsi.org/wp-content/uploads/2016/12/nossdav2015lastn.pdf).
-- **limit the maximum video resolution**, to save up resources on both server and clients
 
 ## Installing
 

--- a/docs/configuring-playbook-jitsi.md
+++ b/docs/configuring-playbook-jitsi.md
@@ -68,8 +68,6 @@ jitsi_prosody_auth_internal_accounts:
 
 **Note**: as Jitsi account removal function is not integrated into the playbook, these accounts will not be able to be removed from the Prosody server automatically, even if they are removed from your `vars.yml` file subsequently.
 
-**Note**: if you get an error like `Error: Account creation/modification not supported.`, it's likely that you had previously installed Jitsi without auth/guest support. In such a case, you should look into [Rebuilding your Jitsi installation](#rebuilding-your-jitsi-installation).
-
 #### Authenticate using Matrix OpenID (Auth-Type `matrix`)
 
 ⚠️ **Warning**: probably this breaks the Jitsi instance in federated rooms and does not allow sharing conference links with guests.
@@ -328,6 +326,12 @@ ansible-playbook -i inventory/hosts --limit jitsi_jvb_servers jitsi_jvb.yml --ta
 ```
 
 ## Troubleshooting
+
+### `Error: Account creation/modification not supported`
+
+If you get an error like `Error: Account creation/modification not supported` with authentication enabled, it's likely that you had previously installed Jitsi without auth/guest support.
+
+In this case, you should consider to rebuild your Jitsi installation.
 
 ### Rebuilding your Jitsi installation
 

--- a/docs/configuring-playbook-user-verification-service.md
+++ b/docs/configuring-playbook-user-verification-service.md
@@ -71,7 +71,7 @@ To set your own Token, add the following configuration to your `vars.yml` file:
 matrix_user_verification_service_uvs_auth_token: "TOKEN"
 ```
 
-In case Jitsi is also managed by this playbook and 'matrix' authentication in Jitsi is enabled, this collection will automatically configure Jitsi to use the configured auth token.
+If a Jitsi instance is also managed by this playbook and [`matrix` authentication](configuring-playbook-jitsi.md#authenticate-using-matrix-openid-auth-type-matrix) is enabled there, this collection will automatically configure Jitsi to use the configured auth token.
 
 ### Disable Auth (optional)
 


### PR DESCRIPTION
This also intends to be a first trial of placing the instruction about adjusting DNS records above the section for adjusting the URL, to make the configuration workflow more natural. Once it is confirmed that this change makes sense, the other instances will be addressed with another PR.

Though working on Jitsi integration stuff might no longer be as worth as it has been thanks to Element Call, improving the docs should always help us some way :)