### PR TITLE
fix: Justfile works when checked out in locations with spaces

### DIFF
--- a/justfile
+++ b/justfile
@@ -6,7 +6,7 @@
 
 # Shows help
 default:
-    @{{ just_executable() }} --list --justfile {{ justfile() }}
+    @{{ just_executable() }} --list --justfile "{{ justfile() }}"
 
 # Pulls external Ansible roles
 roles:
@@ -48,7 +48,7 @@ install-all *extra_args: (run-tags "install-all,ensure-matrix-users-created,star
 
 # Runs installation tasks for a single service
 install-service service *extra_args:
-    {{ just_executable() }} --justfile {{ justfile() }} run \
+    {{ just_executable() }} --justfile "{{ justfile() }}" run \
     --tags=install-{{ service }},start-group \
     --extra-vars=group={{ service }} \
     --extra-vars=devture_systemd_service_manager_service_restart_mode=one-by-one {{ extra_args }}
@@ -62,7 +62,7 @@ run +extra_args:
 
 # Runs the playbook with the given list of comma-separated tags and optional arguments
 run-tags tags *extra_args:
-    {{ just_executable() }} --justfile {{ justfile() }} run --tags={{ tags }} {{ extra_args }}
+    {{ just_executable() }} --justfile "{{ justfile() }}" run --tags={{ tags }} {{ extra_args }}
 
 # Runs the playbook in user-registration mode
 register-user username password admin_yes_or_no *extra_args:
@@ -73,15 +73,15 @@ start-all *extra_args: (run-tags "start-all" extra_args)
 
 # Starts a specific service group
 start-group group *extra_args:
-    @{{ just_executable() }} --justfile {{ justfile() }} run-tags start-group --extra-vars="group={{ group }}" {{ extra_args }}
+    @{{ just_executable() }} --justfile "{{ justfile() }}" run-tags start-group --extra-vars="group={{ group }}" {{ extra_args }}
 
 # Stops all services
 stop-all *extra_args: (run-tags "stop-all" extra_args)
 
 # Stops a specific service group
 stop-group group *extra_args:
-    @{{ just_executable() }} --justfile {{ justfile() }} run-tags stop-group --extra-vars="group={{ group }}" {{ extra_args }}
+    @{{ just_executable() }} --justfile "{{ justfile() }}" run-tags stop-group --extra-vars="group={{ group }}" {{ extra_args }}
 
 # Rebuilds the mautrix-meta-instagram Ansible role using the mautrix-meta-messenger role as a source
 rebuild-mautrix-meta-instagram:
-    /bin/bash {{ justfile_directory() }}/bin/rebuild-mautrix-meta-instagram.sh {{ justfile_directory() }}/roles/custom
+    /bin/bash "{{ justfile_directory() }}/bin/rebuild-mautrix-meta-instagram.sh" "{{ justfile_directory() }}/roles/custom"


### PR DESCRIPTION
If this repository was checked out in a location with spaces in the path, certain `just` tasks would fail.

This fixes those cases by wrapping necessary paths in quotes.