### PR TITLE
Fix Rust Crypto variables being partially missed in Rename

### DIFF
--- a/docs/configuring-playbook-bot-draupnir.md
+++ b/docs/configuring-playbook-bot-draupnir.md
@@ -54,7 +54,7 @@ To enable the native E2EE support, add the following configuration to your `vars
 
 ```yaml
 # Enables the native E2EE support
-matrix_bot_draupnir_enable_experimental_rust_crypto: true
+matrix_bot_draupnir_config_experimentalRustCrypto: true
 
 # Access token which the bot will use for logging in.
 # Comment out `matrix_bot_draupnir_login_native` when using this option.
@@ -76,7 +76,7 @@ matrix_bot_draupnir_enabled: true
 # If creating the user on your own and using `matrix_bot_draupnir_config_accessToken` to login you can comment out this line.
 matrix_bot_draupnir_password: PASSWORD_FOR_THE_BOT
 
-# Comment out if using `matrix_bot_draupnir_enable_experimental_rust_crypto: true` or `matrix_bot_draupnir_config_accessToken` to login.
+# Comment out if using `matrix_bot_draupnir_config_experimentalRustCrypto: true` or `matrix_bot_draupnir_config_accessToken` to login.
 matrix_bot_draupnir_login_native: true
 
 matrix_bot_draupnir_config_managementRoom: "MANAGEMENT_ROOM_ID_HERE"

--- a/roles/custom/matrix-bot-draupnir/defaults/main.yml
+++ b/roles/custom/matrix-bot-draupnir/defaults/main.yml
@@ -71,7 +71,7 @@ matrix_bot_draupnir_pantalaimon_breakage_ignore: false
 # Tells the bot if it should use its native E2EE support in the form of experimental Rust Crypto in the bot SDK.
 # This option is mutually exclusive with `matrix_bot_draupnir_pantalaimon_use`.
 # Rust Crypto requires a clean access token that has not touched E2EE so curl is recommended as a method to obtain it.
-matrix_bot_draupnir_enable_experimental_rust_crypto: false
+matrix_bot_draupnir_config_experimentalRustCrypto: false  # noqa var-naming
 
 # The access token for the bot user. Required if Pantalaimon is NOT used.
 # (Otherwise provide `matrix_bot_draupnir_pantalaimon_username` and `matrix_bot_draupnir_pantalaimon_password` instead.)

--- a/roles/custom/matrix-bot-draupnir/tasks/validate_config.yml
+++ b/roles/custom/matrix-bot-draupnir/tasks/validate_config.yml
@@ -30,7 +30,7 @@
     msg: "The `{{ item.name }}` variable must be defined and have a non-null value."
   with_items:
     - {'name': 'matrix_bot_draupnir_config_accessToken', when: "{{ not matrix_bot_draupnir_pantalaimon_use }}"}
-    - {'name': 'matrix_bot_draupnir_config_accessToken', when: "{{ matrix_bot_draupnir_enable_experimental_rust_crypto }}"}
+    - {'name': 'matrix_bot_draupnir_config_accessToken', when: "{{ matrix_bot_draupnir_config_experimentalRustCrypto }}"}
     - {'name': 'matrix_bot_draupnir_config_managementRoom', when: true}
     - {'name': 'matrix_bot_draupnir_container_network', when: true}
     - {'name': 'matrix_bot_draupnir_config_homeserverUrl', when: true}
@@ -45,7 +45,7 @@
   with_items:
     - {'name': 'matrix_bot_draupnir_config_accessToken', when: "{{ matrix_bot_draupnir_pantalaimon_use }}"}
     - {'name': 'matrix_bot_draupnir_config_accessToken', when: "{{ matrix_bot_draupnir_login_native }}"}
-    - {'name': 'matrix_bot_draupnir_pantalaimon_use', when: "{{  matrix_bot_draupnir_enable_experimental_rust_crypto }}"}
+    - {'name': 'matrix_bot_draupnir_pantalaimon_use', when: "{{  matrix_bot_draupnir_config_experimentalRustCrypto }}"}
   when: "item.when | bool and not (vars[item.name] == '' or vars[item.name] is none)"
 
 - when: "matrix_bot_draupnir_pantalaimon_use == 'true' and matrix_bot_draupnir_pantalaimon_breakage_ignore == 'false'"
@@ -57,6 +57,6 @@
             devture_playbook_runtime_messages_list | default([])
             +
             [
-              "Note: Draupnir does not support running with Pantalaimon as it would break all workflows that involve answering prompts with reactions. To enable E2EE for Draupnir, it is recommended to use matrix_bot_draupnir_enable_experimental_rust_crypto instead. This warning can be disabled by setting matrix_bot_draupnir_pantalaimon_breakage_ignore to true."
+              "Note: Draupnir does not support running with Pantalaimon as it would break all workflows that involve answering prompts with reactions. To enable E2EE for Draupnir, it is recommended to use matrix_bot_draupnir_config_experimentalRustCrypto instead. This warning can be disabled by setting matrix_bot_draupnir_pantalaimon_breakage_ignore to true."
             ]
           }}


### PR DESCRIPTION
Draupnir apparently broke because we missed renaming Rust Crypto for some users atleast. 

So this PR fixes that by well finishing the rename.