### PR TITLE
allow native draupnir (bot) auth using login/password

### DIFF
--- a/roles/custom/matrix-bot-draupnir/tasks/validate_config.yml
+++ b/roles/custom/matrix-bot-draupnir/tasks/validate_config.yml
@@ -36,7 +36,7 @@
   ansible.builtin.fail:
     msg: "The `{{ item.name }}` variable must be defined and have a non-null value."
   with_items:
-    - {'name': 'matrix_bot_draupnir_config_accessToken', when: "{{ not matrix_bot_draupnir_pantalaimon_use }}"}
+    - {'name': 'matrix_bot_draupnir_config_accessToken', when: "{{ not matrix_bot_draupnir_pantalaimon_use and not matrix_bot_draupnir_login_native }}"}
     - {'name': 'matrix_bot_draupnir_config_accessToken', when: "{{ matrix_bot_draupnir_config_experimentalRustCrypto }}"}
     - {'name': 'matrix_bot_draupnir_config_managementRoom', when: true}
     - {'name': 'matrix_bot_draupnir_container_network', when: true}


### PR DESCRIPTION
currently when you try to use the following in your vars.yml, config validation will fail and demand you to use access token, but [playbook docs](https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/docs/configuring-playbook-bot-draupnir.md#adjusting-the-playbook-configuration) mention that it should work

```
matrix_bot_draupnir_login_native: yes
matrix_bot_draupnir_password: your-secret-password
```