### PR TITLE
Prepare Draupnir Roles for move to GHCR.

### DIFF
--- a/roles/custom/matrix-appservice-draupnir-for-all/defaults/main.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/defaults/main.yml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2024 MDAD project contributors
-# SPDX-FileCopyrightText: 2024 - 2025 Catalan Lover <catalanlover@protonmail.com>
+# SPDX-FileCopyrightText: 2024 - 2026 Catalan Lover <catalanlover@protonmail.com>
 # SPDX-FileCopyrightText: 2024 - 2025 Slavi Pantaleev
 # SPDX-FileCopyrightText: 2024 Suguru Hirahara
 #
@@ -20,7 +20,8 @@ matrix_appservice_draupnir_for_all_container_image_self_build_repo: "https://git
 matrix_appservice_draupnir_for_all_container_image_registry_prefix: "{{ 'localhost/' if matrix_appservice_draupnir_for_all_container_image_self_build else matrix_appservice_draupnir_for_all_container_image_registry_prefix_upstream }}"
 matrix_appservice_draupnir_for_all_container_image_registry_prefix_upstream: "{{ matrix_appservice_draupnir_for_all_container_image_registry_prefix_upstream_default }}"
 matrix_appservice_draupnir_for_all_container_image_registry_prefix_upstream_default: "docker.io/"
-matrix_appservice_draupnir_for_all_container_image: "{{ matrix_appservice_draupnir_for_all_container_image_registry_prefix }}gnuxie/draupnir:{{ matrix_appservice_draupnir_for_all_version }}"
+matrix_appservice_draupnir_for_all_container_image: "{{ matrix_appservice_draupnir_for_all_container_image_registry_prefix }}{{ matrix_appservice_draupnir_for_all_container_image_registry_namespace_identifier }}:{{ matrix_appservice_draupnir_for_all_version }}"
+matrix_appservice_draupnir_for_all_container_image_registry_namespace_identifier: "gnuxie/draupnir"
 matrix_appservice_draupnir_for_all_container_image_force_pull: "{{ matrix_appservice_draupnir_for_all_container_image.endswith(':latest') }}"
 
 matrix_appservice_draupnir_for_all_base_path: "{{ matrix_base_data_path }}/draupnir-for-all"

--- a/roles/custom/matrix-bot-draupnir/defaults/main.yml
+++ b/roles/custom/matrix-bot-draupnir/defaults/main.yml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2023 - 2024 MDAD project contributors
-# SPDX-FileCopyrightText: 2023 - 2025 Catalan Lover <catalanlover@protonmail.com>
+# SPDX-FileCopyrightText: 2023 - 2026 Catalan Lover <catalanlover@protonmail.com>
 # SPDX-FileCopyrightText: 2023 Samuel Meenzen
 # SPDX-FileCopyrightText: 2024 - 2025 Slavi Pantaleev
 #
@@ -17,7 +17,8 @@ matrix_bot_draupnir_version: "v2.9.0"
 matrix_bot_draupnir_container_image_self_build: false
 matrix_bot_draupnir_container_image_self_build_repo: "https://github.com/the-draupnir-project/Draupnir.git"
 
-matrix_bot_draupnir_container_image: "{{ matrix_bot_draupnir_container_image_registry_prefix }}gnuxie/draupnir:{{ matrix_bot_draupnir_version }}"
+matrix_bot_draupnir_container_image: "{{ matrix_bot_draupnir_container_image_registry_prefix }}{{ matrix_bot_draupnir_container_image_registry_namespace_identifier }}:{{ matrix_bot_draupnir_version }}"
+matrix_bot_draupnir_container_image_registry_namespace_identifier: "gnuxie/draupnir"
 matrix_bot_draupnir_container_image_registry_prefix: "{{ 'localhost/' if matrix_bot_draupnir_container_image_self_build else matrix_bot_draupnir_container_image_registry_prefix_upstream }}"
 matrix_bot_draupnir_container_image_registry_prefix_upstream: "{{ matrix_bot_draupnir_container_image_registry_prefix_upstream_default }}"
 matrix_bot_draupnir_container_image_registry_prefix_upstream_default: "docker.io/"


### PR DESCRIPTION
As we are going to be moving to GHCR for Draupnir roles with the Draupnir 3.0 release this PR exists to enable far easier use of GHCR before this happens. 

We cant move mdad to GHCR yet as there are no release artifacts on GHCR currently. Only development artifacts.