### PR TITLE
Disable matrix-matrixto for Watchtower

### DIFF
--- a/roles/custom/matrix-matrixto/defaults/main.yml
+++ b/roles/custom/matrix-matrixto/defaults/main.yml
@@ -104,7 +104,7 @@ matrix_matrixto_container_labels_traefik_additional_response_headers_custom: {}
 # matrix_matrixto_container_labels_additional_labels: |
 #   my.label=1
 #   another.label="here"
-matrix_matrixto_container_labels_additional_labels: ""
+matrix_matrixto_container_labels_additional_labels: "com.centurylinklabs.watchtower.enable=false"
 
 # A list of extra arguments to pass to the container (`docker run` command)
 matrix_matrixto_container_extra_arguments: []


### PR DESCRIPTION
This solves #4820.
- Add the additional label for Matrix.to to disable to disable Watchtower's notification.