### PR TITLE
Remove comments before locking threads

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -26,12 +26,4 @@ jobs:
       - uses: dessant/lock-threads@v5
         with:
           add-issue-labels: 'outdated'
-          issue-comment: >
-            This issue is locked to prevent necro-posting on closed
-            issues. Please create a new issue or contact the team members
-            on Matrix if the problem persists.
-          pr-comment: >
-            This pull request has been automatically locked since there
-            has not been any recent activity after it was closed.
-            Please open a new issue for related bugs.
           process-only: 'issues, prs'


### PR DESCRIPTION
Necro-posting and notifying all subscribers for the purpose of preventing necro-posting is somewhat ironic