### PR TITLE
Add copyright attributions to files of inactive projects

### DIFF
--- a/docs/configuring-playbook-bridge-appservice-kakaotalk.md
+++ b/docs/configuring-playbook-bridge-appservice-kakaotalk.md
@@ -1,3 +1,12 @@
+<!--
+SPDX-FileCopyrightText: 2022 Slavi Pantaleev
+SPDX-FileCopyrightText: 2022 Dennis Ciba
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+SPDX-FileCopyrightText: 2024 MDAD project contributors
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Setting up Appservice Kakaotalk bridging (optional)
 
 The playbook can install and configure [matrix-appservice-kakaotalk](https://src.miscworks.net/fair/matrix-appservice-kakaotalk) for you, for bridging to [Kakaotalk](https://www.kakaocorp.com/page/service/service/KakaoTalk?lang=ENG). This bridge is based on [node-kakao](https://github.com/storycraft/node-kakao) (now unmaintained) and some [mautrix-facebook](https://github.com/mautrix/facebook) code.

--- a/docs/configuring-playbook-bridge-wechat.md
+++ b/docs/configuring-playbook-bridge-wechat.md
@@ -1,3 +1,10 @@
+<!--
+SPDX-FileCopyrightText: 2024 - 2025 Slavi Pantaleev
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Setting up WeChat bridging (optional)
 
 The playbook can install and configure [matrix-wechat](https://github.com/duo/matrix-wechat) for you, for bridging to [WeChat](https://www.wechat.com/).

--- a/docs/configuring-playbook-client-hydrogen.md
+++ b/docs/configuring-playbook-client-hydrogen.md
@@ -1,3 +1,12 @@
+<!--
+SPDX-FileCopyrightText: 2021 Aaron Raimist
+SPDX-FileCopyrightText: 2021 MDAD project contributors
+SPDX-FileCopyrightText: 2023 Pierre 'McFly' Marty
+SPDX-FileCopyrightText: 2024 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Setting up Hydrogen (optional)
 
 The playbook can install and configure the [Hydrogen](https://github.com/element-hq/hydrogen-web) Matrix web client for you.

--- a/docs/configuring-playbook-ma1sd.md
+++ b/docs/configuring-playbook-ma1sd.md
@@ -1,3 +1,14 @@
+<!--
+SPDX-FileCopyrightText: 2018 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2019 Noah Fleischmann
+SPDX-FileCopyrightText: 2019 - 2020 MDAD project contributors
+SPDX-FileCopyrightText: 2020 Marcel Partap
+SPDX-FileCopyrightText: 2020 Justin Croonenberghs
+SPDX-FileCopyrightText: 2024 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Setting up ma1sd Identity Server (optional)
 
 **⚠️Note**: ma1sd itself has also been unmaintained for years (the latest commit and release being from 2021). The role of identity servers in the Matrix specification also has an uncertain future. **We recommend not bothering with installing it unless it's the only way you can do what you need to do**. For example, certain things like LDAP integration can also be implemented via [the LDAP provider module for Synapse](./configuring-playbook-ldap-auth.md).

--- a/docs/configuring-playbook-matrix-registration.md
+++ b/docs/configuring-playbook-matrix-registration.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-FileCopyrightText: 2020 - 2022 Slavi Pantaleev
+SPDX-FileCopyrightText: 2022 MDAD project contributors
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Setting up matrix-registration (optional)
 
 > [!WARNING]

--- a/roles/custom/matrix-bridge-appservice-kakaotalk/defaults/main.yml
+++ b/roles/custom/matrix-bridge-appservice-kakaotalk/defaults/main.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2022 - 2025 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2023 Nikita Chernyi
+# SPDX-FileCopyrightText: 2024 MDAD project contributors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 # matrix-appservice-kakaotalk is a Matrix <-> Kakaotalk bridge
 # Project source code URL: https://src.miscworks.net/fair/matrix-appservice-kakaotalk/

--- a/roles/custom/matrix-bridge-appservice-kakaotalk/tasks/main.yml
+++ b/roles/custom/matrix-bridge-appservice-kakaotalk/tasks/main.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 - 2023 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - tags:

--- a/roles/custom/matrix-bridge-appservice-kakaotalk/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-appservice-kakaotalk/tasks/setup_install.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2022 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Sebastian Gumprich
+# SPDX-FileCopyrightText: 2024 David Mehren
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Ensure matrix-appservice-kakaotalk image is pulled

--- a/roles/custom/matrix-bridge-appservice-kakaotalk/tasks/setup_uninstall.yml
+++ b/roles/custom/matrix-bridge-appservice-kakaotalk/tasks/setup_uninstall.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Check existence of matrix-appservice-kakaotalk service

--- a/roles/custom/matrix-bridge-appservice-kakaotalk/tasks/validate_config.yml
+++ b/roles/custom/matrix-bridge-appservice-kakaotalk/tasks/validate_config.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022 - 2025 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Fail if required appservice-kakaotalk settings not defined

--- a/roles/custom/matrix-bridge-appservice-kakaotalk/templates/config.yaml.j2.license
+++ b/roles/custom/matrix-bridge-appservice-kakaotalk/templates/config.yaml.j2.license
@@ -1,0 +1,6 @@
+SPDX-FileCopyrightText: 2022 Slavi Pantaleev
+SPDX-FileCopyrightText: 2022 MDAD project contributors
+SPDX-FileCopyrightText: 2023 Nikita Chernyi
+SPDX-FileCopyrightText: 2024 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-bridge-appservice-kakaotalk/templates/node-config.json.j2.license
+++ b/roles/custom/matrix-bridge-appservice-kakaotalk/templates/node-config.json.j2.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2022 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-bridge-appservice-kakaotalk/templates/systemd/matrix-appservice-kakaotalk-node.service.j2.license
+++ b/roles/custom/matrix-bridge-appservice-kakaotalk/templates/systemd/matrix-appservice-kakaotalk-node.service.j2.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2022 - 2025 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-bridge-appservice-kakaotalk/templates/systemd/matrix-appservice-kakaotalk.service.j2.license
+++ b/roles/custom/matrix-bridge-appservice-kakaotalk/templates/systemd/matrix-appservice-kakaotalk.service.j2.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2022 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-bridge-wechat/defaults/main.yml
+++ b/roles/custom/matrix-bridge-wechat/defaults/main.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2024 - 2025 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 # WeChat Bridge is a Matrix <-> WeChat bridge

--- a/roles/custom/matrix-bridge-wechat/tasks/install.yml
+++ b/roles/custom/matrix-bridge-wechat/tasks/install.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2024 - 2025 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Ensure WeChat Bridge paths exists

--- a/roles/custom/matrix-bridge-wechat/tasks/main.yml
+++ b/roles/custom/matrix-bridge-wechat/tasks/main.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - tags:

--- a/roles/custom/matrix-bridge-wechat/tasks/uninstall.yml
+++ b/roles/custom/matrix-bridge-wechat/tasks/uninstall.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 - 2025 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Check existence of matrix-wechat service

--- a/roles/custom/matrix-bridge-wechat/tasks/validate_config.yml
+++ b/roles/custom/matrix-bridge-wechat/tasks/validate_config.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2024 - 2025 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+
 ---
 
 - name: Fail if required WeChat settings not defined

--- a/roles/custom/matrix-bridge-wechat/templates/agent-config.yaml.j2
+++ b/roles/custom/matrix-bridge-wechat/templates/agent-config.yaml.j2
@@ -1,3 +1,9 @@
+{#
+SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+#}
+
 wechat:
   version: 3.8.1.26
   listen_port: 22222

--- a/roles/custom/matrix-bridge-wechat/templates/config.yaml.j2.license
+++ b/roles/custom/matrix-bridge-wechat/templates/config.yaml.j2.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2024 Nikita Chernyi
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-bridge-wechat/templates/systemd/matrix-wechat-agent.service.j2.license
+++ b/roles/custom/matrix-bridge-wechat/templates/systemd/matrix-wechat-agent.service.j2.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 - 2025 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-bridge-wechat/templates/systemd/matrix-wechat.service.j2.license
+++ b/roles/custom/matrix-bridge-wechat/templates/systemd/matrix-wechat.service.j2.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 - 2025 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-client-hydrogen/defaults/main.yml
+++ b/roles/custom/matrix-client-hydrogen/defaults/main.yml
@@ -1,3 +1,14 @@
+# SPDX-FileCopyrightText: 2021 - 2022 Aaron Raimist
+# SPDX-FileCopyrightText: 2021 - 2022 MDAD project contributors
+# SPDX-FileCopyrightText: 2021 - 2025 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 - 2023 Nikita Chernyi
+# SPDX-FileCopyrightText: 2022 Matthew Cengia
+# SPDX-FileCopyrightText: 2023 Samuel Meenzen
+# SPDX-FileCopyrightText: 2023 Pierre 'McFly' Marty
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 # Project source code URL: https://github.com/element-hq/hydrogen-web
 

--- a/roles/custom/matrix-client-hydrogen/tasks/main.yml
+++ b/roles/custom/matrix-client-hydrogen/tasks/main.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2021 Aaron Raimist
+# SPDX-FileCopyrightText: 2021 - 2023 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - tags:

--- a/roles/custom/matrix-client-hydrogen/tasks/self_check.yml
+++ b/roles/custom/matrix-client-hydrogen/tasks/self_check.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2021 - 2022 Aaron Raimist
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 - 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - ansible.builtin.set_fact:

--- a/roles/custom/matrix-client-hydrogen/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-hydrogen/tasks/setup_install.yml
@@ -1,3 +1,14 @@
+# SPDX-FileCopyrightText: 2021 - 2022 Aaron Raimist
+# SPDX-FileCopyrightText: 2021 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Nikita Chernyi
+# SPDX-FileCopyrightText: 2022 Sebastian Gumprich
+# SPDX-FileCopyrightText: 2022 Matthew Cengia
+# SPDX-FileCopyrightText: 2023 Julian Foad
+# SPDX-FileCopyrightText: 2024 David Mehren
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Ensure Hydrogen paths exists

--- a/roles/custom/matrix-client-hydrogen/tasks/setup_uninstall.yml
+++ b/roles/custom/matrix-client-hydrogen/tasks/setup_uninstall.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2021 - 2022 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Sebastian Gumprich
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Check existence of matrix-client-hydrogen.service

--- a/roles/custom/matrix-client-hydrogen/tasks/validate_config.yml
+++ b/roles/custom/matrix-client-hydrogen/tasks/validate_config.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2021 Aaron Raimist
+# SPDX-FileCopyrightText: 2022 - 2025 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2024 Suguru Hirahara
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Fail if required Hydrogen settings not defined

--- a/roles/custom/matrix-client-hydrogen/templates/config.json.j2.license
+++ b/roles/custom/matrix-client-hydrogen/templates/config.json.j2.license
@@ -1,0 +1,7 @@
+SPDX-FileCopyrightText: 2021 - 2022 Aaron Raimist
+SPDX-FileCopyrightText: 2022 Nikita Chernyi
+SPDX-FileCopyrightText: 2022 - 2023 Slavi Pantaleev
+SPDX-FileCopyrightText: 2022 Matthew Cengia
+SPDX-FileCopyrightText: 2023 Sergio Durigan Junior
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-client-hydrogen/templates/labels.j2
+++ b/roles/custom/matrix-client-hydrogen/templates/labels.j2
@@ -1,3 +1,9 @@
+{#
+SPDX-FileCopyrightText: 2023 - 2024 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+#}
+
 {% if matrix_client_hydrogen_container_labels_traefik_enabled %}
 traefik.enable=true
 

--- a/roles/custom/matrix-client-hydrogen/templates/nginx.conf.j2.license
+++ b/roles/custom/matrix-client-hydrogen/templates/nginx.conf.j2.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2021 Aaron Raimist
+SPDX-FileCopyrightText: 2022 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-client-hydrogen/templates/systemd/matrix-client-hydrogen.service.j2.license
+++ b/roles/custom/matrix-client-hydrogen/templates/systemd/matrix-client-hydrogen.service.j2.license
@@ -1,0 +1,5 @@
+SPDX-FileCopyrightText: 2021 Aaron Raimist
+SPDX-FileCopyrightText: 2021 - 2025 Slavi Pantaleev
+SPDX-FileCopyrightText: 2022 Matthew Cengia
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-ma1sd/defaults/main.yml
+++ b/roles/custom/matrix-ma1sd/defaults/main.yml
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: 2020 Marcel Partap
+# SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2020 - 2022 MDAD project contributors
+# SPDX-FileCopyrightText: 2020 Matt Cengia
+# SPDX-FileCopyrightText: 2021 Ahmad Haghighi
+# SPDX-FileCopyrightText: 2021 boris runakov
+# SPDX-FileCopyrightText: 2021 Aaron Raimist
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Nikita Chernyi
+# SPDX-FileCopyrightText: 2023 Samuel Meenzen
+# SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 # ma1sd is a Federated Matrix Identity Server
 # Project source code URL: https://github.com/ma1uta/ma1sd

--- a/roles/custom/matrix-ma1sd/tasks/main.yml
+++ b/roles/custom/matrix-ma1sd/tasks/main.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2020 Marcel Partap
+# SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - tags:

--- a/roles/custom/matrix-ma1sd/tasks/self_check.yml
+++ b/roles/custom/matrix-ma1sd/tasks/self_check.yml
@@ -1,3 +1,10 @@
+# SPDX-FileCopyrightText: 2020 Marcel Partap
+# SPDX-FileCopyrightText: 2020 MDAD project contributors
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 - 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Check ma1sd Identity Service

--- a/roles/custom/matrix-ma1sd/tasks/setup_install.yml
+++ b/roles/custom/matrix-ma1sd/tasks/setup_install.yml
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: 2020 Marcel Partap
+# SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2020 Chris van Dijk
+# SPDX-FileCopyrightText: 2020 Matt Cengia
+# SPDX-FileCopyrightText: 2020 Stuart Mumford
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 MDAD project contributors
+# SPDX-FileCopyrightText: 2022 Jim Myhrberg
+# SPDX-FileCopyrightText: 2022 Nikita Chernyi
+# SPDX-FileCopyrightText: 2022 Sebastian Gumprich
+# SPDX-FileCopyrightText: 2024 David Mehren
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Ensure ma1sd paths exist

--- a/roles/custom/matrix-ma1sd/tasks/setup_uninstall.yml
+++ b/roles/custom/matrix-ma1sd/tasks/setup_uninstall.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Sebastian Gumprich
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Check existence of matrix-ma1sd service

--- a/roles/custom/matrix-ma1sd/tasks/validate_config.yml
+++ b/roles/custom/matrix-ma1sd/tasks/validate_config.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2020 Marcel Partap
+# SPDX-FileCopyrightText: 2020 - 2025 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2021 boris runakov
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: (Deprecation) Warn about ma1sd variables that are not used anymore

--- a/roles/custom/matrix-ma1sd/templates/labels.j2
+++ b/roles/custom/matrix-ma1sd/templates/labels.j2
@@ -1,3 +1,9 @@
+{#
+SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+#}
+
 {% if matrix_ma1sd_container_labels_traefik_enabled %}
 traefik.enable=true
 

--- a/roles/custom/matrix-ma1sd/templates/ma1sd.yaml.j2.license
+++ b/roles/custom/matrix-ma1sd/templates/ma1sd.yaml.j2.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2020 - 2022 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 MDAD project contributors
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-ma1sd/templates/systemd/matrix-ma1sd.service.j2.license
+++ b/roles/custom/matrix-ma1sd/templates/systemd/matrix-ma1sd.service.j2.license
@@ -1,0 +1,7 @@
+SPDX-FileCopyrightText: 2020 Marcel Partap
+SPDX-FileCopyrightText: 2020 Chris van Dijk
+SPDX-FileCopyrightText: 2020 - 2025 Slavi Pantaleev
+SPDX-FileCopyrightText: 2021 - 2022 MDAD project contributors
+SPDX-FileCopyrightText: 2021 boris runakov
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-ma1sd/vars/main.yml
+++ b/roles/custom/matrix-ma1sd/vars/main.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2020 Marcel Partap
+# SPDX-FileCopyrightText: 2022 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 # Doing `|from_yaml` when the extension contains nothing yields an empty string ("").

--- a/roles/custom/matrix-registration/defaults/main.yml
+++ b/roles/custom/matrix-registration/defaults/main.yml
@@ -1,3 +1,13 @@
+# SPDX-FileCopyrightText: 2020 - 2025 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2021 Ahmad Haghighi
+# SPDX-FileCopyrightText: 2021 Aaron Raimist
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Nikita Chernyi
+# SPDX-FileCopyrightText: 2023 Samuel Meenzen
+# SPDX-FileCopyrightText: 2024 Suguru Hirahara
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 # matrix-registration is a simple python application to have a token based Matrix registration
 # See: https://zeratax.github.io/matrix-registration/

--- a/roles/custom/matrix-registration/tasks/generate_token.yml
+++ b/roles/custom/matrix-registration/tasks/generate_token.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2020 - 2022 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Fail if playbook called incorrectly

--- a/roles/custom/matrix-registration/tasks/list_tokens.yml
+++ b/roles/custom/matrix-registration/tasks/list_tokens.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2021 MDAD project contributors
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Call matrix-registration list all tokens API

--- a/roles/custom/matrix-registration/tasks/main.yml
+++ b/roles/custom/matrix-registration/tasks/main.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2021 MDAD project contributors
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - tags:

--- a/roles/custom/matrix-registration/tasks/setup_install.yml
+++ b/roles/custom/matrix-registration/tasks/setup_install.yml
@@ -1,3 +1,13 @@
+# SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2020 Stuart Mumford
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Jim Myhrberg
+# SPDX-FileCopyrightText: 2022 Nikita Chernyi
+# SPDX-FileCopyrightText: 2022 Sebastian Gumprich
+# SPDX-FileCopyrightText: 2024 David Mehren
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - ansible.builtin.set_fact:

--- a/roles/custom/matrix-registration/tasks/setup_uninstall.yml
+++ b/roles/custom/matrix-registration/tasks/setup_uninstall.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2020 - 2022 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Sebastian Gumprich
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Check existence of matrix-registration service

--- a/roles/custom/matrix-registration/tasks/validate_config.yml
+++ b/roles/custom/matrix-registration/tasks/validate_config.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Fail if required matrix-registration settings not defined

--- a/roles/custom/matrix-registration/templates/config.yaml.j2
+++ b/roles/custom/matrix-registration/templates/config.yaml.j2
@@ -1,3 +1,9 @@
+{#
+SPDX-FileCopyrightText: 2020 - 2022 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+#}
+
 server_location: {{ matrix_registration_server_location|to_json }}
 server_name: {{ matrix_registration_server_name|to_json }}
 shared_secret: {{ matrix_registration_shared_secret|to_json }}

--- a/roles/custom/matrix-registration/templates/labels.j2
+++ b/roles/custom/matrix-registration/templates/labels.j2
@@ -1,3 +1,9 @@
+{#
+SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+#}
+
 {% if matrix_registration_container_labels_traefik_enabled %}
 traefik.enable=true
 

--- a/roles/custom/matrix-registration/templates/systemd/matrix-registration.service.j2.license
+++ b/roles/custom/matrix-registration/templates/systemd/matrix-registration.service.j2.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2020 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later


### PR DESCRIPTION
This PR intends to add copyright attributions to files of projects whose development seem to have been stopped for a while, in case of future deprecation (and removal thereafter) which might happen.