### PR TITLE
Quote YAML mode values to satisfy octal lint rules

### DIFF
--- a/roles/custom/matrix-alertmanager-receiver/tasks/install.yml
+++ b/roles/custom/matrix-alertmanager-receiver/tasks/install.yml
@@ -9,7 +9,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -25,7 +25,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_alertmanager_receiver_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_alertmanager_receiver_config_path }}/config.yml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_alertmanager_receiver_config_result
@@ -34,7 +34,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"
     dest: "{{ matrix_alertmanager_receiver_base_path }}/{{ item }}"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -85,7 +85,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-alertmanager-receiver.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-alertmanager-receiver.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_alertmanager_receiver_systemd_service_result
 
 - name: Determine whether matrix-alertmanager-receiver needs a restart

--- a/roles/custom/matrix-appservice-double-puppet/tasks/install.yml
+++ b/roles/custom/matrix-appservice-double-puppet/tasks/install.yml
@@ -8,7 +8,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -22,6 +22,6 @@
   ansible.builtin.copy:
     content: "{{ matrix_appservice_double_puppet_registration_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_appservice_double_puppet_config_path }}/registration.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"

--- a/roles/custom/matrix-appservice-draupnir-for-all/tasks/setup_install.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/tasks/setup_install.yml
@@ -15,7 +15,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -63,7 +63,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_appservice_draupnir_for_all_configuration_appservice | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_appservice_draupnir_for_all_config_path }}/production-appservice.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_appservice_draupnir_for_all_appservice_config_result
@@ -72,7 +72,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_appservice_draupnir_for_all_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_appservice_draupnir_for_all_config_path }}/production-bots.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_appservice_draupnir_for_all_bot_config_result
@@ -81,7 +81,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_appservice_draupnir_for_all_registration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_appservice_draupnir_for_all_config_path }}/draupnir-for-all-registration.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_appservice_draupnir_for_all_registration_config_result
@@ -97,7 +97,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-appservice-draupnir-for-all.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-appservice-draupnir-for-all.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_appservice_draupnir_for_all_systemd_service_result
 
 - name: Determine whether Draupnir for All needs a restart

--- a/roles/custom/matrix-authentication-service/tasks/install.yml
+++ b/roles/custom/matrix-authentication-service/tasks/install.yml
@@ -8,7 +8,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -37,7 +37,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_authentication_service_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_authentication_service_config_path }}/config.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_authentication_service_config_result
@@ -106,7 +106,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-authentication-service.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-authentication-service.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_authentication_service_systemd_service_result
 
 - name: Determine whether Matrix Authentication Service needs a restart

--- a/roles/custom/matrix-base/tasks/setup_matrix_base.yml
+++ b/roles/custom/matrix-base/tasks/setup_matrix_base.yml
@@ -27,4 +27,4 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/bin/remove-all.j2"
     dest: "{{ matrix_bin_path }}/remove-all"
-    mode: 0750
+    mode: '0750'

--- a/roles/custom/matrix-bot-baibot/tasks/install.yml
+++ b/roles/custom/matrix-bot-baibot/tasks/install.yml
@@ -9,7 +9,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -23,7 +23,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_bot_baibot_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_bot_baibot_config_path }}/config.yml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_bot_baibot_config_result
@@ -34,7 +34,7 @@
     dest: "{{ matrix_bot_baibot_config_path }}/env"
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
-    mode: 0640
+    mode: '0640'
   register: matrix_bot_baibot_env_result
 
 - name: Ensure baibot container image is pulled
@@ -83,7 +83,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-bot-baibot.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-bot-baibot.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_bot_baibot_systemd_service_result
 
 - name: Determine whether baibot needs a restart

--- a/roles/custom/matrix-bot-buscarron/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-buscarron/tasks/setup_install.yml
@@ -38,7 +38,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -54,7 +54,7 @@
     dest: "{{ matrix_bot_buscarron_config_path }}/{{ item }}"
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
-    mode: 0640
+    mode: '0640'
   with_items:
     - env
     - labels
@@ -99,7 +99,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-bot-buscarron.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-bot-buscarron.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_bot_buscarron_systemd_service_result
 
 - name: Determine whether Buscarron needs a restart

--- a/roles/custom/matrix-bot-draupnir/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-draupnir/tasks/setup_install.yml
@@ -15,7 +15,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -31,7 +31,7 @@
     dest: "{{ item.dest }}"
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
-    mode: 0644
+    mode: '0644'
   with_items:
     - src: "{{ role_path }}/templates/labels.j2"
       dest: "{{ matrix_bot_draupnir_base_path }}/labels"
@@ -75,7 +75,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_bot_draupnir_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_bot_draupnir_config_path }}/production.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_bot_draupnir_config_result
@@ -91,7 +91,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-bot-draupnir.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-bot-draupnir.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_bot_draupnir_systemd_service_result
 
 - name: Determine whether Draupnir needs a restart

--- a/roles/custom/matrix-bot-go-neb/tasks/install.yml
+++ b/roles/custom/matrix-bot-go-neb/tasks/install.yml
@@ -14,7 +14,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -27,7 +27,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_bot_go_neb_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_bot_go_neb_config_path }}/config.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_bot_go_neb_config_result
@@ -36,7 +36,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"
     dest: "{{ matrix_bot_go_neb_base_path }}/{{ item }}"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -66,7 +66,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-bot-go-neb.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-bot-go-neb.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_bot_go_neb_systemd_service_result
 
 - name: Determine whether go-neb needs a restart

--- a/roles/custom/matrix-bot-honoroit/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-honoroit/tasks/setup_install.yml
@@ -40,7 +40,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -56,7 +56,7 @@
     dest: "{{ matrix_bot_honoroit_config_path }}/{{ item }}"
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
-    mode: 0640
+    mode: '0640'
   with_items:
     - env
     - labels
@@ -108,7 +108,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-bot-honoroit.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-bot-honoroit.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_bot_honoroit_systemd_service_result
 
 - name: Determine whether Honoroit needs a restart

--- a/roles/custom/matrix-bot-matrix-registration-bot/tasks/clean_cache.yml
+++ b/roles/custom/matrix-bot-matrix-registration-bot/tasks/clean_cache.yml
@@ -8,7 +8,7 @@
   ansible.builtin.file:
     state: "{{ item }}"
     path: "{{ matrix_bot_matrix_registration_bot_data_path }}"
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:

--- a/roles/custom/matrix-bot-matrix-registration-bot/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-matrix-registration-bot/tasks/setup_install.yml
@@ -12,7 +12,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -27,7 +27,7 @@
     dest: "{{ matrix_bot_matrix_registration_bot_config_path }}/config.yaml"
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
-    mode: 0640
+    mode: '0640'
   register: matrix_bot_matrix_registration_bot_config_result
 
 - name: Ensure matrix-registration-bot image is pulled
@@ -76,7 +76,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-bot-matrix-registration-bot.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-bot-matrix-registration-bot.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_bot_matrix_registration_bot_systemd_service_result
 
 - name: Determine whether matrix-registration-bot needs a restart

--- a/roles/custom/matrix-bot-matrix-reminder-bot/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-matrix-reminder-bot/tasks/setup_install.yml
@@ -42,7 +42,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -91,7 +91,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_bot_matrix_reminder_bot_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_bot_matrix_reminder_bot_config_path }}/config.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_bot_matrix_reminder_bot_config_result
@@ -107,7 +107,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-bot-matrix-reminder-bot.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-bot-matrix-reminder-bot.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_bot_matrix_reminder_bot_systemd_service_result
 
 - name: Determine whether matrix-reminder-bot needs a restart

--- a/roles/custom/matrix-bot-maubot/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-maubot/tasks/setup_install.yml
@@ -13,7 +13,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0755
+    mode: '0755'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -79,7 +79,7 @@
         dest: "{{ matrix_bot_maubot_customized_docker_src_files_path }}/Dockerfile"
         owner: "{{ matrix_user_name }}"
         group: "{{ matrix_group_name }}"
-        mode: 0640
+        mode: '0640'
       register: matrix_bot_maubot_container_image_customizations_dockerfile_result
 
     - name: Ensure customized Docker image for maubot is built
@@ -96,7 +96,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"
     dest: "{{ matrix_bot_maubot_base_path }}/{{ item }}"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -114,7 +114,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-bot-maubot.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-bot-maubot.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_bot_maubot_systemd_service_result
 
 - name: Determine whether maubot needs a restart

--- a/roles/custom/matrix-bot-mjolnir/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-mjolnir/tasks/setup_install.yml
@@ -17,7 +17,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -65,7 +65,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_bot_mjolnir_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_bot_mjolnir_config_path }}/production.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_bot_mjolnir_config_result
@@ -81,7 +81,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-bot-mjolnir.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-bot-mjolnir.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_bot_mjolnir_systemd_service_result
 
 - name: Determine whether Mjolnir needs a restart

--- a/roles/custom/matrix-bridge-appservice-discord/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-appservice-discord/tasks/setup_install.yml
@@ -55,7 +55,7 @@
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -92,7 +92,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_appservice_discord_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_appservice_discord_config_path }}/config.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_appservice_discord_config_result
@@ -101,7 +101,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_appservice_discord_registration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_appservice_discord_config_path }}/registration.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_appservice_discord_registration_result
@@ -130,7 +130,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-appservice-discord.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-appservice-discord.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_appservice_discord_systemd_service_result
 
 - name: Determine whether matrix-appservice-discord needs a restart

--- a/roles/custom/matrix-bridge-appservice-irc/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-appservice-irc/tasks/setup_install.yml
@@ -22,7 +22,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -118,7 +118,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_appservice_irc_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_appservice_irc_config_path }}/config.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_appservice_irc_config_result
@@ -127,7 +127,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/labels.j2"
     dest: "{{ matrix_appservice_irc_base_path }}/labels"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_appservice_irc_labels_result
@@ -179,7 +179,7 @@
 - name: (Migration) Ensure Appservice IRC passkey permissions are okay
   ansible.builtin.file:
     path: "{{ matrix_appservice_irc_data_path }}/passkey.pem"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
 
@@ -243,7 +243,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_appservice_irc_registration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_appservice_irc_config_path }}/registration.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_appservice_irc_registration_result
@@ -259,7 +259,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-appservice-irc.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-appservice-irc.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_appservice_irc_systemd_service_result
 
 - name: Determine whether matrix-appservice-irc needs a restart

--- a/roles/custom/matrix-bridge-appservice-kakaotalk/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-appservice-kakaotalk/tasks/setup_install.yml
@@ -34,7 +34,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -83,7 +83,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_appservice_kakaotalk_node_configuration | to_nice_json }}"
     dest: "{{ matrix_appservice_kakaotalk_config_path }}/node-config.json"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
 
@@ -91,7 +91,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_appservice_kakaotalk_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_appservice_kakaotalk_config_path }}/config.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
 
@@ -99,7 +99,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_appservice_kakaotalk_registration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_appservice_kakaotalk_config_path }}/registration.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
 
@@ -114,11 +114,11 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-appservice-kakaotalk-node.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-appservice-kakaotalk-node.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_appservice_kakaotalk_node_systemd_service_result
 
 - name: Ensure matrix-appservice-kakaotalk.service installed
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-appservice-kakaotalk.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-appservice-kakaotalk.service"
-    mode: 0644
+    mode: '0644'

--- a/roles/custom/matrix-bridge-appservice-slack/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-appservice-slack/tasks/setup_install.yml
@@ -16,7 +16,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -82,7 +82,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_appservice_slack_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_appservice_slack_config_path }}/config.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_appservice_slack_config_result
@@ -91,7 +91,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_appservice_slack_registration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_appservice_slack_config_path }}/slack-registration.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_appservice_slack_registration_result
@@ -107,7 +107,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"
     dest: "{{ matrix_appservice_slack_base_path }}/{{ item }}"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -118,7 +118,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-appservice-slack.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-appservice-slack.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_appservice_slack_systemd_service_result
 
 - name: Determine whether matrix-appservice-slack needs a restart

--- a/roles/custom/matrix-bridge-beeper-linkedin/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-beeper-linkedin/tasks/setup_install.yml
@@ -15,7 +15,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -29,7 +29,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_beeper_linkedin_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_beeper_linkedin_config_path }}/config.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_beeper_linkedin_config_result
@@ -38,7 +38,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_beeper_linkedin_registration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_beeper_linkedin_config_path }}/registration.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_beeper_linkedin_registration_result
@@ -106,7 +106,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-beeper-linkedin.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-beeper-linkedin.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_beeper_linkedin_systemd_service_result
 
 - name: Determine whether matrix-beeper-linkedin needs a restart

--- a/roles/custom/matrix-bridge-heisenbridge/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-heisenbridge/tasks/setup_install.yml
@@ -25,7 +25,7 @@
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -35,7 +35,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_heisenbridge_registration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_heisenbridge_base_path }}/registration.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_heisenbridge_registration_result
@@ -44,7 +44,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"
     dest: "{{ matrix_heisenbridge_base_path }}/{{ item }}"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -62,7 +62,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-heisenbridge.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-heisenbridge.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_heisenbridge_systemd_service_result
 
 - name: Determine whether matrix-heisenbridge needs a restart

--- a/roles/custom/matrix-bridge-hookshot/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-hookshot/tasks/setup_install.yml
@@ -20,7 +20,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -80,7 +80,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_hookshot_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_hookshot_base_path }}/config.yml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_hookshot_config_result
@@ -107,7 +107,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_hookshot_registration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_hookshot_base_path }}/registration.yml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_hookshot_registration_result
@@ -116,7 +116,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_hookshot_github_private_key }}"
     dest: "{{ matrix_hookshot_base_path }}/{{ matrix_hookshot_github_private_key_file }}"
-    mode: 0400
+    mode: '0400'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   when: matrix_hookshot_github_enabled | bool and matrix_hookshot_github_private_key|length > 0
@@ -133,7 +133,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"
     dest: "{{ matrix_hookshot_base_path }}/{{ item }}"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -144,7 +144,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-hookshot.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-hookshot.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_hookshot_systemd_service_result
 
 - name: Determine whether matrix-hookshot needs a restart

--- a/roles/custom/matrix-bridge-mautrix-bluesky/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-bluesky/tasks/setup_install.yml
@@ -23,7 +23,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -59,7 +59,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_mautrix_bluesky_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_bluesky_config_path }}/config.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_mautrix_bluesky_config_result
@@ -68,7 +68,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_mautrix_bluesky_registration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_bluesky_config_path }}/registration.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_mautrix_bluesky_registration_result
@@ -77,7 +77,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"
     dest: "{{ matrix_mautrix_bluesky_base_path }}/{{ item }}"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -95,7 +95,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-mautrix-bluesky.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-mautrix-bluesky.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_mautrix_bluesky_systemd_service_result
 
 - name: Determine whether matrix-mautrix-bluesky needs a restart

--- a/roles/custom/matrix-bridge-mautrix-discord/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-discord/tasks/setup_install.yml
@@ -39,7 +39,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -88,7 +88,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_mautrix_discord_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_discord_config_path }}/config.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_mautrix_discord_config_result
@@ -97,7 +97,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_mautrix_discord_registration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_discord_config_path }}/registration.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_mautrix_discord_registration_result
@@ -106,7 +106,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"
     dest: "{{ matrix_mautrix_discord_base_path }}/{{ item }}"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -124,7 +124,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-mautrix-discord.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-mautrix-discord.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_mautrix_discord_systemd_service_result
 
 - name: Determine whether matrix-mautrix-discord needs a restart

--- a/roles/custom/matrix-bridge-mautrix-gmessages/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-gmessages/tasks/setup_install.yml
@@ -39,7 +39,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -121,7 +121,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_mautrix_gmessages_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_gmessages_config_path }}/config.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_mautrix_gmessages_config_result
@@ -130,7 +130,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_mautrix_gmessages_registration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_gmessages_config_path }}/registration.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_mautrix_gmessages_registration_result
@@ -139,14 +139,14 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-mautrix-gmessages.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-mautrix-gmessages.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_mautrix_gmessages_systemd_service_result
 
 - name: Ensure mautrix-gmessages support files installed
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"
     dest: "{{ matrix_mautrix_gmessages_base_path }}/{{ item }}"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:

--- a/roles/custom/matrix-bridge-mautrix-googlechat/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-googlechat/tasks/setup_install.yml
@@ -53,7 +53,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -111,7 +111,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_mautrix_googlechat_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_googlechat_config_path }}/config.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_mautrix_googlechat_config_result
@@ -120,7 +120,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_mautrix_googlechat_registration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_googlechat_config_path }}/registration.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_mautrix_googlechat_registration_result
@@ -129,7 +129,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"
     dest: "{{ matrix_mautrix_googlechat_base_path }}/{{ item }}"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -147,7 +147,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-mautrix-googlechat.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-mautrix-googlechat.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_mautrix_googlechat_systemd_service_result
 
 - name: Determine whether matrix-mautrix-googlechat needs a restart

--- a/roles/custom/matrix-bridge-mautrix-meta-instagram/tasks/install.yml
+++ b/roles/custom/matrix-bridge-mautrix-meta-instagram/tasks/install.yml
@@ -48,7 +48,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -85,7 +85,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_mautrix_meta_instagram_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_meta_instagram_config_path }}/config.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_mautrix_meta_instagram_config_result
@@ -94,7 +94,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_mautrix_meta_instagram_registration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_meta_instagram_config_path }}/registration.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_mautrix_meta_instagram_registration_result
@@ -103,7 +103,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"
     dest: "{{ matrix_mautrix_meta_instagram_base_path }}/{{ item }}"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -121,7 +121,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-mautrix-meta.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ matrix_mautrix_meta_instagram_identifier }}.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_mautrix_meta_instagram_systemd_service_result
 
 - name: Determine whether mautrix-meta-instagram needs a restart

--- a/roles/custom/matrix-bridge-mautrix-meta-messenger/tasks/install.yml
+++ b/roles/custom/matrix-bridge-mautrix-meta-messenger/tasks/install.yml
@@ -48,7 +48,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -85,7 +85,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_mautrix_meta_messenger_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_meta_messenger_config_path }}/config.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_mautrix_meta_messenger_config_result
@@ -94,7 +94,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_mautrix_meta_messenger_registration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_meta_messenger_config_path }}/registration.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_mautrix_meta_messenger_registration_result
@@ -103,7 +103,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"
     dest: "{{ matrix_mautrix_meta_messenger_base_path }}/{{ item }}"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -121,7 +121,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-mautrix-meta.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ matrix_mautrix_meta_messenger_identifier }}.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_mautrix_meta_messenger_systemd_service_result
 
 - name: Determine whether mautrix-meta-messenger needs a restart

--- a/roles/custom/matrix-bridge-mautrix-signal/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-signal/tasks/setup_install.yml
@@ -44,7 +44,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -126,7 +126,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_mautrix_signal_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_signal_config_path }}/config.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_mautrix_signal_config_result
@@ -135,7 +135,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_mautrix_signal_registration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_signal_config_path }}/registration.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_mautrix_signal_registration_result
@@ -144,7 +144,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"
     dest: "{{ matrix_mautrix_signal_base_path }}/{{ item }}"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -162,7 +162,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-mautrix-signal.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-mautrix-signal.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_mautrix_signal_systemd_service_result
 
 - name: Determine whether matrix-mautrix-signal needs a restart

--- a/roles/custom/matrix-bridge-mautrix-slack/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-slack/tasks/setup_install.yml
@@ -38,7 +38,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -87,7 +87,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_mautrix_slack_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_slack_config_path }}/config.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_mautrix_slack_config_result
@@ -96,7 +96,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_mautrix_slack_registration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_slack_config_path }}/registration.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_mautrix_slack_registration_result
@@ -112,7 +112,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-mautrix-slack.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-mautrix-slack.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_mautrix_slack_systemd_service_result
 
 - name: Determine whether matrix-mautrix-slack needs a restart

--- a/roles/custom/matrix-bridge-mautrix-telegram/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-telegram/tasks/setup_install.yml
@@ -48,7 +48,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -143,7 +143,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_mautrix_telegram_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_telegram_config_path }}/config.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_mautrix_telegram_config_result
@@ -152,7 +152,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_mautrix_telegram_registration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_telegram_config_path }}/registration.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_mautrix_telegram_registration_result
@@ -161,7 +161,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"
     dest: "{{ matrix_mautrix_telegram_base_path }}/{{ item }}"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -179,7 +179,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-mautrix-telegram.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-mautrix-telegram.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_mautrix_telegram_systemd_service_result
 
 - name: Determine whether matrix-mautrix-telegram needs a restart

--- a/roles/custom/matrix-bridge-mautrix-twitter/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-twitter/tasks/setup_install.yml
@@ -29,7 +29,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -65,7 +65,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_mautrix_twitter_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_twitter_config_path }}/config.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_mautrix_twitter_config_result
@@ -74,7 +74,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_mautrix_twitter_registration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_twitter_config_path }}/registration.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_mautrix_twitter_registration_result
@@ -83,7 +83,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"
     dest: "{{ matrix_mautrix_twitter_base_path }}/{{ item }}"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -101,7 +101,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-mautrix-twitter.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-mautrix-twitter.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_mautrix_twitter_systemd_service_result
 
 - name: Determine whether matrix-mautrix-twitter needs a restart

--- a/roles/custom/matrix-bridge-mautrix-whatsapp/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-whatsapp/tasks/setup_install.yml
@@ -49,7 +49,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -131,7 +131,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_mautrix_whatsapp_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_whatsapp_config_path }}/config.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_mautrix_whatsapp_config_result
@@ -140,7 +140,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_mautrix_whatsapp_registration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mautrix_whatsapp_config_path }}/registration.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_mautrix_whatsapp_registration_result
@@ -149,7 +149,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"
     dest: "{{ matrix_mautrix_whatsapp_base_path }}/{{ item }}"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -167,7 +167,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-mautrix-whatsapp.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-mautrix-whatsapp.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_mautrix_whatsapp_systemd_service_result
 
 - name: Determine whether matrix-mautrix-whatsapp needs a restart

--- a/roles/custom/matrix-bridge-mautrix-wsproxy/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-wsproxy/tasks/setup_install.yml
@@ -25,7 +25,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -37,7 +37,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"
     dest: "{{ matrix_mautrix_wsproxy_base_path }}/{{ item }}"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -65,7 +65,7 @@
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -81,7 +81,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_mautrix_wsproxy_configuration | to_nice_yaml }}"
     dest: "{{ matrix_mautrix_wsproxy_config_path }}/config.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_mautrix_wsproxy_config_result
@@ -90,7 +90,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_mautrix_androidsms_registration | to_nice_yaml }}"
     dest: "{{ matrix_mautrix_wsproxy_config_path }}/androidsms-registration.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_mautrix_wsproxy_registration_androidsms_result
@@ -99,7 +99,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_mautrix_imessage_registration | to_nice_yaml }}"
     dest: "{{ matrix_mautrix_wsproxy_config_path }}/imessage-registration.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_mautrix_wsproxy_registration_imessage_result
@@ -115,7 +115,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-mautrix-wsproxy.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-mautrix-wsproxy.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_mautrix_wsproxy_systemd_service_result
 
 - name: Determine whether Mautrix wsproxy needs a restart
@@ -146,7 +146,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-mautrix-wsproxy-syncproxy.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-mautrix-wsproxy-syncproxy.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_mautrix_wsproxy_syncproxy_systemd_service_result
 
 - name: Determine whether Mautrix wsproxy syncproxy needs a restart

--- a/roles/custom/matrix-bridge-mx-puppet-groupme/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-groupme/tasks/setup_install.yml
@@ -14,7 +14,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -111,7 +111,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_mx_puppet_groupme_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mx_puppet_groupme_config_path }}/config.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_mx_puppet_groupme_config_result
@@ -120,7 +120,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_mx_puppet_groupme_registration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mx_puppet_groupme_config_path }}/registration.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_mx_puppet_groupme_registration_result
@@ -136,7 +136,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-mx-puppet-groupme.service.j2"
     dest: "/etc/systemd/system/matrix-mx-puppet-groupme.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_mx_puppet_groupme_systemd_service_result
 
 - name: Determine whether matrix-mx-puppet-groupme needs a restart

--- a/roles/custom/matrix-bridge-mx-puppet-steam/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-steam/tasks/setup_install.yml
@@ -16,7 +16,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -113,7 +113,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_mx_puppet_steam_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mx_puppet_steam_config_path }}/config.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_mx_puppet_steam_config_result
@@ -122,7 +122,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_mx_puppet_steam_registration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_mx_puppet_steam_config_path }}/registration.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_mx_puppet_steam_registration_result
@@ -138,7 +138,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-mx-puppet-steam.service.j2"
     dest: "/etc/systemd/system/matrix-mx-puppet-steam.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_mx_puppet_steam_systemd_service_result
 
 - name: Determine whether matrix-mx-puppet-steam needs a restart

--- a/roles/custom/matrix-bridge-postmoogle/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-postmoogle/tasks/setup_install.yml
@@ -60,7 +60,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -75,7 +75,7 @@
     dest: "{{ matrix_postmoogle_config_path }}/env"
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
-    mode: 0640
+    mode: '0640'
   register: matrix_postmoogle_env_result
 
 - name: Ensure postmoogle image is pulled
@@ -124,7 +124,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-postmoogle.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-postmoogle.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_postmoogle_systemd_service_result
 
 - name: Determine whether matrix-postmoogle needs a restart

--- a/roles/custom/matrix-bridge-sms/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-sms/tasks/setup_install.yml
@@ -23,7 +23,7 @@
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -35,7 +35,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_sms_bridge_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_sms_bridge_config_path }}/application.yml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_sms_bridge_config_result
@@ -44,7 +44,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_sms_bridge_registration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_sms_bridge_config_path }}/registration.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_sms_bridge_registration_result
@@ -53,7 +53,7 @@
   ansible.builtin.copy:
     src: "{{ matrix_sms_bridge_provider_android_truststore_local_path }}"
     dest: "{{ matrix_sms_bridge_config_path }}/matrix-sms-gateway-server.p12"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   when: matrix_sms_bridge_provider_android_truststore_local_path != ""
@@ -70,7 +70,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-sms-bridge.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-sms-bridge.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_sms_bridge_systemd_service_result
 
 - name: Determine whether matrix-sms-bridge needs a restart

--- a/roles/custom/matrix-bridge-steam/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-steam/tasks/setup_install.yml
@@ -23,7 +23,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -59,7 +59,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_steam_bridge_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_steam_bridge_config_path }}/config.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_steam_bridge_config_result
@@ -68,7 +68,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_steam_bridge_registration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_steam_bridge_config_path }}/registration.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_steam_bridge_registration_result
@@ -77,7 +77,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"
     dest: "{{ matrix_steam_bridge_base_path }}/{{ item }}"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -95,7 +95,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-steam-bridge.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-steam-bridge.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_steam_bridge_systemd_service_result
 
 - name: Determine whether matrix-steam-bridge needs a restart

--- a/roles/custom/matrix-bridge-wechat/tasks/install.yml
+++ b/roles/custom/matrix-bridge-wechat/tasks/install.yml
@@ -9,7 +9,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -94,7 +94,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_wechat_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_wechat_config_path }}/config.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
 
@@ -102,7 +102,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_wechat_registration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_wechat_config_path }}/registration.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
 
@@ -110,7 +110,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_wechat_agent_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_wechat_config_path }}/agent-config.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
 
@@ -125,12 +125,12 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-wechat.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-wechat.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_wechat_systemd_service_result
 
 - name: Ensure matrix-wechat-agent.service installed
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-wechat-agent.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-wechat-agent.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_wechat_agent_systemd_service_result

--- a/roles/custom/matrix-cactus-comments-client/tasks/install.yml
+++ b/roles/custom/matrix-cactus-comments-client/tasks/install.yml
@@ -9,7 +9,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -23,7 +23,7 @@
     dest: "{{ item.dest }}"
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
-    mode: 0644
+    mode: '0644'
   with_items:
     - src: "{{ role_path }}/templates/env.j2"
       dest: "{{ matrix_cactus_comments_client_base_path }}/env"
@@ -88,7 +88,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-cactus-comments-client.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-cactus-comments-client.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_cactus_comments_client_systemd_service_result
 
 - name: Determine whether matrix-cactus-comments-client needs a restart

--- a/roles/custom/matrix-cactus-comments/tasks/setup_install.yml
+++ b/roles/custom/matrix-cactus-comments/tasks/setup_install.yml
@@ -10,7 +10,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -25,7 +25,7 @@
     dest: "{{ matrix_cactus_comments_app_service_env_file }}"
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
-    mode: 0640
+    mode: '0640'
   register: matrix_cactus_comments_config_env_result
 
 - name: Ensure matrix-cactus-comments appservice file created
@@ -34,7 +34,7 @@
     dest: "{{ matrix_cactus_comments_app_service_config_file }}"
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
-    mode: 0640
+    mode: '0640'
   register: matrix_cactus_comments_config_appservice_result
 
 - name: Ensure matrix-cactus-comments image is pulled
@@ -76,7 +76,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-cactus-comments.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-cactus-comments.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_cactus_comments_systemd_service_result
 
 - name: Determine whether matrix-cactus-comments needs a restart

--- a/roles/custom/matrix-client-element/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-element/tasks/setup_install.yml
@@ -15,7 +15,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -74,7 +74,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_client_element_configuration | to_nice_json }}"
     dest: "{{ matrix_client_element_data_path }}/config.json"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_client_element_config_result
@@ -84,7 +84,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_client_element_location_sharing_map_style | to_nice_json }}"
     dest: "{{ matrix_client_element_data_path }}/map_style.json"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_client_element_config_map_style_result
@@ -93,7 +93,7 @@
   ansible.builtin.template:
     src: "{{ item.src }}"
     dest: "{{ matrix_client_element_data_path }}/{{ item.name }}"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -128,7 +128,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-client-element.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-client-element.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_client_element_systemd_service_result
 
 - name: Determine whether Element Web needs a restart

--- a/roles/custom/matrix-client-fluffychat/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-fluffychat/tasks/setup_install.yml
@@ -8,7 +8,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -54,7 +54,7 @@
   ansible.builtin.template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -74,7 +74,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-client-fluffychat.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-client-fluffychat.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_client_fluffychat_systemd_service_result
 
 - name: Determine whether FluffyChat Web needs a restart

--- a/roles/custom/matrix-client-schildichat/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-schildichat/tasks/setup_install.yml
@@ -12,7 +12,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -71,7 +71,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_client_schildichat_configuration | to_nice_json }}"
     dest: "{{ matrix_client_schildichat_data_path }}/config.json"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_client_schildichat_config_result
@@ -81,7 +81,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_client_schildichat_location_sharing_map_style | to_nice_json }}"
     dest: "{{ matrix_client_schildichat_data_path }}/map_style.json"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_client_schildichat_config_map_style_result
@@ -90,7 +90,7 @@
   ansible.builtin.template:
     src: "{{ item.src }}"
     dest: "{{ matrix_client_schildichat_data_path }}/{{ item.name }}"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -119,7 +119,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-client-schildichat.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-client-schildichat.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_client_schildichat_systemd_service_result
 
 - name: Determine whether SchildiChat Web needs a restart

--- a/roles/custom/matrix-conduit/tasks/setup_install.yml
+++ b/roles/custom/matrix-conduit/tasks/setup_install.yml
@@ -12,7 +12,7 @@
   ansible.builtin.file:
     path: "{{ matrix_conduit_config_path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
 
@@ -20,7 +20,7 @@
   ansible.builtin.file:
     path: "{{ matrix_conduit_data_path }}"
     state: directory
-    mode: 0770
+    mode: '0770'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
 
@@ -28,7 +28,7 @@
   ansible.builtin.template:
     src: "{{ matrix_conduit_template_conduit_config }}"
     dest: "{{ matrix_conduit_config_path }}/conduit.toml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
 
@@ -36,7 +36,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"
     dest: "{{ matrix_conduit_base_path }}/{{ item }}"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -64,4 +64,4 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-conduit.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-conduit.service"
-    mode: 0644
+    mode: '0644'

--- a/roles/custom/matrix-continuwuity/tasks/install.yml
+++ b/roles/custom/matrix-continuwuity/tasks/install.yml
@@ -8,7 +8,7 @@
   ansible.builtin.file:
     path: "{{ matrix_continuwuity_config_path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
 
@@ -16,7 +16,7 @@
   ansible.builtin.file:
     path: "{{ matrix_continuwuity_data_path }}"
     state: directory
-    mode: 0770
+    mode: '0770'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
 
@@ -24,7 +24,7 @@
   ansible.builtin.template:
     src: "{{ matrix_continuwuity_template_continuwuity_config }}"
     dest: "{{ matrix_continuwuity_config_path }}/continuwuity.toml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
 
@@ -32,7 +32,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"
     dest: "{{ matrix_continuwuity_base_path }}/{{ item }}"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -61,4 +61,4 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-continuwuity.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-continuwuity.service"
-    mode: 0644
+    mode: '0644'

--- a/roles/custom/matrix-continuwuity/tasks/setup_install.yml
+++ b/roles/custom/matrix-continuwuity/tasks/setup_install.yml
@@ -8,7 +8,7 @@
   ansible.builtin.file:
     path: "{{ matrix_continuwuity_config_path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
 
@@ -16,7 +16,7 @@
   ansible.builtin.file:
     path: "{{ matrix_continuwuity_data_path }}"
     state: directory
-    mode: 0770
+    mode: '0770'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
 
@@ -24,7 +24,7 @@
   ansible.builtin.template:
     src: "{{ matrix_continuwuity_template_continuwuity_config }}"
     dest: "{{ matrix_continuwuity_config_path }}/continuwuity.toml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
 
@@ -32,7 +32,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"
     dest: "{{ matrix_continuwuity_base_path }}/{{ item }}"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -60,4 +60,4 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-continuwuity.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-continuwuity.service"
-    mode: 0644
+    mode: '0644'

--- a/roles/custom/matrix-corporal/tasks/setup_install.yml
+++ b/roles/custom/matrix-corporal/tasks/setup_install.yml
@@ -15,7 +15,7 @@
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -63,7 +63,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_corporal_configuration | to_nice_json }}"
     dest: "{{ matrix_corporal_config_dir_path }}/config.json"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_corporal_config_result
@@ -72,7 +72,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"
     dest: "{{ matrix_corporal_base_path }}/{{ item }}"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -90,7 +90,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-corporal.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-corporal.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_corporal_systemd_service_result
 
 - name: Determine whether matrix-corporal needs a restart

--- a/roles/custom/matrix-dendrite/tasks/setup_install.yml
+++ b/roles/custom/matrix-dendrite/tasks/setup_install.yml
@@ -14,7 +14,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -43,7 +43,7 @@
   ansible.builtin.file:
     path: "{{ matrix_dendrite_media_store_path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   when: "not local_path_media_store_stat.failed and not local_path_media_store_stat.stat.exists"
@@ -78,7 +78,7 @@
 - name: Ensure Dendrite server key exists
   ansible.builtin.file:
     path: "{{ matrix_dendrite_config_dir_path }}/{{ matrix_server_fqn_matrix }}.signing.pem"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
 
@@ -86,7 +86,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_dendrite_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_dendrite_config_dir_path }}/dendrite.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
 

--- a/roles/custom/matrix-element-admin/tasks/install.yml
+++ b/roles/custom/matrix-element-admin/tasks/install.yml
@@ -9,7 +9,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -23,7 +23,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"
     dest: "{{ matrix_element_admin_base_path }}/{{ item }}"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -75,7 +75,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-element-admin.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-element-admin.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_element_admin_systemd_service_result
 
 - name: Determine whether Element Admin needs a restart

--- a/roles/custom/matrix-element-call/tasks/install.yml
+++ b/roles/custom/matrix-element-call/tasks/install.yml
@@ -10,7 +10,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -20,7 +20,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/config.json.j2"
     dest: "{{ matrix_element_call_base_path }}/config.json"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
 
@@ -28,7 +28,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/labels.j2"
     dest: "{{ matrix_element_call_base_path }}/labels"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
 
@@ -53,4 +53,4 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-element-call.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-element-call.service"
-    mode: 0644
+    mode: '0644'

--- a/roles/custom/matrix-ldap-registration-proxy/tasks/setup_install.yml
+++ b/roles/custom/matrix-ldap-registration-proxy/tasks/setup_install.yml
@@ -12,7 +12,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -45,7 +45,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/ldap-registration-proxy.env.j2"
     dest: "{{ matrix_ldap_registration_proxy_config_path }}/ldap-registration-proxy.env"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_ldap_registration_proxy_config_result
@@ -54,7 +54,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"
     dest: "{{ matrix_ldap_registration_proxy_base_path }}/{{ item }}"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -72,7 +72,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-ldap-registration-proxy.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-ldap-registration-proxy.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_ldap_registration_proxy_systemd_service_result
 
 - name: Determine whether matrix-ldap-registration-proxy needs a restart

--- a/roles/custom/matrix-livekit-jwt-service/tasks/install.yml
+++ b/roles/custom/matrix-livekit-jwt-service/tasks/install.yml
@@ -10,7 +10,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -20,7 +20,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"
     dest: "{{ matrix_livekit_jwt_service_base_path }}/{{ item }}"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -74,7 +74,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-livekit-jwt-service.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-livekit-jwt-service.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_livekit_jwt_service_systemd_service_result
 
 - name: Determine whether LiveKit JWT Service needs a restart

--- a/roles/custom/matrix-media-repo/tasks/setup_install.yml
+++ b/roles/custom/matrix-media-repo/tasks/setup_install.yml
@@ -11,7 +11,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -29,7 +29,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/media-repo/{{ item }}.j2"
     dest: "{{ matrix_media_repo_base_path }}/{{ item }}"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -40,7 +40,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/media-repo/media-repo.yaml.j2"
     dest: "{{ matrix_media_repo_config_path }}/media-repo.yaml"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
 
@@ -127,7 +127,7 @@
         remote_src: true
         src: "{{ matrix_media_repo_homeserver_signing_key }}"
         dest: "{{ matrix_media_repo_homeserver_signing_key }}.{{ matrix_homeserver_implementation }}.backup"
-        mode: 0644
+        mode: '0644'
         owner: "{{ matrix_user_name }}"
         group: "{{ matrix_group_name }}"
 
@@ -152,4 +152,4 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/media-repo/systemd/matrix-media-repo.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ matrix_media_repo_identifier }}.service"
-    mode: 0640
+    mode: '0640'

--- a/roles/custom/matrix-pantalaimon/tasks/install.yml
+++ b/roles/custom/matrix-pantalaimon/tasks/install.yml
@@ -9,7 +9,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -22,7 +22,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_pantalaimon_configuration }}"
     dest: "{{ matrix_pantalaimon_data_path }}/pantalaimon.conf"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_pantalaimon_config_result
@@ -72,7 +72,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-pantalaimon.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-pantalaimon.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_pantalaimon_systemd_service_result
 
 - name: Determine whether Pantalaimon needs a restart

--- a/roles/custom/matrix-prometheus-nginxlog-exporter/tasks/setup_install.yml
+++ b/roles/custom/matrix-prometheus-nginxlog-exporter/tasks/setup_install.yml
@@ -21,7 +21,7 @@
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -32,7 +32,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/prometheus-nginxlog-exporter.yaml.j2"
     dest: "{{ matrix_prometheus_nginxlog_exporter_config_path }}/prometheus-nginxlog-exporter.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_prometheus_nginxlog_exporter_config_result
@@ -41,7 +41,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"
     dest: "{{ matrix_prometheus_nginxlog_exporter_base_path }}/{{ item }}"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -59,7 +59,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-prometheus-nginxlog-exporter.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-prometheus-nginxlog-exporter.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_prometheus_nginxlog_exporter_systemd_service_result
 
 - name: Determine whether matrix-prometheus-nginxlog-exporter needs a restart

--- a/roles/custom/matrix-prometheus-services-connect/tasks/install_synapse_rules.yml
+++ b/roles/custom/matrix-prometheus-services-connect/tasks/install_synapse_rules.yml
@@ -9,7 +9,7 @@
     url: "{{ matrix_prometheus_services_connect_synapse_rules_download_src_url }}"
     dest: "{{ matrix_prometheus_services_connect_synapse_rules_download_dir_path }}/synapse-v2.rules"
     force: true
-    mode: 0440
+    mode: '0440'
     owner: "{{ matrix_prometheus_services_connect_synapse_rules_download_owner }}"
     group: "{{ matrix_prometheus_services_connect_synapse_rules_download_group }}"
   register: result

--- a/roles/custom/matrix-rageshake/tasks/install.yml
+++ b/roles/custom/matrix-rageshake/tasks/install.yml
@@ -11,7 +11,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -29,14 +29,14 @@
     dest: "{{ matrix_rageshake_config_path }}/config.yaml"
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
-    mode: 0640
+    mode: '0640'
   register: matrix_rageshake_config_result
 
 - name: Ensure rageshake labels installed
   ansible.builtin.template:
     src: "{{ role_path }}/templates/labels.j2"
     dest: "{{ matrix_rageshake_base_path }}/labels"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_rageshake_support_files_result
@@ -85,7 +85,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-rageshake.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-rageshake.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_rageshake_systemd_service_result
 
 - name: Determine whether Rageshake needs a restart

--- a/roles/custom/matrix-registration/tasks/setup_install.yml
+++ b/roles/custom/matrix-registration/tasks/setup_install.yml
@@ -46,7 +46,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -103,7 +103,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_registration_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_registration_config_path }}/config.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_registration_config_result
@@ -112,7 +112,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"
     dest: "{{ matrix_registration_base_path }}/{{ item }}"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -130,7 +130,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-registration.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-registration.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_registration_systemd_service_result
 
 - name: Determine whether matrix-registration needs a restart

--- a/roles/custom/matrix-static-files/tasks/install.yml
+++ b/roles/custom/matrix-static-files/tasks/install.yml
@@ -9,7 +9,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -32,7 +32,7 @@
     dest: "{{ item.dest }}"
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
-    mode: 0644
+    mode: '0644'
   with_items:
     - src: "{{ role_path }}/templates/config.toml.j2"
       dest: "{{ matrix_static_files_config_path }}/config.toml"
@@ -48,7 +48,7 @@
   ansible.builtin.copy:
     content: "{{ item.content }}"
     dest: "{{ item.dest }}"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   when: item.when | bool
@@ -106,7 +106,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-static-files.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ matrix_static_files_identifier }}.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_static_files_systemd_service_result
 
 - name: Determine whether matrix-static-files needs a restart

--- a/roles/custom/matrix-sygnal/tasks/install.yml
+++ b/roles/custom/matrix-sygnal/tasks/install.yml
@@ -13,7 +13,7 @@
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -25,7 +25,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_sygnal_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_sygnal_config_path }}/sygnal.yaml"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_sygnal_config_result
@@ -34,7 +34,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/labels.j2"
     dest: "{{ matrix_sygnal_base_path }}/labels"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_sygnal_support_files_result
@@ -61,7 +61,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-sygnal.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-sygnal.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_sygnal_systemd_service_result
 
 - name: Determine whether Sygnal needs a restart

--- a/roles/custom/matrix-synapse-admin/tasks/setup_install.yml
+++ b/roles/custom/matrix-synapse-admin/tasks/setup_install.yml
@@ -15,7 +15,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -30,14 +30,14 @@
     dest: "{{ matrix_synapse_admin_base_path }}/labels"
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
-    mode: 0640
+    mode: '0640'
   register: matrix_synapse_admin_support_files_result
 
 - name: Ensure matrix-synapse-admin configuration installed
   ansible.builtin.copy:
     content: "{{ matrix_synapse_admin_configuration | to_nice_json }}"
     dest: "{{ matrix_synapse_admin_config_path }}/config.json"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_synapse_admin_config_result
@@ -88,7 +88,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-synapse-admin.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-synapse-admin.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_synapse_admin_systemd_service_result
 
 - name: Determine whether Synapse Admin needs a restart

--- a/roles/custom/matrix-synapse-auto-compressor/tasks/install.yml
+++ b/roles/custom/matrix-synapse-auto-compressor/tasks/install.yml
@@ -10,7 +10,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   when: item.when | bool
@@ -24,7 +24,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/env.j2"
     dest: "{{ matrix_synapse_auto_compressor_base_path }}/env"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_synapse_auto_compressor_config_env_result
@@ -33,7 +33,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/matrix-synapse-auto-compressor-fix.sh.j2"
     dest: "{{ matrix_synapse_auto_compressor_base_path }}/matrix-synapse-auto-compressor-fix.sh"
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_synapse_auto_compressor_config_script_result
@@ -95,7 +95,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/matrix-synapse-auto-compressor.{{ item }}.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-synapse-auto-compressor.{{ item }}"
-    mode: 0644
+    mode: '0644'
   with_items:
     - service
     - timer

--- a/roles/custom/matrix-synapse-reverse-proxy-companion/tasks/setup_install.yml
+++ b/roles/custom/matrix-synapse-reverse-proxy-companion/tasks/setup_install.yml
@@ -9,7 +9,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -24,7 +24,7 @@
     dest: "{{ item.dest }}"
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
-    mode: 0644
+    mode: '0644'
   with_items:
     - src: "{{ role_path }}/templates/nginx/nginx.conf.j2"
       dest: "{{ matrix_synapse_reverse_proxy_companion_base_path }}/nginx.conf"
@@ -42,7 +42,7 @@
     dest: "{{ matrix_synapse_reverse_proxy_companion_njs_path }}/whoami_sync_worker_router.js"
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
-    mode: 0644
+    mode: '0644'
   when: matrix_synapse_reverse_proxy_companion_whoami_sync_worker_router_enabled | bool
 
 - name: Ensure matrix-synapse-reverse-proxy-companion njs path is removed when njs is disabled
@@ -73,7 +73,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-synapse-reverse-proxy-companion.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-synapse-reverse-proxy-companion.service"
-    mode: 0644
+    mode: '0644'
   register: matrix_synapse_reverse_proxy_companion_systemd_service_result
 
 - name: Determine whether Synapse reverse-proxy companion needs a restart

--- a/roles/custom/matrix-synapse-usage-exporter/tasks/setup_install.yml
+++ b/roles/custom/matrix-synapse-usage-exporter/tasks/setup_install.yml
@@ -9,7 +9,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -23,7 +23,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"
     dest: "{{ matrix_synapse_usage_exporter_base_path }}/{{ item }}"
-    mode: 0640
+    mode: '0640'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -81,7 +81,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-synapse-usage-exporter.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ matrix_synapse_usage_exporter_identifier }}.service"
-    mode: 0640
+    mode: '0640'
   register: matrix_synapse_usage_exporter_systemd_service_result
 
 - name: Determine whether synapse-usage-exporter needs a restart

--- a/roles/custom/matrix-synapse/tasks/ext/encryption-disabler/setup_install.yml
+++ b/roles/custom/matrix-synapse/tasks/ext/encryption-disabler/setup_install.yml
@@ -10,7 +10,7 @@
     url: "{{ matrix_synapse_ext_encryption_disabler_download_url }}"
     dest: "{{ matrix_synapse_ext_path }}/matrix_e2ee_filter.py"
     force: true
-    mode: 0440
+    mode: '0440'
     owner: "{{ matrix_synapse_uid }}"
     group: "{{ matrix_synapse_gid }}"
   register: result

--- a/roles/custom/matrix-synapse/tasks/ext/rest-auth/setup_install.yml
+++ b/roles/custom/matrix-synapse/tasks/ext/rest-auth/setup_install.yml
@@ -17,7 +17,7 @@
     url: "{{ matrix_synapse_ext_password_provider_rest_auth_download_url }}"
     dest: "{{ matrix_synapse_ext_path }}/rest_auth_provider.py"
     force: true
-    mode: 0440
+    mode: '0440'
     owner: "{{ matrix_synapse_uid }}"
     group: "{{ matrix_synapse_gid }}"
   register: result

--- a/roles/custom/matrix-synapse/tasks/ext/s3-storage-provider/setup_install.yml
+++ b/roles/custom/matrix-synapse/tasks/ext/s3-storage-provider/setup_install.yml
@@ -15,7 +15,7 @@
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_synapse_uid }}"
     group: "{{ matrix_synapse_gid }}"
   with_items:
@@ -26,19 +26,19 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/synapse/ext/s3-storage-provider/env.j2"
     dest: "{{ matrix_synapse_ext_s3_storage_provider_base_path }}/env"
-    mode: 0640
+    mode: '0640'
 
 - name: Ensure s3-storage-provider database.yaml file installed
   ansible.builtin.template:
     src: "{{ role_path }}/templates/synapse/ext/s3-storage-provider/database.yaml.j2"
     dest: "{{ matrix_synapse_ext_s3_storage_provider_data_path }}/database.yaml"
-    mode: 0640
+    mode: '0640'
 
 - name: Ensure s3-storage-provider scripts installed
   ansible.builtin.template:
     src: "{{ role_path }}/templates/synapse/ext/s3-storage-provider/bin/{{ item }}.j2"
     dest: "{{ matrix_synapse_ext_s3_storage_provider_bin_path }}/{{ item }}"
-    mode: 0750
+    mode: '0750'
   with_items:
     - shell
     - migrate
@@ -47,7 +47,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/synapse/ext/s3-storage-provider/systemd/{{ item }}.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ item }}"
-    mode: 0644
+    mode: '0644'
   with_items:
     - matrix-synapse-s3-storage-provider-migrate.service
     - matrix-synapse-s3-storage-provider-migrate.timer

--- a/roles/custom/matrix-synapse/tasks/ext/shared-secret-auth/setup_install.yml
+++ b/roles/custom/matrix-synapse/tasks/ext/shared-secret-auth/setup_install.yml
@@ -22,7 +22,7 @@
     url: "{{ matrix_synapse_ext_password_provider_shared_secret_auth_download_url }}"
     dest: "{{ matrix_synapse_ext_path }}/shared_secret_authenticator.py"
     force: true
-    mode: 0440
+    mode: '0440'
     owner: "{{ matrix_synapse_uid }}"
     group: "{{ matrix_synapse_gid }}"
   register: result

--- a/roles/custom/matrix-synapse/tasks/goofys/setup_install.yml
+++ b/roles/custom/matrix-synapse/tasks/goofys/setup_install.yml
@@ -36,7 +36,7 @@
   ansible.builtin.file:
     path: "{{ matrix_s3_media_store_path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_synapse_uid }}"
     group: "{{ matrix_synapse_gid }}"
   when: "not local_path_matrix_s3_media_store_path_stat.failed and not local_path_matrix_s3_media_store_path_stat.stat.exists"
@@ -46,10 +46,10 @@
     src: "{{ role_path }}/templates/goofys/env-goofys.j2"
     dest: "{{ matrix_synapse_config_dir_path }}/env-goofys"
     owner: root
-    mode: 0600
+    mode: '0600'
 
 - name: Ensure matrix-goofys.service installed
   ansible.builtin.template:
     src: "{{ role_path }}/templates/goofys/systemd/matrix-goofys.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-goofys.service"
-    mode: 0644
+    mode: '0644'

--- a/roles/custom/matrix-synapse/tasks/rust-synapse-compress-state/main.yml
+++ b/roles/custom/matrix-synapse/tasks/rust-synapse-compress-state/main.yml
@@ -46,7 +46,7 @@
   ansible.builtin.file:
     path: "{{ matrix_synapse_rust_synapse_compress_state_base_path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_synapse_uid }}"
     group: "{{ matrix_synapse_gid }}"
 

--- a/roles/custom/matrix-synapse/tasks/setup_install.yml
+++ b/roles/custom/matrix-synapse/tasks/setup_install.yml
@@ -15,7 +15,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_synapse_uid }}"
     group: "{{ matrix_synapse_gid }}"
   with_items:

--- a/roles/custom/matrix-synapse/tasks/synapse/setup_install.yml
+++ b/roles/custom/matrix-synapse/tasks/synapse/setup_install.yml
@@ -28,7 +28,7 @@
   ansible.builtin.file:
     path: "{{ matrix_synapse_media_store_path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_synapse_uid }}"
     group: "{{ matrix_synapse_gid }}"
   when: "not local_path_media_store_stat.failed and not local_path_media_store_stat.stat.exists"
@@ -86,7 +86,7 @@
         dest: "{{ matrix_synapse_customized_docker_src_files_path }}/Dockerfile"
         owner: "{{ matrix_synapse_uid }}"
         group: "{{ matrix_synapse_gid }}"
-        mode: 0640
+        mode: '0640'
       register: matrix_synapse_container_image_customizations_dockerfile_result
 
     - name: Ensure customized Docker image for Synapse is built
@@ -126,7 +126,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_synapse_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_synapse_config_dir_path }}/homeserver.yaml"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_synapse_uid }}"
     group: "{{ matrix_synapse_gid }}"
 
@@ -162,5 +162,5 @@
     dest: "{{ matrix_synapse_base_path }}/external_prometheus.yml.example"
     owner: "{{ matrix_synapse_uid }}"
     group: "{{ matrix_synapse_gid }}"
-    mode: 0644
+    mode: '0644'
   when: matrix_synapse_metrics_proxying_enabled | bool

--- a/roles/custom/matrix-synapse/tasks/synapse/workers/util/setup_files_for_worker.yml
+++ b/roles/custom/matrix-synapse/tasks/synapse/workers/util/setup_files_for_worker.yml
@@ -17,7 +17,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/synapse/worker.yaml.j2"
     dest: "{{ matrix_synapse_config_dir_path }}/{{ matrix_synapse_worker_config_file_name }}"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_synapse_uid }}"
     group: "{{ matrix_synapse_gid }}"
 
@@ -25,7 +25,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/synapse/worker-labels.j2"
     dest: "{{ matrix_synapse_base_path }}/{{ matrix_synapse_worker_labels_file_name }}"
-    mode: 0644
+    mode: '0644'
     owner: "{{ matrix_synapse_uid }}"
     group: "{{ matrix_synapse_gid }}"
 
@@ -33,4 +33,4 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/synapse/systemd/matrix-synapse-worker.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ matrix_synapse_worker_systemd_service_name }}.service"
-    mode: 0644
+    mode: '0644'

--- a/roles/custom/matrix-user-verification-service/tasks/setup_install.yml
+++ b/roles/custom/matrix-user-verification-service/tasks/setup_install.yml
@@ -10,7 +10,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: '0750'
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -59,7 +59,7 @@
     dest: "{{ matrix_user_verification_service_config_env_file }}"
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
-    mode: 0644
+    mode: '0644'
   register: matrix_user_verification_service_config_result
 
 - name: Ensure matrix-user-verification-service container network is created
@@ -73,7 +73,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-user-verification-service.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ matrix_user_verification_service_systemd_service_name }}"
-    mode: 0644
+    mode: '0644'
   register: matrix_user_verification_service_systemd_service_result
 
 - name: Determine whether Matrix User Verification Service needs a restart


### PR DESCRIPTION
Quotes YAML file mode values (e.g. 0644 -> '0644') across role task files to satisfy yaml[octal-values] without changing runtime behavior.