### PR TITLE
Add copyright attributions to deprecated/archived components

### DIFF
--- a/docs/configuring-playbook-bot-chatgpt.md
+++ b/docs/configuring-playbook-bot-chatgpt.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-FileCopyrightText: 2023 MDAD project contributors
+SPDX-FileCopyrightText: 2023 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Setting up matrix-bot-chatgpt (optional, unmaintained)
 
 **Note**: [matrix-chatgpt-bot](https://github.com/matrixgpt/matrix-chatgpt-bot) is now an archived (**unmaintained**) project. Talking to ChatGPT (and many other LLM providers) can happen via the much more featureful [baibot](https://github.com/etkecc/baibot), which can be installed using [this playbook](configuring-playbook-bot-baibot.md). Consider using that bot instead of this one.

--- a/docs/configuring-playbook-bot-go-neb.md
+++ b/docs/configuring-playbook-bot-go-neb.md
@@ -1,3 +1,13 @@
+<!--
+SPDX-FileCopyrightText: 2021 Yannick Goossens
+SPDX-FileCopyrightText: 2021 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2022 Dennis Ciba
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+SPDX-FileCopyrightText: 2025 MDAD project contributors
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Setting up Go-NEB (optional, unmaintained)
 
 **Note**: [Go-NEB](https://github.com/matrix-org/go-neb) is now an archived (**unmaintained**) project. We recommend not bothering with installing it. While not a 1:1 replacement, the bridge's author suggests taking a look at [matrix-hookshot](https://github.com/matrix-org/matrix-hookshot) as a replacement, which can also be installed using [this playbook](configuring-playbook-bridge-hookshot.md). Consider using that bot instead of this one.

--- a/docs/configuring-playbook-bridge-mautrix-hangouts.md
+++ b/docs/configuring-playbook-bridge-mautrix-hangouts.md
@@ -1,3 +1,13 @@
+<!--
+SPDX-FileCopyrightText: 2019 Eduardo Beltrame
+SPDX-FileCopyrightText: 2019 - 2025 Slavi Pantaleev
+SPDX-FileCopyrightText: 2021 MDAD project contributors
+SPDX-FileCopyrightText: 2022 Dennis Ciba
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Setting up Mautrix Hangouts bridging (optional, deprecated)
 
 🪦 The playbook used to be able to install and configure [mautrix-hangouts](https://github.com/mautrix/hangouts), but no longer includes this component, because Google Hangouts has been discontinued since the 1st of November 2022.

--- a/docs/configuring-playbook-dimension.md
+++ b/docs/configuring-playbook-dimension.md
@@ -1,3 +1,18 @@
+<!--
+SPDX-FileCopyrightText: 2019 Edgars Voroboks
+SPDX-FileCopyrightText: 2019 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2019 - 2025 MDAD project contributors
+SPDX-FileCopyrightText: 2020 Chris van Dijk
+SPDX-FileCopyrightText: 2020 jens quade
+SPDX-FileCopyrightText: 2022 Kim Brose
+SPDX-FileCopyrightText: 2022 Yan Minagawa
+SPDX-FileCopyrightText: 2022 Travis Ralston
+SPDX-FileCopyrightText: 2022 Dennis Ciba
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Setting up Dimension integration manager (optional, unmaintained)
 
 **Notes**:

--- a/docs/configuring-playbook-email2matrix.md
+++ b/docs/configuring-playbook-email2matrix.md
@@ -1,3 +1,13 @@
+<!--
+SPDX-FileCopyrightText: 2019 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2022 Dennis Ciba
+SPDX-FileCopyrightText: 2022 Nikita Chernyi
+SPDX-FileCopyrightText: 2024 MDAD project contributors
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Setting up Email2Matrix (optional, deprecated)
 
 **Note**: this component has been deprecated. We recommend not bothering with installing it. While not a 1:1 replacement, the author suggests taking a look at [Postmoogle](https://github.com/etkecc/postmoogle) as a replacement, which can also be installed using [this playbook](configuring-playbook-bridge-postmoogle.md). Consider using that component instead of this one.

--- a/docs/configuring-playbook-sliding-sync-proxy.md
+++ b/docs/configuring-playbook-sliding-sync-proxy.md
@@ -1,3 +1,16 @@
+<!--
+SPDX-FileCopyrightText: 2023 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2023 Justin Croonenberghs
+SPDX-FileCopyrightText: 2023 Samuel Meenzen
+SPDX-FileCopyrightText: 2023 Kuba Orlik
+SPDX-FileCopyrightText: 2023 Pierre 'McFly' Marty
+SPDX-FileCopyrightText: 2024 Fabio Bonelli
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+SPDX-FileCopyrightText: 2024 MDAD project contributors
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Setting up the Sliding Sync proxy (optional)
 
 **Note**: The sliding-sync proxy is **not required** anymore as it's been replaced with a different method (called Simplified Sliding Sync) which is integrated into newer homeservers by default (**Conduit** homeserver from version `0.6.0` or **Synapse** from version `1.114`). This component and documentation remain here for historical purposes, but **installing this old sliding-sync proxy is generally not recommended anymore**.

--- a/roles/custom/matrix-bot-chatgpt/defaults/main.yml
+++ b/roles/custom/matrix-bot-chatgpt/defaults/main.yml
@@ -1,3 +1,12 @@
+# SPDX-FileCopyrightText: 2023 MDAD project contributors
+# SPDX-FileCopyrightText: 2023 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2023 Joe Kappus
+# SPDX-FileCopyrightText: 2023 Nikita Chernyi
+# SPDX-FileCopyrightText: 2023 Samuel Meenzen
+# SPDX-FileCopyrightText: 2024 Suguru Hirahara
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 # chatgpt is a bot for chatting to openAI chatgpt Matrix bot
 # Project source code URL: https://github.com/matrixgpt/matrix-chatgpt-bot

--- a/roles/custom/matrix-bot-chatgpt/tasks/install.yml
+++ b/roles/custom/matrix-bot-chatgpt/tasks/install.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2024 David Mehren
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Ensure chatgpt paths exist

--- a/roles/custom/matrix-bot-chatgpt/tasks/main.yml
+++ b/roles/custom/matrix-bot-chatgpt/tasks/main.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023 MDAD project contributors
+# SPDX-FileCopyrightText: 2023 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 -

--- a/roles/custom/matrix-bot-chatgpt/tasks/uninstall.yml
+++ b/roles/custom/matrix-bot-chatgpt/tasks/uninstall.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023 MDAD project contributors
+# SPDX-FileCopyrightText: 2023 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Check existence of matrix-chatgpt service

--- a/roles/custom/matrix-bot-chatgpt/tasks/validate_config.yml
+++ b/roles/custom/matrix-bot-chatgpt/tasks/validate_config.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023 MDAD project contributors
+# SPDX-FileCopyrightText: 2023 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Fail if required Chatgpt settings not defined

--- a/roles/custom/matrix-bot-chatgpt/templates/env.j2
+++ b/roles/custom/matrix-bot-chatgpt/templates/env.j2
@@ -1,3 +1,12 @@
+{#
+SPDX-FileCopyrightText: 2023 MDAD project contributors
+SPDX-FileCopyrightText: 2023 Slavi Pantaleev
+SPDX-FileCopyrightText: 2023 Joe Kappus
+SPDX-FileCopyrightText: 2024 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+#}
+
 MATRIX_HOMESERVER_URL={{ matrix_bot_chatgpt_matrix_homeserver_url }}
 MATRIX_ACCESS_TOKEN={{ matrix_bot_chatgpt_matrix_access_token }}
 

--- a/roles/custom/matrix-bot-chatgpt/templates/systemd/matrix-bot-chatgpt.service.j2.license
+++ b/roles/custom/matrix-bot-chatgpt/templates/systemd/matrix-bot-chatgpt.service.j2.license
@@ -1,0 +1,5 @@
+SPDX-FileCopyrightText: 2023 MDAD project contributors
+SPDX-FileCopyrightText: 2023 Vladimir Panteleev
+SPDX-FileCopyrightText: 2023 - 2025 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-bot-go-neb/defaults/main.yml
+++ b/roles/custom/matrix-bot-go-neb/defaults/main.yml
@@ -1,3 +1,12 @@
+# SPDX-FileCopyrightText: 2021 Yannick Goossens
+# SPDX-FileCopyrightText: 2021 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Nikita Chernyi
+# SPDX-FileCopyrightText: 2023 Samuel Meenzen
+# SPDX-FileCopyrightText: 2024 Suguru Hirahara
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 # Go-NEB is a Matrix bot written in Go. It is the successor to Matrix-NEB, the original Matrix bot written in Python.

--- a/roles/custom/matrix-bot-go-neb/tasks/install.yml
+++ b/roles/custom/matrix-bot-go-neb/tasks/install.yml
@@ -1,3 +1,13 @@
+# SPDX-FileCopyrightText: 2021 Yannick Goossens
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Jim Myhrberg
+# SPDX-FileCopyrightText: 2022 Nikita Chernyi
+# SPDX-FileCopyrightText: 2022 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Sebastian Gumprich
+# SPDX-FileCopyrightText: 2024 David Mehren
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Ensure go-neb paths exist

--- a/roles/custom/matrix-bot-go-neb/tasks/main.yml
+++ b/roles/custom/matrix-bot-go-neb/tasks/main.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2021 Yannick Goossens
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 - 2023 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - tags:

--- a/roles/custom/matrix-bot-go-neb/tasks/uninstall.yml
+++ b/roles/custom/matrix-bot-go-neb/tasks/uninstall.yml
@@ -1,3 +1,10 @@
+# SPDX-FileCopyrightText: 2021 Yannick Goossens
+# SPDX-FileCopyrightText: 2021 - 2023 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Sebastian Gumprich
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Check existence of matrix-go-neb service

--- a/roles/custom/matrix-bot-go-neb/tasks/validate_config.yml
+++ b/roles/custom/matrix-bot-go-neb/tasks/validate_config.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2021 Yannick Goossens
+# SPDX-FileCopyrightText: 2022 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Fail if there's not at least 1 client

--- a/roles/custom/matrix-bot-go-neb/templates/config.yaml.j2.license
+++ b/roles/custom/matrix-bot-go-neb/templates/config.yaml.j2.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2021 Yannick Goossens
+SPDX-FileCopyrightText: 2022 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-bot-go-neb/templates/env.j2
+++ b/roles/custom/matrix-bot-go-neb/templates/env.j2
@@ -1,3 +1,9 @@
+{#
+SPDX-FileCopyrightText: 2023 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+#}
+
 BIND_ADDRESS=:4050
 
 DATABASE_TYPE={{ matrix_bot_go_neb_database_engine }}

--- a/roles/custom/matrix-bot-go-neb/templates/labels.j2
+++ b/roles/custom/matrix-bot-go-neb/templates/labels.j2
@@ -1,3 +1,9 @@
+{#
+SPDX-FileCopyrightText: 2023 - 2024 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+#}
+
 {% if matrix_bot_go_neb_container_labels_traefik_enabled %}
 traefik.enable=true
 

--- a/roles/custom/matrix-bot-go-neb/templates/systemd/matrix-bot-go-neb.service.j2.license
+++ b/roles/custom/matrix-bot-go-neb/templates/systemd/matrix-bot-go-neb.service.j2.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2021 Yannick Goossens
+SPDX-FileCopyrightText: 2022 - 2025 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-dimension/defaults/main.yml
+++ b/roles/custom/matrix-dimension/defaults/main.yml
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: 2019 Edgars Voroboks
+# SPDX-FileCopyrightText: 2019 - 2025 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2019 - 2021 MDAD project contributors
+# SPDX-FileCopyrightText: 2019 Sylvia van Os
+# SPDX-FileCopyrightText: 2019 Dan Arnfield
+# SPDX-FileCopyrightText: 2020 Chris van Dijk
+# SPDX-FileCopyrightText: 2021 Ahmad Haghighi
+# SPDX-FileCopyrightText: 2021 Aaron Raimist
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Nikita Chernyi
+# SPDX-FileCopyrightText: 2023 Samuel Meenzen
+# SPDX-FileCopyrightText: 2024 Suguru Hirahara
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 # Project source code URL: https://github.com/turt2live/matrix-dimension
 

--- a/roles/custom/matrix-dimension/tasks/main.yml
+++ b/roles/custom/matrix-dimension/tasks/main.yml
@@ -1,3 +1,10 @@
+# SPDX-FileCopyrightText: 2019 Edgars Voroboks
+# SPDX-FileCopyrightText: 2019 - 2023 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2019 Dan Arnfield
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - tags:

--- a/roles/custom/matrix-dimension/tasks/setup_install.yml
+++ b/roles/custom/matrix-dimension/tasks/setup_install.yml
@@ -1,3 +1,16 @@
+# SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2020 Stuart Mumford
+# SPDX-FileCopyrightText: 2021 Yannick Goossens
+# SPDX-FileCopyrightText: 2021 MDAD project contributors
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Jim Myhrberg
+# SPDX-FileCopyrightText: 2022 Nikita Chernyi
+# SPDX-FileCopyrightText: 2022 Sebastian Gumprich
+# SPDX-FileCopyrightText: 2024 David Mehren
+# SPDX-FileCopyrightText: 2025 Suguru Hirahara
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - ansible.builtin.set_fact:

--- a/roles/custom/matrix-dimension/tasks/setup_uninstall.yml
+++ b/roles/custom/matrix-dimension/tasks/setup_uninstall.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2020 - 2022 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Sebastian Gumprich
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Check existence of matrix-dimension service

--- a/roles/custom/matrix-dimension/tasks/validate_config.yml
+++ b/roles/custom/matrix-dimension/tasks/validate_config.yml
@@ -1,3 +1,11 @@
+# SPDX-FileCopyrightText: 2019 Edgars Voroboks
+# SPDX-FileCopyrightText: 2019 Dan Arnfield
+# SPDX-FileCopyrightText: 2019 - 2023 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2020 Chris van Dijk
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Fail if required Dimension settings not defined

--- a/roles/custom/matrix-dimension/templates/config.yaml.j2.license
+++ b/roles/custom/matrix-dimension/templates/config.yaml.j2.license
@@ -1,0 +1,5 @@
+SPDX-FileCopyrightText: 2020 - 2023 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 MDAD project contributors
+SPDX-FileCopyrightText: 2024 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-dimension/templates/labels.j2
+++ b/roles/custom/matrix-dimension/templates/labels.j2
@@ -1,3 +1,9 @@
+{#
+SPDX-FileCopyrightText: 2023 - 2024 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+#}
+
 {% if matrix_dimension_container_labels_traefik_enabled %}
 traefik.enable=true
 

--- a/roles/custom/matrix-dimension/templates/systemd/matrix-dimension.service.j2.license
+++ b/roles/custom/matrix-dimension/templates/systemd/matrix-dimension.service.j2.license
@@ -1,0 +1,7 @@
+SPDX-FileCopyrightText: 2019 Edgars Voroboks
+SPDX-FileCopyrightText: 2019 - 2025 Slavi Pantaleev
+SPDX-FileCopyrightText: 2019 Sylvia van Os
+SPDX-FileCopyrightText: 2019 Hugues De Keyzer
+SPDX-FileCopyrightText: 2020 Chris van Dijk
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-dimension/vars/main.yml
+++ b/roles/custom/matrix-dimension/vars/main.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2019 Edgars Voroboks
+# SPDX-FileCopyrightText: 2019 - 2022 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 # Doing `|from_yaml` when the extension contains nothing yields an empty string ("").

--- a/roles/custom/matrix-email2matrix/defaults/main.yml
+++ b/roles/custom/matrix-email2matrix/defaults/main.yml
@@ -1,4 +1,15 @@
+# SPDX-FileCopyrightText: 2019 - 2025 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2021 MDAD project contributors
+# SPDX-FileCopyrightText: 2021 Ahmad Haghighi
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Nikita Chernyi
+# SPDX-FileCopyrightText: 2023 Samuel Meenzen
+# SPDX-FileCopyrightText: 2024 Suguru Hirahara
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
+
 # Project source code URL: https://github.com/devture/email2matrix
 
 matrix_email2matrix_enabled: true

--- a/roles/custom/matrix-email2matrix/tasks/main.yml
+++ b/roles/custom/matrix-email2matrix/tasks/main.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2019 - 2023 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - tags:

--- a/roles/custom/matrix-email2matrix/tasks/setup_install.yml
+++ b/roles/custom/matrix-email2matrix/tasks/setup_install.yml
@@ -1,3 +1,11 @@
+# SPDX-FileCopyrightText: 2021 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Nikita Chernyi
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Sebastian Gumprich
+# SPDX-FileCopyrightText: 2024 David Mehren
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Ensure Email2Matrix paths exist

--- a/roles/custom/matrix-email2matrix/tasks/setup_uninstall.yml
+++ b/roles/custom/matrix-email2matrix/tasks/setup_uninstall.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2021 - 2022 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Sebastian Gumprich
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Check existence of matrix-email2matrix service

--- a/roles/custom/matrix-email2matrix/tasks/validate_config.yml
+++ b/roles/custom/matrix-email2matrix/tasks/validate_config.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 - 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Fail if no Email2Matrix mappings

--- a/roles/custom/matrix-email2matrix/templates/config.json.j2.license
+++ b/roles/custom/matrix-email2matrix/templates/config.json.j2.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2019 - 2022 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-email2matrix/templates/systemd/matrix-email2matrix.service.j2.license
+++ b/roles/custom/matrix-email2matrix/templates/systemd/matrix-email2matrix.service.j2.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2019 - 2025 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 Chris van Dijk
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-sliding-sync/defaults/main.yml
+++ b/roles/custom/matrix-sliding-sync/defaults/main.yml
@@ -1,3 +1,14 @@
+# SPDX-FileCopyrightText: 2023 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2023 Kabir Kwatra
+# SPDX-FileCopyrightText: 2023 David Mehren
+# SPDX-FileCopyrightText: 2023 Nikita Chernyi
+# SPDX-FileCopyrightText: 2023 Samuel Meenzen
+# SPDX-FileCopyrightText: 2024 HarHarLinks
+# SPDX-FileCopyrightText: 2024 MDAD project contributors
+# SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 # Sliding Sync proxy is an implementation of MSC3575 for the new sliding sync

--- a/roles/custom/matrix-sliding-sync/tasks/install.yml
+++ b/roles/custom/matrix-sliding-sync/tasks/install.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2024 David Mehren
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Ensure matrix-sliding-sync paths exist

--- a/roles/custom/matrix-sliding-sync/tasks/main.yml
+++ b/roles/custom/matrix-sliding-sync/tasks/main.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - tags:

--- a/roles/custom/matrix-sliding-sync/tasks/uninstall.yml
+++ b/roles/custom/matrix-sliding-sync/tasks/uninstall.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Check existence of matrix-sliding-sync service

--- a/roles/custom/matrix-sliding-sync/tasks/validate_config.yml
+++ b/roles/custom/matrix-sliding-sync/tasks/validate_config.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2023 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2024 MDAD project contributors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 - name: Fail if required matrix-sliding-sync settings not defined
   ansible.builtin.fail:

--- a/roles/custom/matrix-sliding-sync/templates/env.j2
+++ b/roles/custom/matrix-sliding-sync/templates/env.j2
@@ -1,3 +1,10 @@
+{#
+SPDX-FileCopyrightText: 2023 Slavi Pantaleev
+SPDX-FileCopyrightText: 2024 MDAD project contributors
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+#}
+
 SYNCV3_SERVER={{ matrix_sliding_sync_environment_variable_syncv3_server }}
 SYNCV3_SECRET={{ matrix_sliding_sync_environment_variable_syncv3_secret }}
 SYNCV3_BINDADDR=:8008

--- a/roles/custom/matrix-sliding-sync/templates/labels.j2
+++ b/roles/custom/matrix-sliding-sync/templates/labels.j2
@@ -1,3 +1,10 @@
+{#
+SPDX-FileCopyrightText: 2023 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2024 MDAD project contributors
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+#}
+
 {% if matrix_sliding_sync_container_labels_traefik_enabled %}
 traefik.enable=true
 

--- a/roles/custom/matrix-sliding-sync/templates/systemd/matrix-sliding-sync.service.j2.license
+++ b/roles/custom/matrix-sliding-sync/templates/systemd/matrix-sliding-sync.service.j2.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 - 2025 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-sliding-sync/vars/main.yml
+++ b/roles/custom/matrix-sliding-sync/vars/main.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 # Public facing base URL of the Sliding Sync service.


### PR DESCRIPTION
This PR intends to:

- Add license information to files for matrix-email2matrix
- Add license information to files for matrix-dimension
- Update docs/configuring-playbook-bridge-mautrix-hangouts.md
- Add license information to files for matrix-sliding-sync
- Add license information to files for matrix-bot-go-neb
- Add license information to files for matrix-bot-chatgpt