### PR TITLE
Add Synapse Postgres keepalive configuration variables

### DIFF
--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -1329,6 +1329,9 @@ matrix_synapse_database_host: ''
 matrix_synapse_database_port: 5432
 matrix_synapse_database_cp_min: 5
 matrix_synapse_database_cp_max: 10
+matrix_synapse_database_keepalives_idle: null
+matrix_synapse_database_keepalives_interval: null
+matrix_synapse_database_keepalives_count: null
 matrix_synapse_database_user: "synapse"
 matrix_synapse_database_password: ""
 matrix_synapse_database_database: "synapse"

--- a/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -868,6 +868,15 @@ database:
     port: {{ matrix_synapse_database_port }}
     cp_min: {{ matrix_synapse_database_cp_min | to_json }}
     cp_max: {{ matrix_synapse_database_cp_max | to_json }}
+{% if matrix_synapse_database_keepalives_idle is not none %}
+    keepalives_idle: {{ matrix_synapse_database_keepalives_idle | to_json }}
+{% endif %}
+{% if matrix_synapse_database_keepalives_interval is not none %}
+    keepalives_interval: {{ matrix_synapse_database_keepalives_interval | to_json }}
+{% endif %}
+{% if matrix_synapse_database_keepalives_count is not none %}
+    keepalives_count: {{ matrix_synapse_database_keepalives_count | to_json }}
+{% endif %}
 
 
 ## Logging ##


### PR DESCRIPTION
Adds three optional variables for Synapse's PostgreSQL keepalive settings:
- `matrix_synapse_database_keepalives_idle`
- `matrix_synapse_database_keepalives_interval`
- `matrix_synapse_database_keepalives_count`

These map directly to the corresponding `psycopg2` connection args in `homeserver.yaml` (as explained in the [official doc](https://element-hq.github.io/synapse/latest/postgres.html#synapse-config)). Each defaults to `""` and is only rendered when explicitly set, so existing deployments are unaffected.

Useful for deployments where idle database connections may be silently dropped by intermediate network infrastructure (firewalls, NAT gateways, etc.).

#### Example usage

```yaml
matrix_synapse_database_keepalives_idle: 60
matrix_synapse_database_keepalives_interval: 10
matrix_synapse_database_keepalives_count: 5
```