### PR TITLE
feat(synapse): add ca_certs_file support for LDAP TLS

### DIFF
--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -1410,6 +1410,7 @@ matrix_synapse_ext_password_provider_ldap_filter: ""
 matrix_synapse_ext_password_provider_ldap_active_directory: false
 matrix_synapse_ext_password_provider_ldap_default_domain: ""
 matrix_synapse_ext_password_provider_ldap_tls_options_validate: true
+matrix_synapse_ext_password_provider_ldap_tls_options_ca_certs_file: ""
 
 # Enable this to activate the Synapse Antispam spam-checker module.
 # See: https://github.com/t2bot/synapse-simple-antispam

--- a/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -2540,6 +2540,9 @@ password_providers:
       filter: {{ matrix_synapse_ext_password_provider_ldap_filter | string|to_json }}
       tls_options:
         validate: {{ matrix_synapse_ext_password_provider_ldap_tls_options_validate | to_json }}
+{% if matrix_synapse_ext_password_provider_ldap_tls_options_ca_certs_file %}
+        ca_certs_file: {{ matrix_synapse_ext_password_provider_ldap_tls_options_ca_certs_file | string | to_json }}
+{% endif %}
 {% endif %}
 {% endif %}
 


### PR DESCRIPTION
## Summary

Add `matrix_synapse_ext_password_provider_ldap_tls_options_ca_certs_file` variable to allow specifying a custom CA certificate file for LDAP TLS verification.

This is useful when Synapse runs in a Docker container that does not trust a private or internal CA by default. Without this option, the only workaround is to set `tls_options_validate: false` or to duplicate the entire `password_providers` block in `matrix_synapse_configuration_extension_yaml` (which overrides all dedicated LDAP variables).

## Changes

- `roles/custom/matrix-synapse/defaults/main.yml`: add `matrix_synapse_ext_password_provider_ldap_tls_options_ca_certs_file` with empty default
- `roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2`: conditionally render `ca_certs_file` when the variable is set

## Example usage

```yaml
matrix_synapse_container_additional_volumes:
  - src: /usr/local/share/ca-certificates/my-ca.crt
    dst: /etc/ssl/certs/my-ca.crt
    options: ro

matrix_synapse_ext_password_provider_ldap_tls_options_validate: true
matrix_synapse_ext_password_provider_ldap_tls_options_ca_certs_file: /etc/ssl/certs/my-ca.crt
```