### PR TITLE
Update Traefik labels for Prometheus Node and  Postgres Exporters

### DIFF
--- a/docs/configuring-playbook-prometheus-grafana.md
+++ b/docs/configuring-playbook-prometheus-grafana.md
@@ -178,7 +178,7 @@ Name | Description
 `matrix_metrics_exposure_http_basic_auth_enabled`|Set this to `true` to protect all `https://matrix.example.com/metrics/*` endpoints with [Basic Authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) (see the other variables below for supplying the actual credentials).
 `matrix_metrics_exposure_http_basic_auth_users`|Set this to the Basic Authentication credentials (raw `htpasswd` file content) used to protect `/metrics/*`. This htpasswd-file needs to be generated with the `htpasswd` tool and can include multiple username/password pairs.
 `prometheus_node_exporter_enabled`|Set this to `true` to enable the node (general system stats) exporter (locally, on the container network).
-`prometheus_node_exporter_container_labels_traefik_enabled`|Set this to `true` to expose the node (general system stats) metrics on `https://matrix.example.com/metrics/node-exporter`.
+`prometheus_node_exporter_container_labels_metrics_enabled`|Set this to `true` to expose the node (general system stats) metrics on `https://matrix.example.com/metrics/node-exporter`.
 `prometheus_postgres_exporter_enabled`|Set this to `true` to enable the [Postgres exporter](#enable-metrics-and-graphs-for-postgres-optional) (locally, on the container network).
 `prometheus_postgres_exporter_container_labels_metrics_enabled`|Set this to `true` to expose the [Postgres exporter](#enable-metrics-and-graphs-for-postgres-optional) metrics on `https://matrix.example.com/metrics/postgres-exporter`.
 `prometheus_nginxlog_exporter_enabled`|Set this to `true` to enable the [prometheus-nginxlog-exporter](#enable-metrics-and-graphs-for-nginx-logs-optional) (locally, on the container network).

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -5212,11 +5212,10 @@ prometheus_node_exporter_container_network: "{{ matrix_monitoring_container_netw
 
 prometheus_node_exporter_container_additional_networks_auto: "{{ [matrix_playbook_reverse_proxyable_services_additional_network] if matrix_playbook_reverse_proxyable_services_additional_network else [] }}"
 
-prometheus_node_exporter_container_labels_traefik_enabled: "{{ matrix_metrics_exposure_enabled }}"
-prometheus_node_exporter_container_labels_traefik_docker_network: "{{ matrix_playbook_reverse_proxyable_services_additional_network }}"
-prometheus_node_exporter_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
-prometheus_node_exporter_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
-
+prometheus_node_exporter_container_labels_metrics_enabled: "{{ matrix_metrics_exposure_enabled }}"
+prometheus_node_exporter_container_labels_metrics_docker_network: "{{ matrix_playbook_reverse_proxyable_services_additional_network }}"
+prometheus_node_exporter_container_labels_metrics_entrypoints: "{{ traefik_entrypoint_primary }}"
+prometheus_node_exporter_container_labels_metrics_tls_certResolver: "{{ traefik_certResolver_primary }}"
 prometheus_node_exporter_container_labels_metrics_middleware_basic_auth_enabled: "{{ matrix_metrics_exposure_http_basic_auth_enabled }}"
 prometheus_node_exporter_container_labels_metrics_middleware_basic_auth_users: "{{ matrix_metrics_exposure_http_basic_auth_users }}"
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -69,7 +69,7 @@
   version: v1.10.0-0
   name: prometheus_nginxlog_exporter
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-prometheus-node-exporter.git
-  version: v1.9.1-14
+  version: v1.9.1-15
   name: prometheus_node_exporter
 - src: git+https://github.com/mother-of-all-self-hosting/ansible-role-prometheus-postgres-exporter.git
   version: v0.19.1-1

--- a/roles/custom/matrix_playbook_migration/tasks/validate_config.yml
+++ b/roles/custom/matrix_playbook_migration/tasks/validate_config.yml
@@ -40,7 +40,7 @@
     - {'old': 'matrix_systemd_services_list', 'new': 'devture_systemd_service_manager_services_list_additional'}
     - {'old': 'matrix_common_after_systemd_service_start_wait_for_timeout_seconds', 'new': 'devture_systemd_service_manager_up_verification_delay_seconds'}
     - {'old': 'matrix_systemd_services_autostart_enabled', 'new': 'devture_systemd_service_manager_services_autostart_enabled'}
-    - {'old': 'matrix_prometheus_node_exporter_metrics_proxying_enabled', 'new': '<prometheus_node_exporter_container_labels_traefik_enabled or matrix_metrics_exposure_enabled>'}
+    - {'old': 'matrix_prometheus_node_exporter_metrics_proxying_enabled', 'new': '<prometheus_node_exporter_container_labels_metrics_enabled or matrix_metrics_exposure_enabled>'}
     - {'old': 'matrix_prometheus_postgres_exporter_metrics_proxying_enabled', 'new': '<prometheus_postgres_exporter_container_labels_metrics_enabled or matrix_metrics_exposure_enabled>'}
     - {'old': 'matrix_playbook_traefik_certs_dumper_role_enabled', 'new': 'traefik_certs_dumper_enabled'}
     - {'old': 'matrix_playbook_traefik_role_enabled', 'new': 'traefik_enabled'}


### PR DESCRIPTION
Based on:
- https://github.com/mother-of-all-self-hosting/mash-playbook/commit/ee5d3b794d0053070eb71dc6689c2e56e2ab1b63
- https://github.com/mother-of-all-self-hosting/mash-playbook/commit/afdacf2300776db568ad11ee90684b80f6876dee

Old names should be picked up with https://github.com/mother-of-all-self-hosting/ansible-role-prometheus-node-exporter/blob/main/tasks/validate_config.yml and https://github.com/mother-of-all-self-hosting/ansible-role-prometheus-postgres-exporter/blob/main/tasks/validate_config.yml.