### PR TITLE
Add license information to files for quiet projects

### DIFF
--- a/docs/configuring-playbook-bot-matrix-reminder-bot.md
+++ b/docs/configuring-playbook-bot-matrix-reminder-bot.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-FileCopyrightText: 2020 - 2022 Slavi Pantaleev
+SPDX-FileCopyrightText: 2022 MDAD project contributors
+SPDX-FileCopyrightText: 2024 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Setting up matrix-reminder-bot (optional)
 
 The playbook can install and configure [matrix-reminder-bot](https://github.com/anoadragon453/matrix-reminder-bot) for you.

--- a/docs/configuring-playbook-bridge-go-skype-bridge.md
+++ b/docs/configuring-playbook-bridge-go-skype-bridge.md
@@ -1,3 +1,10 @@
+<!--
+SPDX-FileCopyrightText: 2022 Vladimir Panteleev
+SPDX-FileCopyrightText: 2024 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Setting up Go Skype Bridge bridging (optional)
 
 The playbook can install and configure [go-skype-bridge](https://github.com/kelaresg/go-skype-bridge) for you, for bridging to [Skype](https://www.skype.com/). This bridge was created based on [mautrix-whatsapp](https://github.com/mautrix/whatsapp) and can be configured in a similar way to it.

--- a/roles/custom/matrix-bot-matrix-reminder-bot/defaults/main.yml
+++ b/roles/custom/matrix-bot-matrix-reminder-bot/defaults/main.yml
@@ -1,3 +1,13 @@
+# SPDX-FileCopyrightText: 2020 - 2025 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2021 - 2022 MDAD project contributors
+# SPDX-FileCopyrightText: 2021 Ahmad Haghighi
+# SPDX-FileCopyrightText: 2021 Richard Meyer
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Nikita Chernyi
+# SPDX-FileCopyrightText: 2023 Samuel Meenzen
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 # matrix-reminder-bot is a bot for one-off and recurring reminders
 # Project source code URL: https://github.com/anoadragon453/matrix-reminder-bot

--- a/roles/custom/matrix-bot-matrix-reminder-bot/tasks/main.yml
+++ b/roles/custom/matrix-bot-matrix-reminder-bot/tasks/main.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2020 - 2023 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - tags:

--- a/roles/custom/matrix-bot-matrix-reminder-bot/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-matrix-reminder-bot/tasks/setup_install.yml
@@ -1,3 +1,14 @@
+# SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2020 Stuart Mumford
+# SPDX-FileCopyrightText: 2021 - 2022 MDAD project contributors
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Jim Myhrberg
+# SPDX-FileCopyrightText: 2022 Nikita Chernyi
+# SPDX-FileCopyrightText: 2022 Sebastian Gumprich
+# SPDX-FileCopyrightText: 2024 David Mehren
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - ansible.builtin.set_fact:

--- a/roles/custom/matrix-bot-matrix-reminder-bot/tasks/setup_uninstall.yml
+++ b/roles/custom/matrix-bot-matrix-reminder-bot/tasks/setup_uninstall.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2020 - 2022 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Sebastian Gumprich
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Check existence of matrix-matrix-reminder-bot service

--- a/roles/custom/matrix-bot-matrix-reminder-bot/tasks/validate_config.yml
+++ b/roles/custom/matrix-bot-matrix-reminder-bot/tasks/validate_config.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2020 - 2025 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 MDAD project contributors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Fail if required matrix-reminder-bot settings not defined

--- a/roles/custom/matrix-bot-matrix-reminder-bot/templates/config.yaml.j2.license
+++ b/roles/custom/matrix-bot-matrix-reminder-bot/templates/config.yaml.j2.license
@@ -1,0 +1,5 @@
+SPDX-FileCopyrightText: 2020 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2022 MDAD project contributors
+SPDX-FileCopyrightText: 2024 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-bot-matrix-reminder-bot/templates/systemd/matrix-bot-matrix-reminder-bot.service.j2.license
+++ b/roles/custom/matrix-bot-matrix-reminder-bot/templates/systemd/matrix-bot-matrix-reminder-bot.service.j2.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2020 - 2025 Slavi Pantaleev
+SPDX-FileCopyrightText: 2020 Scott Crossen
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-bridge-go-skype-bridge/defaults/main.yml
+++ b/roles/custom/matrix-bridge-go-skype-bridge/defaults/main.yml
@@ -1,3 +1,13 @@
+# SPDX-FileCopyrightText: 2022 Vladimir Panteleev
+# SPDX-FileCopyrightText: 2022 - 2025 MDAD project contributors
+# SPDX-FileCopyrightText: 2022 - 2023 Nikita Chernyi
+# SPDX-FileCopyrightText: 2022 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Arthur Brugière
+# SPDX-FileCopyrightText: 2023 Samuel Meenzen
+# SPDX-FileCopyrightText: 2024 Suguru Hirahara
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 # Go Skype Bridge is a Matrix <-> Skype bridge
 # Project source code URL: https://github.com/kelaresg/go-skype-bridge

--- a/roles/custom/matrix-bridge-go-skype-bridge/tasks/main.yml
+++ b/roles/custom/matrix-bridge-go-skype-bridge/tasks/main.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2022 Vladimir Panteleev
+# SPDX-FileCopyrightText: 2019 - 2023 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - tags:

--- a/roles/custom/matrix-bridge-go-skype-bridge/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-go-skype-bridge/tasks/setup_install.yml
@@ -1,3 +1,10 @@
+# SPDX-FileCopyrightText: 2022 Vladimir Panteleev
+# SPDX-FileCopyrightText: 2022 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Sebastian Gumprich
+# SPDX-FileCopyrightText: 2024 David Mehren
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - ansible.builtin.set_fact:

--- a/roles/custom/matrix-bridge-go-skype-bridge/tasks/setup_uninstall.yml
+++ b/roles/custom/matrix-bridge-go-skype-bridge/tasks/setup_uninstall.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2022 Vladimir Panteleev
+# SPDX-FileCopyrightText: 2022 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Check existence of matrix-go-skype-bridge service

--- a/roles/custom/matrix-bridge-go-skype-bridge/tasks/validate_config.yml
+++ b/roles/custom/matrix-bridge-go-skype-bridge/tasks/validate_config.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2022 Vladimir Panteleev
+# SPDX-FileCopyrightText: 2022 - 2025 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Fail if required go-skype-bridge settings not defined

--- a/roles/custom/matrix-bridge-go-skype-bridge/templates/config.yaml.j2.license
+++ b/roles/custom/matrix-bridge-go-skype-bridge/templates/config.yaml.j2.license
@@ -1,0 +1,6 @@
+SPDX-FileCopyrightText: 2022 Vladimir Panteleev
+SPDX-FileCopyrightText: 2022 Nikita Chernyi
+SPDX-FileCopyrightText: 2022 MDAD project contributors
+SPDX-FileCopyrightText: 2024 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-bridge-go-skype-bridge/templates/systemd/matrix-go-skype-bridge.service.j2.license
+++ b/roles/custom/matrix-bridge-go-skype-bridge/templates/systemd/matrix-go-skype-bridge.service.j2.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2022 Vladimir Panteleev
+SPDX-FileCopyrightText: 2022 - 2025 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-prometheus-nginxlog-exporter/defaults/main.yml
+++ b/roles/custom/matrix-prometheus-nginxlog-exporter/defaults/main.yml
@@ -1,3 +1,10 @@
+# SPDX-FileCopyrightText: 2022 MDAD project contributors
+# SPDX-FileCopyrightText: 2023 - 2025 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2023 Samuel Meenzen
+# SPDX-FileCopyrightText: 2024 Suguru Hirahara
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 # prometheus-nginxlog-exporter exports nginx logs in a prometheus usable format on a `/metrics/ endpoint
 # See: https://github.com/martin-helmich/prometheus-nginxlog-exporter/

--- a/roles/custom/matrix-prometheus-nginxlog-exporter/examples/grafana.png.license
+++ b/roles/custom/matrix-prometheus-nginxlog-exporter/examples/grafana.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2022 MDAD project contributors
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-prometheus-nginxlog-exporter/examples/metrics.png.license
+++ b/roles/custom/matrix-prometheus-nginxlog-exporter/examples/metrics.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2022 MDAD project contributors
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-prometheus-nginxlog-exporter/tasks/main.yml
+++ b/roles/custom/matrix-prometheus-nginxlog-exporter/tasks/main.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2022 MDAD project contributors
+# SPDX-FileCopyrightText: 2023 - 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - tags:

--- a/roles/custom/matrix-prometheus-nginxlog-exporter/tasks/setup_install.yml
+++ b/roles/custom/matrix-prometheus-nginxlog-exporter/tasks/setup_install.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2022 MDAD project contributors
+# SPDX-FileCopyrightText: 2023 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2024 David Mehren
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Ensure matrix-prometheus-nginxlog-exporter image is pulled

--- a/roles/custom/matrix-prometheus-nginxlog-exporter/tasks/setup_uninstall.yml
+++ b/roles/custom/matrix-prometheus-nginxlog-exporter/tasks/setup_uninstall.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2022 MDAD project contributors
+# SPDX-FileCopyrightText: 2023 - 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Check existence of matrix-prometheus-nginxlog-exporter service

--- a/roles/custom/matrix-prometheus-nginxlog-exporter/tasks/validate_config.yml
+++ b/roles/custom/matrix-prometheus-nginxlog-exporter/tasks/validate_config.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2022 MDAD project contributors
+# SPDX-FileCopyrightText: 2023 - 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: (Deprecation) Catch and report renamed prometheus-nginxlog-exporter settings

--- a/roles/custom/matrix-prometheus-nginxlog-exporter/templates/grafana/nginx-proxy.json.license
+++ b/roles/custom/matrix-prometheus-nginxlog-exporter/templates/grafana/nginx-proxy.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-prometheus-nginxlog-exporter/templates/labels.j2
+++ b/roles/custom/matrix-prometheus-nginxlog-exporter/templates/labels.j2
@@ -1,3 +1,9 @@
+{#
+SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+#}
+
 {% if matrix_prometheus_nginxlog_exporter_container_labels_traefik_enabled %}
 traefik.enable=true
 

--- a/roles/custom/matrix-prometheus-nginxlog-exporter/templates/nginx-proxy.json.license
+++ b/roles/custom/matrix-prometheus-nginxlog-exporter/templates/nginx-proxy.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2022 MDAD project contributors
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-prometheus-nginxlog-exporter/templates/prometheus-nginxlog-exporter.yaml.j2
+++ b/roles/custom/matrix-prometheus-nginxlog-exporter/templates/prometheus-nginxlog-exporter.yaml.j2
@@ -1,3 +1,10 @@
+{#
+SPDX-FileCopyrightText: 2022 MDAD project contributors
+SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+#}
+
 listen:
   port: {{ matrix_prometheus_nginxlog_exporter_container_metrics_port }}
   address: "0.0.0.0"

--- a/roles/custom/matrix-prometheus-nginxlog-exporter/templates/systemd/matrix-prometheus-nginxlog-exporter.service.j2.license
+++ b/roles/custom/matrix-prometheus-nginxlog-exporter/templates/systemd/matrix-prometheus-nginxlog-exporter.service.j2.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2022 MDAD project contributors
+SPDX-FileCopyrightText: 2023 - 2025 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later


### PR DESCRIPTION
This PR intends to:
- add license information to files for matrix-bot-matrix-reminder-bot
- add license information to files for matrix-bridge-go-skype-bridge
- add license information to files for matrix-prometheus-nginxlog-exporter