### PR TITLE
Update Etherpad (v2.6.1-1 → v2.6.1-2)

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -3600,6 +3600,9 @@ etherpad_scheme: "{{ 'https' if matrix_playbook_ssl_enabled else 'http' }}"
 
 etherpad_base_path: "{{ matrix_base_data_path }}/etherpad"
 
+etherpad_uid: "{{ matrix_user_uid }}"
+etherpad_gid: "{{ matrix_user_gid }}"
+
 etherpad_framing_enabled: "{{ jitsi_enabled }}"
 
 etherpad_hostname: "{{ matrix_server_fqn_etherpad }}"

--- a/requirements.yml
+++ b/requirements.yml
@@ -27,7 +27,7 @@
   version: 542a2d68db4e9a8e9bb4b508052760b900c7dce6
   name: docker_sdk_for_python
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-etherpad.git
-  version: v2.6.1-1
+  version: v2.6.1-2
   name: etherpad
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-exim-relay.git
   version: v4.98.1-r0-2-3


### PR DESCRIPTION
Now that UID and GID are not specified by default, it is necessary for the playbook to specify them. MASH playbook has already taken care of them on https://github.com/mother-of-all-self-hosting/mash-playbook/blob/9707a4786bff74046ffa76349569e11431da8726/templates/group_vars_mash_servers#L4794-L4795.