### PR TITLE
fix: conditionally include m.identity_server in Element Web config.json

### DIFF
--- a/roles/custom/matrix-client-element/templates/config.json.j2
+++ b/roles/custom/matrix-client-element/templates/config.json.j2
@@ -3,10 +3,12 @@
 		"m.homeserver": {
 			"base_url": {{ matrix_client_element_default_hs_url | string | to_json }},
 			"server_name": {{ matrix_client_element_default_server_name | string | to_json }}
-		},
+		}
+		{% if matrix_client_element_default_is_url %},
 		"m.identity_server": {
 			"base_url": {{ matrix_client_element_default_is_url | string | to_json }}
 		}
+		{% endif %}
 	},
 	"setting_defaults": {
 		"custom_themes": {{ matrix_client_element_setting_defaults_custom_themes | to_json }}


### PR DESCRIPTION
## Summary

When no identity server is configured, `matrix_client_element_default_is_url` defaults to `~` (YAML null). The `| string | to_json` filter chain converts this to the literal string `"None"`, causing Element Web to log console errors on every page load:

- `TypeError: URL constructor: None is not a valid URL`
- `Invalid base_url for m.identity_server`

The well-known template (`.well-known/matrix/client.j2`) already handles this correctly with a conditional guard (introduced in #314). This PR applies the same pattern to the Element Web `config.json.j2` template — only including the `m.identity_server` block when a URL is actually configured.