### PR TITLE
feature/matrix-bot-registration-bot enable command prefix

### DIFF
--- a/docs/configuring-playbook-bot-matrix-registration-bot.md
+++ b/docs/configuring-playbook-bot-matrix-registration-bot.md
@@ -37,6 +37,10 @@ matrix_synapse_enable_registration: true
 
 # Restrict registration to users with a token
 matrix_synapse_registration_requires_token: true
+
+# Set an optional command prefix for the bot. This can be any arbitrary string, including whitespace.
+# Example: "!regbot "
+matrix_bot_matrix_registration_bot_bot_prefix: ""
 ```
 
 The bot account will be created automatically.

--- a/roles/custom/matrix-bot-matrix-registration-bot/defaults/main.yml
+++ b/roles/custom/matrix-bot-matrix-registration-bot/defaults/main.yml
@@ -43,6 +43,9 @@ matrix_bot_matrix_registration_bot_matrix_user_id: '@{{ matrix_bot_matrix_regist
 # The bot's password (can also be used to login via a client like Element Web)
 matrix_bot_matrix_registration_bot_bot_password: ''
 
+# Optional bot command prefix
+matrix_bot_matrix_registration_bot_bot_prefix: ""
+
 # Homeserver base URL
 matrix_bot_matrix_registration_bot_api_base_url: "{{ matrix_homeserver_url }}"
 

--- a/roles/custom/matrix-bot-matrix-registration-bot/templates/config.yaml.j2
+++ b/roles/custom/matrix-bot-matrix-registration-bot/templates/config.yaml.j2
@@ -10,6 +10,7 @@ bot:
   server: {{ matrix_bot_matrix_registration_bot_bot_server|to_json }}
   username: {{ matrix_bot_matrix_registration_bot_matrix_user_id_localpart|to_json }}
   password: {{ matrix_bot_matrix_registration_bot_bot_password|to_json }}
+  prefix: {{ matrix_bot_matrix_registration_bot_bot_prefix|to_json }}
 
 api:
   # API endpoint of the registration tokens


### PR DESCRIPTION
This adds the bot prefix configuration option for matrix-bot-register-bot to that custom role.