### PR TITLE
Add support for some matrix-steam presence tracking vars

### DIFF
--- a/roles/custom/matrix-bridge-steam/defaults/main.yml
+++ b/roles/custom/matrix-bridge-steam/defaults/main.yml
@@ -34,6 +34,12 @@ matrix_steam_bridge_appservice_port: "8080"
 matrix_steam_bridge_msc4190_enabled: "{{ matrix_bridges_msc4190_enabled }}"
 matrix_steam_bridge_self_sign_enabled: "{{ matrix_bridges_self_sign_enabled }}"
 
+# matrix -> steam presence
+matrix_steam_bridge_network_presence_enabled: true
+# Default inactivity state
+# This is what the bridge sets it's status to after some time of no user interaction
+matrix_steam_bridge_network_presence_inactivity_status: 'invisible'
+
 # A public address that external services can use to reach this appservice
 matrix_steam_bridge_appservice_public_address: "https://{{ matrix_server_fqn_matrix }}"
 

--- a/roles/custom/matrix-bridge-steam/templates/config.yaml.j2
+++ b/roles/custom/matrix-bridge-steam/templates/config.yaml.j2
@@ -17,6 +17,32 @@ network:
     steam_bridge_auto_start: true
     steam_bridge_startup_timeout: 30
 
+    # Presence synchronization settings
+    presence:
+        # Enable presence tracking from Matrix to Steam
+        # When enabled, your Steam status will automatically change based on
+        # your Matrix presence and activity
+        enabled: {{ matrix_steam_bridge_network_presence_enabled | to_json }}
+
+        # Inactivity timeout in minutes before changing Steam status
+        # This is used as a fallback when your Matrix server doesn't support
+        # presence tracking. After this many minutes without Matrix activity,
+        # your Steam status will change (see inactivity_status below)
+        # Set to 0 to disable automatic away
+        inactivity_timeout: 15
+
+        # Status to set after inactivity timeout
+        # Valid values: "snooze" (appear away/idle) or "invisible" (appear offline)
+        inactivity_status: {{ matrix_steam_bridge_network_presence_inactivity_status | to_json }}
+        # Whether typing events in Matrix should reset the inactivity timer
+        # When true, typing will count as activity and keep you marked as online
+        typing_resets_presence: true
+
+        # Whether sending read receipts in Matrix should reset the inactivity timer
+        # When true, reading messages will count as activity and keep you marked as online
+        read_receipts_reset_presence: false
+
+
 # Config options that affect the central bridge module.
 bridge:
     # The prefix for commands. Only required in non-management rooms.


### PR DESCRIPTION
Some of these vars aren't used yet, those will be in the next release of matrix-steam-bridge. I think merging it now doesn't do any harm, otherwise this should be merged with the next renovate pr.