### PR TITLE
fix indentation in ma1sd validate_config

### DIFF
--- a/roles/custom/matrix-ma1sd/tasks/validate_config.yml
+++ b/roles/custom/matrix-ma1sd/tasks/validate_config.yml
@@ -83,4 +83,4 @@
       mxisd is deprecated and has been replaced with ma1sd (https://github.com/ma1uta/ma1sd), a compatible fork.
       The playbook will migrate your existing mxisd configuration and data automatically, but you need to adjust variable names.
       Please rename these variables (`matrix_mxisd_*` -> `matrix_ma1sd_*`) on your configuration file (vars.yml): {{ lookup('ansible.builtin.varnames', '^matrix_mxisd_.+', wantlist=True) | join(', ') }}
-    when: "lookup('ansible.builtin.varnames', '^matrix_mxisd_.+', wantlist=True) | length > 0"
+  when: "lookup('ansible.builtin.varnames', '^matrix_mxisd_.+', wantlist=True) | length > 0"


### PR DESCRIPTION
Classic install was failing due to a miss-indented  `when` in the `ma1sd` config validator. (The line was changed 3 days ago)

I'm running `ansible-playbook` version `[core 2.19.0b6]`