### PR TITLE
Update docs: edit titles of the removed components

### DIFF
--- a/docs/configuring-playbook-bridge-mautrix-hangouts.md
+++ b/docs/configuring-playbook-bridge-mautrix-hangouts.md
@@ -8,7 +8,7 @@ SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-# Setting up Mautrix Hangouts bridging (optional, deprecated)
+# Setting up Mautrix Hangouts bridging (optional, removed)
 
 🪦 The playbook used to be able to install and configure [mautrix-hangouts](https://github.com/mautrix/hangouts), but no longer includes this component, because Google Hangouts has been discontinued since the 1st of November 2022.
 

--- a/docs/configuring-playbook-email2matrix.md
+++ b/docs/configuring-playbook-email2matrix.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2019 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2019 - 2025 Slavi Pantaleev
 SPDX-FileCopyrightText: 2022 Dennis Ciba
 SPDX-FileCopyrightText: 2022 Nikita Chernyi
 SPDX-FileCopyrightText: 2024 MDAD project contributors
@@ -8,7 +8,7 @@ SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-# Setting up Email2Matrix (optional, deprecated)
+# Setting up Email2Matrix (optional, removed)
 
 🪦 The playbook used to be able to install and configure [Email2Matrix](https://github.com/devture/email2matrix), but no longer includes this component.
 


### PR DESCRIPTION
This commit updates titles of the docs for removed components, following 0bc4ef8f4d6611f4b18a94d0b4439f69922a8279.