### PR TITLE
Modernise Draupnir Configuration Variable Names

### DIFF
--- a/docs/configuring-playbook-bot-draupnir.md
+++ b/docs/configuring-playbook-bot-draupnir.md
@@ -58,7 +58,7 @@ matrix_bot_draupnir_enable_experimental_rust_crypto: true
 
 # Access token which the bot will use for logging in.
 # Comment out `matrix_bot_draupnir_login_native` when using this option.
-matrix_bot_draupnir_access_token: "CLEAN_ACCESS_TOKEN_HERE"
+matrix_bot_draupnir_config_accessToken: "CLEAN_ACCESS_TOKEN_HERE"
 ```
 
 ## Adjusting the playbook configuration
@@ -73,13 +73,13 @@ matrix_bot_draupnir_enabled: true
 # matrix_bot_draupnir_login: bot.draupnir
 
 # Generate a strong password for the bot. You can create one with a command like `pwgen -s 64 1`.
-# If creating the user on your own and using `matrix_bot_draupnir_access_token` to login you can comment out this line.
+# If creating the user on your own and using `matrix_bot_draupnir_config_accessToken` to login you can comment out this line.
 matrix_bot_draupnir_password: PASSWORD_FOR_THE_BOT
 
-# Comment out if using `matrix_bot_draupnir_enable_experimental_rust_crypto: true` or `matrix_bot_draupnir_access_token` to login.
+# Comment out if using `matrix_bot_draupnir_enable_experimental_rust_crypto: true` or `matrix_bot_draupnir_config_accessToken` to login.
 matrix_bot_draupnir_login_native: true
 
-matrix_bot_draupnir_management_room: "MANAGEMENT_ROOM_ID_HERE"
+matrix_bot_draupnir_config_managementRoom: "MANAGEMENT_ROOM_ID_HERE"
 ```
 
 ### Create and invite the bot to the management room
@@ -142,7 +142,7 @@ Draupnir can receive reports in the management room.
 The bot can intercept the report API endpoint of the client-server API, which requires integration with the reverse proxy in front of the homeserver. If you are using Traefik, this playbook can set this up for you:
 
 ```yaml
-matrix_bot_draupnir_abuse_reporting_enabled: true
+matrix_bot_draupnir_config_web_abuseReporting: true
 ```
 
 <!--

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -3188,10 +3188,10 @@ matrix_bot_draupnir_container_additional_networks_auto: |-
     ) | unique
   }}
 
-matrix_bot_draupnir_homeserver_url: "{{ 'http://matrix-pantalaimon:8009' if matrix_bot_draupnir_pantalaimon_use else matrix_addons_homeserver_client_api_url }}"
-matrix_bot_draupnir_raw_homeserver_url: "{{ matrix_addons_homeserver_client_api_url }}"
+matrix_bot_draupnir_config_homeserverUrl: "{{ 'http://matrix-pantalaimon:8009' if matrix_bot_draupnir_pantalaimon_use else matrix_addons_homeserver_client_api_url }}"  # noqa var-naming
+matrix_bot_draupnir_config_rawHomeserverUrl: "{{ matrix_addons_homeserver_client_api_url }}"  # noqa var-naming
 
-matrix_bot_draupnir_container_labels_traefik_enabled: "{{ matrix_bot_draupnir_web_enabled and matrix_playbook_reverse_proxy_type in ['playbook-managed-traefik', 'other-traefik-container'] }}"
+matrix_bot_draupnir_container_labels_traefik_enabled: "{{ matrix_bot_draupnir_config_web_enabled and matrix_playbook_reverse_proxy_type in ['playbook-managed-traefik', 'other-traefik-container'] }}"
 matrix_bot_draupnir_container_labels_traefik_docker_network: "{{ matrix_playbook_reverse_proxyable_services_additional_network }}"
 matrix_bot_draupnir_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 matrix_bot_draupnir_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"

--- a/group_vars/matrix_servers.license
+++ b/group_vars/matrix_servers.license
@@ -52,7 +52,7 @@ SPDX-FileCopyrightText: 2023 - 2024 Michael Hollister
 SPDX-FileCopyrightText: 2023 - 2024 Pierre 'McFly' Marty
 SPDX-FileCopyrightText: 2023 Antonis Christofides
 SPDX-FileCopyrightText: 2023 Benjamin Kampmann
-SPDX-FileCopyrightText: 2023 Catalan Lover
+SPDX-FileCopyrightText: 2023 - 2025 Catalan Lover <catalanlover@protonmail.com>
 SPDX-FileCopyrightText: 2023 Cody Wyatt Neiman
 SPDX-FileCopyrightText: 2023 Johan Swetzén
 SPDX-FileCopyrightText: 2023 Kabir Kwatra

--- a/roles/custom/matrix-bot-draupnir/defaults/main.yml
+++ b/roles/custom/matrix-bot-draupnir/defaults/main.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2023 - 2024 MDAD project contributors
+# SPDX-FileCopyrightText: 2023 - 2025 Catalan Lover <catalanlover@protonmail.com>
 # SPDX-FileCopyrightText: 2023 Samuel Meenzen
 # SPDX-FileCopyrightText: 2024 - 2025 Slavi Pantaleev
 #
@@ -27,9 +28,9 @@ matrix_bot_draupnir_config_path: "{{ matrix_bot_draupnir_base_path }}/config"
 matrix_bot_draupnir_data_path: "{{ matrix_bot_draupnir_base_path }}/data"
 matrix_bot_draupnir_docker_src_files_path: "{{ matrix_bot_draupnir_base_path }}/docker-src"
 
-matrix_bot_draupnir_abuse_reporting_enabled: false
-matrix_bot_draupnir_web_enabled: "{{ matrix_bot_draupnir_abuse_reporting_enabled }}"
-matrix_bot_draupnir_display_reports: "{{ matrix_bot_draupnir_abuse_reporting_enabled }}"
+matrix_bot_draupnir_config_web_abuseReporting: false  # noqa var-naming
+matrix_bot_draupnir_config_web_enabled: "{{ matrix_bot_draupnir_config_web_abuseReporting }}"  # noqa var-naming
+matrix_bot_draupnir_config_displayReports: "{{ matrix_bot_draupnir_config_web_abuseReporting }}"  # noqa var-naming
 
 matrix_bot_draupnir_container_network: ""
 
@@ -56,7 +57,7 @@ matrix_bot_draupnir_systemd_wanted_services_list: []
 
 # Whether Draupnir should talk to the homeserver through Pantalaimon
 # If true, then other variables must be provided including pointing
-# `matrix_bot_draupnir_homeserver_url` to the Pantalaimon URL.
+# `matrix_bot_draupnir_config_homeserverUrl` to the Pantalaimon URL.
 #
 # The upstream project discourages enabling this option, because it is
 # known that running Draupnir along with Pantalaimon breaks all workflows that involve
@@ -74,35 +75,37 @@ matrix_bot_draupnir_enable_experimental_rust_crypto: false
 
 # The access token for the bot user. Required if Pantalaimon is NOT used.
 # (Otherwise provide `matrix_bot_draupnir_pantalaimon_username` and `matrix_bot_draupnir_pantalaimon_password` instead.)
-matrix_bot_draupnir_access_token: ""
+matrix_bot_draupnir_config_accessToken: ""  # noqa var-naming
 
 # Username and password for the bot. Required if Pantalaimon is used.
-# (Otherwise provide `matrix_bot_draupnir_access_token` instead.)
+# (Otherwise provide `matrix_bot_draupnir_config_accessToken` instead.)
 matrix_bot_draupnir_pantalaimon_username: ""
 matrix_bot_draupnir_pantalaimon_password: ""
 
 # Username and password the bot uses for logging in directly. If Pantalaimon is used,
 # these values become the values of `matrix_bot_draupnir_pantalaimon_username` and `matrix_bot_draupnir_pantalaimon_password`
+# These config options do not follow the common naming schema as to not cause user confusion over them being called Pantalaimon when using native login.
 matrix_bot_draupnir_login: "{{ matrix_bot_draupnir_pantalaimon_username if matrix_bot_draupnir_pantalaimon_use == 'true' else 'bot.draupnir' }}"
 matrix_bot_draupnir_password: "{{ matrix_bot_draupnir_pantalaimon_password }}"
 
 # Controls if we activate the config block for Pantalaimon for now. Its name will
 # probably be changed for our usecase due to Draupnir's push to scrub Pantalaimon from the codebase.
+# This configuration option does not follow the common naming schema as its not controlling a config key directly.
 matrix_bot_draupnir_login_native: ""
 
 # The room ID where people can use the bot. The bot has no access controls, so
 # anyone in this room can use the bot - secure your room!
 # This should be a room alias or room ID - not a matrix.to URL.
 # Note: Draupnir is fairly verbose - expect a lot of messages from it.
-matrix_bot_draupnir_management_room: ""
+matrix_bot_draupnir_config_managementRoom: ""  # noqa var-naming
 
 # Endpoint URL that Draupnir uses to interact with the Matrix homeserver (client-server API).
 # Set this to the Pantalaimon URL if you're using that.
-matrix_bot_draupnir_homeserver_url: ""
+matrix_bot_draupnir_config_homeserverUrl: ""  # noqa var-naming
 
 # Endpoint URL that Draupnir could use to fetch events related to reports (client-server API and /_synapse/).
 # Only set this to the public-internet homeserver client API URL. Do NOT set this to the Pantalaimon URL.
-matrix_bot_draupnir_raw_homeserver_url: ""
+matrix_bot_draupnir_config_rawHomeserverUrl: ""  # noqa var-naming
 
 # Disable Server ACL is used if you do not want to give the bot the right to apply Server ACLs in rooms without complaints from the bot.
 # This setting is described the following way in the configuration.
@@ -112,12 +115,12 @@ matrix_bot_draupnir_raw_homeserver_url: ""
 # It is recommended to consult with people from the upstream project beforehand.
 #
 # It is exposed here because it is common enough to be valid to expose.
-matrix_bot_draupnir_disable_server_acl: "false"
+matrix_bot_draupnir_config_disableServerACL: false  # noqa var-naming
 
 # Controls if the room state backing store is activated.
 # Room state backing store makes restarts of the bot lightning fast as the bot does not suffer from amnesia.
 # This config option has diminished improvements for bots on extremely fast homeservers or very very small bots on fast homeservers.
-matrix_bot_draupnir_enable_room_state_backing_store: "true"
+matrix_bot_draupnir_config_roomStateBackingStore_enabled: true  # noqa var-naming
 
 # Default configuration template which covers the generic use case.
 # You can customize it by controlling the various variables inside it.

--- a/roles/custom/matrix-bot-draupnir/tasks/main.yml
+++ b/roles/custom/matrix-bot-draupnir/tasks/main.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2023 MDAD project contributors
+# SPDX-FileCopyrightText: 2023 Catalan Lover <catalanlover@protonmail.com>
 # SPDX-FileCopyrightText: 2023 Slavi Pantaleev
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/roles/custom/matrix-bot-draupnir/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-draupnir/tasks/setup_install.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2023 - 2024 MDAD project contributors
+# SPDX-FileCopyrightText: 2023 Catalan Lover <catalanlover@protonmail.com>
 # SPDX-FileCopyrightText: 2024 David Mehren
 # SPDX-FileCopyrightText: 2024 Slavi Pantaleev
 # SPDX-FileCopyrightText: 2024 Suguru Hirahara

--- a/roles/custom/matrix-bot-draupnir/tasks/setup_uninstall.yml
+++ b/roles/custom/matrix-bot-draupnir/tasks/setup_uninstall.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2023 MDAD project contributors
+# SPDX-FileCopyrightText: 2023 Catalan Lover <catalanlover@protonmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/roles/custom/matrix-bot-draupnir/tasks/validate_config.yml
+++ b/roles/custom/matrix-bot-draupnir/tasks/validate_config.yml
@@ -6,6 +6,25 @@
 
 ---
 
+- name: (Deprecation) Catch and report renamed Draupnir settings
+  ansible.builtin.fail:
+    msg: >-
+      Your configuration contains a variable, which now has a different name.
+      Please rename the variable (`{{ item.old }}` -> `{{ item.new }}`) on your configuration file (vars.yml).
+  when: "item.old in vars"
+  with_items:
+    - {'old': 'matrix_bot_draupnir_container_image_name_prefix', 'new': 'matrix_bot_draupnir_container_image_registry_prefix'}
+    - {'old': 'matrix_bot_draupnir_enable_room_state_backing_store', 'new': 'matrix_bot_draupnir_config_roomStateBackingStore_enabled'}
+    - {'old': 'matrix_bot_draupnir_disable_server_acl', 'new': 'matrix_bot_draupnir_config_disableServerACL'}
+    - {'old': 'matrix_bot_draupnir_enable_experimental_rust_crypto', 'new': 'matrix_bot_draupnir_config_experimentalRustCrypto'}
+    - {'old': 'matrix_bot_draupnir_access_token', 'new': 'matrix_bot_draupnir_config_accessToken'}
+    - {'old': 'matrix_bot_draupnir_management_room', 'new': 'matrix_bot_draupnir_config_managementRoom'}
+    - {'old': 'matrix_bot_draupnir_homeserver_url', 'new': 'matrix_bot_draupnir_config_homeserverUrl'}
+    - {'old': 'matrix_bot_draupnir_raw_homeserver_url', 'new': 'matrix_bot_draupnir_config_rawHomeserverUrl'}
+    - {'old': 'matrix_bot_draupnir_web_enabled', 'new': 'matrix_bot_draupnir_config_web_enabled'}
+    - {'old': 'matrix_bot_draupnir_abuse_reporting_enabled', 'new': 'matrix_bot_draupnir_config_web_abuseReporting'}
+    - {'old': 'matrix_bot_draupnir_display_reports', 'new': 'matrix_bot_draupnir_config_displayReports'}
+ 
 - name: Fail if required matrix-bot-draupnir variables are undefined
   ansible.builtin.fail:
     msg: "The `{{ item.name }}` variable must be defined and have a non-null value."
@@ -41,22 +60,3 @@
               "Note: Draupnir does not support running with Pantalaimon as it would break all workflows that involve answering prompts with reactions. To enable E2EE for Draupnir, it is recommended to use matrix_bot_draupnir_enable_experimental_rust_crypto instead. This warning can be disabled by setting matrix_bot_draupnir_pantalaimon_breakage_ignore to true."
             ]
           }}
-
-- name: (Deprecation) Catch and report renamed Draupnir settings
-  ansible.builtin.fail:
-    msg: >-
-      Your configuration contains a variable, which now has a different name.
-      Please rename the variable (`{{ item.old }}` -> `{{ item.new }}`) on your configuration file (vars.yml).
-  when: "item.old in vars"
-  with_items:
-    - {'old': 'matrix_bot_draupnir_container_image_name_prefix', 'new': 'matrix_bot_draupnir_container_image_registry_prefix'}
-    - {'old': 'matrix_bot_draupnir_enable_room_state_backing_store', 'new': 'matrix_bot_draupnir_config_roomStateBackingStore_enabled'}
-    - {'old': 'matrix_bot_draupnir_disable_server_acl', 'new': 'matrix_bot_draupnir_config_disableServerACL'}
-    - {'old': 'matrix_bot_draupnir_enable_experimental_rust_crypto', 'new': 'matrix_bot_draupnir_config_experimentalRustCrypto'}
-    - {'old': 'matrix_bot_draupnir_access_token', 'new': 'matrix_bot_draupnir_config_accessToken'}
-    - {'old': 'matrix_bot_draupnir_management_room', 'new': 'matrix_bot_draupnir_config_managementRoom'}
-    - {'old': 'matrix_bot_draupnir_homeserver_url', 'new': 'matrix_bot_draupnir_config_homeserverUrl'}
-    - {'old': 'matrix_bot_draupnir_raw_homeserver_url', 'new': 'matrix_bot_draupnir_config_rawHomeserverUrl'}
-    - {'old': 'matrix_bot_draupnir_web_enabled', 'new': 'matrix_bot_draupnir_config_web_enabled'}
-    - {'old': 'matrix_bot_draupnir_abuse_reporting_enabled', 'new': 'matrix_bot_draupnir_config_web_abuseReporting'}
-    - {'old': 'matrix_bot_draupnir_display_reports', 'new': 'matrix_bot_draupnir_config_displayReports'}

--- a/roles/custom/matrix-bot-draupnir/tasks/validate_config.yml
+++ b/roles/custom/matrix-bot-draupnir/tasks/validate_config.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2023 - 2025 MDAD project contributors
+# SPDX-FileCopyrightText: 2023 - 2025 Catalan Lover <catalanlover@protonmail.com>
 # SPDX-FileCopyrightText: 2024 - 2025 Slavi Pantaleev
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
@@ -9,12 +10,12 @@
   ansible.builtin.fail:
     msg: "The `{{ item.name }}` variable must be defined and have a non-null value."
   with_items:
-    - {'name': 'matrix_bot_draupnir_access_token', when: "{{ not matrix_bot_draupnir_pantalaimon_use }}"}
-    - {'name': 'matrix_bot_draupnir_access_token', when: "{{ matrix_bot_draupnir_enable_experimental_rust_crypto }}"}
-    - {'name': 'matrix_bot_draupnir_management_room', when: true}
+    - {'name': 'matrix_bot_draupnir_config_accessToken', when: "{{ not matrix_bot_draupnir_pantalaimon_use }}"}
+    - {'name': 'matrix_bot_draupnir_config_accessToken', when: "{{ matrix_bot_draupnir_enable_experimental_rust_crypto }}"}
+    - {'name': 'matrix_bot_draupnir_config_managementRoom', when: true}
     - {'name': 'matrix_bot_draupnir_container_network', when: true}
-    - {'name': 'matrix_bot_draupnir_homeserver_url', when: true}
-    - {'name': 'matrix_bot_draupnir_raw_homeserver_url', when: true}
+    - {'name': 'matrix_bot_draupnir_config_homeserverUrl', when: true}
+    - {'name': 'matrix_bot_draupnir_config_rawHomeserverUrl', when: true}
     - {'name': 'matrix_bot_draupnir_pantalaimon_username', when: "{{ matrix_bot_draupnir_pantalaimon_use }}"}
     - {'name': 'matrix_bot_draupnir_pantalaimon_password', when: "{{ matrix_bot_draupnir_pantalaimon_use }}"}
   when: "item.when | bool and (vars[item.name] == '' or vars[item.name] is none)"
@@ -23,8 +24,8 @@
   ansible.builtin.fail:
     msg: "The `{{ item.name }}` variable must be undefined or have a null value."
   with_items:
-    - {'name': 'matrix_bot_draupnir_access_token', when: "{{ matrix_bot_draupnir_pantalaimon_use }}"}
-    - {'name': 'matrix_bot_draupnir_access_token', when: "{{ matrix_bot_draupnir_login_native }}"}
+    - {'name': 'matrix_bot_draupnir_config_accessToken', when: "{{ matrix_bot_draupnir_pantalaimon_use }}"}
+    - {'name': 'matrix_bot_draupnir_config_accessToken', when: "{{ matrix_bot_draupnir_login_native }}"}
     - {'name': 'matrix_bot_draupnir_pantalaimon_use', when: "{{  matrix_bot_draupnir_enable_experimental_rust_crypto }}"}
   when: "item.when | bool and not (vars[item.name] == '' or vars[item.name] is none)"
 
@@ -49,3 +50,13 @@
   when: "item.old in vars"
   with_items:
     - {'old': 'matrix_bot_draupnir_container_image_name_prefix', 'new': 'matrix_bot_draupnir_container_image_registry_prefix'}
+    - {'old': 'matrix_bot_draupnir_enable_room_state_backing_store', 'new': 'matrix_bot_draupnir_config_roomStateBackingStore_enabled'}
+    - {'old': 'matrix_bot_draupnir_disable_server_acl', 'new': 'matrix_bot_draupnir_config_disableServerACL'}
+    - {'old': 'matrix_bot_draupnir_enable_experimental_rust_crypto', 'new': 'matrix_bot_draupnir_config_experimentalRustCrypto'}
+    - {'old': 'matrix_bot_draupnir_access_token', 'new': 'matrix_bot_draupnir_config_accessToken'}
+    - {'old': 'matrix_bot_draupnir_management_room', 'new': 'matrix_bot_draupnir_config_managementRoom'}
+    - {'old': 'matrix_bot_draupnir_homeserver_url', 'new': 'matrix_bot_draupnir_config_homeserverUrl'}
+    - {'old': 'matrix_bot_draupnir_raw_homeserver_url', 'new': 'matrix_bot_draupnir_config_rawHomeserverUrl'}
+    - {'old': 'matrix_bot_draupnir_web_enabled', 'new': 'matrix_bot_draupnir_config_web_enabled'}
+    - {'old': 'matrix_bot_draupnir_abuse_reporting_enabled', 'new': 'matrix_bot_draupnir_config_web_abuseReporting'}
+    - {'old': 'matrix_bot_draupnir_display_reports', 'new': 'matrix_bot_draupnir_config_displayReports'}

--- a/roles/custom/matrix-bot-draupnir/tasks/validate_config.yml
+++ b/roles/custom/matrix-bot-draupnir/tasks/validate_config.yml
@@ -24,7 +24,7 @@
     - {'old': 'matrix_bot_draupnir_web_enabled', 'new': 'matrix_bot_draupnir_config_web_enabled'}
     - {'old': 'matrix_bot_draupnir_abuse_reporting_enabled', 'new': 'matrix_bot_draupnir_config_web_abuseReporting'}
     - {'old': 'matrix_bot_draupnir_display_reports', 'new': 'matrix_bot_draupnir_config_displayReports'}
- 
+
 - name: Fail if required matrix-bot-draupnir variables are undefined
   ansible.builtin.fail:
     msg: "The `{{ item.name }}` variable must be defined and have a non-null value."

--- a/roles/custom/matrix-bot-draupnir/templates/production.yaml.j2
+++ b/roles/custom/matrix-bot-draupnir/templates/production.yaml.j2
@@ -1,5 +1,6 @@
 {#
 SPDX-FileCopyrightText: 2023 - 2024 MDAD project contributors
+SPDX-FileCopyrightText: 2023 - 2025 Catalan Lover <catalanlover@protonmail.com>
 SPDX-FileCopyrightText: 2024 Slavi Pantaleev
 SPDX-FileCopyrightText: 2024 Suguru Hirahara
 
@@ -7,16 +8,16 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 #}
 
 # Endpoint URL that Draupnir uses to interact with the Matrix homeserver (client-server API),
-homeserverUrl: {{ matrix_bot_draupnir_homeserver_url | to_json }}
+homeserverUrl: {{ matrix_bot_draupnir_config_homeserverUrl | to_json }}
 
 # Endpoint URL that Draupnir could use to fetch events related to reports (client-server API and /_synapse/),
 # only set this to the public-internet homeserver client API URL, do NOT set this to the pantalaimon URL.
-rawHomeserverUrl: {{ matrix_bot_draupnir_raw_homeserver_url | to_json }}
+rawHomeserverUrl: {{ matrix_bot_draupnir_config_rawHomeserverUrl | to_json }}
 
 # Matrix Access Token to use, Draupnir will only use this if pantalaimon.use is false.
 # This option can be loaded from a file by passing "--access-token-path <path>" at the command line,
 # which would allow using secret management systems such as systemd's service credentials.
-accessToken: {{ matrix_bot_draupnir_access_token | to_json }}
+accessToken: {{ matrix_bot_draupnir_config_accessToken | to_json }}
 
 {% if matrix_bot_draupnir_pantalaimon_use or matrix_bot_draupnir_login_native %}
 # Options related to Pantalaimon (https://github.com/matrix-org/pantalaimon)
@@ -42,7 +43,7 @@ pantalaimon:
 # Make sure Pantalaimon is disabled in Draupnir's configuration.
 #
 # Warning: At this time this is not considered production safe.
-experimentalRustCrypto: {{ matrix_bot_draupnir_enable_experimental_rust_crypto | to_json }}
+experimentalRustCrypto: {{ matrix_bot_draupnir_config_experimentalRustCrypto | to_json }}
 
 # The path Draupnir will store its state/data in, leave default ("/data/storage") when using containers.
 dataPath: "/data"
@@ -65,7 +66,7 @@ recordIgnoredInvites: false
 #
 # Note: By default, Draupnir is fairly verbose - expect a lot of messages in this room.
 # (see verboseLogging to adjust this a bit.)
-managementRoom: {{ matrix_bot_draupnir_management_room | to_json }}
+managementRoom: {{ matrix_bot_draupnir_config_managementRoom | to_json }}
 
 # Deprecated and will be removed in a future version.
 # Running with verboseLogging is unsupported.
@@ -93,7 +94,7 @@ noop: false
 
 # Whether or not Draupnir should apply `m.room.server_acl` events.
 # DO NOT change this to `true` unless you are very confident that you know what you are doing.
-disableServerACL: {{ matrix_bot_draupnir_disable_server_acl | to_json }}
+disableServerACL: {{ matrix_bot_draupnir_config_disableServerACL | to_json }}
 
 # A case-insensitive list of ban reasons to have the bot also automatically redact the user's messages for.
 #
@@ -199,7 +200,7 @@ commands:
 # homeserver and know that Draupnir is starting up quickly. If your homeserver can
 # respond quickly to Draupnir's requests for `/state` then you might not need this option.
 roomStateBackingStore:
-  enabled: {{ matrix_bot_draupnir_enable_room_state_backing_store | to_json }}
+  enabled: {{ matrix_bot_draupnir_config_roomStateBackingStore_enabled | to_json }}
 
 # Safe mode provides recovery options for some failure modes when Draupnir
 # fails to start. For example, if the bot fails to resolve a room alias in
@@ -261,7 +262,7 @@ health:
     # and 1.0 means "trace performance at every opportunity".
     # tracesSampleRate: 0.5
 
-{% if matrix_bot_draupnir_web_enabled %}
+{% if matrix_bot_draupnir_config_web_enabled %}
 # Options for exposing web APIs.
 web:
   # Whether to enable web APIs.
@@ -287,7 +288,7 @@ web:
   # to configure a reverse proxy, see e.g. test/nginx.conf
   abuseReporting:
     # Whether to enable this feature.
-    enabled: {{ matrix_bot_draupnir_abuse_reporting_enabled | to_json }}
+    enabled: {{ matrix_bot_draupnir_config_web_abuseReporting | to_json }}
 {% endif %}
 
 # FIXME: This configuration option is currently broken in the playbook as admin APIs cannot
@@ -300,4 +301,4 @@ web:
 
 # Whether or not new reports, received either by webapi or polling,
 # should be printed to our managementRoom.
-displayReports: {{ matrix_bot_draupnir_display_reports | to_json }}
+displayReports: {{ matrix_bot_draupnir_config_displayReports | to_json }}

--- a/roles/custom/matrix-bot-draupnir/templates/systemd/matrix-bot-draupnir.service.j2.license
+++ b/roles/custom/matrix-bot-draupnir/templates/systemd/matrix-bot-draupnir.service.j2.license
@@ -1,4 +1,5 @@
 SPDX-FileCopyrightText: 2023 - 2025 Slavi Pantaleev
+SPDX-FileCopyrightText: 2023 - 2024 Catalan Lover <catalanlover@protonmail.com>
 SPDX-FileCopyrightText: 2024 MDAD project contributors
 
 SPDX-License-Identifier: AGPL-3.0-or-later


### PR DESCRIPTION
As the PR name states.

This PR modernises the Draupnir configuration inline with the changes discussed during review of #4166 hopefully leading to a more predictable configuration format. This should help users go between upstream and mdad very easily docs wise due to the new predictable naming schema.