### PR TITLE
Update Synapse from v1.127.0 to v1.127.1

### DIFF
--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -16,7 +16,7 @@ matrix_synapse_enabled: true
 matrix_synapse_github_org_and_repo: element-hq/synapse
 
 # renovate: datasource=docker depName=ghcr.io/element-hq/synapse
-matrix_synapse_version: v1.127.0
+matrix_synapse_version: v1.127.1
 
 matrix_synapse_username: ''
 matrix_synapse_uid: ''


### PR DESCRIPTION
This is a security patch for Synapse that fixes an actively exploited bug.

This PR was made before the release was cut but the docker images are built on the release tag and ready.