### PR TITLE
Update docs/configuring-playbook-email.md: copy from the ansible-role…

### DIFF
--- a/docs/configuring-playbook-email.md
+++ b/docs/configuring-playbook-email.md
@@ -25,15 +25,21 @@ Docker automatically opens these ports in the server's firewall, so you likely d
 
 ## Adjusting the playbook configuration
 
-### Relaying email through another SMTP server (optional)
+### Enable DKIM authentication to improve deliverability (optional)
 
-By default, exim-relay attempts to deliver emails directly. This may or may not work, depending on your domain configuration (SPF settings, etc.)
+By default, exim-relay attempts to deliver emails directly. This may or may not work, depending on your domain configuration.
+
+To improve email deliverability, you can configure authentication methods such as DKIM (DomainKeys Identified Mail), SPF, and DMARC for your domain. Without setting any of these authentication methods, your outgoing email is most likely to be quarantined as spam at recipient's mail servers.
+
+For details about configuring DKIM, refer [this section](https://github.com/mother-of-all-self-hosting/ansible-role-exim-relay/blob/main/docs/configuring-exim-relay.md#enable-dkim-support-optional) on the role's document.
+
+💡 If you cannot enable DKIM, SPF, or DMARC on your domain for some reason, we recommend relaying email through another SMTP server.
+
+### Relaying email through another SMTP server (optional)
 
 **On some cloud providers such as Google Cloud, [port 25 is always blocked](https://cloud.google.com/compute/docs/tutorials/sending-mail/), so sending email directly from your server is not possible.** In this case, you will need to relay email through another SMTP server.
 
 For details about configuration, refer [this section](https://github.com/mother-of-all-self-hosting/ansible-role-exim-relay/blob/main/docs/configuring-exim-relay.md#relaying-email-through-another-smtp-server) on the role's document.
-
-💡 To improve deliverability, we recommend relaying email through another SMTP server anyway.
 
 ### Disable mail service (optional)
 


### PR DESCRIPTION
…-exim-relay role's document and edit

Based on https://github.com/mother-of-all-self-hosting/ansible-role-exim-relay/blob/eac4201a0253e098983cdfee47c112790b3b198c/docs/configuring-exim-relay.md

- Add instruction to enable DKIM
- Replace the recommendation to use another SMTP server as relay, as DKIM has become available on exim-relay and configuring it greatly improves deliverability