### PR TITLE
Change matrix_synapse_forgotten_room_retention_period  from null to 28d

### DIFF
--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -1456,7 +1456,7 @@ matrix_synapse_redaction_retention_period: 7d
 # Controls how long to keep locally forgotten rooms before purging them from the DB.
 # Defaults to `null`, meaning it's disabled.
 # Example value: 28d
-matrix_synapse_forgotten_room_retention_period: ~
+matrix_synapse_forgotten_room_retention_period: 28d
 
 matrix_synapse_user_ips_max_age: 28d
 

--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -1415,6 +1415,7 @@ matrix_synapse_default_room_version: "10"
 
 # Controls whether leaving a room will automatically forget it.
 # The upstream default is `false`, but we try to make Synapse less wasteful of resources, so we do things differently.
+# Also see: `matrix_synapse_forgotten_room_retention_period`
 matrix_synapse_forget_rooms_on_leave: true
 
 # Controls the Synapse `modules` list.
@@ -1455,6 +1456,7 @@ matrix_synapse_redaction_retention_period: 7d
 
 # Controls how long to keep locally forgotten rooms before purging them from the DB.
 # Defaults to `null`, meaning it's disabled.
+# Also see: `matrix_synapse_forget_rooms_on_leave`
 # Example value: 28d
 matrix_synapse_forgotten_room_retention_period: 28d
 


### PR DESCRIPTION
As we automatically forget rooms on leave in the playbook this option working at all is probably heavily desired.

Timing is copied from upstream example.

Credit goes to Anoa for making me even check this.

https://element-hq.github.io/synapse/latest/usage/configuration/config_documentation.html#forgotten_room_retention_period for the documentation on this matter.