### PR TITLE
[continuwuity] allow configuring default room version

### DIFF
--- a/roles/custom/matrix-continuwuity/defaults/main.yml
+++ b/roles/custom/matrix-continuwuity/defaults/main.yml
@@ -199,6 +199,10 @@ matrix_continuwuity_config_allow_encryption: true
 # Appservices and admins are always allowed to create new rooms.
 matrix_continuwuity_config_allow_room_creation: true
 
+# Controls the default room version continuwuity will create rooms with.
+# Per spec, room version '11' is the default.
+matrix_continuwuity_config_default_room_version: '11'
+
 # List/vector of room IDs or room aliases that continuwuity will make
 # newly registered users join. The rooms specified must be rooms that you
 # have joined at least once on the server, and must be public.

--- a/roles/custom/matrix-continuwuity/templates/continuwuity.toml.j2
+++ b/roles/custom/matrix-continuwuity/templates/continuwuity.toml.j2
@@ -608,7 +608,7 @@ allow_room_creation = {{ matrix_continuwuity_config_allow_room_creation | to_jso
 #
 # Per spec, room version "11" is the default.
 #
-#default_room_version = "11"
+default_room_version = {{ matrix_continuwuity_config_default_room_version | to_json }}
 
 # Enable OpenTelemetry OTLP tracing export. This replaces the deprecated
 # Jaeger exporter. Traces will be sent via OTLP to a collector (such as


### PR DESCRIPTION
Allows configuring the default room version that Continuwuity will use for new rooms.

From the [docs](https://continuwuity.org/reference/config.html):

> ```
> # Default room version continuwuity will create rooms with.
> # Note that this has to be a string since the room version is a string
> # rather than an integer. Forgetting the quotes will make the server fail
> # to start!
> #
> # Per spec, room version "11" is the default.
> ```

 I tested this on my server, and the configuration option works as expected.