### PR TITLE
Update docs for maintenance: add the description about providers blocking the federation port

### DIFF
--- a/docs/maintenance-and-troubleshooting.md
+++ b/docs/maintenance-and-troubleshooting.md
@@ -107,6 +107,14 @@ If it's all green, everything is probably running correctly.
 
 Besides this self-check, you can also check whether your server federates with the Matrix network by using the [Federation Tester](https://federationtester.matrix.org/) against your base domain (`example.com`), not the `matrix.example.com` subdomain.
 
+#### In case of Matrix Federation API port not being able to be reached
+
+Please note that some server providers block TCP/UDP ports which are not quite often used based on their judgment (in order to improve security, to mitigate the risk of abuse, etc). It can cause that your Matrix instance cannot be reached via Matrix Federation API port (`8448`), resulting in the error about federation when running self-check test.
+
+In this case, make sure that your server provider does not block the port by default. As this playbook makes Docker configure the server's internal firewall for you as described [here](prerequisites.md), you mostly do not have to edit the firewall rules by yourself, unless your server is running behind another firewall.
+
+If the provider was indeed found to disallow the port, you need to allow it explicitly on the server configuration for managing ports (control panel, etc), as it is not able for this playbook to update the upstream configuration. Please consult the documentation of the provider for details about it.
+
 ### How to debug or force SSL certificate renewal
 
 SSL certificates are managed automatically by the [Traefik](https://doc.traefik.io/traefik/) reverse-proxy server.

--- a/docs/maintenance-migrating.md
+++ b/docs/maintenance-migrating.md
@@ -78,3 +78,5 @@ The shortcut command with `just` program is also available: `just run-tags insta
 After starting the services, you probably might want to ensure that you've migrated things correctly and that services are running. For instructions, see: [check if services work](maintenance-and-troubleshooting.md#how-to-check-if-services-work)
 
 Having make sure that both services and federation work as expected, you can safely shutdown the old server.
+
+**Note**: if Matrix Federation API port cannot be reached after migration, it might be due to the server provider not allowing the port by default. Take a look at [this section](maintenance-and-troubleshooting.md#in-case-of-matrix-federation-api-port-not-being-able-to-be-reached) to troubleshoot.


### PR DESCRIPTION
This PR intends to update the migration guide based on my own experience. During migration I've scratched my head for the federation API port not being available, and it turned out the server provider blocked ports other than basic ones (for SSH, HTTPS, etc.)

This kind of stuff can sometimes be difficult to realize, and I think it deserves to be noted for the sake of troubleshooting.