### PR TITLE
fix yaml templating failing when bridge user displaynames contain emoji

### DIFF
--- a/roles/custom/matrix-bridge-beeper-linkedin/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-beeper-linkedin/templates/config.yaml.j2
@@ -67,7 +67,7 @@ appservice:
     bot_username: {{ matrix_beeper_linkedin_appservice_bot_username | to_json }}
     # Display name and avatar for bot. Set to "remove" to remove display name/avatar, leave empty
     # to leave display name/avatar as-is.
-    bot_displayname: {{ matrix_beeper_linkedin_appservice_bot_displayname | to_json }}
+    bot_displayname: {{ matrix_beeper_linkedin_appservice_bot_displayname | to_json(ensure_ascii=False) }}
     bot_avatar: {{ matrix_beeper_linkedin_appservice_bot_avatar | to_json }}
 
     # Whether or not to receive ephemeral events via appservice transactions.

--- a/roles/custom/matrix-bridge-hookshot/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-hookshot/templates/config.yaml.j2
@@ -103,7 +103,7 @@ passFile:
 bot:
   # (Optional) Define profile information for the bot user
   #
-  displayname: {{ matrix_hookshot_bot_displayname | to_json }}
+  displayname: {{ matrix_hookshot_bot_displayname | to_json(ensure_ascii=False) }}
   avatar: {{ matrix_hookshot_bot_avatar | to_json }}
 metrics:
   # (Optional) Prometheus metrics support

--- a/roles/custom/matrix-bridge-mautrix-bluesky/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mautrix-bluesky/templates/config.yaml.j2
@@ -199,7 +199,7 @@ appservice:
         username: {{ matrix_mautrix_bluesky_appservice_bot_username | to_json }}
         # Display name and avatar for bot. Set to "remove" to remove display name/avatar, leave empty
         # to leave display name/avatar as-is.
-        displayname: {{ matrix_mautrix_bluesky_appservice_bot_displayname | to_json }}
+        displayname: {{ matrix_mautrix_bluesky_appservice_bot_displayname | to_json(ensure_ascii=False) }}
         avatar: {{ matrix_mautrix_bluesky_appservice_bot_avatar | to_json }}
 
     # Whether to receive ephemeral events via appservice transactions.

--- a/roles/custom/matrix-bridge-mautrix-discord/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mautrix-discord/templates/config.yaml.j2
@@ -61,7 +61,7 @@ appservice:
         username: {{ matrix_mautrix_discord_appservice_bot_username | to_json }}
         # Display name and avatar for bot. Set to "remove" to remove display name/avatar, leave empty
         # to leave display name/avatar as-is.
-        displayname: {{ matrix_mautrix_discord_appservice_bot_displayname | to_json }}
+        displayname: {{ matrix_mautrix_discord_appservice_bot_displayname | to_json(ensure_ascii=False) }}
         avatar: {{ matrix_mautrix_discord_appservice_bot_avatar | to_json }}
 
     # Whether or not to receive ephemeral events via appservice transactions.

--- a/roles/custom/matrix-bridge-mautrix-meta-instagram/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mautrix-meta-instagram/templates/config.yaml.j2
@@ -212,7 +212,7 @@ appservice:
         username: {{ matrix_mautrix_meta_instagram_appservice_username | to_json }}
         # Display name and avatar for bot. Set to "remove" to remove display name/avatar, leave empty
         # to leave display name/avatar as-is.
-        displayname: {{ matrix_mautrix_meta_instagram_appservice_displayname | to_json }}
+        displayname: {{ matrix_mautrix_meta_instagram_appservice_displayname | to_json(ensure_ascii=False) }}
         avatar: {{ matrix_mautrix_meta_instagram_appservice_avatar | to_json }}
 
     # Whether to receive ephemeral events via appservice transactions.

--- a/roles/custom/matrix-bridge-mautrix-meta-messenger/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mautrix-meta-messenger/templates/config.yaml.j2
@@ -212,7 +212,7 @@ appservice:
         username: {{ matrix_mautrix_meta_messenger_appservice_username | to_json }}
         # Display name and avatar for bot. Set to "remove" to remove display name/avatar, leave empty
         # to leave display name/avatar as-is.
-        displayname: {{ matrix_mautrix_meta_messenger_appservice_displayname | to_json }}
+        displayname: {{ matrix_mautrix_meta_messenger_appservice_displayname | to_json(ensure_ascii=False) }}
         avatar: {{ matrix_mautrix_meta_messenger_appservice_avatar | to_json }}
 
     # Whether to receive ephemeral events via appservice transactions.

--- a/roles/custom/matrix-bridge-mautrix-twitter/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mautrix-twitter/templates/config.yaml.j2
@@ -199,7 +199,7 @@ appservice:
         username: {{ matrix_mautrix_twitter_appservice_bot_username | to_json }}
         # Display name and avatar for bot. Set to "remove" to remove display name/avatar, leave empty
         # to leave display name/avatar as-is.
-        displayname: {{ matrix_mautrix_twitter_appservice_bot_displayname | to_json }}
+        displayname: {{ matrix_mautrix_twitter_appservice_bot_displayname | to_json(ensure_ascii=False) }}
         avatar: {{ matrix_mautrix_twitter_appservice_bot_avatar | to_json }}
 
     # Whether to receive ephemeral events via appservice transactions.


### PR DESCRIPTION
fixes #2346

quick tests indicated that `to_json` with `ensure_ascii` would break a later `to_yaml` step (needed before the merging with `_yaml_extensions` when displayname settings included emoji.

some of these bridges support further templates e.g. for the bridge puppet displaynames, but I don't need and didn't check those and so also didn't adjust them.