### PR TITLE
Update docs for Element Web and SchildiChat Web

### DIFF
--- a/docs/configuring-playbook-client-element-web.md
+++ b/docs/configuring-playbook-client-element-web.md
@@ -17,11 +17,19 @@ When setting, replace `example.com` with your own.
 
 ## Adjusting the playbook configuration
 
+### Set the country code for phone number inputs
+
+You can change the country code (default: `GB`) to use when showing phone number inputs. To change it to `FR` for example, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:
+
+```yaml
+matrix_client_element_default_country_code: "FR"
+```
+
 ### Themes
 
 #### Change the default theme
 
-You can change the default theme from `light` to `dark`. To do so, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:
+You can change the default theme from `light` to `dark`. To do so, add the following configuration to your `vars.yml` file:
 
 ```yaml
 # Controls the default theme

--- a/docs/configuring-playbook-client-element-web.md
+++ b/docs/configuring-playbook-client-element-web.md
@@ -129,3 +129,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 The shortcut commands with the [`just` program](just.md) are also available: `just install-all` or `just setup-all`
 
 `just install-all` is useful for maintaining your setup quickly ([2x-5x faster](../CHANGELOG.md#2x-5x-performance-improvements-in-playbook-runtime) than `just setup-all`) when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. Note these shortcuts run the `ensure-matrix-users-created` tag too.
+
+## Troubleshooting
+
+As with all other services, you can find the logs in [systemd-journald](https://www.freedesktop.org/software/systemd/man/systemd-journald.service.html) by logging in to the server with SSH and running `journalctl -fu matrix-client-element`.

--- a/docs/configuring-playbook-client-element-web.md
+++ b/docs/configuring-playbook-client-element-web.md
@@ -19,11 +19,20 @@ When setting, replace `example.com` with your own.
 
 ### Themes
 
-You can change the look of Element Web by pulling themes provided by the [aaronraimist/element-themes](https://github.com/aaronraimist/element-themes) project or defining your own themes manually.
+#### Change the default theme
+
+You can change the default theme from `light` to `dark`. To do so, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:
+
+```yaml
+# Controls the default theme
+matrix_client_element_default_theme: 'dark'
+```
 
 #### Use themes by `element-themes`
 
-To pull the themes from the `element-themes` project and use them for your Element Web instance, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:
+You can change the look of Element Web by pulling themes provided by the [aaronraimist/element-themes](https://github.com/aaronraimist/element-themes) project or defining your own themes manually.
+
+To pull the themes and use them for your Element Web instance, add the following configuration to your `vars.yml` file:
 
 ```yaml
 matrix_client_element_themes_enabled: true

--- a/docs/configuring-playbook-client-schildichat-web.md
+++ b/docs/configuring-playbook-client-schildichat-web.md
@@ -126,3 +126,7 @@ ansible-playbook -i inventory/hosts setup.yml --tags=setup-all,start
 The shortcut commands with the [`just` program](just.md) are also available: `just install-all` or `just setup-all`
 
 `just install-all` is useful for maintaining your setup quickly ([2x-5x faster](../CHANGELOG.md#2x-5x-performance-improvements-in-playbook-runtime) than `just setup-all`) when its components remain unchanged. If you adjust your `vars.yml` to remove other components, you'd need to run `just setup-all`, or these components will still remain installed. Note these shortcuts run the `ensure-matrix-users-created` tag too.
+
+## Troubleshooting
+
+As with all other services, you can find the logs in [systemd-journald](https://www.freedesktop.org/software/systemd/man/systemd-journald.service.html) by logging in to the server with SSH and running `journalctl -fu matrix-client-schildichat`.

--- a/docs/configuring-playbook-client-schildichat-web.md
+++ b/docs/configuring-playbook-client-schildichat-web.md
@@ -24,11 +24,20 @@ matrix_client_schildichat_enabled: true
 
 ### Themes
 
-You can change the look of SchildiChat Web by pulling themes provided by the [aaronraimist/element-themes](https://github.com/aaronraimist/element-themes) project or defining your own themes manually.
+#### Change the default theme
+
+You can change the default theme from `light` to `dark`. To do so, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:
+
+```yaml
+# Controls the default theme
+matrix_client_schildichat_default_theme: 'dark'
+```
 
 #### Use themes by `element-themes`
 
-To pull the themes from the `element-themes` project and use them for your SchildiChat Web instance, add the following configuration to your `vars.yml` file:
+You can change the look of SchildiChat Web by pulling themes provided by the [aaronraimist/element-themes](https://github.com/aaronraimist/element-themes) project or defining your own themes manually.
+
+To pull the themes and use them for your SchildiChat Web instance, add the following configuration to your `vars.yml` file:
 
 ```yaml
 matrix_client_schildichat_themes_enabled: true

--- a/docs/configuring-playbook-client-schildichat-web.md
+++ b/docs/configuring-playbook-client-schildichat-web.md
@@ -22,11 +22,19 @@ To enable SchildiChat Web, add the following configuration to your `inventory/ho
 matrix_client_schildichat_enabled: true
 ```
 
+### Set the country code for phone number inputs
+
+You can change the country code (default: `GB`) to use when showing phone number inputs. To change it to `FR` for example, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:
+
+```yaml
+matrix_client_schildichat_default_country_code: "FR"
+```
+
 ### Themes
 
 #### Change the default theme
 
-You can change the default theme from `light` to `dark`. To do so, add the following configuration to your `inventory/host_vars/matrix.example.com/vars.yml` file:
+You can change the default theme from `light` to `dark`. To do so, add the following configuration to your `vars.yml` file:
 
 ```yaml
 # Controls the default theme

--- a/roles/custom/matrix-client-element/defaults/main.yml
+++ b/roles/custom/matrix-client-element/defaults/main.yml
@@ -194,7 +194,7 @@ matrix_client_element_self_check_validate_certificates: true
 # don't show the registration button on welcome page
 matrix_client_element_registration_enabled: false
 
-# Default country code on welcome page when login by phone number
+# An optional ISO 3166 alpha2 country code (eg: GB, the default) to use when showing phone number inputs
 matrix_client_element_default_country_code: "GB"
 
 # Controls whether presence will be enabled

--- a/roles/custom/matrix-client-schildichat/defaults/main.yml
+++ b/roles/custom/matrix-client-schildichat/defaults/main.yml
@@ -189,7 +189,7 @@ matrix_client_schildichat_self_check_validate_certificates: true
 # don't show the registration button on welcome page
 matrix_client_schildichat_registration_enabled: false
 
-# Default country code on welcome page when login by phone number
+# An optional ISO 3166 alpha2 country code (eg: GB, the default) to use when showing phone number inputs
 matrix_client_schildichat_default_country_code: "GB"
 
 # Controls whether presence will be enabled


### PR DESCRIPTION
- add the instruction to change the default theme from light to dark
- add the instruction to change the default country code to help to make the clients less British
- add the common sections "Troubleshooting"

The first two changes (dark theme and default country code) should be helpful in general to customize those clients.