### PR TITLE
Fix renamed variable for encryption in docs for matrix-hookshot

### DIFF
--- a/docs/configuring-playbook-bridge-hookshot.md
+++ b/docs/configuring-playbook-bridge-hookshot.md
@@ -35,7 +35,7 @@ matrix_hookshot_enabled: true
 
 # Uncomment to enable end-to-bridge encryption.
 # See: https://matrix-org.github.io/matrix-hookshot/latest/advanced/encryption.html
-# matrix_hookshot_experimental_encryption_enabled: true
+# matrix_hookshot_encryption_enabled: true
 
 # Uncomment and paste the contents of GitHub app private key to enable GitHub bridge.
 # Alternatively, you can use one of the other methods explained below on the "Manage GitHub Private Key with aux role" section.


### PR DESCRIPTION
`matrix_hookshot_experimental_encryption_enabled` was renamed to `matrix_hookshot_encryption_enabled` in 119e78bc11c42b1c521812d6f0f3467a03d3ddd5 
Later, a8372f3613d88fc8ddad4113569395d685b8625b updates the docs but the variable rename is missing.


Refer to defaults for the role:
https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/9bcfbc13fb0c226806b9f7912eee6429b0a3cc6c/roles/custom/matrix-bridge-hookshot/defaults/main.yml#L77