### PR TITLE
Update default room version to 11 in line with the specification.

### DIFF
--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -1562,7 +1562,7 @@ matrix_synapse_room_list_publication_rules:
     room_id: "*"
     action: allow
 
-matrix_synapse_default_room_version: "10"
+matrix_synapse_default_room_version: "11"
 
 # Controls whether leaving a room will automatically forget it.
 # The upstream default is `false`, but we try to make Synapse less wasteful of resources, so we do things differently.


### PR DESCRIPTION
The specification was updated in January to make this the default but well it appears that we all forgot to implement this. Its part of Spec version 1.14 and listed on this page. https://spec.matrix.org/v1.14/rooms/