### PR TITLE
Update c10y default room version to match specification.

### DIFF
--- a/roles/custom/matrix-continuwuity/defaults/main.yml
+++ b/roles/custom/matrix-continuwuity/defaults/main.yml
@@ -200,8 +200,8 @@ matrix_continuwuity_config_allow_encryption: true
 matrix_continuwuity_config_allow_room_creation: true
 
 # Controls the default room version continuwuity will create rooms with.
-# Per spec, room version '11' is the default.
-matrix_continuwuity_config_default_room_version: '11'
+# Per spec, room version '12' is the default (According to spec release 1.18).
+matrix_continuwuity_config_default_room_version: '12'
 
 # List/vector of room IDs or room aliases that continuwuity will make
 # newly registered users join. The rooms specified must be rooms that you


### PR DESCRIPTION
The official project rooms are on v12 and support has been stable enough for quite some releases now. Its also just plain old bad security practice to run v11 outside of closed federations.

The upstream docs are simply out of date on this one.

Signed-off-by: Catalan Lover <catalanlover@protonmail.com>