### PR TITLE
Add license information to files for two components

### DIFF
--- a/docs/configuring-playbook-alertmanager-receiver.md
+++ b/docs/configuring-playbook-alertmanager-receiver.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2025 MDAD project contributors
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Setting up Prometheus Alertmanager integration via matrix-alertmanager-receiver (optional)
 
 The playbook can install and configure the [matrix-alertmanager-receiver](https://github.com/metio/matrix-alertmanager-receiver) service for you. It's a [client](https://prometheus.io/docs/alerting/latest/clients/) for Prometheus' [Alertmanager](https://prometheus.io/docs/alerting/latest/alertmanager/), allowing you to deliver alerts to Matrix rooms.

--- a/docs/configuring-playbook-appservice-double-puppet.md
+++ b/docs/configuring-playbook-appservice-double-puppet.md
@@ -1,3 +1,10 @@
+<!--
+SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Setting up Appservice Double Puppet (optional)
 
 The playbook can install and configure the Appservice Double Puppet service for you. It is a homeserver appservice through which bridges (and potentially other services) can impersonate any user on the homeserver.

--- a/roles/custom/matrix-alertmanager-receiver/defaults/main.yml
+++ b/roles/custom/matrix-alertmanager-receiver/defaults/main.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2024 - 2025 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 # matrix-alertmanager-receiver is a service which receives webhook payloads from Prometheus' Alertmanager and forwards them to a Matrix room.

--- a/roles/custom/matrix-alertmanager-receiver/tasks/install.yml
+++ b/roles/custom/matrix-alertmanager-receiver/tasks/install.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2024 David Mehren
+# SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Ensure matrix-alertmanager-receiver paths exist

--- a/roles/custom/matrix-alertmanager-receiver/tasks/main.yml
+++ b/roles/custom/matrix-alertmanager-receiver/tasks/main.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - tags:

--- a/roles/custom/matrix-alertmanager-receiver/tasks/uninstall.yml
+++ b/roles/custom/matrix-alertmanager-receiver/tasks/uninstall.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Check existence of matrix-alertmanager-receiver service

--- a/roles/custom/matrix-alertmanager-receiver/tasks/validate_config.yml
+++ b/roles/custom/matrix-alertmanager-receiver/tasks/validate_config.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 - name: Fail if required matrix-alertmanager-receiver settings not defined
   ansible.builtin.fail:

--- a/roles/custom/matrix-alertmanager-receiver/templates/config.yaml.j2.license
+++ b/roles/custom/matrix-alertmanager-receiver/templates/config.yaml.j2.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+SPDX-FileCopyrightText: 2024 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-alertmanager-receiver/templates/labels.j2
+++ b/roles/custom/matrix-alertmanager-receiver/templates/labels.j2
@@ -1,3 +1,9 @@
+{#
+SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+#}
+
 {% if matrix_alertmanager_receiver_container_labels_traefik_enabled %}
 traefik.enable=true
 

--- a/roles/custom/matrix-alertmanager-receiver/templates/systemd/matrix-alertmanager-receiver.service.j2.license
+++ b/roles/custom/matrix-alertmanager-receiver/templates/systemd/matrix-alertmanager-receiver.service.j2.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 - 2025 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-appservice-double-puppet/defaults/main.yml
+++ b/roles/custom/matrix-appservice-double-puppet/defaults/main.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 matrix_appservice_double_puppet_enabled: true

--- a/roles/custom/matrix-appservice-double-puppet/tasks/install.yml
+++ b/roles/custom/matrix-appservice-double-puppet/tasks/install.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Ensure matrix-appservice-double-puppet paths exist

--- a/roles/custom/matrix-appservice-double-puppet/tasks/main.yml
+++ b/roles/custom/matrix-appservice-double-puppet/tasks/main.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Suguru Hirahara
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - tags:

--- a/roles/custom/matrix-appservice-double-puppet/tasks/uninstall.yml
+++ b/roles/custom/matrix-appservice-double-puppet/tasks/uninstall.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Ensure matrix-appservice-double-puppet paths don't exist

--- a/roles/custom/matrix-appservice-double-puppet/tasks/validate_config.yml
+++ b/roles/custom/matrix-appservice-double-puppet/tasks/validate_config.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 - name: Fail if required matrix-appservice-double-puppet settings not defined
   ansible.builtin.fail:

--- a/roles/custom/matrix-appservice-double-puppet/templates/registration.yaml.j2
+++ b/roles/custom/matrix-appservice-double-puppet/templates/registration.yaml.j2
@@ -1,3 +1,9 @@
+{#
+SPDX-FileCopyrightText: 2024 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+#}
+
 # The ID doesn't really matter, put whatever you want.
 id: {{ matrix_appservice_double_puppet_registration_id | to_json }}
 # The URL is intentionally left empty (null), as the homeserver shouldn't


### PR DESCRIPTION
This one is for matrix-alertmanager-receiver and appservice-double-puppet.