### PR TITLE
Bump Synapse to v1.130.0

### DIFF
--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -16,7 +16,7 @@ matrix_synapse_enabled: true
 matrix_synapse_github_org_and_repo: element-hq/synapse
 
 # renovate: datasource=docker depName=ghcr.io/element-hq/synapse
-matrix_synapse_version: v1.129.0
+matrix_synapse_version: v1.130.0
 
 matrix_synapse_username: ''
 matrix_synapse_uid: ''


### PR DESCRIPTION
Update for synapse v1.130.0

Release notes; https://github.com/element-hq/synapse/releases/tag/v1.130.0