### PR TITLE
fix: displayname_template lost during parsing to dict

### DIFF
--- a/roles/custom/matrix-bridge-mautrix-whatsapp/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-mautrix-whatsapp/templates/config.yaml.j2
@@ -16,12 +16,6 @@ network:
     proxy_only_login: false
 
     # Displayname template for WhatsApp users.
-    # {% raw %}
-    # {{.PushName}}     - nickname set by the WhatsApp user
-    # {{.BusinessName}} - validated WhatsApp business name
-    # {{.Phone}}        - phone number (international format)
-    # {{.FullName}}     - Name you set in the contacts list
-    # {% endraw %}
     displayname_template: {{ matrix_mautrix_whatsapp_network_displayname_template | to_json }}
 
     # Should incoming calls send a message to the Matrix room?


### PR DESCRIPTION
Coming from https://github.com/mautrix/whatsapp/issues/565 , I noticed that the variable displayname_template was missing complete in the final configuration file. Therefore the bridge was overwriting it with a default value. (Might be another discussion if these fields should be left out anyway for the most recent defaults to be taken from the official bridge repo). As the creation of the final file is done here via casting to a dict and back to a yaml I removed the raw comment text as a) it is not used anymore and does not appear in the final file and b) this lead to the key being recognised as comment because the "endraw" statement lead to the # being infront of the entry for the parser.

Small fix, but good if anyone wants to customize their displaynames via the playbook.