### PR TITLE
Fix bug in marking Pantal and Rust Crypto as mutually exclusive.

### DIFF
--- a/roles/custom/matrix-bot-draupnir/tasks/validate_config.yml
+++ b/roles/custom/matrix-bot-draupnir/tasks/validate_config.yml
@@ -45,8 +45,16 @@
   with_items:
     - {'name': 'matrix_bot_draupnir_config_accessToken', when: "{{ matrix_bot_draupnir_pantalaimon_use }}"}
     - {'name': 'matrix_bot_draupnir_config_accessToken', when: "{{ matrix_bot_draupnir_login_native }}"}
-    - {'name': 'matrix_bot_draupnir_pantalaimon_use', when: "{{  matrix_bot_draupnir_config_experimentalRustCrypto }}"}
   when: "item.when | bool and not (vars[item.name] == '' or vars[item.name] is none)"
+
+- name: Fail when matrix_bot_draupnir_config_experimentalRustCrypto is enabled together with matrix_bot_draupnir_pantalaimon_use
+  ansible.builtin.fail:
+    msg: >-
+      Your configuration is trying to enable matrix_bot_draupnir_config_experimentalRustCrypto and matrix_bot_draupnir_pantalaimon_use at the same time.
+      These settings are mutually incompatible and therefore cant be used at the same time.
+  when:
+    - matrix_bot_draupnir_pantalaimon_use
+    - matrix_bot_draupnir_config_experimentalRustCrypto
 
 - when: "matrix_bot_draupnir_pantalaimon_use == 'true' and matrix_bot_draupnir_pantalaimon_breakage_ignore == 'false'"
   block:


### PR DESCRIPTION
So it was reported that when configuring rust crypto the playbook can complain about the fact that Pantal use isnt null.

This PR hopefully moves to a method of detecting this conflict that works for this specific situation. This PR is a draft as i dont know if the logic is sound.

This logic is copied from https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/e073685632b97d0ad837c2119f773e81a756ee44/roles/custom/matrix-synapse/tasks/validate_config.yml#L144-L153

Like to me it looks like a similar situation. 