### PR TITLE
Fix commet client missing defintion

### DIFF
--- a/roles/custom/matrix-client-commet/defaults/main.yml
+++ b/roles/custom/matrix-client-commet/defaults/main.yml
@@ -30,6 +30,7 @@ matrix_client_commet_container_image_self_build_repo: "https://github.com/commet
 matrix_client_commet_container_image_self_build_git_hash: ""
 matrix_client_commet_container_image_self_build_version_tag: "{{ matrix_client_commet_version }}"
 matrix_client_commet_container_image: "localhost/matrix-client-commet:{{ matrix_client_commet_version }}"
+matrix_client_commet_container_image_force_pull: "{{ matrix_client_commet_container_image.endswith(':latest') or matrix_client_commet_container_image.endswith(':main') }}"
 
 # The in-container port nginx listens on
 matrix_client_commet_container_port: 8080

--- a/roles/custom/matrix-client-commet/defaults/main.yml
+++ b/roles/custom/matrix-client-commet/defaults/main.yml
@@ -5,7 +5,7 @@
 ---
 # Project source code URL: https://github.com/commetchat/commet
 
-matrix_client_commet_enabled: false
+matrix_client_commet_enabled: true
 
 # The git branch, tag, or SHA to build from
 matrix_client_commet_version: "main"

--- a/roles/custom/matrix-client-commet/defaults/main.yml
+++ b/roles/custom/matrix-client-commet/defaults/main.yml
@@ -5,7 +5,7 @@
 ---
 # Project source code URL: https://github.com/commetchat/commet
 
-matrix_client_commet_enabled: true
+matrix_client_commet_enabled: false
 
 # The git branch, tag, or SHA to build from
 matrix_client_commet_version: "main"


### PR DESCRIPTION
There's an issue with the current version when pulling the commet client image, its asking for this definition which does not exist. +Default enabled is probably not the way.