### PR TITLE
Fix GitHub issue template selector

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,10 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2022 Slavi Pantaleev
-SPDX-FileCopyrightText: 2024 Suguru Hirahara
-
-SPDX-License-Identifier: AGPL-3.0-or-later
--->
-
 ---
 name: Bug report
 about: Create a report to help us improve

--- a/.github/ISSUE_TEMPLATE/bug_report.md.license
+++ b/.github/ISSUE_TEMPLATE/bug_report.md.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2022 Slavi Pantaleev
+SPDX-FileCopyrightText: 2024 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,10 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2022 Slavi Pantaleev
-SPDX-FileCopyrightText: 2024 Suguru Hirahara
-
-SPDX-License-Identifier: AGPL-3.0-or-later
--->
-
 ---
 name: Feature request
 about: Suggest an idea for this project

--- a/.github/ISSUE_TEMPLATE/feature_request.md.license
+++ b/.github/ISSUE_TEMPLATE/feature_request.md.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2022 Slavi Pantaleev
+SPDX-FileCopyrightText: 2024 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/.github/ISSUE_TEMPLATE/i-need-help.md
+++ b/.github/ISSUE_TEMPLATE/i-need-help.md
@@ -1,10 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2022 Slavi Pantaleev
-SPDX-FileCopyrightText: 2024 Suguru Hirahara
-
-SPDX-License-Identifier: AGPL-3.0-or-later
--->
-
 ---
 name: I need help
 about: Get support from our community

--- a/.github/ISSUE_TEMPLATE/i-need-help.md.license
+++ b/.github/ISSUE_TEMPLATE/i-need-help.md.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2022 Slavi Pantaleev
+SPDX-FileCopyrightText: 2024 Suguru Hirahara
+
+SPDX-License-Identifier: AGPL-3.0-or-later


### PR DESCRIPTION
Apparently those Markdown files are not expected to put something before the three hyphens on the top.