### PR TITLE
Update D4A Configuration

### DIFF
--- a/roles/custom/matrix-appservice-draupnir-for-all/defaults/main.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/defaults/main.yml
@@ -52,7 +52,7 @@ matrix_appservice_draupnir_for_all_systemd_wanted_services_list: []
 # Note: Draupnir is fairly verbose - expect a lot of messages from it.
 # This room is diffrent for Appservice Mode compared to normal mode.
 # In Appservice mode it provides functions like user management.
-matrix_appservice_draupnir_for_all_config_adminRoom: "" # noqa var-naming
+matrix_appservice_draupnir_for_all_config_adminRoom: ""  # noqa var-naming
 
 # Controls if the room state backing store is activated.
 # Room state backing store makes restarts of the bot lightning fast as the bot does not suffer from amnesia.

--- a/roles/custom/matrix-appservice-draupnir-for-all/defaults/main.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/defaults/main.yml
@@ -52,12 +52,7 @@ matrix_appservice_draupnir_for_all_systemd_wanted_services_list: []
 # Note: Draupnir is fairly verbose - expect a lot of messages from it.
 # This room is diffrent for Appservice Mode compared to normal mode.
 # In Appservice mode it provides functions like user management.
-matrix_appservice_draupnir_for_all_master_control_room_alias: ""
-
-# Placeholder Remenant of the fact that Cat belived Master Control Room to be separated from Access Control Policy List.
-# The alias of the Policy list used to control who can provision a bot for them selfs.
-# This should be a room alias - not a matrix.to URL.
-# matrix_appservice_draupnir_for_all_management_policy_list_alias: ""
+matrix_appservice_draupnir_for_all_config_adminRoom: "" # noqa var-naming
 
 # Controls if the room state backing store is activated.
 # Room state backing store makes restarts of the bot lightning fast as the bot does not suffer from amnesia.

--- a/roles/custom/matrix-appservice-draupnir-for-all/defaults/main.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/defaults/main.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 MDAD project contributors
+# SPDX-FileCopyrightText: 2024 - 2025 Catalan Lover <catalanlover@protonmail.com>
 # SPDX-FileCopyrightText: 2024 - 2025 Slavi Pantaleev
 # SPDX-FileCopyrightText: 2024 Suguru Hirahara
 #
@@ -57,6 +57,11 @@ matrix_appservice_draupnir_for_all_master_control_room_alias: ""
 # The alias of the Policy list used to control who can provision a bot for them selfs.
 # This should be a room alias - not a matrix.to URL.
 # matrix_appservice_draupnir_for_all_management_policy_list_alias: ""
+
+# Controls if the room state backing store is activated.
+# Room state backing store makes restarts of the bot lightning fast as the bot does not suffer from amnesia.
+# This config option has diminished improvements for bots on extremely fast homeservers or very very small bots on fast homeservers.
+matrix_appservice_draupnir_for_all_enable_room_state_backing_store: "false"
 
 matrix_appservice_draupnir_for_all_database_username: matrix_appservice_draupnir_for_all
 matrix_appservice_draupnir_for_all_database_password: 'some-passsword'

--- a/roles/custom/matrix-appservice-draupnir-for-all/defaults/main.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/defaults/main.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2024 MDAD project contributors
 # SPDX-FileCopyrightText: 2024 - 2025 Catalan Lover <catalanlover@protonmail.com>
 # SPDX-FileCopyrightText: 2024 - 2025 Slavi Pantaleev
 # SPDX-FileCopyrightText: 2024 Suguru Hirahara
@@ -61,7 +62,7 @@ matrix_appservice_draupnir_for_all_master_control_room_alias: ""
 # Controls if the room state backing store is activated.
 # Room state backing store makes restarts of the bot lightning fast as the bot does not suffer from amnesia.
 # This config option has diminished improvements for bots on extremely fast homeservers or very very small bots on fast homeservers.
-matrix_appservice_draupnir_for_all_enable_room_state_backing_store: "false"
+matrix_appservice_draupnir_for_all_config_roomStateBackingStore_enabled: false  # noqa var-naming
 
 matrix_appservice_draupnir_for_all_database_username: matrix_appservice_draupnir_for_all
 matrix_appservice_draupnir_for_all_database_password: 'some-passsword'

--- a/roles/custom/matrix-appservice-draupnir-for-all/tasks/main.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/tasks/main.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024 MDAD project contributors
+# SPDX-FileCopyrightText: 2024 Catalan Lover <catalanlover@protonmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/roles/custom/matrix-appservice-draupnir-for-all/tasks/setup_install.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/tasks/setup_install.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2024 David Mehren
 # SPDX-FileCopyrightText: 2024 MDAD project contributors
+# SPDX-FileCopyrightText: 2024 Catalan Lover <catalanlover@protonmail.com>
 # SPDX-FileCopyrightText: 2024 Slavi Pantaleev
 # SPDX-FileCopyrightText: 2024 Suguru Hirahara
 #

--- a/roles/custom/matrix-appservice-draupnir-for-all/tasks/setup_uninstall.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/tasks/setup_uninstall.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2023 - 2024 MDAD project contributors
+# SPDX-FileCopyrightText: 2024 Catalan Lover <catalanlover@protonmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/roles/custom/matrix-appservice-draupnir-for-all/tasks/validate_config.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/tasks/validate_config.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024 MDAD project contributors
+# SPDX-FileCopyrightText: 2024 Catalan Lover <catalanlover@protonmail.com>
 # SPDX-FileCopyrightText: 2024 Slavi Pantaleev
 # SPDX-FileCopyrightText: 2025 Suguru Hirahara
 #

--- a/roles/custom/matrix-appservice-draupnir-for-all/tasks/validate_config.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/tasks/validate_config.yml
@@ -23,3 +23,4 @@
   with_items:
     - {'old': 'matrix_appservice_draupnir_for_all_docker_image_name_prefix', 'new': 'matrix_appservice_draupnir_for_all_docker_image_registry_prefix'}
     - {'old': 'matrix_appservice_draupnir_for_all_enable_room_state_backing_store', 'new': 'matrix_appservice_draupnir_for_all_config_roomStateBackingStore_enabled'}
+    - {'old': 'matrix_appservice_draupnir_for_all_master_control_room_alias', 'new': 'matrix_appservice_draupnir_for_all_config_adminRoom'}

--- a/roles/custom/matrix-appservice-draupnir-for-all/tasks/validate_config.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/tasks/validate_config.yml
@@ -22,3 +22,4 @@
   when: "item.old in vars"
   with_items:
     - {'old': 'matrix_appservice_draupnir_for_all_docker_image_name_prefix', 'new': 'matrix_appservice_draupnir_for_all_docker_image_registry_prefix'}
+    - {'old': 'matrix_appservice_draupnir_for_all_enable_room_state_backing_store', 'new': 'matrix_appservice_draupnir_for_all_config_roomStateBackingStore_enabled'}

--- a/roles/custom/matrix-appservice-draupnir-for-all/templates/production-appservice.yaml.j2
+++ b/roles/custom/matrix-appservice-draupnir-for-all/templates/production-appservice.yaml.j2
@@ -1,5 +1,5 @@
 {#
-SPDX-FileCopyrightText: 2024 MDAD project contributors
+SPDX-FileCopyrightText: 2024-2025 Catalan Lover <catalanlover@protonmail.com>
 SPDX-FileCopyrightText: 2024 Suguru Hirahara
 
 SPDX-License-Identifier: AGPL-3.0-or-later
@@ -23,3 +23,9 @@ adminRoom: "{{ matrix_appservice_draupnir_for_all_master_control_room_alias }}"
 # This is a web api that the widget connects to in order to interact with the appservice.
 webAPI:
   port: 9000
+
+# The directory the bot should store various bits of information in
+dataPath: "/data/storage"
+
+roomStateBackingStore:
+  enabled: {{ matrix_appservice_draupnir_for_all_enable_room_state_backing_store }}

--- a/roles/custom/matrix-appservice-draupnir-for-all/templates/production-appservice.yaml.j2
+++ b/roles/custom/matrix-appservice-draupnir-for-all/templates/production-appservice.yaml.j2
@@ -19,7 +19,7 @@ db:
 
 # A room you have created that scopes who can access the appservice.
 # See docs/access_control.md
-adminRoom: "{{ matrix_appservice_draupnir_for_all_config_adminRoom | to_json }}"
+adminRoom: {{ matrix_appservice_draupnir_for_all_config_adminRoom | to_json }}
 
 # This is a web api that the widget connects to in order to interact with the appservice.
 webAPI:

--- a/roles/custom/matrix-appservice-draupnir-for-all/templates/production-appservice.yaml.j2
+++ b/roles/custom/matrix-appservice-draupnir-for-all/templates/production-appservice.yaml.j2
@@ -1,5 +1,6 @@
 {#
-SPDX-FileCopyrightText: 2024-2025 Catalan Lover <catalanlover@protonmail.com>
+SPDX-FileCopyrightText: 2024 MDAD project contributors
+SPDX-FileCopyrightText: 2024 - 2025 Catalan Lover <catalanlover@protonmail.com>
 SPDX-FileCopyrightText: 2024 Suguru Hirahara
 
 SPDX-License-Identifier: AGPL-3.0-or-later
@@ -28,4 +29,4 @@ webAPI:
 dataPath: "/data"
 
 roomStateBackingStore:
-  enabled: {{ matrix_appservice_draupnir_for_all_enable_room_state_backing_store }}
+  enabled: {{ matrix_appservice_draupnir_for_all_config_roomStateBackingStore_enabled | to_json }}

--- a/roles/custom/matrix-appservice-draupnir-for-all/templates/production-appservice.yaml.j2
+++ b/roles/custom/matrix-appservice-draupnir-for-all/templates/production-appservice.yaml.j2
@@ -19,7 +19,7 @@ db:
 
 # A room you have created that scopes who can access the appservice.
 # See docs/access_control.md
-adminRoom: "{{ matrix_appservice_draupnir_for_all_master_control_room_alias }}"
+adminRoom: "{{ matrix_appservice_draupnir_for_all_config_adminRoom | to_json }}"
 
 # This is a web api that the widget connects to in order to interact with the appservice.
 webAPI:

--- a/roles/custom/matrix-appservice-draupnir-for-all/templates/production-appservice.yaml.j2
+++ b/roles/custom/matrix-appservice-draupnir-for-all/templates/production-appservice.yaml.j2
@@ -25,7 +25,7 @@ webAPI:
   port: 9000
 
 # The directory the bot should store various bits of information in
-dataPath: "/data/storage"
+dataPath: "/data"
 
 roomStateBackingStore:
   enabled: {{ matrix_appservice_draupnir_for_all_enable_room_state_backing_store }}

--- a/roles/custom/matrix-appservice-draupnir-for-all/templates/production-bots.yaml.j2
+++ b/roles/custom/matrix-appservice-draupnir-for-all/templates/production-bots.yaml.j2
@@ -1,5 +1,6 @@
 {#
-SPDX-FileCopyrightText: 2024-2025 Catalan Lover <catalanlover@protonmail.com>
+SPDX-FileCopyrightText: 2024 MDAD project contributors
+SPDX-FileCopyrightText: 2024 - 2025 Catalan Lover <catalanlover@protonmail.com>
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}

--- a/roles/custom/matrix-appservice-draupnir-for-all/templates/production-bots.yaml.j2
+++ b/roles/custom/matrix-appservice-draupnir-for-all/templates/production-bots.yaml.j2
@@ -1,5 +1,5 @@
 {#
-SPDX-FileCopyrightText: 2024 MDAD project contributors
+SPDX-FileCopyrightText: 2024-2025 Catalan Lover <catalanlover@protonmail.com>
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
@@ -73,3 +73,20 @@ commands:
       - "brigading"
       - "harassment"
       - "disagreement"
+
+# Safe mode provides recovery options for some failure modes when Draupnir
+# fails to start. For example, if the bot fails to resolve a room alias in
+# a watched list, or if the server has parted from a protected room and can't
+# find a way back in. Safe mode will provide different options to recover from
+# these. Such as unprotecting the room or unwatching the policy list.
+# By default Draupnir will boot into safe mode only when the failure mode
+# is recoverable.
+# It may be desirable to prevent the bot from starting into safe mode if you have
+# a pager system when Draupnir is down, as Draupnir could prevent your monitoring
+# system from identifying a failure to start.
+#safeMode:
+#  # The option for entering safe mode when Draupnir fails to start up.
+#  # - "RecoveryOnly" will only start the bot in safe mode when there are recovery options available. This is the default.
+#  # - "Never" will never start the bot in safe mode when Draupnir fails to start normally.
+#  # - "Always" will always start the bot in safe mode when Draupnir fails to start normally.
+#  bootOption: RecoveryOnly

--- a/roles/custom/matrix-appservice-draupnir-for-all/templates/systemd/matrix-appservice-draupnir-for-all.service.j2.license
+++ b/roles/custom/matrix-appservice-draupnir-for-all/templates/systemd/matrix-appservice-draupnir-for-all.service.j2.license
@@ -1,4 +1,5 @@
 SPDX-FileCopyrightText: 2024 MDAD project contributors
+SPDX-FileCopyrightText: 2024 Catalan Lover <catalanlover@protonmail.com>
 SPDX-FileCopyrightText: 2024 Slavi Pantaleev
 
 SPDX-License-Identifier: AGPL-3.0-or-later


### PR DESCRIPTION
D4A had some breaking config changes so this commit fixes them and gets us back into compliance with upstream. 

Now this PR also deals with a second matter. It updates the SPDX headers in the affected files to be correct by only crediting Cat in addition to the named other contributors as well Cat is the only mdad side contributor to these files as far as git blame is concerned.

Now Draupnir doesnt use AGPL and all the config is taken straight from Draupnir so atleast for production-bots.yaml.j2 it could be argued that it should be Gnuxie and CC0 as thats the upstream licence and Credit. And Draupnir is also doing Reuse. 

Anyways Cat isnt an expert at the reuse stuff. The code it self runs as its what runs on my System currently and was required to unbreak D4A.

And yes Room state variable is a carbon copy of the bot mode config as its the same option and i cba writing new text.