### PR TITLE
Add more Continuwuity URL preview vars

### DIFF
--- a/roles/custom/matrix-continuwuity/defaults/main.yml
+++ b/roles/custom/matrix-continuwuity/defaults/main.yml
@@ -202,6 +202,9 @@ matrix_continuwuity_config_url_preview_domain_contains_allowlist: []
 # Controls the `url_preview_domain_explicit_allowlist` setting.
 matrix_continuwuity_config_url_preview_domain_explicit_allowlist: []
 
+# Controls the `url_preview_check_root_domain` setting.
+matrix_continuwuity_config_url_preview_check_root_domain: false
+
 # Additional environment variables to pass to the container.
 #
 # Environment variables take priority over settings in the configuration file.

--- a/roles/custom/matrix-continuwuity/templates/continuwuity.toml.j2
+++ b/roles/custom/matrix-continuwuity/templates/continuwuity.toml.j2
@@ -1359,7 +1359,7 @@ url_preview_domain_explicit_allowlist = {{ matrix_continuwuity_config_url_previe
 # allowlist is still too broad for you but you still want to allow all the
 # subdomains under a root domain.
 #
-#url_preview_check_root_domain = false
+url_preview_check_root_domain = {{ matrix_continuwuity_config_url_preview_check_root_domain | to_json }}
 
 # List of forbidden room aliases and room IDs as strings of regex
 # patterns.


### PR DESCRIPTION
Adds two more configuration options to control how Continuwuity fetches URL previews.

### url_preview_domain_explicit_allowlist

> ```toml
> # Vector list of explicit domains allowed to send requests to for URL
> # previews.
> #
> # This is an *explicit* match, not a contains match. Putting "google.com"
> # will match "https://google.com", "http://google.com", but not
> # "https://mymaliciousdomainexamplegoogle.com". Setting this to "*" will
> # allow all URL previews. Please note that this opens up significant
> # attack surface to your server, you are expected to be aware of the risks
> # by doing so.
> ```

### url_preview_check_root_domain

> ```toml
> # Option to decide whether you would like to run the domain allowlist
> # checks (contains and explicit) on the root domain or not. Does not apply
> # to URL contains allowlist. Defaults to false.
> #
> # Example usecase: If this is enabled and you have "wikipedia.org" allowed
> # in the explicit and/or contains domain allowlist, it will allow all
> # subdomains under "wikipedia.org" such as "en.m.wikipedia.org" as the
> # root domain is checked and matched. Useful if the domain contains
> # allowlist is still too broad for you but you still want to allow all the
> # subdomains under a root domain.
> ```

[Reference](https://continuwuity.org/reference/config)