### PR TITLE
Update renovate.json: apply versioning=loose

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,6 +20,7 @@
 	"packageRules": [
 		{
 			"ignoreUnstable": false,
+			"versioning": "loose",
 			"matchSourceUrls": [
 				"https://github.com/devture/com.devture.ansible.role{/,}**",
 				"https://github.com/mother-of-all-self-hosting{/,}**"


### PR DESCRIPTION
This makes it possible for Renovate to detect updates such as from `x.x.x-0` to `x.x.x-1`.

References:
- https://docs.renovatebot.com/modules/versioning/loose/
- https://docs.renovatebot.com/configuration-options/#versioning

Setting [pruneStaleBranches=false](https://docs.renovatebot.com/configuration-options/#prunestalebranches) will disable autoclosing, but it is not clear to me what kind of side-effect it could have :thinking: 