### PR TITLE
Fix rogue missing `_client_synapse` in internal admin api

### DIFF
--- a/roles/custom/matrix-synapse-reverse-proxy-companion/templates/labels.j2
+++ b/roles/custom/matrix-synapse-reverse-proxy-companion/templates/labels.j2
@@ -163,7 +163,7 @@ traefik.http.routers.matrix-synapse-reverse-proxy-companion-public-client-synaps
 #                                                          #
 ############################################################
 
-traefik.http.routers.matrix-synapse-reverse-proxy-companion-internal-client-synapse-admin-api.rule={{ matrix_synapse_reverse_proxy_companion_container_labels_internal_admin_api_traefik_rule }}
+traefik.http.routers.matrix-synapse-reverse-proxy-companion-internal-client-synapse-admin-api.rule={{ matrix_synapse_reverse_proxy_companion_container_labels_internal_client_synapse_admin_api_traefik_rule }}
 
 {% if matrix_synapse_reverse_proxy_companion_container_labels_internal_client_synapse_admin_api_traefik_priority | int > 0 %}
 traefik.http.routers.matrix-synapse-reverse-proxy-companion-public-client-synapse-admin-api.priority={{ matrix_synapse_reverse_proxy_companion_container_labels_internal_client_synapse_admin_api_traefik_priority }}


### PR DESCRIPTION
This makes admin API work atleast in the capacity of if you flip the enable admin API variable to true draupnir successfully shuts down the "forbidden room" test room created by my test user and invites them, and force joins them to the content violation room and sends a test message as it was the reason for shutdown.