### PR TITLE
Upgrade Valkey (v9.0.2-0 → v9.0.2-1)

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -769,7 +769,7 @@ devture_systemd_service_manager_services_list_auto: |
     ([{
       'name': (valkey_identifier + '.service'),
       'priority': 750,
-      'restart_necessary': true,
+      'restart_necessary': (valkey_restart_necessary | bool),
       'groups': ['matrix', 'valkey'],
     }] if valkey_enabled else [])
     +

--- a/requirements.yml
+++ b/requirements.yml
@@ -90,5 +90,5 @@
   version: v2.10.0-5
   name: traefik_certs_dumper
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-valkey.git
-  version: v9.0.2-0
+  version: v9.0.2-1
   name: valkey


### PR DESCRIPTION
I have confirmed it worked on MASH playbook; double-check in case of me having missed something would be appreciated!

https://github.com/mother-of-all-self-hosting/ansible-role-valkey/blob/e43635549663182b9fd0981dc1a0a4da66680967/tasks/install.yml#L118