### PR TITLE
Add support for configuring Synapse's MSC4133 (Custom Profile Fields)

### DIFF
--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -1275,6 +1275,13 @@ matrix_synapse_experimental_features_msc4140_enabled: false
 # See `matrix_synapse_experimental_features_msc4140_enabled`.
 matrix_synapse_max_event_delay_duration: 24h
 
+# Controls whether to enable the MSC4133 experimental feature (Custom profile fields).
+#
+# This allows clients to set custom profile fields (e.g. User Time Zone in Element Web)
+#
+# See https://github.com/matrix-org/matrix-spec-proposals/pull/4133
+matrix_synapse_experimental_features_msc4133_enabled: false
+
 # Controls whether to enable the MSC4222 experimental feature (adding `state_after` to sync v2).
 #
 # Allow clients to opt-in to a change of the sync v2 API that allows them to correctly track the state of the room.

--- a/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -2990,6 +2990,9 @@ experimental_features:
   {% if matrix_synapse_experimental_features_msc4140_enabled %}
   msc4140_enabled: true
   {% endif %}
+  {% if matrix_synapse_experimental_features_msc4133_enabled %}
+  msc4133_enabled: true
+  {% endif %}
   {% if matrix_synapse_experimental_features_msc4222_enabled %}
   msc4222_enabled: true
   {% endif %}

--- a/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -2987,11 +2987,11 @@ experimental_features:
   {% if matrix_synapse_experimental_features_msc4108_enabled %}
   msc4108_enabled: true
   {% endif %}
-  {% if matrix_synapse_experimental_features_msc4140_enabled %}
-  msc4140_enabled: true
-  {% endif %}
   {% if matrix_synapse_experimental_features_msc4133_enabled %}
   msc4133_enabled: true
+  {% endif %}
+  {% if matrix_synapse_experimental_features_msc4140_enabled %}
+  msc4140_enabled: true
   {% endif %}
   {% if matrix_synapse_experimental_features_msc4222_enabled %}
   msc4222_enabled: true


### PR DESCRIPTION
This adds a new variable for enabling custom profile fields with synapse.
This is my first contribution to this project so I figured I'd start with something small :)