### PR TITLE
Fix D4A Config Validation checking for old admin room variable

### DIFF
--- a/docs/configuring-playbook-appservice-draupnir-for-all.md
+++ b/docs/configuring-playbook-appservice-draupnir-for-all.md
@@ -45,7 +45,7 @@ Add the following configuration to your `inventory/host_vars/matrix.example.com/
 ```yaml
 matrix_appservice_draupnir_for_all_enabled: true
 
-matrix_appservice_draupnir_for_all_master_control_room_alias: "MANAGEMENT_ROOM_ALIAS_HERE"
+matrix_appservice_draupnir_for_all_config_adminRoom: "MANAGEMENT_ROOM_ALIAS_HERE"
 ```
 
 ### Extending the configuration

--- a/roles/custom/matrix-appservice-draupnir-for-all/tasks/validate_config.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/tasks/validate_config.yml
@@ -11,7 +11,7 @@
   ansible.builtin.fail:
     msg: "The `{{ item }}` variable must be defined and have a non-null value."
   with_items:
-    - "matrix_appservice_draupnir_for_all_master_control_room_alias"
+    - "matrix_appservice_draupnir_for_all_config_adminRoom"
     - "matrix_bot_draupnir_container_network"
   when: "vars[item] == '' or vars[item] is none"
 


### PR DESCRIPTION
Im so happy to have hopefully caught the last of the errors like this that happened because i didnt use a find and replace based workflow during the first stage of writing these patches.