### PR TITLE
Add matrix_continuwuity_url_preview_domain_contains_allowlist variable

### DIFF
--- a/roles/custom/matrix-continuwuity/defaults/main.yml
+++ b/roles/custom/matrix-continuwuity/defaults/main.yml
@@ -196,3 +196,6 @@ matrix_continuwuity_environment_variables_extension: ''
 
 matrix_continuwuity_forbidden_remote_server_names: []
 matrix_continuwuity_forbidden_remote_room_directory_server_names: []
+
+# Controls the `url_preview_domain_contains_allowlist` setting.
+matrix_continuwuity_url_preview_domain_contains_allowlist: []

--- a/roles/custom/matrix-continuwuity/templates/continuwuity.toml.j2
+++ b/roles/custom/matrix-continuwuity/templates/continuwuity.toml.j2
@@ -1215,7 +1215,7 @@ forbidden_remote_room_directory_server_names = {{ matrix_continuwuity_forbidden_
 # attack surface to your server, you are expected to be aware of the risks
 # by doing so.
 #
-#url_preview_domain_contains_allowlist = []
+url_preview_domain_contains_allowlist = {{ matrix_continuwuity_url_preview_domain_contains_allowlist | to_json }}
 
 # Vector list of explicit domains allowed to send requests to for URL
 # previews.


### PR DESCRIPTION
Adds a variable to control the url previews in Continuwuity. 
From the setting documentation:

> Vector list of domains allowed to send requests to for URL previews.
>
> This is a *contains* match, not an explicit match. Putting "google.com"
> will match "https://google.com" and
> "http://mymaliciousdomainexamplegoogle.com" Setting this to "*" will
> allow all URL previews. Please note that this opens up significant
> attack surface to your server, you are expected to be aware of the risks
> by doing so.