### PR TITLE
Modernise Draupnir Role ansible modules and update restart logic

### DIFF
--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -1,8 +1,4 @@
 ---
 collections:
-  # community.docker >= 3.6.0 is required for:
-  # - community.docker.docker_image_pull module (pull-only operations)
-  # - community.docker.docker_image_build module (build with BuildKit support)
   - name: community.general
   - name: community.docker
-    version: ">=3.6.0"

--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -1,4 +1,8 @@
 ---
 collections:
+  # community.docker >= 3.6.0 is required for:
+  # - community.docker.docker_image_pull module (pull-only operations)
+  # - community.docker.docker_image_build module (build with BuildKit support)
   - name: community.general
   - name: community.docker
+    version: ">=3.6.0"

--- a/docs/configuring-playbook-appservice-draupnir-for-all.md
+++ b/docs/configuring-playbook-appservice-draupnir-for-all.md
@@ -48,6 +48,14 @@ matrix_appservice_draupnir_for_all_enabled: true
 matrix_appservice_draupnir_for_all_config_adminRoom: "MANAGEMENT_ROOM_ALIAS_HERE"
 ```
 
+### Running Both Bot Mode and Appservice Mode
+
+When running both [Bot mode](./configuring-playbook-bot-draupnir.md) and appservice mode the playbook will force restart
+the bot if running a non release tag like `latest` or `main` or development builds.
+This is due to the conditional restart logic not being able to tell when a update happened correctly.
+
+Conditional restarts work perfectly for all tags when running only one of these two operating modes.
+
 ### Extending the configuration
 
 There are some additional things you may wish to configure about the component.

--- a/docs/configuring-playbook-bot-draupnir.md
+++ b/docs/configuring-playbook-bot-draupnir.md
@@ -82,6 +82,14 @@ matrix_bot_draupnir_login_native: true
 matrix_bot_draupnir_config_managementRoom: "MANAGEMENT_ROOM_ID_HERE"
 ```
 
+### Running Both Bot Mode and Appservice Mode
+
+When running both Bot mode and [appservice mode](./configuring-playbook-appservice-draupnir-for-all.md)(Draupnir for all) the
+playbook will force restart the bot if running a non release tag like `latest` or `main` or development builds.
+This is due to the conditional restart logic not being able to tell when a update happened correctly.
+
+Conditional restarts work perfectly for all tags when running only one of these two operating modes.
+
 ### Create and invite the bot to the management room
 
 Before proceeding to the next step, run the playbook with the following command to create the bot user.

--- a/roles/custom/matrix-appservice-draupnir-for-all/defaults/main.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/defaults/main.yml
@@ -49,11 +49,16 @@ matrix_appservice_draupnir_for_all_systemd_wanted_services_list: []
 # Force restart tag is used to control if the tag that is used is rolling or not.
 # When both Draupnir roles are enabled, we only force restart if they are on the same
 # version string and that version string matches the moving tag.
-matrix_appservice_draupnir_for_all_force_restart_tag: "latest"
+matrix_appservice_draupnir_for_all_force_rolling_tag: "latest"
 
 # Force restart the service on all runs only when both roles are enabled, both roles
 # are using the same version string, and that version is the moving tag.
-matrix_appservice_draupnir_for_all_force_restart: "if {{ matrix_bot_draupnir_enabled | bool and matrix_appservice_draupnir_for_all_enabled | bool and matrix_bot_draupnir_version == matrix_appservice_draupnir_for_all_version and matrix_appservice_draupnir_for_all_version == matrix_appservice_draupnir_for_all_force_restart_tag }} then true else false end"
+matrix_appservice_draupnir_for_all_force_restart: "{{
+  matrix_bot_draupnir_enabled | bool and
+  matrix_appservice_draupnir_for_all_enabled | bool and
+  matrix_bot_draupnir_version == matrix_appservice_draupnir_for_all_version and
+  matrix_appservice_draupnir_for_all_version == matrix_appservice_draupnir_for_all_force_rolling_tag
+}}"
 
 # The room ID where people can use the bot. The bot has no access controls, so
 # anyone in this room can use the bot - secure your room!

--- a/roles/custom/matrix-appservice-draupnir-for-all/defaults/main.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/defaults/main.yml
@@ -46,18 +46,16 @@ matrix_appservice_draupnir_for_all_systemd_required_services_list_custom: []
 # List of systemd services that matrix-bot-draupnir.service wants
 matrix_appservice_draupnir_for_all_systemd_wanted_services_list: []
 
-# Force restart tag is used to control if the tag that is used is rolling or not.
-# When both Draupnir roles are enabled, we only force restart if they are on the same
-# version string and that version string matches the moving tag.
-matrix_appservice_draupnir_for_all_force_rolling_tag: "latest"
+# Rolling tag: true if version doesn't match semver shape (vX.Y.Z with optional prerelease/build), false otherwise.
+matrix_appservice_draupnir_for_all_rolling_tag: "{{ not (matrix_appservice_draupnir_for_all_version is match('^v[0-9]+\\.[0-9]+\\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?$')) }}"
 
 # Force restart the service on all runs only when both roles are enabled, both roles
-# are using the same version string, and that version is the moving tag.
+# are using the same version string, and that version is a classified as a moving tag.
 matrix_appservice_draupnir_for_all_force_restart: "{{
   matrix_bot_draupnir_enabled | bool and
   matrix_appservice_draupnir_for_all_enabled | bool and
   matrix_bot_draupnir_version == matrix_appservice_draupnir_for_all_version and
-  matrix_appservice_draupnir_for_all_version == matrix_appservice_draupnir_for_all_force_rolling_tag
+  matrix_appservice_draupnir_for_all_rolling_tag | bool
 }}"
 
 # The room ID where people can use the bot. The bot has no access controls, so

--- a/roles/custom/matrix-appservice-draupnir-for-all/defaults/main.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/defaults/main.yml
@@ -22,7 +22,6 @@ matrix_appservice_draupnir_for_all_container_image_registry_prefix_upstream: "{{
 matrix_appservice_draupnir_for_all_container_image_registry_prefix_upstream_default: "ghcr.io/"
 matrix_appservice_draupnir_for_all_container_image: "{{ matrix_appservice_draupnir_for_all_container_image_registry_prefix }}{{ matrix_appservice_draupnir_for_all_container_image_registry_namespace_identifier }}:{{ matrix_appservice_draupnir_for_all_version }}"
 matrix_appservice_draupnir_for_all_container_image_registry_namespace_identifier: "the-draupnir-project/draupnir"
-matrix_appservice_draupnir_for_all_container_image_force_pull: "{{ matrix_appservice_draupnir_for_all_container_image.endswith(':latest') }}"
 
 matrix_appservice_draupnir_for_all_base_path: "{{ matrix_base_data_path }}/draupnir-for-all"
 matrix_appservice_draupnir_for_all_config_path: "{{ matrix_appservice_draupnir_for_all_base_path }}/config"
@@ -46,6 +45,15 @@ matrix_appservice_draupnir_for_all_systemd_required_services_list_custom: []
 
 # List of systemd services that matrix-bot-draupnir.service wants
 matrix_appservice_draupnir_for_all_systemd_wanted_services_list: []
+
+# Force restart tag is used to control if the tag that is used is rolling or not.
+# When both Draupnir roles are enabled, we only force restart if they are on the same
+# version string and that version string matches the moving tag.
+matrix_appservice_draupnir_for_all_force_restart_tag: "latest"
+
+# Force restart the service on all runs only when both roles are enabled, both roles
+# are using the same version string, and that version is the moving tag.
+matrix_appservice_draupnir_for_all_force_restart: "if {{ matrix_bot_draupnir_enabled | bool and matrix_appservice_draupnir_for_all_enabled | bool and matrix_bot_draupnir_version == matrix_appservice_draupnir_for_all_version and matrix_appservice_draupnir_for_all_version == matrix_appservice_draupnir_for_all_force_restart_tag }} then true else false end"
 
 # The room ID where people can use the bot. The bot has no access controls, so
 # anyone in this room can use the bot - secure your room!

--- a/roles/custom/matrix-appservice-draupnir-for-all/tasks/setup_install.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/tasks/setup_install.yml
@@ -48,14 +48,16 @@
 
 - name: Ensure Draupnir Docker image is built
   # Using docker_image_build with BuildKit for modern, efficient builds.
-  # docker_image_build automatically rebuilds when the Dockerfile or build context changes.
-  # The git_pull_results will show if the source was updated above.
+  # Rebuild when the git checkout advanced to a new commit; otherwise keep the build idempotent.
+  # Technically the idempotency of rebuilds is more that if a build has already been executed for that name:tag
+  # then we wont rebuild while in idempotent mode even if git moved. Thats what the force rebuild logic is for.
   community.docker.docker_image_build:
     name: "{{ matrix_appservice_draupnir_for_all_container_image }}"
     dockerfile: Dockerfile
     path: "{{ matrix_appservice_draupnir_for_all_container_src_files_path }}"
     pull: true
-  when: "matrix_appservice_draupnir_for_all_container_image_self_build | bool and matrix_appservice_draupnir_for_all_git_pull_results.changed"
+    rebuild: "{{ 'always' if matrix_appservice_draupnir_for_all_git_pull_results.changed | bool else 'never' }}"
+  when: "matrix_appservice_draupnir_for_all_container_image_self_build | bool"
   register: matrix_appservice_draupnir_for_all_container_image_build_result
 
 - name: Ensure matrix-appservice-draupnir-for-all appservice config installed

--- a/roles/custom/matrix-appservice-draupnir-for-all/tasks/setup_install.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/tasks/setup_install.yml
@@ -50,7 +50,7 @@
   # Using docker_image_build with BuildKit for modern, efficient builds.
   # Rebuild when the git checkout advanced to a new commit; otherwise keep the build idempotent.
   # Technically the idempotency of rebuilds is more that if a build has already been executed for that name:tag
-  # then we wont rebuild while in idempotent mode even if git moved. Thats what the force rebuild logic is for.
+  # then we won't rebuild while in idempotent mode even if git moved. That's what the force rebuild logic is for.
   community.docker.docker_image_build:
     name: "{{ matrix_appservice_draupnir_for_all_container_image }}"
     dockerfile: Dockerfile

--- a/roles/custom/matrix-appservice-draupnir-for-all/tasks/setup_install.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/tasks/setup_install.yml
@@ -26,11 +26,9 @@
   when: "item.when | bool"
 
 - name: Ensure Draupnir Docker image is pulled
-  community.docker.docker_image:
+  community.docker.docker_image_pull:
     name: "{{ matrix_appservice_draupnir_for_all_container_image }}"
-    source: "{{ 'pull' if ansible_version.major > 2 or ansible_version.minor > 7 else omit }}"
-    force_source: "{{ matrix_appservice_draupnir_for_all_container_image_force_pull if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
-    force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_appservice_draupnir_for_all_container_image_force_pull }}"
+    pull: always
   when: "not matrix_appservice_draupnir_for_all_container_image_self_build | bool"
   register: matrix_appservice_draupnir_for_all_container_image_pull_result
   retries: "{{ devture_playbook_help_container_retries_count }}"
@@ -49,15 +47,16 @@
   when: "matrix_appservice_draupnir_for_all_container_image_self_build | bool"
 
 - name: Ensure Draupnir Docker image is built
-  community.docker.docker_image:
+  # Using docker_image_build with BuildKit for modern, efficient builds.
+  # docker_image_build automatically rebuilds when the Dockerfile or build context changes.
+  # The git_pull_results will show if the source was updated above.
+  community.docker.docker_image_build:
     name: "{{ matrix_appservice_draupnir_for_all_container_image }}"
-    source: build
-    force_source: "{{ matrix_appservice_draupnir_for_all_git_pull_results.changed }}"
-    build:
-      dockerfile: Dockerfile
-      path: "{{ matrix_appservice_draupnir_for_all_container_src_files_path }}"
-      pull: true
-  when: "matrix_appservice_draupnir_for_all_container_image_self_build | bool"
+    dockerfile: Dockerfile
+    path: "{{ matrix_appservice_draupnir_for_all_container_src_files_path }}"
+    pull: true
+  when: "matrix_appservice_draupnir_for_all_container_image_self_build | bool and matrix_appservice_draupnir_for_all_git_pull_results.changed"
+  register: matrix_appservice_draupnir_for_all_container_image_build_result
 
 - name: Ensure matrix-appservice-draupnir-for-all appservice config installed
   ansible.builtin.copy:
@@ -120,7 +119,8 @@
         or matrix_appservice_draupnir_for_all_registration_config_result.changed | default(false)
         or matrix_appservice_draupnir_for_all_systemd_service_result.changed | default(false)
         or matrix_appservice_draupnir_for_all_container_image_pull_result.changed | default(false)
-        or matrix_appservice_draupnir_for_all_container_image_force_pull | bool
+        or matrix_appservice_draupnir_for_all_container_image_build_result.changed | default(false)
+        or matrix_appservice_draupnir_for_all_force_restart | bool
       }}
 
 - name: Ensure matrix-appservice-draupnir-for-all.service restarted, if necessary

--- a/roles/custom/matrix-appservice-draupnir-for-all/tasks/validate_config.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/tasks/validate_config.yml
@@ -23,7 +23,7 @@
     - {'old': 'matrix_appservice_draupnir_for_all_docker_image_registry_prefix_upstream', 'new': 'matrix_appservice_draupnir_for_all_container_image_registry_prefix_upstream'}
     - {'old': 'matrix_appservice_draupnir_for_all_docker_image_registry_prefix_upstream_default', 'new': 'matrix_appservice_draupnir_for_all_container_image_registry_prefix_upstream_default'}
     - {'old': 'matrix_appservice_draupnir_for_all_docker_src_files_path', 'new': 'matrix_appservice_draupnir_for_all_container_src_files_path'}
-    - {'old': 'matrix_appservice_draupnir_for_all_container_image_force_pull', 'new': '<removed> (No longer needed due to new docker module doing this natively only if needed. If you run both bot mode and appservice mode matrix_appservice_draupnir_for_all_rolling_tag_force_pull is needed to make sure restart logic works correctly for both roles.)'}
+    - {'old': 'matrix_appservice_draupnir_for_all_container_image_force_pull', 'new': '<removed> (No longer needed due to new docker module doing this natively only if needed.)'}
 
 - name: Fail if required matrix-bot-draupnir variables are undefined
   ansible.builtin.fail:

--- a/roles/custom/matrix-appservice-draupnir-for-all/tasks/validate_config.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/tasks/validate_config.yml
@@ -23,6 +23,7 @@
     - {'old': 'matrix_appservice_draupnir_for_all_docker_image_registry_prefix_upstream', 'new': 'matrix_appservice_draupnir_for_all_container_image_registry_prefix_upstream'}
     - {'old': 'matrix_appservice_draupnir_for_all_docker_image_registry_prefix_upstream_default', 'new': 'matrix_appservice_draupnir_for_all_container_image_registry_prefix_upstream_default'}
     - {'old': 'matrix_appservice_draupnir_for_all_docker_src_files_path', 'new': 'matrix_appservice_draupnir_for_all_container_src_files_path'}
+    - {'old': 'matrix_appservice_draupnir_for_all_container_image_force_pull', 'new': '<removed>'}
 
 - name: Fail if required matrix-bot-draupnir variables are undefined
   ansible.builtin.fail:

--- a/roles/custom/matrix-appservice-draupnir-for-all/tasks/validate_config.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/tasks/validate_config.yml
@@ -23,7 +23,7 @@
     - {'old': 'matrix_appservice_draupnir_for_all_docker_image_registry_prefix_upstream', 'new': 'matrix_appservice_draupnir_for_all_container_image_registry_prefix_upstream'}
     - {'old': 'matrix_appservice_draupnir_for_all_docker_image_registry_prefix_upstream_default', 'new': 'matrix_appservice_draupnir_for_all_container_image_registry_prefix_upstream_default'}
     - {'old': 'matrix_appservice_draupnir_for_all_docker_src_files_path', 'new': 'matrix_appservice_draupnir_for_all_container_src_files_path'}
-    - {'old': 'matrix_appservice_draupnir_for_all_container_image_force_pull', 'new': '<removed>'}
+    - {'old': 'matrix_appservice_draupnir_for_all_container_image_force_pull', 'new': '<removed> (No longer needed due to new docker module doing this natively only if needed. If you run both bot mode and appservice mode matrix_appservice_draupnir_for_all_rolling_tag_force_pull is needed to make sure restart logic works correctly for both roles.)'}
 
 - name: Fail if required matrix-bot-draupnir variables are undefined
   ansible.builtin.fail:

--- a/roles/custom/matrix-bot-draupnir/defaults/main.yml
+++ b/roles/custom/matrix-bot-draupnir/defaults/main.yml
@@ -31,11 +31,16 @@ matrix_bot_draupnir_container_src_files_path: "{{ matrix_bot_draupnir_base_path 
 # Force restart tag is used to control if the tag that is used is rolling or not.
 # When both Draupnir roles are enabled, we only force restart if they are on the same
 # version string and that version string matches the moving tag.
-matrix_bot_draupnir_force_restart_tag: "latest"
+matrix_bot_draupnir_force_rolling_tag: "latest"
 
 # Force restart the service on all runs only when both roles are enabled, both roles
 # are using the same version string, and that version is the moving tag.
-matrix_bot_draupnir_force_restart: "if {{ matrix_bot_draupnir_enabled | bool and matrix_appservice_draupnir_for_all_enabled | bool and matrix_bot_draupnir_version == matrix_appservice_draupnir_for_all_version and matrix_bot_draupnir_version == matrix_bot_draupnir_force_restart_tag }} then true else false end"
+matrix_bot_draupnir_force_restart: "{{
+  matrix_bot_draupnir_enabled | bool and
+  matrix_appservice_draupnir_for_all_enabled | bool and
+  matrix_bot_draupnir_version == matrix_appservice_draupnir_for_all_version and
+  matrix_bot_draupnir_version == matrix_bot_draupnir_rolling_tag
+}}"
 
 matrix_bot_draupnir_config_web_enabled: "{{ matrix_bot_draupnir_config_web_abuseReporting or matrix_bot_draupnir_config_web_synapseHTTPAntispam_enabled }}"  # noqa var-naming
 

--- a/roles/custom/matrix-bot-draupnir/defaults/main.yml
+++ b/roles/custom/matrix-bot-draupnir/defaults/main.yml
@@ -22,12 +22,20 @@ matrix_bot_draupnir_container_image_registry_namespace_identifier: "the-draupnir
 matrix_bot_draupnir_container_image_registry_prefix: "{{ 'localhost/' if matrix_bot_draupnir_container_image_self_build else matrix_bot_draupnir_container_image_registry_prefix_upstream }}"
 matrix_bot_draupnir_container_image_registry_prefix_upstream: "{{ matrix_bot_draupnir_container_image_registry_prefix_upstream_default }}"
 matrix_bot_draupnir_container_image_registry_prefix_upstream_default: "ghcr.io/"
-matrix_bot_draupnir_container_image_force_pull: "{{ matrix_bot_draupnir_container_image.endswith(':latest') }}"
 
 matrix_bot_draupnir_base_path: "{{ matrix_base_data_path }}/draupnir"
 matrix_bot_draupnir_config_path: "{{ matrix_bot_draupnir_base_path }}/config"
 matrix_bot_draupnir_data_path: "{{ matrix_bot_draupnir_base_path }}/data"
 matrix_bot_draupnir_container_src_files_path: "{{ matrix_bot_draupnir_base_path }}/docker-src"
+
+# Force restart tag is used to control if the tag that is used is rolling or not.
+# When both Draupnir roles are enabled, we only force restart if they are on the same
+# version string and that version string matches the moving tag.
+matrix_bot_draupnir_force_restart_tag: "latest"
+
+# Force restart the service on all runs only when both roles are enabled, both roles
+# are using the same version string, and that version is the moving tag.
+matrix_bot_draupnir_force_restart: "if {{ matrix_bot_draupnir_enabled | bool and matrix_appservice_draupnir_for_all_enabled | bool and matrix_bot_draupnir_version == matrix_appservice_draupnir_for_all_version and matrix_bot_draupnir_version == matrix_bot_draupnir_force_restart_tag }} then true else false end"
 
 matrix_bot_draupnir_config_web_enabled: "{{ matrix_bot_draupnir_config_web_abuseReporting or matrix_bot_draupnir_config_web_synapseHTTPAntispam_enabled }}"  # noqa var-naming
 

--- a/roles/custom/matrix-bot-draupnir/defaults/main.yml
+++ b/roles/custom/matrix-bot-draupnir/defaults/main.yml
@@ -28,18 +28,16 @@ matrix_bot_draupnir_config_path: "{{ matrix_bot_draupnir_base_path }}/config"
 matrix_bot_draupnir_data_path: "{{ matrix_bot_draupnir_base_path }}/data"
 matrix_bot_draupnir_container_src_files_path: "{{ matrix_bot_draupnir_base_path }}/docker-src"
 
-# Force restart tag is used to control if the tag that is used is rolling or not.
-# When both Draupnir roles are enabled, we only force restart if they are on the same
-# version string and that version string matches the moving tag.
-matrix_bot_draupnir_force_rolling_tag: "latest"
+# Rolling tag: true if version doesn't match semver shape (vX.Y.Z with optional prerelease/build), false otherwise.
+matrix_bot_draupnir_rolling_tag: "{{ not (matrix_bot_draupnir_version is match('^v[0-9]+\\.[0-9]+\\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?$')) }}"
 
 # Force restart the service on all runs only when both roles are enabled, both roles
-# are using the same version string, and that version is the moving tag.
+# are using the same version string, and that version is a classified as a moving tag.
 matrix_bot_draupnir_force_restart: "{{
   matrix_bot_draupnir_enabled | bool and
   matrix_appservice_draupnir_for_all_enabled | bool and
   matrix_bot_draupnir_version == matrix_appservice_draupnir_for_all_version and
-  matrix_bot_draupnir_version == matrix_bot_draupnir_rolling_tag
+  matrix_bot_draupnir_rolling_tag | bool
 }}"
 
 matrix_bot_draupnir_config_web_enabled: "{{ matrix_bot_draupnir_config_web_abuseReporting or matrix_bot_draupnir_config_web_synapseHTTPAntispam_enabled }}"  # noqa var-naming

--- a/roles/custom/matrix-bot-draupnir/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-draupnir/tasks/setup_install.yml
@@ -38,11 +38,9 @@
   register: matrix_bot_draupnir_support_files_result
 
 - name: Ensure Draupnir Docker image is pulled
-  community.docker.docker_image:
+  community.docker.docker_image_pull:
     name: "{{ matrix_bot_draupnir_container_image }}"
-    source: "{{ 'pull' if ansible_version.major > 2 or ansible_version.minor > 7 else omit }}"
-    force_source: "{{ matrix_bot_draupnir_container_image_force_pull if ansible_version.major > 2 or ansible_version.minor >= 8 else omit }}"
-    force: "{{ omit if ansible_version.major > 2 or ansible_version.minor >= 8 else matrix_bot_draupnir_container_image_force_pull }}"
+    pull: always
   when: "not matrix_bot_draupnir_container_image_self_build | bool"
   register: matrix_bot_draupnir_container_image_pull_result
   retries: "{{ devture_playbook_help_container_retries_count }}"
@@ -61,15 +59,16 @@
   when: "matrix_bot_draupnir_container_image_self_build | bool"
 
 - name: Ensure Draupnir Docker image is built
-  community.docker.docker_image:
+  # Using docker_image_build with BuildKit for modern, efficient builds.
+  # docker_image_build automatically rebuilds when the Dockerfile or build context changes.
+  # The git_pull_results will show if the source was updated above.
+  community.docker.docker_image_build:
     name: "{{ matrix_bot_draupnir_container_image }}"
-    source: build
-    force_source: "{{ matrix_bot_draupnir_git_pull_results.changed }}"
-    build:
-      dockerfile: Dockerfile
-      path: "{{ matrix_bot_draupnir_container_src_files_path }}"
-      pull: true
-  when: "matrix_bot_draupnir_container_image_self_build | bool"
+    dockerfile: Dockerfile
+    path: "{{ matrix_bot_draupnir_container_src_files_path }}"
+    pull: true
+  when: "matrix_bot_draupnir_container_image_self_build | bool and matrix_bot_draupnir_git_pull_results.changed"
+  register: matrix_bot_draupnir_container_image_build_result
 
 - name: Ensure matrix-bot-draupnir config installed
   ansible.builtin.copy:
@@ -113,7 +112,8 @@
         or matrix_bot_draupnir_config_result.changed | default(false)
         or matrix_bot_draupnir_systemd_service_result.changed | default(false)
         or matrix_bot_draupnir_container_image_pull_result.changed | default(false)
-        or matrix_bot_draupnir_container_image_force_pull | bool
+        or matrix_bot_draupnir_container_image_build_result.changed | default(false)
+        or matrix_bot_draupnir_force_restart | bool
       }}
 
 - name: Ensure matrix-bot-draupnir.service restarted, if necessary

--- a/roles/custom/matrix-bot-draupnir/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-draupnir/tasks/setup_install.yml
@@ -60,14 +60,16 @@
 
 - name: Ensure Draupnir Docker image is built
   # Using docker_image_build with BuildKit for modern, efficient builds.
-  # docker_image_build automatically rebuilds when the Dockerfile or build context changes.
-  # The git_pull_results will show if the source was updated above.
+  # Rebuild when the git checkout advanced to a new commit; otherwise keep the build idempotent.
+  # Technically the idempotency of rebuilds is more that if a build has already been executed for that name:tag
+  # then we wont rebuild while in idempotent mode even if git moved. Thats what the force rebuild logic is for.
   community.docker.docker_image_build:
     name: "{{ matrix_bot_draupnir_container_image }}"
     dockerfile: Dockerfile
     path: "{{ matrix_bot_draupnir_container_src_files_path }}"
     pull: true
-  when: "matrix_bot_draupnir_container_image_self_build | bool and matrix_bot_draupnir_git_pull_results.changed"
+    rebuild: "{{ 'always' if matrix_bot_draupnir_git_pull_results.changed | bool else 'never' }}"
+  when: "matrix_bot_draupnir_container_image_self_build | bool"
   register: matrix_bot_draupnir_container_image_build_result
 
 - name: Ensure matrix-bot-draupnir config installed

--- a/roles/custom/matrix-bot-draupnir/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-draupnir/tasks/setup_install.yml
@@ -62,7 +62,7 @@
   # Using docker_image_build with BuildKit for modern, efficient builds.
   # Rebuild when the git checkout advanced to a new commit; otherwise keep the build idempotent.
   # Technically the idempotency of rebuilds is more that if a build has already been executed for that name:tag
-  # then we wont rebuild while in idempotent mode even if git moved. Thats what the force rebuild logic is for.
+  # then we won't rebuild while in idempotent mode even if git moved. That's what the force rebuild logic is for.
   community.docker.docker_image_build:
     name: "{{ matrix_bot_draupnir_container_image }}"
     dockerfile: Dockerfile

--- a/roles/custom/matrix-bot-draupnir/tasks/validate_config.yml
+++ b/roles/custom/matrix-bot-draupnir/tasks/validate_config.yml
@@ -37,7 +37,7 @@
     - {'old': 'matrix_bot_draupnir_docker_image_registry_prefix_upstream', 'new': 'matrix_bot_draupnir_container_image_registry_prefix_upstream'}
     - {'old': 'matrix_bot_draupnir_docker_image_registry_prefix_upstream_default', 'new': 'matrix_bot_draupnir_container_image_registry_prefix_upstream_default'}
     - {'old': 'matrix_bot_draupnir_docker_src_files_path', 'new': 'matrix_bot_draupnir_container_src_files_path'}
-    - {'old': 'matrix_bot_draupnir_container_image_force_pull', 'new': '<removed>'}
+    - {'old': 'matrix_bot_draupnir_container_image_force_pull', 'new': '<removed> (No longer needed due to new docker module doing this natively only if needed. If you run both bot mode and appservice mode matrix_bot_draupnir_rolling_tag_force_pull is needed to make sure restart logic works correctly for both roles.)'}
 
 - name: Fail if required matrix-bot-draupnir variables are undefined
   ansible.builtin.fail:

--- a/roles/custom/matrix-bot-draupnir/tasks/validate_config.yml
+++ b/roles/custom/matrix-bot-draupnir/tasks/validate_config.yml
@@ -37,6 +37,7 @@
     - {'old': 'matrix_bot_draupnir_docker_image_registry_prefix_upstream', 'new': 'matrix_bot_draupnir_container_image_registry_prefix_upstream'}
     - {'old': 'matrix_bot_draupnir_docker_image_registry_prefix_upstream_default', 'new': 'matrix_bot_draupnir_container_image_registry_prefix_upstream_default'}
     - {'old': 'matrix_bot_draupnir_docker_src_files_path', 'new': 'matrix_bot_draupnir_container_src_files_path'}
+    - {'old': 'matrix_bot_draupnir_container_image_force_pull', 'new': '<removed>'}
 
 - name: Fail if required matrix-bot-draupnir variables are undefined
   ansible.builtin.fail:

--- a/roles/custom/matrix-bot-draupnir/tasks/validate_config.yml
+++ b/roles/custom/matrix-bot-draupnir/tasks/validate_config.yml
@@ -37,7 +37,7 @@
     - {'old': 'matrix_bot_draupnir_docker_image_registry_prefix_upstream', 'new': 'matrix_bot_draupnir_container_image_registry_prefix_upstream'}
     - {'old': 'matrix_bot_draupnir_docker_image_registry_prefix_upstream_default', 'new': 'matrix_bot_draupnir_container_image_registry_prefix_upstream_default'}
     - {'old': 'matrix_bot_draupnir_docker_src_files_path', 'new': 'matrix_bot_draupnir_container_src_files_path'}
-    - {'old': 'matrix_bot_draupnir_container_image_force_pull', 'new': '<removed> (No longer needed due to new docker module doing this natively only if needed. If you run both bot mode and appservice mode matrix_bot_draupnir_rolling_tag_force_pull is needed to make sure restart logic works correctly for both roles.)'}
+    - {'old': 'matrix_bot_draupnir_container_image_force_pull', 'new': '<removed> (No longer needed due to new docker module doing this natively only if needed.)'}
 
 - name: Fail if required matrix-bot-draupnir variables are undefined
   ansible.builtin.fail:


### PR DESCRIPTION
Move the draupnir role to use modern ansible docker modules so we get access to fancy features like buildx and smart pulls. No more force pull bullshit.

And also make the force restart logic that this commit breaks work again but much smarter. Since if we are pulling diffrent tags (Will happen a lot with test environments) then we dont need to force a restart unessecarily.

This also allows people who exclusively run bot mode to still benefit from conditional restarts even if targeting a moving tag like main or latest.

This PR is currently untested properly. Im publishing it as a PR early to gather feedback but please do note its not exactly my most pretty work currently as im using some hacks to allow the roles to be unaware of each others container pull success.

Edit: This PR is now tested on my dev system and it seems to work atleast when it comes to force restarting and not doing wasteful docker pulling when running this branch ontop of the branch for a upcomming draupnir feature. (The feature branch only contains new config keys. Its the Zero Touch Deployment branch found on my fork of this repo. That branch isnt ready and the draupnir PR its tied to isnt merged yet.)