### PR TITLE
Add Synapse support for MSC4429

### DIFF
--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -1473,6 +1473,14 @@ matrix_synapse_experimental_features_msc4306_enabled: false
 # See https://github.com/matrix-org/matrix-spec-proposals/pull/4354
 matrix_synapse_experimental_features_msc4354_enabled: false
 
+# Controls whether to enable the MSC4429 experimental feature (profile updates for legacy `/sync`).
+#
+# This allows servers to notify clients using the legacy `/sync` endpoint of profile changes
+# for other users, enabling features such as user status.
+#
+# See https://github.com/matrix-org/matrix-spec-proposals/pull/4429
+matrix_synapse_experimental_features_msc4429_enabled: false
+
 # Enable this to activate the REST auth password provider module.
 # See: https://github.com/ma1uta/matrix-synapse-rest-password-provider
 matrix_synapse_ext_password_provider_rest_auth_enabled: false

--- a/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/homeserver.yaml.j2
@@ -3031,6 +3031,9 @@ experimental_features:
   {% if matrix_synapse_experimental_features_msc4354_enabled %}
   msc4354_enabled: true
   {% endif %}
+  {% if matrix_synapse_experimental_features_msc4429_enabled %}
+  msc4429_enabled: true
+  {% endif %}
 
 {% if matrix_synapse_experimental_features_msc4140_enabled %}
 max_event_delay_duration: {{ matrix_synapse_max_event_delay_duration | to_json }}


### PR DESCRIPTION
Introduces the `matrix_synapse_experimental_features_msc4429_enabled` variable (disabled by default), allowing Synapse to notify clients using the legacy /sync endpoint of profile changes for other users.

See <https://github.com/matrix-org/matrix-spec-proposals/pull/4429>