### PR TITLE
Linting: skip checking var-naming for encodedCharacters vars

### DIFF
--- a/roles/custom/matrix-base/defaults/main.yml
+++ b/roles/custom/matrix-base/defaults/main.yml
@@ -326,8 +326,8 @@ matrix_playbook_public_matrix_federation_api_traefik_entrypoint_config: "{{ (mat
 # Ref:
 # - https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/4798
 # - https://doc.traefik.io/traefik/migrate/v3/#v364
-matrix_playbook_public_matrix_federation_api_traefik_entrypoint_config_http_encodedCharacters_allowEncodedSlash: true  # noqa var-naming
-matrix_playbook_public_matrix_federation_api_traefik_entrypoint_config_http_encodedCharacters_allowEncodedHash: true  # noqa var-naming
+matrix_playbook_public_matrix_federation_api_traefik_entrypoint_config_http_encodedCharacters_allowEncodedSlash: true  # noqa: var-naming[pattern]
+matrix_playbook_public_matrix_federation_api_traefik_entrypoint_config_http_encodedCharacters_allowEncodedHash: true  # noqa: var-naming[pattern]
 matrix_playbook_public_matrix_federation_api_traefik_entrypoint_config_http3_enabled: true
 matrix_playbook_public_matrix_federation_api_traefik_entrypoint_config_http3_advertisedPort: "{{ matrix_playbook_public_matrix_federation_api_traefik_entrypoint_port }}"  # noqa var-naming
 matrix_playbook_public_matrix_federation_api_traefik_entrypoint_config_transport_respondingTimeouts_readTimeout: "{{ traefik_config_entrypoint_web_secure_transport_respondingTimeouts_readTimeout }}"  # noqa var-naming
@@ -417,8 +417,8 @@ matrix_playbook_internal_matrix_client_api_traefik_entrypoint_config: "{{ (matri
 # Ref:
 # - https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/4798
 # - https://doc.traefik.io/traefik/migrate/v3/#v364
-matrix_playbook_internal_matrix_client_api_traefik_entrypoint_config_http_encodedCharacters_allowEncodedSlash: true  # noqa var-naming
-matrix_playbook_internal_matrix_client_api_traefik_entrypoint_config_http_encodedCharacters_allowEncodedHash: true  # noqa var-naming
+matrix_playbook_internal_matrix_client_api_traefik_entrypoint_config_http_encodedCharacters_allowEncodedSlash: true  # noqa: var-naming[pattern]
+matrix_playbook_internal_matrix_client_api_traefik_entrypoint_config_http_encodedCharacters_allowEncodedHash: true  # noqa: var-naming[pattern]
 matrix_playbook_internal_matrix_client_api_traefik_entrypoint_config_default: |
   {{
     {}


### PR DESCRIPTION
`matrix_playbook_public_matrix_federation_api_traefik_entrypoint_config_http_encodedCharacters_allowEncodedSlash` and related variables have partial snakecase which the linting doesn't like. 

Either:
a) `Characters_allowEncodedSlash` should be changed to all lower case or
b) We can ignore the check of these variables by telling the linting to skip the pattern check:

> var-naming[pattern]: Variables names should match ... regex.
> https://docs.ansible.com/projects/lint/rules/var-naming/

error 
```
var-naming[pattern]: Variables names should match ^[a-z_][a-z0-9_]*$ regex. (matrix_playbook_public_matrix_federation_api_traefik_entrypoint_config_http_encodedCharacters_allowEncodedSlash) (vars: matrix_playbook_public_matrix_federation_api_traefik_entrypoint_config_http_encodedCharacters_allowEncodedSlash)
roles/custom/matrix-base/defaults/main.yml:329:1

var-naming[pattern]: Variables names should match ^[a-z_][a-z0-9_]*$ regex. (matrix_playbook_public_matrix_federation_api_traefik_entrypoint_config_http_encodedCharacters_allowEncodedHash) (vars: matrix_playbook_public_matrix_federation_api_traefik_entrypoint_config_http_encodedCharacters_allowEncodedHash)
roles/custom/matrix-base/defaults/main.yml:330:1

var-naming[pattern]: Variables names should match ^[a-z_][a-z0-9_]*$ regex. (matrix_playbook_internal_matrix_client_api_traefik_entrypoint_config_http_encodedCharacters_allowEncodedSlash) (vars: matrix_playbook_internal_matrix_client_api_traefik_entrypoint_config_http_encodedCharacters_allowEncodedSlash)
roles/custom/matrix-base/defaults/main.yml:420:1

var-naming[pattern]: Variables names should match ^[a-z_][a-z0-9_]*$ regex. (matrix_playbook_internal_matrix_client_api_traefik_entrypoint_config_http_encodedCharacters_allowEncodedHash) (vars: matrix_playbook_internal_matrix_client_api_traefik_entrypoint_config_http_encodedCharacters_allowEncodedHash)
roles/custom/matrix-base/defaults/main.yml:421:1

```