### PR TITLE
Remove an obsolete variable: backup_borg_retention_prefix

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -3199,7 +3199,6 @@ matrix_pantalaimon_homeserver_url: "{{ matrix_addons_homeserver_client_api_url }
 backup_borg_enabled: false
 
 backup_borg_identifier: matrix-backup-borg
-backup_borg_retention_prefix: matrix-
 backup_borg_storage_archive_name_format: matrix-{now:%Y-%m-%d-%H%M%S}
 
 backup_borg_base_path: "{{ matrix_base_data_path }}/backup-borg"


### PR DESCRIPTION
Please let me know if the variable is still useful somehow. Thanks in advance!