### PR TITLE
Add license information to files for MX bridges

### DIFF
--- a/docs/configuring-playbook-bridge-mx-puppet-discord.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-discord.md
@@ -1,3 +1,12 @@
+<!--
+SPDX-FileCopyrightText: 2020 Hugues Morisset
+SPDX-FileCopyrightText: 2020 - 2022 Slavi Pantaleev
+SPDX-FileCopyrightText: 2022 MDAD project contributors
+SPDX-FileCopyrightText: 2024 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Setting up MX Puppet Discord bridging (optional)
 
 **Note**: bridging to [Discord](https://discordapp.com/) can also happen via the [matrix-appservice-discord](configuring-playbook-bridge-appservice-discord.md)and [mautrix-discord](configuring-playbook-bridge-mautrix-discord.md) bridges supported by the playbook.   

--- a/docs/configuring-playbook-bridge-mx-puppet-groupme.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-groupme.md
@@ -1,3 +1,12 @@
+<!--
+SPDX-FileCopyrightText: 2021 Cody Neiman
+SPDX-FileCopyrightText: 2021 Slavi Pantaleev
+SPDX-FileCopyrightText: 2022 Cody Wyatt Neiman
+SPDX-FileCopyrightText: 2024 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Setting up MX Puppet GroupMe bridging (optional)
 
 The playbook can install and configure [mx-puppet-groupme](https://gitlab.com/xangelix-pub/matrix/mx-puppet-groupme) for you.

--- a/docs/configuring-playbook-bridge-mx-puppet-instagram.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-instagram.md
@@ -1,3 +1,10 @@
+<!--
+SPDX-FileCopyrightText: 2021 MDAD project contributors
+SPDX-FileCopyrightText: 2024 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Setting up MX Puppet Instagram bridging (optional)
 
 The playbook can install and configure [mx-puppet-instagram](https://github.com/Sorunome/mx-puppet-instagram) for you.

--- a/docs/configuring-playbook-bridge-mx-puppet-skype.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-skype.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-FileCopyrightText: 2020 Rodrigo Belem
+SPDX-FileCopyrightText: 2020 - 2025 Slavi Pantaleev
+SPDX-FileCopyrightText: 2024 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Setting up MX Puppet Skype bridging (optional, removed)
 
 🪦 The playbook used to be able to install and configure [mx-puppet-skype](https://github.com/Sorunome/mx-puppet-skype), but no longer includes this component, because it has been broken and unmaintained for a long time.

--- a/docs/configuring-playbook-bridge-mx-puppet-slack.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-slack.md
@@ -1,3 +1,14 @@
+<!--
+SPDX-FileCopyrightText: 2020 Rodrigo Belem
+SPDX-FileCopyrightText: 2020 - 2023 Slavi Pantaleev
+SPDX-FileCopyrightText: 2021 Marcel Ackermann
+SPDX-FileCopyrightText: 2022 Jim Myhrberg
+SPDX-FileCopyrightText: 2022 Nikita Chernyi
+SPDX-FileCopyrightText: 2024 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Setting up MX Puppet Slack bridging (optional)
 
 **Note**: bridging to [Slack](https://slack.com) can also happen via the [matrix-appservice-slack](configuring-playbook-bridge-appservice-slack.md) and [mautrix-slack](configuring-playbook-bridge-mautrix-slack.md) bridges supported by the playbook. Note that `matrix-appservice-slack` is not available for new installation unless you have already created a classic Slack application, because the creation of classic Slack applications, which this bridge makes use of, has been discontinued.

--- a/docs/configuring-playbook-bridge-mx-puppet-steam.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-steam.md
@@ -1,3 +1,12 @@
+<!--
+SPDX-FileCopyrightText: 2020 Hugues Morisset
+SPDX-FileCopyrightText: 2020 - 2021 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 Panagiotis Vasilopoulos
+SPDX-FileCopyrightText: 2024 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Setting up MX Puppet Steam bridging (optional)
 
 The playbook can install and configure [mx-puppet-steam](https://github.com/icewind1991/mx-puppet-steam) for you.

--- a/docs/configuring-playbook-bridge-mx-puppet-twitter.md
+++ b/docs/configuring-playbook-bridge-mx-puppet-twitter.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-FileCopyrightText: 2020 Tulir Asokan
+SPDX-FileCopyrightText: 2021 Slavi Pantaleev
+SPDX-FileCopyrightText: 2024 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Setting up MX Puppet Twitter bridging (optional)
 
 **Note**: bridging to [Twitter](https://twitter.com/) can also happen via the [mautrix-twitter](configuring-playbook-bridge-mautrix-twitter.md) bridge supported by the playbook.

--- a/roles/custom/matrix-bridge-mx-puppet-discord/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-discord/defaults/main.yml
@@ -1,3 +1,15 @@
+# SPDX-FileCopyrightText: 2020 Hugues Morisset
+# SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2020 - 2024 MDAD project contributors
+# SPDX-FileCopyrightText: 2021 Ahmad Haghighi
+# SPDX-FileCopyrightText: 2022 Daniel Sonck
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Nikita Chernyi
+# SPDX-FileCopyrightText: 2023 Samuel Meenzen
+# SPDX-FileCopyrightText: 2024 Suguru Hirahara
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 # Mx Puppet Discord is a Matrix <-> Discord bridge
 # Project source code URL: https://gitlab.com/mx-puppet/discord/mx-puppet-discord

--- a/roles/custom/matrix-bridge-mx-puppet-discord/tasks/main.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-discord/tasks/main.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2020 Hugues Morisset
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 - 2023 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - tags:

--- a/roles/custom/matrix-bridge-mx-puppet-discord/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-discord/tasks/setup_install.yml
@@ -1,3 +1,14 @@
+# SPDX-FileCopyrightText: 2020 Hugues Morisset
+# SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2020 Stuart Mumford
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Jim Myhrberg
+# SPDX-FileCopyrightText: 2022 Nikita Chernyi
+# SPDX-FileCopyrightText: 2022 Sebastian Gumprich
+# SPDX-FileCopyrightText: 2024 David Mehren
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Ensure MX Puppet Discord paths exist

--- a/roles/custom/matrix-bridge-mx-puppet-discord/tasks/setup_uninstall.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-discord/tasks/setup_uninstall.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2020 Hugues Morisset
+# SPDX-FileCopyrightText: 2021 - 2022 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Check existence of matrix-mx-puppet-discord service

--- a/roles/custom/matrix-bridge-mx-puppet-discord/tasks/validate_config.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-discord/tasks/validate_config.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2020 Hugues Morisset
+# SPDX-FileCopyrightText: 2022 - 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Fail if required mx-puppet-discord settings not defined

--- a/roles/custom/matrix-bridge-mx-puppet-discord/templates/config.yaml.j2.license
+++ b/roles/custom/matrix-bridge-mx-puppet-discord/templates/config.yaml.j2.license
@@ -1,0 +1,6 @@
+SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 Hugues Morisset
+SPDX-FileCopyrightText: 2020 MDAD project contributors
+SPDX-FileCopyrightText: 2022 Nikita Chernyi
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-bridge-mx-puppet-discord/templates/systemd/matrix-mx-puppet-discord.service.j2.license
+++ b/roles/custom/matrix-bridge-mx-puppet-discord/templates/systemd/matrix-mx-puppet-discord.service.j2.license
@@ -1,0 +1,5 @@
+SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 Hugues Morisset
+SPDX-FileCopyrightText: 2020 Scott Crossen
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-bridge-mx-puppet-groupme/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-groupme/defaults/main.yml
@@ -1,3 +1,14 @@
+# SPDX-FileCopyrightText: 2021 Cody Neiman
+# SPDX-FileCopyrightText: 2021 MDAD project contributors
+# SPDX-FileCopyrightText: 2021 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2021 Ahmad Haghighi
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Nikita Chernyi
+# SPDX-FileCopyrightText: 2022 Cody Wyatt Neiman
+# SPDX-FileCopyrightText: 2024 Suguru Hirahara
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 # Mx Puppet GroupMe is a Matrix <-> GroupMe bridge
 # Project source code URL: https://gitlab.com/xangelix-pub/matrix/mx-puppet-groupme

--- a/roles/custom/matrix-bridge-mx-puppet-groupme/tasks/main.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-groupme/tasks/main.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2021 Cody Neiman
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 - 2023 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - tags:

--- a/roles/custom/matrix-bridge-mx-puppet-groupme/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-groupme/tasks/setup_install.yml
@@ -1,3 +1,13 @@
+# SPDX-FileCopyrightText: 2021 Cody Neiman
+# SPDX-FileCopyrightText: 2021 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Jim Myhrberg
+# SPDX-FileCopyrightText: 2022 Nikita Chernyi
+# SPDX-FileCopyrightText: 2022 Sebastian Gumprich
+# SPDX-FileCopyrightText: 2024 David Mehren
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Ensure MX Puppet Groupme paths exist

--- a/roles/custom/matrix-bridge-mx-puppet-groupme/tasks/setup_uninstall.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-groupme/tasks/setup_uninstall.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2021 Cody Neiman
+# SPDX-FileCopyrightText: 2021 - 2022 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Check existence of matrix-mx-puppet-groupme service

--- a/roles/custom/matrix-bridge-mx-puppet-groupme/tasks/validate_config.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-groupme/tasks/validate_config.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2021 Cody Neiman
+# SPDX-FileCopyrightText: 2022 - 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Fail if required mx-puppet-groupme settings not defined

--- a/roles/custom/matrix-bridge-mx-puppet-groupme/templates/config.yaml.j2.license
+++ b/roles/custom/matrix-bridge-mx-puppet-groupme/templates/config.yaml.j2.license
@@ -1,0 +1,5 @@
+SPDX-FileCopyrightText: 2021 Cody Neiman
+SPDX-FileCopyrightText: 2022 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2022 Nikita Chernyi
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-bridge-mx-puppet-groupme/templates/systemd/matrix-mx-puppet-groupme.service.j2.license
+++ b/roles/custom/matrix-bridge-mx-puppet-groupme/templates/systemd/matrix-mx-puppet-groupme.service.j2.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2021 Cody Neiman
+SPDX-FileCopyrightText: 2022 - 2024 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-bridge-mx-puppet-instagram/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-instagram/defaults/main.yml
@@ -1,3 +1,13 @@
+# SPDX-FileCopyrightText: 2020 - 2021 MDAD project contributors
+# SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2021 Ahmad Haghighi
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Nikita Chernyi
+# SPDX-FileCopyrightText: 2023 Samuel Meenzen
+# SPDX-FileCopyrightText: 2024 Suguru Hirahara
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 # mx-puppet-instagram bridges instagram DMs
 # Project source code URL: https://github.com/Sorunome/mx-puppet-instagram

--- a/roles/custom/matrix-bridge-mx-puppet-instagram/tasks/main.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-instagram/tasks/main.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2020 - 2021 MDAD project contributors
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 - 2023 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - tags:

--- a/roles/custom/matrix-bridge-mx-puppet-instagram/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-instagram/tasks/setup_install.yml
@@ -1,3 +1,14 @@
+# SPDX-FileCopyrightText: 2020 - 2021 MDAD project contributors
+# SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2020 Stuart Mumford
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Jim Myhrberg
+# SPDX-FileCopyrightText: 2022 Nikita Chernyi
+# SPDX-FileCopyrightText: 2022 Sebastian Gumprich
+# SPDX-FileCopyrightText: 2024 David Mehren
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - ansible.builtin.set_fact:

--- a/roles/custom/matrix-bridge-mx-puppet-instagram/tasks/setup_uninstall.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-instagram/tasks/setup_uninstall.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2020 MDAD project contributors
+# SPDX-FileCopyrightText: 2021 - 2022 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Check existence of matrix-mx-puppet-instagram service

--- a/roles/custom/matrix-bridge-mx-puppet-instagram/tasks/validate_config.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-instagram/tasks/validate_config.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2020 MDAD project contributors
+# SPDX-FileCopyrightText: 2022 - 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Fail if required mx-puppet-instagram settings not defined

--- a/roles/custom/matrix-bridge-mx-puppet-instagram/templates/config.yaml.j2.license
+++ b/roles/custom/matrix-bridge-mx-puppet-instagram/templates/config.yaml.j2.license
@@ -1,0 +1,5 @@
+SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 MDAD project contributors
+SPDX-FileCopyrightText: 2022 Nikita Chernyi
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-bridge-mx-puppet-instagram/templates/systemd/matrix-mx-puppet-instagram.service.j2.license
+++ b/roles/custom/matrix-bridge-mx-puppet-instagram/templates/systemd/matrix-mx-puppet-instagram.service.j2.license
@@ -1,0 +1,5 @@
+SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 MDAD project contributors
+SPDX-FileCopyrightText: 2020 Scott Crossen
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-bridge-mx-puppet-slack/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-slack/defaults/main.yml
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: 2020 Rodrigo Belem
+# SPDX-FileCopyrightText: 2020 - 2021 MDAD project contributors
+# SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2020 Hugues Morisset
+# SPDX-FileCopyrightText: 2021 Ahmad Haghighi
+# SPDX-FileCopyrightText: 2021 Marcel Ackermann
+# SPDX-FileCopyrightText: 2022 Jim Myhrberg
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Nikita Chernyi
+# SPDX-FileCopyrightText: 2022 Daniel Sonck
+# SPDX-FileCopyrightText: 2023 Samuel Meenzen
+# SPDX-FileCopyrightText: 2024 Suguru Hirahara
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 # Mx Puppet Slack is a Matrix <-> Slack bridge
 # Project source code URL: https://gitlab.com/mx-puppet/slack/mx-puppet-slack

--- a/roles/custom/matrix-bridge-mx-puppet-slack/tasks/main.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-slack/tasks/main.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2020 Rodrigo Belem
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 - 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - tags:

--- a/roles/custom/matrix-bridge-mx-puppet-slack/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-slack/tasks/setup_install.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2020 Rodrigo Belem
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 - 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Ensure MX Puppet Slack paths exist

--- a/roles/custom/matrix-bridge-mx-puppet-slack/tasks/setup_uninstall.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-slack/tasks/setup_uninstall.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2020 Rodrigo Belem
+# SPDX-FileCopyrightText: 2021 - 2022 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Check existence of matrix-mx-puppet-slack service

--- a/roles/custom/matrix-bridge-mx-puppet-slack/tasks/validate_config.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-slack/tasks/validate_config.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2020 Rodrigo Belem
+# SPDX-FileCopyrightText: 2022 - 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Fail if required mx-puppet-slack settings not defined

--- a/roles/custom/matrix-bridge-mx-puppet-slack/templates/config.yaml.j2.license
+++ b/roles/custom/matrix-bridge-mx-puppet-slack/templates/config.yaml.j2.license
@@ -1,0 +1,8 @@
+SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 Hugues Morisset
+SPDX-FileCopyrightText: 2020 MDAD project contributors
+SPDX-FileCopyrightText: 2021 Marcel Ackermann
+SPDX-FileCopyrightText: 2022 Jim Myhrberg
+SPDX-FileCopyrightText: 2022 Nikita Chernyi
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-bridge-mx-puppet-slack/templates/labels.j2
+++ b/roles/custom/matrix-bridge-mx-puppet-slack/templates/labels.j2
@@ -1,3 +1,9 @@
+{#
+SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+#}
+
 {% if matrix_mx_puppet_slack_container_labels_traefik_enabled %}
 traefik.enable=true
 

--- a/roles/custom/matrix-bridge-mx-puppet-slack/templates/systemd/matrix-mx-puppet-slack.service.j2.license
+++ b/roles/custom/matrix-bridge-mx-puppet-slack/templates/systemd/matrix-mx-puppet-slack.service.j2.license
@@ -1,0 +1,6 @@
+SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 Chris van Dijk
+SPDX-FileCopyrightText: 2020 Rodrigo Belem
+SPDX-FileCopyrightText: 2020 Scott Crossen
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-bridge-mx-puppet-steam/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-steam/defaults/main.yml
@@ -1,3 +1,14 @@
+# SPDX-FileCopyrightText: 2020 Hugues Morisset
+# SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2020 - 2022 MDAD project contributors
+# SPDX-FileCopyrightText: 2021 Ahmad Haghighi
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Nikita Chernyi
+# SPDX-FileCopyrightText: 2023 Samuel Meenzen
+# SPDX-FileCopyrightText: 2024 Suguru Hirahara
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 # Mx Puppet Steam is a Matrix <-> Steam bridge
 # Project source code URL: https://github.com/icewind1991/mx-puppet-steam

--- a/roles/custom/matrix-bridge-mx-puppet-steam/tasks/main.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-steam/tasks/main.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2020 Hugues Morisset
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 - 2023 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - tags:

--- a/roles/custom/matrix-bridge-mx-puppet-steam/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-steam/tasks/setup_install.yml
@@ -1,3 +1,15 @@
+# SPDX-FileCopyrightText: 2020 Hugues Morisset
+# SPDX-FileCopyrightText: 2020 Panagiotis Vasilopoulos
+# SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2020 Stuart Mumford
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Jim Myhrberg
+# SPDX-FileCopyrightText: 2022 Nikita Chernyi
+# SPDX-FileCopyrightText: 2022 Sebastian Gumprich
+# SPDX-FileCopyrightText: 2024 David Mehren
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Ensure MX Puppet Steam paths exist

--- a/roles/custom/matrix-bridge-mx-puppet-steam/tasks/setup_uninstall.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-steam/tasks/setup_uninstall.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2020 Hugues Morisset
+# SPDX-FileCopyrightText: 2021 - 2022 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Check existence of matrix-mx-puppet-steam service

--- a/roles/custom/matrix-bridge-mx-puppet-steam/tasks/validate_config.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-steam/tasks/validate_config.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2020 Hugues Morisset
+# SPDX-FileCopyrightText: 2022 - 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Fail if required mx-puppet-steam settings not defined

--- a/roles/custom/matrix-bridge-mx-puppet-steam/templates/config.yaml.j2.license
+++ b/roles/custom/matrix-bridge-mx-puppet-steam/templates/config.yaml.j2.license
@@ -1,0 +1,6 @@
+SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 Hugues Morisset
+SPDX-FileCopyrightText: 2020 MDAD project contributors
+SPDX-FileCopyrightText: 2022 Nikita Chernyi
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-bridge-mx-puppet-steam/templates/systemd/matrix-mx-puppet-steam.service.j2.license
+++ b/roles/custom/matrix-bridge-mx-puppet-steam/templates/systemd/matrix-mx-puppet-steam.service.j2.license
@@ -1,0 +1,5 @@
+SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 Hugues Morisset
+SPDX-FileCopyrightText: 2020 Scott Crossen
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-bridge-mx-puppet-twitter/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-twitter/defaults/main.yml
@@ -1,3 +1,14 @@
+# SPDX-FileCopyrightText: 2020 Tulir Asokan
+# SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2020 - 2021 MDAD project contributors
+# SPDX-FileCopyrightText: 2021 Ahmad Haghighi
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Nikita Chernyi
+# SPDX-FileCopyrightText: 2023 Samuel Meenzen
+# SPDX-FileCopyrightText: 2024 Suguru Hirahara
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 # Mx Puppet Twitter is a Matrix <-> Twitter bridge

--- a/roles/custom/matrix-bridge-mx-puppet-twitter/tasks/main.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-twitter/tasks/main.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2020 Tulir Asokan
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 - 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - tags:

--- a/roles/custom/matrix-bridge-mx-puppet-twitter/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-twitter/tasks/setup_install.yml
@@ -1,3 +1,14 @@
+# SPDX-FileCopyrightText: 2020 Tulir Asokan
+# SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2020 Stuart Mumford
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Jim Myhrberg
+# SPDX-FileCopyrightText: 2022 Nikita Chernyi
+# SPDX-FileCopyrightText: 2022 Sebastian Gumprich
+# SPDX-FileCopyrightText: 2024 David Mehren
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Ensure MX Puppet Twitter paths exist

--- a/roles/custom/matrix-bridge-mx-puppet-twitter/tasks/setup_uninstall.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-twitter/tasks/setup_uninstall.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2020 Tulir Asokan
+# SPDX-FileCopyrightText: 2021 - 2022 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Check existence of matrix-mx-puppet-twitter service

--- a/roles/custom/matrix-bridge-mx-puppet-twitter/tasks/validate_config.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-twitter/tasks/validate_config.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2020 Tulir Asokan
+# SPDX-FileCopyrightText: 2022 - 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Fail if required mx-puppet-twitter settings not defined

--- a/roles/custom/matrix-bridge-mx-puppet-twitter/templates/config.yaml.j2.license
+++ b/roles/custom/matrix-bridge-mx-puppet-twitter/templates/config.yaml.j2.license
@@ -1,0 +1,5 @@
+SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 MDAD project contributors
+SPDX-FileCopyrightText: 2020 Tulir Asokan
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-bridge-mx-puppet-twitter/templates/labels.j2
+++ b/roles/custom/matrix-bridge-mx-puppet-twitter/templates/labels.j2
@@ -1,3 +1,9 @@
+{#
+SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+#}
+
 {% if matrix_mx_puppet_twitter_container_labels_traefik_enabled %}
 traefik.enable=true
 

--- a/roles/custom/matrix-bridge-mx-puppet-twitter/templates/systemd/matrix-mx-puppet-twitter.service.j2.license
+++ b/roles/custom/matrix-bridge-mx-puppet-twitter/templates/systemd/matrix-mx-puppet-twitter.service.j2.license
@@ -1,0 +1,5 @@
+SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 Scott Crossen
+SPDX-FileCopyrightText: 2020 Tulir Asokan
+
+SPDX-License-Identifier: AGPL-3.0-or-later


### PR DESCRIPTION
As the future for the MX bridges in this playbook and by themselves seems uncertain, this commit adds license information in SPDX format to the files for those bridges, before the bridges would be deprecated and possibly get removed from the project.

Please note that .license files are added for the files which would be broken if such information are added as header, following the REUSE's specification.