### PR TITLE
feat(synapse s3 storage): prune empty dir when migrate to s3 storage

### DIFF
--- a/docs/configuring-playbook-synapse-s3-storage-provider.md
+++ b/docs/configuring-playbook-synapse-s3-storage-provider.md
@@ -177,6 +177,8 @@ By default, we periodically ensure that all local files are uploaded to S3 and a
 - … invoked via the `matrix-synapse-s3-storage-provider-migrate.service` service
 - … triggered by the `matrix-synapse-s3-storage-provider-migrate.timer` timer, every day at 05:00
 
+The same `migrate` script also prunes empty directories in the local media repository (`remote_content` and `remote_thumbnail`) after upload/delete operations.
+
 So… you don't need to perform any maintenance yourself.
 
 The schedule is defined in the format of systemd timer calendar. To edit the schedule, add the following configuration to your `vars.yml` file (adapt to your needs):

--- a/roles/custom/matrix-synapse/templates/synapse/ext/s3-storage-provider/bin/migrate.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/ext/s3-storage-provider/bin/migrate.j2
@@ -24,3 +24,8 @@ container_id=$(\
 {% endfor %}
 
 {{ devture_systemd_docker_base_host_command_docker }} start --attach $container_id
+
+for prune_dir in "{{ matrix_synapse_storage_path }}/{{ matrix_synapse_media_store_directory_name }}/remote_content" "{{ matrix_synapse_storage_path }}/{{ matrix_synapse_media_store_directory_name }}/remote_thumbnail"; do
+	[ -d "$prune_dir" ] || continue
+	find "$prune_dir" -depth -mindepth 1 -type d -empty -print -delete
+done


### PR DESCRIPTION
currently only files are dropped locally leading to tons of empty folders