### PR TITLE
Enable room summary API (MSC3266) support for Synapse

### DIFF
--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -1252,6 +1252,15 @@ matrix_synapse_experimental_features_msc4108_enabled: false
 ################################################################################
 
 
+# Controls whether to enable the "room summary API" experimental feature.
+# See https://github.com/matrix-org/matrix-spec-proposals/pull/3266
+# Despite being experimental, this feature is mandatory for the next-generation Element X clients, which is why it is enabled by default:
+# https://github.com/element-hq/element-x-ios/issues/3713#issuecomment-2620958291
+# If you're worried about the privacy implications of this unauthenticated API, see:
+# https://github.com/deepbluev7/matrix-doc/blob/room-summaries/proposals/3266-room-summary.md#client-server-api
+# Set this to false if you still want to disable to API for some reason. Note that doing so breaks Element X compatibility though.
+matrix_synapse_experimental_features_msc3266_enabled: true
+
 # Enable this to activate the REST auth password provider module.
 # See: https://github.com/ma1uta/matrix-synapse-rest-password-provider
 matrix_synapse_ext_password_provider_rest_auth_enabled: false

--- a/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -2984,5 +2984,8 @@ experimental_features:
   {% if matrix_synapse_experimental_features_msc4108_enabled %}
   msc4108_enabled: true
   {% endif %}
+  {% if matrix_synapse_experimental_features_msc3266_enabled %}
+  msc3266_enabled: true
+  {% endif %}
 
 # vim:ft=yaml


### PR DESCRIPTION
This PR enables the room summary API as specified in MSC3266 (https://github.com/matrix-org/matrix-spec-proposals/pull/3266) by default as it is a hard requirement for the Element X clients (https://github.com/element-hq/element-x-ios/issues/3713#issuecomment-2620958291).

I tested this on two of our private/non-federating instances with the current Element X codebase on iOS and Android. It fixes the issue of not being able to accept/decline room invites.
