### PR TITLE
Upgrade Coturn (4.6.2-r11 -> 4.8.0-r0)

### DIFF
--- a/roles/custom/matrix-coturn/defaults/main.yml
+++ b/roles/custom/matrix-coturn/defaults/main.yml
@@ -18,7 +18,7 @@
 
 matrix_coturn_enabled: true
 
-matrix_coturn_hostname: ''
+matrix_coturn_hostname: ""
 
 matrix_coturn_container_image_self_build: false
 matrix_coturn_container_image_self_build_repo: "https://github.com/coturn/coturn"
@@ -26,7 +26,7 @@ matrix_coturn_container_image_self_build_repo_version: "docker/{{ matrix_coturn_
 matrix_coturn_container_image_self_build_repo_dockerfile_path: "docker/coturn/alpine/Dockerfile"
 
 # renovate: datasource=docker depName=coturn/coturn
-matrix_coturn_version: 4.6.2-r11
+matrix_coturn_version: 4.8.0-r0
 matrix_coturn_docker_image: "{{ matrix_coturn_docker_image_registry_prefix }}coturn/coturn:{{ matrix_coturn_version }}-alpine"
 matrix_coturn_docker_image_registry_prefix: "{{ 'localhost/' if matrix_coturn_container_image_self_build else matrix_coturn_docker_image_registry_prefix_upstream }}"
 matrix_coturn_docker_image_registry_prefix_upstream: "{{ matrix_coturn_docker_image_registry_prefix_upstream_default }}"
@@ -139,7 +139,7 @@ matrix_coturn_lt_cred_mech_password: ""
 # The external IP address of the machine where coturn is.
 # If do not define an IP address here or in `matrix_coturn_turn_external_ip_addresses`, auto-detection via an EchoIP service will be done.
 # See `matrix_coturn_turn_external_ip_address_auto_detection_enabled`
-matrix_coturn_turn_external_ip_address: ''
+matrix_coturn_turn_external_ip_address: ""
 matrix_coturn_turn_external_ip_addresses: "{{ [matrix_coturn_turn_external_ip_address] if matrix_coturn_turn_external_ip_address != '' else [] }}"
 
 # Controls whether external IP address auto-detection should be attempted.
@@ -218,7 +218,7 @@ matrix_coturn_response_origin_only_with_rfc5780_enabled: true
 #   simple-log
 #   aux-server=1.2.3.4
 #   relay-ip=4.3.2.1
-matrix_coturn_additional_configuration: ''
+matrix_coturn_additional_configuration: ""
 
 # To enable TLS, you need to provide paths to certificates.
 # Paths defined in `matrix_coturn_tls_cert_path` and `matrix_coturn_tls_key_path` are in-container paths.


### PR DESCRIPTION
Major version bump to 4.8.0. This update tracks the [latest upstream](https://github.com/coturn/coturn/blob/docker/4.8.0-r0/docker/coturn/CHANGELOG.md) security fixes and minor protocol improvements.