### PR TITLE
Correct the name of matrix-bot-baibot's configuration file

### DIFF
--- a/roles/custom/matrix-bot-baibot/templates/systemd/matrix-bot-baibot.service.j2
+++ b/roles/custom/matrix-bot-baibot/templates/systemd/matrix-bot-baibot.service.j2
@@ -29,7 +29,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			--read-only \
 			--network={{ matrix_bot_baibot_container_network }} \
 			--env-file={{ matrix_bot_baibot_config_path }}/env \
-			--mount type=bind,src={{ matrix_bot_baibot_config_path }}/config.yaml,dst=/app/config.yaml,ro \
+			--mount type=bind,src={{ matrix_bot_baibot_config_path }}/config.yaml,dst=/app/config.yml,ro \
 			--mount type=bind,src={{ matrix_bot_baibot_data_path }},dst=/data \
 			--tmpfs=/tmp:rw,noexec,nosuid,size=1024m \
 			{% for arg in matrix_bot_baibot_container_extra_arguments %}


### PR DESCRIPTION
Commit 30dad8ba277bc renamed the config file for baibot from `config.yml` to `config.yaml`. While this increases consistency, it actually broke my baibot setup: the service `matrix-bot-baitbot.service` failed to start because the baibot container apparently expects the file's name to be `config.yml` (without the 'a').

This PR reverts part of the changes introduced in 30dad8ba277bc to ensure the container gets the file name it expects.