### PR TITLE
Update s3 storage provider version to 1.6.0, add renovate

### DIFF
--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -1471,7 +1471,8 @@ matrix_synapse_ext_encryption_config_yaml: |
 # Installing it requires building a customized Docker image for Synapse (see `matrix_synapse_container_image_customizations_enabled`).
 # Enabling this will enable customizations and inject the appropriate Dockerfile clauses for installing synapse-s3-storage-provider.
 matrix_synapse_ext_synapse_s3_storage_provider_enabled: false
-matrix_synapse_ext_synapse_s3_storage_provider_version: 1.5.0
+# renovate: datasource=github-releases packageName=matrix-org/synapse-s3-storage-provider
+matrix_synapse_ext_synapse_s3_storage_provider_version: 1.6.0
 # Controls whether media from this (local) server is stored in s3-storage-provider
 matrix_synapse_ext_synapse_s3_storage_provider_store_local: true
 # Controls whether media from remote servers is stored in s3-storage-provider


### PR DESCRIPTION
https://github.com/matrix-org/synapse-s3-storage-provider/releases/tag/v1.6.0

I don't know if this is the preferred way to have renovate handle non-docker updates.
The update to 1.6.0 is needed for https://github.com/element-hq/synapse/releases/tag/v1.140.0rc1