### PR TITLE
Fix regression introduced in a77a875

### DIFF
--- a/roles/custom/matrix-synapse/templates/synapse/systemd/matrix-synapse.service.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/systemd/matrix-synapse.service.j2
@@ -74,7 +74,7 @@ ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach m
 ExecStartPost={{ matrix_synapse_systemd_healthcheck_command }}
 {% endif %}
 
-{% if matrix_synapse_systemd_service_post_start_delay_seconds > 0 %}
+{% if matrix_synapse_systemd_service_post_start_delay_seconds | int > 0 %}
 ExecStartPost=-{{ matrix_host_command_sleep }} {{ matrix_synapse_systemd_service_post_start_delay_seconds }}
 {% endif %}
 


### PR DESCRIPTION
`matrix_synapse_systemd_service_post_start_delay_seconds` is [assigned a string value](https://github.com/spantaleev/matrix-docker-ansible-deploy/commit/a77a8753d9e50f7587e4ccf35203111c502c6e6d#diff-250fee5433c247b39e35580376e6e53e3b229255269e453a092ac9b3b12848b7R4472), and setup fails while creating the service file. It is impossible to compare str and int.

---

Edit: meta: I can't find a contributing guide. If DCO or `*.license` file should be updated please let me know and I will amend that. Otherwise it's such a miniature change that I don't believe it necessary.