### PR TITLE
synapse: add missing server_notices configuration variables

### DIFF
--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -1657,6 +1657,12 @@ matrix_synapse_server_notices_system_mxid_display_name: "Server Notices"
 matrix_synapse_server_notices_system_mxid_avatar_url: ~
 # The name of the room where server notices will be sent, this room will be created if it doesn't exist.
 matrix_synapse_server_notices_room_name: "Server Notices"
+# Optional avatar URL for the server notices room, example: mxc://example.com/abc123
+matrix_synapse_server_notices_room_avatar_url: ~
+# Optional topic for the server notices room.
+matrix_synapse_server_notices_room_topic: ~
+# If true, users will be automatically joined to the server notices room instead of being invited.
+matrix_synapse_server_notices_auto_join: false
 
 # Controls whether searching the public room list is enabled.
 matrix_synapse_enable_room_list_search: true

--- a/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -2730,6 +2730,13 @@ server_notices:
   system_mxid_avatar_url: {{ matrix_synapse_server_notices_system_mxid_avatar_url | string | to_json }}
 {% endif %}
   room_name: {{ matrix_synapse_server_notices_room_name | string | to_json }}
+{% if matrix_synapse_server_notices_room_avatar_url %}
+  room_avatar_url: {{ matrix_synapse_server_notices_room_avatar_url | string | to_json }}
+{% endif %}
+{% if matrix_synapse_server_notices_room_topic %}
+  room_topic: {{ matrix_synapse_server_notices_room_topic | string | to_json }}
+{% endif %}
+  auto_join: {{ matrix_synapse_server_notices_auto_join | to_json }}
 {% endif %}
 
 


### PR DESCRIPTION
Add support for all `server_notices` settings documented by Synapse:
- `room_avatar_url`: optional avatar for the server notices room
- `room_topic`: optional topic for the server notices room
- `auto_join`: whether users are auto-joined instead of invited (default: false)

* Closes #5045


#### References
- Synapse docs: https://element-hq.github.io/synapse/latest/server_notices.html#sending-notices
