### PR TITLE
append websocket upgrade rule to apache example config

### DIFF
--- a/examples/reverse-proxies/apache/matrix-domain.conf
+++ b/examples/reverse-proxies/apache/matrix-domain.conf
@@ -33,6 +33,12 @@
 	ProxyRequests Off
 	ProxyVia On
 	RequestHeader set "X-Forwarded-Proto" expr=%{REQUEST_SCHEME}
+	ProxyTimeout 86400
+
+	RewriteEngine On
+	RewriteCond %{HTTP:Connection} Upgrade [NC]
+	RewriteCond %{HTTP:Upgrade} websocket [NC]
+	RewriteRule /(.*) ws://127.0.0.1:81/$1 [P,L]
 
 	AllowEncodedSlashes NoDecode
 	ProxyPass / http://127.0.0.1:81/ retry=0 nocanon


### PR DESCRIPTION
This fixes the "Insufficient capacity" error described [here](https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/4281) in a self-maintained apache reverse proxy setup.