### PR TITLE
add 302 redirect option as well as reverse-proxy

### DIFF
--- a/docs/configuring-well-known.md
+++ b/docs/configuring-well-known.md
@@ -97,7 +97,7 @@ This is relatively easy to do and possibly your only choice if you can only host
 
 This option is less fragile and generally better.
 
-On the base domain's server (e.g. `example.com`), you can set up reverse-proxying, so that any access for the `/.well-known/matrix` location prefix is forwarded to the Matrix domain's server (e.g. `matrix.example.com`).
+On the base domain's server (e.g. `example.com`), you can set up reverse-proxying (or simply a 302 redirect), so that any access for the `/.well-known/matrix` location prefix is forwarded to the Matrix domain's server (e.g. `matrix.example.com`).
 
 With this method, you **don't need** to add special HTTP headers for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) reasons (like `Access-Control-Allow-Origin`), because your Matrix server (where requests ultimately go) will be configured by this playbook correctly.
 


### PR DESCRIPTION
As discussed some time ago on the matrix channel for this project, a 302 redirect from the base domain (rather than a reverse proxy) is a little more realistic in a large institution (this is what we have done in epfl.ch).
Just adding a few words to clarify that this is an option