### PR TITLE
Update synapse to v1.142.1

### DIFF
--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -16,7 +16,7 @@ matrix_synapse_enabled: true
 matrix_synapse_github_org_and_repo: element-hq/synapse
 
 # renovate: datasource=docker depName=ghcr.io/element-hq/synapse
-matrix_synapse_version: v1.141.0
+matrix_synapse_version: v1.142.1
 
 matrix_synapse_username: ''
 matrix_synapse_uid: ''


### PR DESCRIPTION
Update synapse to v1.142.1

Release notes: https://github.com/element-hq/synapse/releases/tag/v1.142.1 