### PR TITLE
Fix user-verification-service room membership check

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -5884,7 +5884,10 @@ matrix_user_verification_service_container_http_host_bind_port: "{{  '' if (jits
 # URL exposed in the docker network
 matrix_user_verification_service_container_url: "http://{{  matrix_user_verification_service_container_name }}:3000"
 
-matrix_user_verification_service_uvs_homeserver_url: "{{ matrix_addons_homeserver_client_api_url }}"
+# Using `matrix_addons_homeserver_client_api_url` would not work here,
+# because `matrix-traefik:8008` (matrix-internal-client-api) does not expose any `/_synapse` paths.
+# UVS accesses `/_synapse/admin/v1/rooms` API to check room membership.
+matrix_user_verification_service_uvs_homeserver_url: "{{ matrix_homeserver_container_url }}"
 
 # We connect via the container network (private IPs), so we need to disable IP checks
 matrix_user_verification_service_uvs_disable_ip_blacklist: "{{ matrix_synapse_enabled }}"


### PR DESCRIPTION
Fixes a regression that prevented the user verification service from checking room memberships. It must have been introduced somewhere on the road from nginx to traefik as reverse proxy.

The debug logs from the user-verification-service say:
~~~
Mar 10 20:10:46 <redacted> matrix-user-verification-service[80636]: {
Mar 10 20:10:46 <redacted> matrix-user-verification-service[80636]:   requestId: '5469d587-1d5d-4654-a646-59cec6ab0b3d',
Mar 10 20:10:46 <redacted> matrix-user-verification-service[80636]:   level: 'debug',
Mar 10 20:10:46 <redacted> matrix-user-verification-service[80636]:   message: 'Making request to: http://matrix-traefik:8008/_synapse/admin/v1/rooms/!F2...<redacted>/members',
Mar 10 20:10:46 <redacted> matrix-user-verification-service[80636]:   timestamp: '2026-03-10T20:10:46.308Z'
Mar 10 20:10:46 <redacted> matrix-user-verification-service[80636]: }
Mar 10 20:10:46 <redacted> matrix-user-verification-service[80636]: {
Mar 10 20:10:46 <redacted> matrix-user-verification-service[80636]:   requestId: '5469d587-1d5d-4654-a646-59cec6ab0b3d',
Mar 10 20:10:46 <redacted> matrix-user-verification-service[80636]:   level: 'debug',
Mar 10 20:10:46 <redacted> matrix-user-verification-service[80636]:   message: 'Verify token failed: 404, {"content-type":"text/plain; charset=utf-8","x-content-type-options":"nosniff","date":"Tue, 10 Mar 2026 20:10:46 GMT","content-length":"19","connection":"close"}, "404 page not found\\n"',
Mar 10 20:10:46 <redacted> matrix-user-verification-service[80636]:   timestamp: '2026-03-10T20:10:46.316Z'
Mar 10 20:10:46 <redacted> matrix-user-verification-service[80636]: }
~~~

So traefik returns a 404 here instead of passsing the request to synapse. This is because the traefik rule for the router exposing the admin api (`matrix-synapse-public-client-synapse-admin-api`) enforces the Host of the request to be set to the `matrix_synapse_container_labels_public_client_synapse_admin_api_traefik_hostname`. As the host is set to `matrix-traefik` instead, the rule does not match, traefik returns a 404 to the user verification service and it will tell jitsi (or whoever asked) that the token could not be validated.


My proposal is to changed the plugging to make the user-verification-service send its request directly to the synapse container.  I'm not sure if that is the best way to fix that, but I verified it's working and it's similiar to what has been done in c0559870.

Fixes #3332