### PR TITLE
Add (Discord) to discord displaynames

### DIFF
--- a/roles/custom/matrix-bridge-mautrix-discord/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-discord/defaults/main.yml
@@ -59,7 +59,7 @@ matrix_mautrix_discord_bridge_avatar_proxy_key: ''
 matrix_mautrix_discord_bridge_username_template: "{% raw %}discord_{{.}}{% endraw %}"
 
 # Displayname template for Discord users. This is also used as the room name in DMs if private_chat_portal_meta is enabled.
-matrix_mautrix_discord_bridge_displayname_template: "{% raw %}{{or .GlobalName .Username}}{{if .Bot}} (bot){{end}}{% endraw %}"
+matrix_mautrix_discord_bridge_displayname_template: "{% raw %}{{or .GlobalName .Username}}{{if .Bot}} (bot){{end}} (Discord){% endraw %}"
 
 # Displayname template for Discord channels (bridged as rooms, or spaces when type=4).
 matrix_mautrix_discord_bridge_channel_name_template: "{% raw %}{{if or (eq .Type 3) (eq .Type 4)}}{{.Name}}{{else}}#{{.Name}}{{end}}{% endraw %}"


### PR DESCRIPTION
This adds (Discord) to bridge usernames, similar to the default config of mautrix-whatsapp and mautrix-signal.