### PR TITLE
Update Draupnir from v2.9.0 to v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## (BC Break) Draupnir for all Self Service Provisioning is now disabled by default
 
-[Draupnir for all](./docs/configuring-playbook-appservice-draupnir-for-all.md) now ships with `allowSelfServiceProvisioning: false` as default upstream and in mdad.
+💡 If you don't use [Draupnir for all](./docs/configuring-playbook-appservice-draupnir-for-all.md), then this breaking change does not concern you..
+
+[Draupnir for all](./docs/configuring-playbook-appservice-draupnir-for-all.md) now ships with `allowSelfServiceProvisioning: false` as default upstream and in this playbook.
 
 This means users can no longer provision Draupnir instances by inviting the appservice bot unless you explicitly opt in.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 2026-04-02
+
+## (BC Break) Draupnir for all Self Service Provisioning is now disabled by default
+
+[Draupnir for all](./docs/configuring-playbook-appservice-draupnir-for-all.md) now ships with `allowSelfServiceProvisioning: false` as default upstream and in mdad.
+
+This means users can no longer provision Draupnir instances by inviting the appservice bot unless you explicitly opt in.
+
+Manual provisioning by administrators is now the recommended approach. You do not want to enable Self Service Provisioning unless you have additional custom safeguards like those used by asgard.chat in place.
+
+If you want to enable Self Service Provisioning, add the following to your `vars.yml`:
+
+```yaml
+matrix_appservice_draupnir_for_all_configuration_extension_yaml: |
+  allowSelfServiceProvisioning: true
+```
+
 # 2026-03-23
 
 ## Migration validation system introduced

--- a/examples/vars.yml
+++ b/examples/vars.yml
@@ -2,7 +2,7 @@
 # This variable acknowledges that you've reviewed breaking changes up to this version.
 # The playbook will fail if this is outdated, guiding you through what changed.
 # See the changelog: https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/CHANGELOG.md
-matrix_playbook_migration_validated_version: v2026.03.23.0
+matrix_playbook_migration_validated_version: v2026.04.02.0
 
 # The bare domain name which represents your Matrix identity.
 # Matrix user IDs for your server will be of the form (`@alice:example.com`).

--- a/roles/custom/matrix-appservice-draupnir-for-all/defaults/main.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/defaults/main.yml
@@ -11,17 +11,17 @@
 
 matrix_appservice_draupnir_for_all_enabled: true
 
-# renovate: datasource=docker depName=gnuxie/draupnir
-matrix_appservice_draupnir_for_all_version: "v2.9.0"
+# renovate: datasource=docker depName=depName=ghcr.io/the-draupnir-project/draupnir
+matrix_appservice_draupnir_for_all_version: "v3.0.0"
 
 matrix_appservice_draupnir_for_all_container_image_self_build: false
 matrix_appservice_draupnir_for_all_container_image_self_build_repo: "https://github.com/the-draupnir-project/Draupnir.git"
 
 matrix_appservice_draupnir_for_all_container_image_registry_prefix: "{{ 'localhost/' if matrix_appservice_draupnir_for_all_container_image_self_build else matrix_appservice_draupnir_for_all_container_image_registry_prefix_upstream }}"
 matrix_appservice_draupnir_for_all_container_image_registry_prefix_upstream: "{{ matrix_appservice_draupnir_for_all_container_image_registry_prefix_upstream_default }}"
-matrix_appservice_draupnir_for_all_container_image_registry_prefix_upstream_default: "docker.io/"
+matrix_appservice_draupnir_for_all_container_image_registry_prefix_upstream_default: "ghcr.io/"
 matrix_appservice_draupnir_for_all_container_image: "{{ matrix_appservice_draupnir_for_all_container_image_registry_prefix }}{{ matrix_appservice_draupnir_for_all_container_image_registry_namespace_identifier }}:{{ matrix_appservice_draupnir_for_all_version }}"
-matrix_appservice_draupnir_for_all_container_image_registry_namespace_identifier: "gnuxie/draupnir"
+matrix_appservice_draupnir_for_all_container_image_registry_namespace_identifier: "the-draupnir-project/draupnir"
 matrix_appservice_draupnir_for_all_container_image_force_pull: "{{ matrix_appservice_draupnir_for_all_container_image.endswith(':latest') }}"
 
 matrix_appservice_draupnir_for_all_base_path: "{{ matrix_base_data_path }}/draupnir-for-all"

--- a/roles/custom/matrix-appservice-draupnir-for-all/templates/production-appservice.yaml.j2
+++ b/roles/custom/matrix-appservice-draupnir-for-all/templates/production-appservice.yaml.j2
@@ -1,6 +1,6 @@
 {#
 SPDX-FileCopyrightText: 2024 MDAD project contributors
-SPDX-FileCopyrightText: 2024 - 2025 Catalan Lover <catalanlover@protonmail.com>
+SPDX-FileCopyrightText: 2024 - 2026 Catalan Lover <catalanlover@protonmail.com>
 SPDX-FileCopyrightText: 2024 Suguru Hirahara
 
 SPDX-License-Identifier: AGPL-3.0-or-later
@@ -27,6 +27,16 @@ webAPI:
 
 # The directory the bot should store various bits of information in
 dataPath: "/data"
+
+# Maximum number of bots each user can provision.
+# Defaults to 1 when omitted.
+maxDraupnirsPerUser: 1
+
+# Allow users to self-provision by inviting the appservice bot.
+# When false, provisioning must be done through admin commands.
+# Defaults to false when omitted.
+allowSelfServiceProvisioning: false
+
 
 roomStateBackingStore:
   enabled: {{ matrix_appservice_draupnir_for_all_config_roomStateBackingStore_enabled | to_json }}

--- a/roles/custom/matrix-appservice-draupnir-for-all/templates/production-bots.yaml.j2
+++ b/roles/custom/matrix-appservice-draupnir-for-all/templates/production-bots.yaml.j2
@@ -1,6 +1,6 @@
 {#
 SPDX-FileCopyrightText: 2024 MDAD project contributors
-SPDX-FileCopyrightText: 2024 - 2025 Catalan Lover <catalanlover@protonmail.com>
+SPDX-FileCopyrightText: 2024 - 2026 Catalan Lover <catalanlover@protonmail.com>
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
@@ -60,6 +60,14 @@ commands:
   # the !draupnir prefix. For example, "my_moderator_bot: ban @spammer:example.org"
   # will address only my_moderator_bot.
   allowNoPrefix: false
+
+  # Controls which symbol will prefix a secondary prefix that is described in additionalPrefixes.
+  # For example the `!` in `!draupnir`.
+  # If you wish the bot to use "slash commands" with the "/" character instead of the exclamation mark "!" change the value to `"/"` and the bot will start responding to slash commands.
+
+  symbolPrefixes:
+    - "!"
+
 
   # Any additional bot prefixes that Draupnir will listen to. i.e. adding `mod` will allow `!mod help`.
   additionalPrefixes:

--- a/roles/custom/matrix-bot-draupnir/defaults/main.yml
+++ b/roles/custom/matrix-bot-draupnir/defaults/main.yml
@@ -11,17 +11,17 @@
 
 matrix_bot_draupnir_enabled: true
 
-# renovate: datasource=docker depName=gnuxie/draupnir
-matrix_bot_draupnir_version: "v2.9.0"
+# renovate: datasource=docker depName=depName=ghcr.io/the-draupnir-project/draupnir
+matrix_bot_draupnir_version: "v3.0.0"
 
 matrix_bot_draupnir_container_image_self_build: false
 matrix_bot_draupnir_container_image_self_build_repo: "https://github.com/the-draupnir-project/Draupnir.git"
 
 matrix_bot_draupnir_container_image: "{{ matrix_bot_draupnir_container_image_registry_prefix }}{{ matrix_bot_draupnir_container_image_registry_namespace_identifier }}:{{ matrix_bot_draupnir_version }}"
-matrix_bot_draupnir_container_image_registry_namespace_identifier: "gnuxie/draupnir"
+matrix_bot_draupnir_container_image_registry_namespace_identifier: "the-draupnir-project/draupnir"
 matrix_bot_draupnir_container_image_registry_prefix: "{{ 'localhost/' if matrix_bot_draupnir_container_image_self_build else matrix_bot_draupnir_container_image_registry_prefix_upstream }}"
 matrix_bot_draupnir_container_image_registry_prefix_upstream: "{{ matrix_bot_draupnir_container_image_registry_prefix_upstream_default }}"
-matrix_bot_draupnir_container_image_registry_prefix_upstream_default: "docker.io/"
+matrix_bot_draupnir_container_image_registry_prefix_upstream_default: "ghcr.io/"
 matrix_bot_draupnir_container_image_force_pull: "{{ matrix_bot_draupnir_container_image.endswith(':latest') }}"
 
 matrix_bot_draupnir_base_path: "{{ matrix_base_data_path }}/draupnir"

--- a/roles/custom/matrix-bot-draupnir/templates/production.yaml.j2
+++ b/roles/custom/matrix-bot-draupnir/templates/production.yaml.j2
@@ -1,6 +1,6 @@
 {#
 SPDX-FileCopyrightText: 2023 - 2024 MDAD project contributors
-SPDX-FileCopyrightText: 2023 - 2025 Catalan Lover <catalanlover@protonmail.com>
+SPDX-FileCopyrightText: 2023 - 2026 Catalan Lover <catalanlover@protonmail.com>
 SPDX-FileCopyrightText: 2024 Slavi Pantaleev
 SPDX-FileCopyrightText: 2024 Suguru Hirahara
 
@@ -147,6 +147,13 @@ commands:
   # the !draupnir prefix. For example, "my_moderator_bot: ban @spammer:example.org"
   # will address only my_moderator_bot.
   allowNoPrefix: false
+
+  # Controls which symbol will prefix a secondary prefix that is described in additionalPrefixes.
+  # For example the `!` in `!draupnir`.
+  # If you wish the bot to use "slash commands" with the "/" character instead of the exclamation mark "!" change the value to `"/"` and the bot will start responding to slash commands.
+
+  symbolPrefixes:
+    - "!"
 
   # Any additional bot prefixes that Draupnir will listen to. i.e. adding `mod` will allow `!mod help`.
   additionalPrefixes:

--- a/roles/custom/matrix_playbook_migration/defaults/main.yml
+++ b/roles/custom/matrix_playbook_migration/defaults/main.yml
@@ -14,10 +14,13 @@ matrix_playbook_migration_validated_version: ''
 # The version that the playbook expects the user to have validated against.
 # This is bumped whenever a breaking change is introduced.
 # The value configured here needs to exist in `matrix_playbook_migration_breaking_changes` as well.
-matrix_playbook_migration_expected_version: "v2026.03.23.0"
+matrix_playbook_migration_expected_version: "v2026.04.02.0"
 
 # A list of breaking changes, used to inform users what changed between their validated version and the expected version.
 matrix_playbook_migration_breaking_changes:
+  - version: "v2026.04.02.0"
+    summary: "(BC Break) Draupnir-for-all self-service provisioning is now disabled by default"
+    changelog_url: "https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/CHANGELOG.md#2026-04-02"
   - version: "v2026.03.23.0"
     summary: "Initial migration validation system"
     changelog_url: "https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/CHANGELOG.md#2026-03-22"


### PR DESCRIPTION
Please note that this update also includes a breaking change for Appservice mode installations where Self Service Provision is default disabled due to a flaw.

Force manual provisioning was added to compensate.

Signed-off-by: Catalan Lover <catalanlover@protonmail.com>