### PR TITLE
Add license information to some active project components

### DIFF
--- a/docs/configuring-playbook-cactus-comments.md
+++ b/docs/configuring-playbook-cactus-comments.md
@@ -1,3 +1,12 @@
+<!--
+SPDX-FileCopyrightText: 2022 Julian-Samuel Gebühr
+SPDX-FileCopyrightText: 2022 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2023 MDAD project contributors
+SPDX-FileCopyrightText: 2024 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Setting up Cactus Comments (optional)
 
 The playbook can install and configure the [Cactus Comments](https://cactus.chat) system for you.

--- a/docs/configuring-playbook-client-cinny.md
+++ b/docs/configuring-playbook-client-cinny.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-FileCopyrightText: 2022 MDAD project contributors
+SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Setting up Cinny (optional)
 
 The playbook can install and configure the [Cinny](https://github.com/ajbura/cinny) Matrix web client for you.

--- a/docs/configuring-playbook-client-fluffychat-web.md
+++ b/docs/configuring-playbook-client-fluffychat-web.md
@@ -1,3 +1,10 @@
+<!--
+SPDX-FileCopyrightText: 2025 Nikita Chernyi
+SPDX-FileCopyrightText: 2025 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Setting up FluffyChat Web (optional)
 
 The playbook can install and configure the [FluffyChat Web](https://github.com/krille-chan/fluffychat) Matrix client for you.

--- a/docs/configuring-playbook-conduwuit.md
+++ b/docs/configuring-playbook-conduwuit.md
@@ -1,3 +1,10 @@
+<!--
+SPDX-FileCopyrightText: 2025 Slavi Pantaleev
+SPDX-FileCopyrightText: 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Configuring conduwuit (optional)
 
 The playbook can install and configure the [conduwuit](https://conduwuit.puppyirl.gay/) Matrix server for you.

--- a/roles/custom/matrix-cactus-comments-client/defaults/main.yml
+++ b/roles/custom/matrix-cactus-comments-client/defaults/main.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2024 - 2025 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2024 Suguru Hirahara
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 # Cactus Comments is a federated comment system built on Matrix.
 # This role installs the client assets (JS, CSS files).

--- a/roles/custom/matrix-cactus-comments-client/tasks/install.yml
+++ b/roles/custom/matrix-cactus-comments-client/tasks/install.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2024 David Mehren
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Ensure matrix-cactus-comments-client paths exist

--- a/roles/custom/matrix-cactus-comments-client/tasks/main.yml
+++ b/roles/custom/matrix-cactus-comments-client/tasks/main.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - tags:

--- a/roles/custom/matrix-cactus-comments-client/tasks/uninstall.yml
+++ b/roles/custom/matrix-cactus-comments-client/tasks/uninstall.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Check existence of matrix-cactus-comments-client service

--- a/roles/custom/matrix-cactus-comments-client/tasks/validate_config.yml
+++ b/roles/custom/matrix-cactus-comments-client/tasks/validate_config.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Fail if required matrix-cactus-comments-client settings not defined

--- a/roles/custom/matrix-cactus-comments-client/templates/env.j2.license
+++ b/roles/custom/matrix-cactus-comments-client/templates/env.j2.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-cactus-comments-client/templates/labels.j2
+++ b/roles/custom/matrix-cactus-comments-client/templates/labels.j2
@@ -1,3 +1,9 @@
+{#
+SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+#}
+
 {% if matrix_cactus_comments_client_container_labels_traefik_enabled %}
 traefik.enable=true
 

--- a/roles/custom/matrix-cactus-comments-client/templates/systemd/matrix-cactus-comments-client.service.j2.license
+++ b/roles/custom/matrix-cactus-comments-client/templates/systemd/matrix-cactus-comments-client.service.j2.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-cactus-comments/defaults/main.yml
+++ b/roles/custom/matrix-cactus-comments/defaults/main.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Julian-Samuel Gebühr
+# SPDX-FileCopyrightText: 2022 - 2025 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2023 Samuel Meenzen
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 # Cactus Comments is a federated comment system built on Matrix.
 # This role installs the backend appservice.

--- a/roles/custom/matrix-cactus-comments/tasks/main.yml
+++ b/roles/custom/matrix-cactus-comments/tasks/main.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2022 Julian-Samuel Gebühr
+# SPDX-FileCopyrightText: 2022 - 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - tags:

--- a/roles/custom/matrix-cactus-comments/tasks/setup_install.yml
+++ b/roles/custom/matrix-cactus-comments/tasks/setup_install.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Julian-Samuel Gebühr
+# SPDX-FileCopyrightText: 2022 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Sebastian Gumprich
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Ensure matrix-cactus-comments paths exist

--- a/roles/custom/matrix-cactus-comments/tasks/setup_uninstall.yml
+++ b/roles/custom/matrix-cactus-comments/tasks/setup_uninstall.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2022 Julian-Samuel Gebühr
+# SPDX-FileCopyrightText: 2022 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Sebastian Gumprich
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Check existence of matrix-cactus-comments service

--- a/roles/custom/matrix-cactus-comments/tasks/validate_config.yml
+++ b/roles/custom/matrix-cactus-comments/tasks/validate_config.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2022 Julian-Samuel Gebühr
+# SPDX-FileCopyrightText: 2019 - 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: (Deprecation) Catch and report renamed matrix-cactus-comments settings

--- a/roles/custom/matrix-cactus-comments/templates/cactus_appservice.yaml.j2
+++ b/roles/custom/matrix-cactus-comments/templates/cactus_appservice.yaml.j2
@@ -1,3 +1,11 @@
+{#
+SPDX-FileCopyrightText: 2022 Julian-Samuel Gebühr
+SPDX-FileCopyrightText: 2022 Slavi Pantaleev
+SPDX-FileCopyrightText: 2024 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+#}
+
 # A unique, user-defined ID of the application service which will never change.
 id: "Cactus Comments"
 

--- a/roles/custom/matrix-cactus-comments/templates/env.j2.license
+++ b/roles/custom/matrix-cactus-comments/templates/env.j2.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2022  Julian-Samuel Gebühr
+SPDX-FileCopyrightText: 2022 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-cactus-comments/templates/systemd/matrix-cactus-comments.service.j2.license
+++ b/roles/custom/matrix-cactus-comments/templates/systemd/matrix-cactus-comments.service.j2.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2022 Julian-Samuel Gebühr
+SPDX-FileCopyrightText: 2022 - 2025 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-client-cinny/defaults/main.yml
+++ b/roles/custom/matrix-client-cinny/defaults/main.yml
@@ -1,3 +1,13 @@
+# SPDX-FileCopyrightText: 2022 MDAD project contributors
+# SPDX-FileCopyrightText: 2022 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 László Várady
+# SPDX-FileCopyrightText: 2022 - 2024 Nikita Chernyi
+# SPDX-FileCopyrightText: 2023 Samuel Meenzen
+# SPDX-FileCopyrightText: 2024 Suguru Hirahara
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 # Project source code URL: https://github.com/ajbura/cinny
 

--- a/roles/custom/matrix-client-cinny/tasks/main.yml
+++ b/roles/custom/matrix-client-cinny/tasks/main.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2022 MDAD project contributors
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - tags:

--- a/roles/custom/matrix-client-cinny/tasks/self_check.yml
+++ b/roles/custom/matrix-client-cinny/tasks/self_check.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2022 MDAD project contributors
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 - 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - ansible.builtin.set_fact:

--- a/roles/custom/matrix-client-cinny/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-cinny/tasks/setup_install.yml
@@ -1,3 +1,12 @@
+# SPDX-FileCopyrightText: 2022 MDAD project contributors
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Nikita Chernyi
+# SPDX-FileCopyrightText: 2022 - 2024 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Sebastian Gumprich
+# SPDX-FileCopyrightText: 2024 David Mehren
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 - name: Ensure Cinny paths exists
   ansible.builtin.file:

--- a/roles/custom/matrix-client-cinny/tasks/setup_uninstall.yml
+++ b/roles/custom/matrix-client-cinny/tasks/setup_uninstall.yml
@@ -1,3 +1,10 @@
+# SPDX-FileCopyrightText: 2022 MDAD project contributors
+# SPDX-FileCopyrightText: 2022 Marko Weltzer
+# SPDX-FileCopyrightText: 2022 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2022 Sebastian Gumprich
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 - name: Check existence of matrix-client-cinny.service
   ansible.builtin.stat:

--- a/roles/custom/matrix-client-cinny/tasks/validate_config.yml
+++ b/roles/custom/matrix-client-cinny/tasks/validate_config.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2022 MDAD project contributors
+# SPDX-FileCopyrightText: 2022 - 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 - name: Fail if required Cinny settings not defined
   ansible.builtin.fail:

--- a/roles/custom/matrix-client-cinny/templates/config.json.j2.license
+++ b/roles/custom/matrix-client-cinny/templates/config.json.j2.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2022 MDAD project contributors
+SPDX-FileCopyrightText: 2022 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-client-cinny/templates/labels.j2
+++ b/roles/custom/matrix-client-cinny/templates/labels.j2
@@ -1,3 +1,9 @@
+{#
+SPDX-FileCopyrightText: 2023 - 2024 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+#}
+
 {% if matrix_client_cinny_container_labels_traefik_enabled %}
 traefik.enable=true
 

--- a/roles/custom/matrix-client-cinny/templates/nginx.conf.j2.license
+++ b/roles/custom/matrix-client-cinny/templates/nginx.conf.j2.license
@@ -1,0 +1,5 @@
+SPDX-FileCopyrightText: 2022 MDAD project contributors
+SPDX-FileCopyrightText: 2019 - 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2024 James Reilly
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-client-cinny/templates/systemd/matrix-client-cinny.service.j2.license
+++ b/roles/custom/matrix-client-cinny/templates/systemd/matrix-client-cinny.service.j2.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2022 MDAD project contributors
+SPDX-FileCopyrightText: 2022 - 2025 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-client-fluffychat/defaults/main.yml
+++ b/roles/custom/matrix-client-fluffychat/defaults/main.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2025 Nikita Chernyi
+# SPDX-FileCopyrightText: 2025 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 # Project source code URL: https://github.com/krille-chan/fluffychat
 

--- a/roles/custom/matrix-client-fluffychat/tasks/main.yml
+++ b/roles/custom/matrix-client-fluffychat/tasks/main.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Nikita Chernyi
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - tags:

--- a/roles/custom/matrix-client-fluffychat/tasks/self_check.yml
+++ b/roles/custom/matrix-client-fluffychat/tasks/self_check.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Nikita Chernyi
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - ansible.builtin.set_fact:

--- a/roles/custom/matrix-client-fluffychat/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-fluffychat/tasks/setup_install.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Nikita Chernyi
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Ensure FluffyChat Web paths exists

--- a/roles/custom/matrix-client-fluffychat/tasks/setup_uninstall.yml
+++ b/roles/custom/matrix-client-fluffychat/tasks/setup_uninstall.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Nikita Chernyi
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Check existence of matrix-client-fluffychat.service

--- a/roles/custom/matrix-client-fluffychat/tasks/validate_config.yml
+++ b/roles/custom/matrix-client-fluffychat/tasks/validate_config.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2025 Nikita Chernyi
+# SPDX-FileCopyrightText: 2025 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Fail if required FluffyChat Web settings not defined

--- a/roles/custom/matrix-client-fluffychat/templates/labels.j2
+++ b/roles/custom/matrix-client-fluffychat/templates/labels.j2
@@ -1,3 +1,9 @@
+{#
+SPDX-FileCopyrightText: 2025 Nikita Chernyi
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+#}
+
 {% if matrix_client_fluffychat_container_labels_traefik_enabled %}
 traefik.enable=true
 

--- a/roles/custom/matrix-client-fluffychat/templates/systemd/matrix-client-fluffychat.service.j2.license
+++ b/roles/custom/matrix-client-fluffychat/templates/systemd/matrix-client-fluffychat.service.j2.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2025 Nikita Chernyi
+SPDX-FileCopyrightText: 2025 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-conduwuit/defaults/main.yml
+++ b/roles/custom/matrix-conduwuit/defaults/main.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2025 MDAD project contributors
+# SPDX-FileCopyrightText: 2025 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 # conduwuit is a very cool, featureful fork of conduit (https://gitlab.com/famedly/conduit).
 # Project source code URL: https://github.com/girlbossceo/conduwuit

--- a/roles/custom/matrix-conduwuit/tasks/install.yml
+++ b/roles/custom/matrix-conduwuit/tasks/install.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Ensure conduwuit config path exists

--- a/roles/custom/matrix-conduwuit/tasks/main.yml
+++ b/roles/custom/matrix-conduwuit/tasks/main.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2025 MDAD project contributors
+# SPDX-FileCopyrightText: 2025 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - tags:

--- a/roles/custom/matrix-conduwuit/tasks/self_check_client_api.yml
+++ b/roles/custom/matrix-conduwuit/tasks/self_check_client_api.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2025 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2025 Suguru Hirahara
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Check Matrix Client API

--- a/roles/custom/matrix-conduwuit/tasks/self_check_federation_api.yml
+++ b/roles/custom/matrix-conduwuit/tasks/self_check_federation_api.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Check Matrix Federation API

--- a/roles/custom/matrix-conduwuit/tasks/setup_install.yml
+++ b/roles/custom/matrix-conduwuit/tasks/setup_install.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 MDAD project contributors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Ensure conduwuit config path exists

--- a/roles/custom/matrix-conduwuit/tasks/setup_uninstall.yml
+++ b/roles/custom/matrix-conduwuit/tasks/setup_uninstall.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 MDAD project contributors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Check existence of matrix-conduwuit service

--- a/roles/custom/matrix-conduwuit/tasks/uninstall.yml
+++ b/roles/custom/matrix-conduwuit/tasks/uninstall.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Check existence of matrix-conduwuit service

--- a/roles/custom/matrix-conduwuit/tasks/validate_config.yml
+++ b/roles/custom/matrix-conduwuit/tasks/validate_config.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 MDAD project contributors
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Fail if required conduwuit settings not defined

--- a/roles/custom/matrix-conduwuit/templates/conduwuit.toml.j2
+++ b/roles/custom/matrix-conduwuit/templates/conduwuit.toml.j2
@@ -1,3 +1,11 @@
+{#
+SPDX-FileCopyrightText: 2025 MDAD project contributors
+SPDX-FileCopyrightText: 2025 Slavi Pantaleev
+SPDX-FileCopyrightText: 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+#}
+
 ### conduwuit Configuration
 ### See:
 ### https://conduwuit.puppyirl.gay/configuration.html

--- a/roles/custom/matrix-conduwuit/templates/env.j2.license
+++ b/roles/custom/matrix-conduwuit/templates/env.j2.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-conduwuit/templates/labels.j2
+++ b/roles/custom/matrix-conduwuit/templates/labels.j2
@@ -1,3 +1,11 @@
+{#
+SPDX-FileCopyrightText: 2025 MDAD project contributors
+SPDX-FileCopyrightText: 2025 Slavi Pantaleev
+SPDX-FileCopyrightText: 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+#}
+
 {% if matrix_conduwuit_container_labels_traefik_enabled %}
 traefik.enable=true
 

--- a/roles/custom/matrix-conduwuit/templates/systemd/matrix-conduwuit.service.j2.license
+++ b/roles/custom/matrix-conduwuit/templates/systemd/matrix-conduwuit.service.j2.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2025 MDAD project contributors
+SPDX-FileCopyrightText: 2025 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-conduwuit/vars/main.yml
+++ b/roles/custom/matrix-conduwuit/vars/main.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2025 MDAD project contributors
+# SPDX-FileCopyrightText: 2025 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 matrix_conduwuit_client_api_url_endpoint_public: "{{ 'https' if matrix_playbook_ssl_enabled else 'http' }}://{{ matrix_conduwuit_hostname }}/_matrix/client/versions"


### PR DESCRIPTION
This PR intends to:
- Add license information to files for matrix-conduwuit
- Add license information to files for matrix-client-fluffychat
- Add license information to files for matrix-client-cinny
- Add license information to files for matrix-cactus-comments and matrix-cactus-comments-client