### PR TITLE
Enable mautrix-slack relay mode with `matrix_bridges_relay_enabled`

### DIFF
--- a/docs/configuring-playbook-bridge-mautrix-slack.md
+++ b/docs/configuring-playbook-bridge-mautrix-slack.md
@@ -45,8 +45,7 @@ matrix_mautrix_slack_enabled: true
 
 There are some additional things you may wish to configure about the bridge.
 
-<!-- NOTE: relay mode is not supported for this bridge -->
-See [this section](configuring-playbook-bridge-mautrix-bridges.md#extending-the-configuration) on the [common guide for configuring mautrix bridges](configuring-playbook-bridge-mautrix-bridges.md) for details about variables that you can customize and the bridge's default configuration, including [bridge permissions](configuring-playbook-bridge-mautrix-bridges.md#configure-bridge-permissions-optional), [encryption support](configuring-playbook-bridge-mautrix-bridges.md#enable-encryption-optional), [bot's username](configuring-playbook-bridge-mautrix-bridges.md#set-the-bots-username-optional), etc.
+See [this section](configuring-playbook-bridge-mautrix-bridges.md#extending-the-configuration) on the [common guide for configuring mautrix bridges](configuring-playbook-bridge-mautrix-bridges.md) for details about variables that you can customize and the bridge's default configuration, including [bridge permissions](configuring-playbook-bridge-mautrix-bridges.md#configure-bridge-permissions-optional), [encryption support](configuring-playbook-bridge-mautrix-bridges.md#enable-encryption-optional), [relay mode](configuring-playbook-bridge-mautrix-bridges.md#enable-relay-mode-optional), [bot's username](configuring-playbook-bridge-mautrix-bridges.md#set-the-bots-username-optional), etc.
 
 ## Installing
 

--- a/roles/custom/matrix-bridge-mautrix-slack/defaults/main.yml
+++ b/roles/custom/matrix-bridge-mautrix-slack/defaults/main.yml
@@ -195,7 +195,7 @@ matrix_mautrix_slack_provisioning_shared_secret: ''
 matrix_mautrix_slack_public_media_signing_key: ''
 
 # Controls whether relay mode is enabled
-matrix_mautrix_slack_bridge_relay_enabled: false
+matrix_mautrix_slack_bridge_relay_enabled: "{{ matrix_bridges_relay_enabled }}"
 
 # Controls whether only admins can set themselves as relay users
 matrix_mautrix_slack_bridge_relay_admin_only: true


### PR DESCRIPTION
I found a comment that mautrix-slack didn't support relay mode. However, relay mode has been supported since the [september release](https://github.com/mautrix/slack/commit/8179a5d5f630dac6ab22e245268a2c9fcdd78837).

This commit enables mautrix-slack relay mode when `matrix_bridges_relay_enabled` is set and updates the docs.