### PR TITLE
Add devcontainer config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,22 @@
+FROM geerlingguy/docker-debian12-ansible:latest
+
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends \
+		python3-passlib \
+		git \
+		pwgen \
+		openssh-client \
+		curl && \
+	rm -rf /var/lib/apt/lists/* && \
+	rm -Rf /usr/share/doc && rm -Rf /usr/share/man && \
+	apt-get clean
+
+# Install Just
+RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+
+# Preserve command history across container restarts
+RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+    && echo "$SNIPPET" >> "/root/.bashrc"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,22 +1,9 @@
-FROM geerlingguy/docker-debian12-ansible:latest
+FROM ghcr.io/devture/ansible:11.1.0-r0-0
 
-ENV LANG=C.UTF-8
-ENV LC_ALL=C.UTF-8
-
-RUN apt-get update && \
-	apt-get install -y --no-install-recommends \
-		python3-passlib \
-		git \
-		pwgen \
-		openssh-client \
-		curl && \
-	rm -rf /var/lib/apt/lists/* && \
-	rm -Rf /usr/share/doc && rm -Rf /usr/share/man && \
-	apt-get clean
-
-# Install Just
-RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+# Install additional packages
+RUN apk add --no-cache \
+	pwgen
 
 # Preserve command history across container restarts
-RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
-    && echo "$SNIPPET" >> "/root/.bashrc"
+RUN SNIPPET="export HISTFILE=/commandhistory/.ash_history" \
+	&& echo "$SNIPPET" >> "/root/.profile"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,24 +6,15 @@
 		"context": ".."
 	},
 	"postCreateCommand": {
-		"Fix Volume Permissions": "sudo chown -R $(whoami): /commandhistory"
+		"Fix Volume Permissions": "chown -R $(whoami): /commandhistory"
 	},
-	"postAttachCommand": "bash",
 	"mounts": [
-		{
-			"source": "${localEnv:SSH_AUTH_SOCK}",
-			"target": "/agent.sock",
-			"type": "bind"
-		},
 		{
 			"source": "matrix-docker-ansible-deploy-bashhistory",
 			"target": "/commandhistory",
 			"type": "volume"
 		}
 	],
-	"containerEnv": {
-		"SSH_AUTH_SOCK": "/agent.sock"
-	},
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,37 @@
+// For format details, see https://aka.ms/devcontainer.json.
+{
+	"name": "matrix-docker-ansible-deploy",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": ".."
+	},
+	"postCreateCommand": {
+		"Fix Volume Permissions": "sudo chown -R $(whoami): /commandhistory"
+	},
+	"postAttachCommand": "bash",
+	"mounts": [
+		{
+			"source": "${localEnv:SSH_AUTH_SOCK}",
+			"target": "/agent.sock",
+			"type": "bind"
+		},
+		{
+			"source": "matrix-docker-ansible-deploy-bashhistory",
+			"target": "/commandhistory",
+			"type": "volume"
+		}
+	],
+	"containerEnv": {
+		"SSH_AUTH_SOCK": "/agent.sock"
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"EditorConfig.EditorConfig",
+				"redhat.ansible",
+				"redhat.vscode-yaml",
+				"ms-python.python"
+			]
+		}
+	}
+}


### PR DESCRIPTION
You can feel free to close this if it's out of scope, but since I had to make it for my own purposes anyways I figured there's no harm in sharing.

This installs all the [prerequisites for your local computer](https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/docs/prerequisites.md#your-local-computer) in a [dev container](https://containers.dev/).

Since I got a new laptop I have been trying to avoid installing developer tools whenever possible, in favor of running containerized workspaces instead. All this does is open a Debian 12 container with all the tools installed to run the playbooks here, and it integrates with your local SSH agent for authentication. I do this in VS Code personally but it should work with a variety of tools or just the [devcontainers cli](https://github.com/devcontainers/cli).