### PR TITLE
Add unicode_normalization option to MAS password config

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -666,6 +666,7 @@ matrix_authentication_service_config_passwords_schemes:
   - version: 1
     secret: "{{ matrix_synapse_password_config_pepper }}"
     algorithm: bcrypt
+    unicode_normalization: true
   - version: 2
     algorithm: argon2id
 


### PR DESCRIPTION
The MAS docs recommend this option for migrated Synapse passwords to work: https://element-hq.github.io/matrix-authentication-service/setup/migration.html#local-passwords

Fixes #4536 