### PR TITLE
perf(ansible): add ControlPersist for SSH connection reuse

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -4,3 +4,6 @@ result_format = yaml
 
 [connection]
 pipelining = True
+
+[ssh_connection]
+ssh_args = -o ControlMaster=auto -o ControlPersist=60s


### PR DESCRIPTION
Should speed up playbook execution significantly for most users.
While pipelining is already enabled and reduces per-task work inside each SSH session, ControlPersist reduces the cost of establishing SSH sessions by reusing the master connection.