### PR TITLE
Add agru to flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,15 +1,31 @@
 {
   "nodes": {
+    "agru-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772059918,
+        "narHash": "sha256-o3ZNyJjDEY2RCwIiBWSjWTo6/DqAVMK+ElTuwAVdZrg=",
+        "owner": "etkecc",
+        "repo": "agru",
+        "rev": "31a799242c4546ad1f9dbac79abcfafc79daba64",
+        "type": "github"
+      },
+      "original": {
+        "owner": "etkecc",
+        "repo": "agru",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,21 +36,23 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712578459,
-        "narHash": "sha256-r+rjtYIdwV7mEqFwbvaS7dZSH+3xNW9loR3Rh9C0ifI=",
+        "lastModified": 1771923393,
+        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b1a486be09c354e25a18689eb21425e43892e38c",
+        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
+        "agru-src": "agru-src",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,30 +1,44 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    agru-src = {
+      url = "github:etkecc/agru";
+      flake = false;
+    };
   };
-  outputs = {
-    self,
-    nixpkgs,
-    flake-utils,
-  }:
-    flake-utils.lib.eachDefaultSystem
-    (
-      system: let
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      agru-src,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
         pkgs = import nixpkgs {
           inherit system;
         };
+        agru = pkgs.buildGo125Module {
+          pname = "agru";
+          version = "0.1.19";
+          src = agru-src;
+          vendorHash = null;
+        };
       in
-        with pkgs; {
-          devShells.default = mkShell {
-            buildInputs = [
-              just
-              ansible
-            ];
-            shellHook = ''
-              echo "$(ansible --version)"
-            '';
-          };
-        }
+      with pkgs;
+      {
+        devShells.default = mkShell {
+          buildInputs = [
+            just
+            ansible
+            agru
+          ];
+          shellHook = ''
+            echo "$(ansible --version)"
+          '';
+        };
+      }
     );
 }


### PR DESCRIPTION
The [nixpgks pr for agru](https://github.com/NixOS/nixpkgs/pull/492883) is still simmering so I figured I'd add it here directly in the meantime. That means that it'll download and compile agru on first run of `nix develop`. It doesn't take that long though, so I'd judge it worth it. 

This pr also updates the nix dependencies. The existing version of ansible fails when determining the existing postgres docker version. I think it's using an old docker api or something.