### PR TITLE
Rework Draupnir report interception to accommodate other Web API uses.

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -3199,8 +3199,8 @@ matrix_bot_draupnir_config_rawHomeserverUrl: "{{ matrix_addons_homeserver_client
 
 matrix_bot_draupnir_container_labels_traefik_enabled: "{{ matrix_bot_draupnir_config_web_enabled and matrix_playbook_reverse_proxy_type in ['playbook-managed-traefik', 'other-traefik-container'] }}"
 matrix_bot_draupnir_container_labels_traefik_docker_network: "{{ matrix_playbook_reverse_proxyable_services_additional_network }}"
-matrix_bot_draupnir_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-matrix_bot_draupnir_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+matrix_bot_draupnir_container_labels_web_abuseReporting_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+matrix_bot_draupnir_container_labels_web_abuseReporting_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 
 ######################################################################
 #

--- a/roles/custom/matrix-bot-draupnir/defaults/main.yml
+++ b/roles/custom/matrix-bot-draupnir/defaults/main.yml
@@ -157,13 +157,13 @@ matrix_bot_draupnir_configuration: "{{ matrix_bot_draupnir_configuration_yaml | 
 # See `matrix_synapse_container_labels_traefik_enabled` or `matrix_synapse_container_labels_matrix_related_labels_enabled`
 matrix_bot_draupnir_container_labels_traefik_enabled: false
 matrix_bot_draupnir_container_labels_traefik_docker_network: "{{ matrix_draupnir_bot_container_network }}"
-matrix_bot_draupnir_container_labels_traefik_hostname: "{{ matrix_synapse_container_labels_traefik_hostname }}"
-matrix_bot_draupnir_container_labels_traefik_path_regexp: "^/_matrix/client/(r0|v3)/rooms/([^/]*)/report/"
-matrix_bot_draupnir_container_labels_traefik_rule: "Host(`{{ matrix_bot_draupnir_container_labels_traefik_hostname }}`) && PathRegexp(`{{ matrix_bot_draupnir_container_labels_traefik_path_regexp }}`)"
-matrix_bot_draupnir_container_labels_traefik_priority: 0
-matrix_bot_draupnir_container_labels_traefik_entrypoints: "{{ matrix_synapse_container_labels_traefik_entrypoints }}"
-matrix_bot_draupnir_container_labels_traefik_tls: "{{ matrix_bot_draupnir_container_labels_traefik_entrypoints != 'web' }}"
-matrix_bot_draupnir_container_labels_traefik_tls_certResolver: "{{ matrix_synapse_container_labels_traefik_tls_certResolver }}"  # noqa var-naming
+matrix_bot_draupnir_container_labels_web_abuseReporting_traefik_hostname: "{{ matrix_synapse_container_labels_traefik_hostname }}"  # noqa var-naming
+matrix_bot_draupnir_container_labels_web_abuseReporting_traefik_path_regexp: "^/_matrix/client/(r0|v3)/rooms/([^/]*)/report/(.*)$"  # noqa var-naming
+matrix_bot_draupnir_container_labels_web_abuseReporting_traefik_rule: "Host(`{{ matrix_bot_draupnir_container_labels_web_abuseReporting_traefik_hostname }}`) && PathRegexp(`{{ matrix_bot_draupnir_container_labels_web_abuseReporting_traefik_path_regexp }}`)"  # noqa var-naming
+matrix_bot_draupnir_container_labels_web_abuseReporting_traefik_priority: 0  # noqa var-naming
+matrix_bot_draupnir_container_labels_web_abuseReporting_traefik_entrypoints: "{{ matrix_synapse_container_labels_traefik_entrypoints }}"  # noqa var-naming
+matrix_bot_draupnir_container_labels_web_abuseReporting_traefik_tls: "{{ matrix_bot_draupnir_container_labels_web_abuseReporting_traefik_entrypoints != 'web' }}"  # noqa var-naming
+matrix_bot_draupnir_container_labels_web_abuseReporting_traefik_tls_certResolver: "{{ matrix_synapse_container_labels_traefik_tls_certResolver }}"  # noqa var-naming
 # matrix_bot_draupnir_container_labels_traefik_labels_additional_labels contains a multiline string with additional labels to add to the container label file.
 # See `../templates/labels.j2` for details.
 #

--- a/roles/custom/matrix-bot-draupnir/tasks/validate_config.yml
+++ b/roles/custom/matrix-bot-draupnir/tasks/validate_config.yml
@@ -24,6 +24,13 @@
     - {'old': 'matrix_bot_draupnir_web_enabled', 'new': 'matrix_bot_draupnir_config_web_enabled'}
     - {'old': 'matrix_bot_draupnir_abuse_reporting_enabled', 'new': 'matrix_bot_draupnir_config_web_abuseReporting'}
     - {'old': 'matrix_bot_draupnir_display_reports', 'new': 'matrix_bot_draupnir_config_displayReports'}
+    - {'old': 'matrix_bot_draupnir_container_labels_traefik_hostname', 'new': 'matrix_bot_draupnir_container_labels_web_abuseReporting_traefik_hostname'}
+    - {'old': 'matrix_bot_draupnir_container_labels_traefik_path_regexp', 'new': 'matrix_bot_draupnir_container_labels_web_abuseReporting_traefik_path_regexp'}
+    - {'old': 'matrix_bot_draupnir_container_labels_traefik_rule', 'new': 'matrix_bot_draupnir_container_labels_web_abuseReporting_traefik_rule'}
+    - {'old': 'matrix_bot_draupnir_container_labels_traefik_priority', 'new': 'matrix_bot_draupnir_container_labels_web_abuseReporting_traefik_priority'}
+    - {'old': 'matrix_bot_draupnir_container_labels_traefik_entrypoints', 'new': 'matrix_bot_draupnir_container_labels_web_abuseReporting_traefik_entrypoints'}
+    - {'old': 'matrix_bot_draupnir_container_labels_traefik_tls', 'new': 'matrix_bot_draupnir_container_labels_web_abuseReporting_traefik_tls'}
+    - {'old': 'matrix_bot_draupnir_container_labels_traefik_tls_certResolver', 'new': 'matrix_bot_draupnir_container_labels_web_abuseReporting_traefik_tls_certResolver'}
 
 - name: Fail if required matrix-bot-draupnir variables are undefined
   ansible.builtin.fail:

--- a/roles/custom/matrix-bot-draupnir/templates/labels.j2
+++ b/roles/custom/matrix-bot-draupnir/templates/labels.j2
@@ -1,5 +1,6 @@
 {#
 SPDX-FileCopyrightText: 2024 MDAD project contributors
+SPDX-FileCopyrightText: 2025 Catalan Lover <catalanlover@protonmail.com>
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
@@ -13,6 +14,7 @@ traefik.docker.network={{ matrix_bot_draupnir_container_labels_traefik_docker_ne
 
 traefik.http.services.matrix-bot-draupnir.loadbalancer.server.port=8080
 
+{% if matrix_bot_draupnir_config_web_abuseReporting %}
 ############################################################
 #                                                          #
 # Abuse Reports (/_matrix/client/../rooms/../report)       #
@@ -21,32 +23,32 @@ traefik.http.services.matrix-bot-draupnir.loadbalancer.server.port=8080
 
 {% set middlewares = [] %}
 
-traefik.http.middlewares.matrix-bot-draupnir-redirect.replacepathregex.regex=^/_matrix/client/(r0|v3)/rooms/([^/]*)/report/(.*)$
-traefik.http.middlewares.matrix-bot-draupnir-redirect.replacepathregex.replacement=/api/1/report/$2/$3
+traefik.http.middlewares.matrix-bot-draupnir-web-abuseReporting-redirect.replacepathregex.regex={{ matrix_bot_draupnir_container_labels_web_abuseReporting_traefik_path_regexp }}
+traefik.http.middlewares.matrix-bot-draupnir-web-abuseReporting-redirect.replacepathregex.replacement=/api/1/report/$2/$3
 
-{% set middlewares = middlewares + ['matrix-bot-draupnir-redirect'] %}
+{% set middlewares = middlewares + ['matrix-bot-draupnir-web-abuseReporting-redirect'] %}
 
-traefik.http.middlewares.matrix-bot-draupnir-cors.headers.accesscontrolalloworiginlist=*
-traefik.http.middlewares.matrix-bot-draupnir-cors.headers.accesscontrolallowheaders=Content-Type,Authorization
-traefik.http.middlewares.matrix-bot-draupnir-cors.headers.accesscontrolallowmethods=POST,OPTIONS
+traefik.http.middlewares.matrix-bot-draupnir-web-abuseReporting-cors.headers.accesscontrolalloworiginlist=*
+traefik.http.middlewares.matrix-bot-draupnir-web-abuseReporting-cors.headers.accesscontrolallowheaders=Content-Type,Authorization
+traefik.http.middlewares.matrix-bot-draupnir-web-abuseReporting-cors.headers.accesscontrolallowmethods=POST,OPTIONS
 
-{% set middlewares = middlewares + ['matrix-bot-draupnir-cors'] %}
+{% set middlewares = middlewares + ['matrix-bot-draupnir-web-abuseReporting-cors'] %}
 
-traefik.http.routers.matrix-bot-draupnir.rule={{ matrix_bot_draupnir_container_labels_traefik_rule }}
+traefik.http.routers.matrix-bot-draupnir-web-abuseReporting.rule={{ matrix_bot_draupnir_container_labels_web_abuseReporting_traefik_rule }}
 
-{% if matrix_bot_draupnir_container_labels_traefik_priority | int > 0 %}
-traefik.http.routers.matrix-bot-draupnir.priority={{ matrix_bot_draupnir_container_labels_traefik_priority }}
+{% if matrix_bot_draupnir_container_labels_web_abuseReporting_traefik_priority | int > 0 %}
+traefik.http.routers.matrix-bot-draupnir-web-abuseReporting.priority={{ matrix_bot_draupnir_container_labels_web_abuseReporting_traefik_priority }}
 {% endif %}
 {% if middlewares | length > 0 %}
-traefik.http.routers.matrix-bot-draupnir.middlewares={{ middlewares | join(',') }}
+traefik.http.routers.matrix-bot-draupnir-web-abuseReporting.middlewares={{ middlewares | join(',') }}
 {% endif %}
 
-traefik.http.routers.matrix-bot-draupnir.service=matrix-bot-draupnir
-traefik.http.routers.matrix-bot-draupnir.entrypoints={{ matrix_bot_draupnir_container_labels_traefik_entrypoints }}
-traefik.http.routers.matrix-bot-draupnir.tls={{ matrix_bot_draupnir_container_labels_traefik_tls | to_json }}
+traefik.http.routers.matrix-bot-draupnir-web-abuseReporting.service=matrix-bot-draupnir
+traefik.http.routers.matrix-bot-draupnir-web-abuseReporting.entrypoints={{ matrix_bot_draupnir_container_labels_web_abuseReporting_traefik_entrypoints }}
+traefik.http.routers.matrix-bot-draupnir-web-abuseReporting.tls={{ matrix_bot_draupnir_container_labels_web_abuseReporting_traefik_tls | to_json }}
 
-{% if matrix_bot_draupnir_container_labels_traefik_tls %}
-traefik.http.routers.matrix-bot-draupnir.tls.certResolver={{ matrix_bot_draupnir_container_labels_traefik_tls_certResolver }}
+{% if matrix_bot_draupnir_container_labels_web_abuseReporting_traefik_tls %}
+traefik.http.routers.matrix-bot-draupnir-web-abuseReporting.tls.certResolver={{ matrix_bot_draupnir_container_labels_web_abuseReporting_traefik_tls_certResolver }}
 {% endif %}
 
 ############################################################
@@ -54,6 +56,7 @@ traefik.http.routers.matrix-bot-draupnir.tls.certResolver={{ matrix_bot_draupnir
 # /Abuse Reports (/_matrix/client/../rooms/../report)      #
 #                                                          #
 ############################################################
+{% endif %}
 {% endif %}
 
 {{ matrix_bot_draupnir_container_labels_traefik_labels_additional_labels }}


### PR DESCRIPTION
<del>This PR is marked as a draft as i have not yet gone and tested this on my production machine but i wanted to push a PR so that it can be reviewed before it has gone thru validation on my dev box.<del>

Edit: This successfully deployed on my dev box without changes and abuse reporting flows work as expected.