### PR TITLE
Allow host network mode for MDAD-managed containers

### DIFF
--- a/roles/custom/matrix-alertmanager-receiver/tasks/install.yml
+++ b/roles/custom/matrix-alertmanager-receiver/tasks/install.yml
@@ -73,7 +73,7 @@
       changed_when: true
 
 - name: Ensure matrix-alertmanager-receiver container network is created
-  when: matrix_alertmanager_receiver_container_network not in ['', 'host']
+  when: matrix_alertmanager_receiver_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_alertmanager_receiver_container_network }}"

--- a/roles/custom/matrix-alertmanager-receiver/tasks/install.yml
+++ b/roles/custom/matrix-alertmanager-receiver/tasks/install.yml
@@ -73,6 +73,7 @@
       changed_when: true
 
 - name: Ensure matrix-alertmanager-receiver container network is created
+  when: matrix_alertmanager_receiver_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_alertmanager_receiver_container_network }}"

--- a/roles/custom/matrix-alertmanager-receiver/templates/systemd/matrix-alertmanager-receiver.service.j2
+++ b/roles/custom/matrix-alertmanager-receiver/templates/systemd/matrix-alertmanager-receiver.service.j2
@@ -33,9 +33,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			--config-path=/config/config.yml {{ matrix_alertmanager_receiver_container_process_extra_arguments | join(' ') }} \
 			--log-level={{ matrix_alertmanager_receiver_container_process_argument_log_level }}
 
+{% if matrix_alertmanager_receiver_container_network not in ['', 'host'] %}
 {% for network in matrix_alertmanager_receiver_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-alertmanager-receiver
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-alertmanager-receiver
 

--- a/roles/custom/matrix-alertmanager-receiver/templates/systemd/matrix-alertmanager-receiver.service.j2
+++ b/roles/custom/matrix-alertmanager-receiver/templates/systemd/matrix-alertmanager-receiver.service.j2
@@ -33,7 +33,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			--config-path=/config/config.yml {{ matrix_alertmanager_receiver_container_process_extra_arguments | join(' ') }} \
 			--log-level={{ matrix_alertmanager_receiver_container_process_argument_log_level }}
 
-{% if matrix_alertmanager_receiver_container_network not in ['', 'host'] %}
+{% if matrix_alertmanager_receiver_container_network != 'host' %}
 {% for network in matrix_alertmanager_receiver_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-alertmanager-receiver
 {% endfor %}

--- a/roles/custom/matrix-appservice-draupnir-for-all/tasks/setup_install.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/tasks/setup_install.yml
@@ -88,7 +88,7 @@
   register: matrix_appservice_draupnir_for_all_registration_config_result
 
 - name: Ensure matrix-appservice-draupnir-for-all container network is created
-  when: matrix_appservice_draupnir_for_all_container_network not in ['', 'host']
+  when: matrix_appservice_draupnir_for_all_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_appservice_draupnir_for_all_container_network }}"

--- a/roles/custom/matrix-appservice-draupnir-for-all/tasks/setup_install.yml
+++ b/roles/custom/matrix-appservice-draupnir-for-all/tasks/setup_install.yml
@@ -88,6 +88,7 @@
   register: matrix_appservice_draupnir_for_all_registration_config_result
 
 - name: Ensure matrix-appservice-draupnir-for-all container network is created
+  when: matrix_appservice_draupnir_for_all_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_appservice_draupnir_for_all_container_network }}"

--- a/roles/custom/matrix-appservice-draupnir-for-all/templates/systemd/matrix-appservice-draupnir-for-all.service.j2
+++ b/roles/custom/matrix-appservice-draupnir-for-all/templates/systemd/matrix-appservice-draupnir-for-all.service.j2
@@ -32,7 +32,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_appservice_draupnir_for_all_container_image }} \
 			appservice -c /data/config/production-appservice.yaml -f /data/config/draupnir-for-all-registration.yaml -p {{ matrix_appservice_draupnir_for_all_appservice_port }} --draupnir-config /data/config/production-bots.yaml
 
-{% if matrix_appservice_draupnir_for_all_container_network not in ['', 'host'] %}
+{% if matrix_appservice_draupnir_for_all_container_network != 'host' %}
 {% for network in matrix_appservice_draupnir_for_all_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-appservice-draupnir-for-all
 {% endfor %}

--- a/roles/custom/matrix-appservice-draupnir-for-all/templates/systemd/matrix-appservice-draupnir-for-all.service.j2
+++ b/roles/custom/matrix-appservice-draupnir-for-all/templates/systemd/matrix-appservice-draupnir-for-all.service.j2
@@ -32,9 +32,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_appservice_draupnir_for_all_container_image }} \
 			appservice -c /data/config/production-appservice.yaml -f /data/config/draupnir-for-all-registration.yaml -p {{ matrix_appservice_draupnir_for_all_appservice_port }} --draupnir-config /data/config/production-bots.yaml
 
+{% if matrix_appservice_draupnir_for_all_container_network not in ['', 'host'] %}
 {% for network in matrix_appservice_draupnir_for_all_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-appservice-draupnir-for-all
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-appservice-draupnir-for-all
 

--- a/roles/custom/matrix-authentication-service/tasks/install.yml
+++ b/roles/custom/matrix-authentication-service/tasks/install.yml
@@ -114,6 +114,7 @@
       changed_when: true
 
 - name: Ensure Matrix Authentication Service container network is created
+  when: matrix_authentication_service_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_authentication_service_container_network }}"

--- a/roles/custom/matrix-authentication-service/tasks/install.yml
+++ b/roles/custom/matrix-authentication-service/tasks/install.yml
@@ -114,7 +114,7 @@
       changed_when: true
 
 - name: Ensure Matrix Authentication Service container network is created
-  when: matrix_authentication_service_container_network not in ['', 'host']
+  when: matrix_authentication_service_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_authentication_service_container_network }}"

--- a/roles/custom/matrix-authentication-service/templates/systemd/matrix-authentication-service.service.j2
+++ b/roles/custom/matrix-authentication-service/templates/systemd/matrix-authentication-service.service.j2
@@ -36,9 +36,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_authentication_service_container_image }}
 
+{% if matrix_authentication_service_container_network not in ['', 'host'] %}
 {% for network in matrix_authentication_service_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-authentication-service
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-authentication-service
 

--- a/roles/custom/matrix-authentication-service/templates/systemd/matrix-authentication-service.service.j2
+++ b/roles/custom/matrix-authentication-service/templates/systemd/matrix-authentication-service.service.j2
@@ -36,7 +36,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_authentication_service_container_image }}
 
-{% if matrix_authentication_service_container_network not in ['', 'host'] %}
+{% if matrix_authentication_service_container_network != 'host' %}
 {% for network in matrix_authentication_service_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-authentication-service
 {% endfor %}

--- a/roles/custom/matrix-bot-baibot/tasks/install.yml
+++ b/roles/custom/matrix-bot-baibot/tasks/install.yml
@@ -69,6 +69,7 @@
       register: matrix_bot_baibot_container_image_build_result
 
 - name: Ensure baibot container network is created
+  when: matrix_bot_baibot_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_baibot_container_network }}"

--- a/roles/custom/matrix-bot-baibot/tasks/install.yml
+++ b/roles/custom/matrix-bot-baibot/tasks/install.yml
@@ -69,7 +69,7 @@
       register: matrix_bot_baibot_container_image_build_result
 
 - name: Ensure baibot container network is created
-  when: matrix_bot_baibot_container_network not in ['', 'host']
+  when: matrix_bot_baibot_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_baibot_container_network }}"

--- a/roles/custom/matrix-bot-baibot/templates/systemd/matrix-bot-baibot.service.j2
+++ b/roles/custom/matrix-bot-baibot/templates/systemd/matrix-bot-baibot.service.j2
@@ -37,9 +37,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_bot_baibot_container_image }}
 
+{% if matrix_bot_baibot_container_network not in ['', 'host'] %}
 {% for network in matrix_bot_baibot_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-bot-baibot
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-bot-baibot
 

--- a/roles/custom/matrix-bot-baibot/templates/systemd/matrix-bot-baibot.service.j2
+++ b/roles/custom/matrix-bot-baibot/templates/systemd/matrix-bot-baibot.service.j2
@@ -37,7 +37,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_bot_baibot_container_image }}
 
-{% if matrix_bot_baibot_container_network not in ['', 'host'] %}
+{% if matrix_bot_baibot_container_network != 'host' %}
 {% for network in matrix_bot_baibot_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-bot-baibot
 {% endfor %}

--- a/roles/custom/matrix-bot-buscarron/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-buscarron/tasks/setup_install.yml
@@ -110,6 +110,7 @@
       }}
 
 - name: Ensure Buscarron container network is created
+  when: matrix_bot_buscarron_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_buscarron_container_network }}"

--- a/roles/custom/matrix-bot-buscarron/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-buscarron/tasks/setup_install.yml
@@ -110,7 +110,7 @@
       }}
 
 - name: Ensure Buscarron container network is created
-  when: matrix_bot_buscarron_container_network not in ['', 'host']
+  when: matrix_bot_buscarron_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_buscarron_container_network }}"

--- a/roles/custom/matrix-bot-buscarron/templates/systemd/matrix-bot-buscarron.service.j2
+++ b/roles/custom/matrix-bot-buscarron/templates/systemd/matrix-bot-buscarron.service.j2
@@ -32,7 +32,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_bot_buscarron_container_image }}
 
-{% if matrix_bot_buscarron_container_network not in ['', 'host'] %}
+{% if matrix_bot_buscarron_container_network != 'host' %}
 {% for network in matrix_bot_buscarron_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-bot-buscarron
 {% endfor %}

--- a/roles/custom/matrix-bot-buscarron/templates/systemd/matrix-bot-buscarron.service.j2
+++ b/roles/custom/matrix-bot-buscarron/templates/systemd/matrix-bot-buscarron.service.j2
@@ -32,9 +32,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_bot_buscarron_container_image }}
 
+{% if matrix_bot_buscarron_container_network not in ['', 'host'] %}
 {% for network in matrix_bot_buscarron_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-bot-buscarron
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-bot-buscarron
 

--- a/roles/custom/matrix-bot-draupnir/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-draupnir/tasks/setup_install.yml
@@ -82,6 +82,7 @@
   register: matrix_bot_draupnir_config_result
 
 - name: Ensure matrix-bot-draupnir container network is created
+  when: matrix_bot_draupnir_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_draupnir_container_network }}"

--- a/roles/custom/matrix-bot-draupnir/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-draupnir/tasks/setup_install.yml
@@ -82,7 +82,7 @@
   register: matrix_bot_draupnir_config_result
 
 - name: Ensure matrix-bot-draupnir container network is created
-  when: matrix_bot_draupnir_container_network not in ['', 'host']
+  when: matrix_bot_draupnir_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_draupnir_container_network }}"

--- a/roles/custom/matrix-bot-draupnir/templates/systemd/matrix-bot-draupnir.service.j2
+++ b/roles/custom/matrix-bot-draupnir/templates/systemd/matrix-bot-draupnir.service.j2
@@ -36,7 +36,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_bot_draupnir_container_image }} \
 			bot --draupnir-config /data/config/production.yaml
 
-{% if matrix_bot_draupnir_container_network not in ['', 'host'] %}
+{% if matrix_bot_draupnir_container_network != 'host' %}
 {% for network in matrix_bot_draupnir_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-bot-draupnir
 {% endfor %}

--- a/roles/custom/matrix-bot-draupnir/templates/systemd/matrix-bot-draupnir.service.j2
+++ b/roles/custom/matrix-bot-draupnir/templates/systemd/matrix-bot-draupnir.service.j2
@@ -36,9 +36,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_bot_draupnir_container_image }} \
 			bot --draupnir-config /data/config/production.yaml
 
+{% if matrix_bot_draupnir_container_network not in ['', 'host'] %}
 {% for network in matrix_bot_draupnir_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-bot-draupnir
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-bot-draupnir
 

--- a/roles/custom/matrix-bot-honoroit/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-honoroit/tasks/setup_install.yml
@@ -94,6 +94,7 @@
   register: matrix_bot_honoroit_container_image_build_result
 
 - name: Ensure Honoroit container network is created
+  when: matrix_bot_honoroit_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_honoroit_container_network }}"

--- a/roles/custom/matrix-bot-honoroit/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-honoroit/tasks/setup_install.yml
@@ -94,7 +94,7 @@
   register: matrix_bot_honoroit_container_image_build_result
 
 - name: Ensure Honoroit container network is created
-  when: matrix_bot_honoroit_container_network not in ['', 'host']
+  when: matrix_bot_honoroit_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_honoroit_container_network }}"

--- a/roles/custom/matrix-bot-honoroit/templates/systemd/matrix-bot-honoroit.service.j2
+++ b/roles/custom/matrix-bot-honoroit/templates/systemd/matrix-bot-honoroit.service.j2
@@ -32,7 +32,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_bot_honoroit_container_image }}
 
-{% if matrix_bot_honoroit_container_network not in ['', 'host'] %}
+{% if matrix_bot_honoroit_container_network != 'host' %}
 {% for network in matrix_bot_honoroit_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-bot-honoroit
 {% endfor %}

--- a/roles/custom/matrix-bot-honoroit/templates/systemd/matrix-bot-honoroit.service.j2
+++ b/roles/custom/matrix-bot-honoroit/templates/systemd/matrix-bot-honoroit.service.j2
@@ -32,9 +32,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_bot_honoroit_container_image }}
 
+{% if matrix_bot_honoroit_container_network not in ['', 'host'] %}
 {% for network in matrix_bot_honoroit_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-bot-honoroit
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-bot-honoroit
 

--- a/roles/custom/matrix-bot-matrix-registration-bot/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-matrix-registration-bot/tasks/setup_install.yml
@@ -62,6 +62,7 @@
       register: matrix_bot_matrix_registration_bot_container_image_build_result
 
 - name: Ensure matrix-registration-bot container network is created
+  when: matrix_bot_matrix_registration_bot_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_matrix_registration_bot_container_network }}"

--- a/roles/custom/matrix-bot-matrix-registration-bot/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-matrix-registration-bot/tasks/setup_install.yml
@@ -62,7 +62,7 @@
       register: matrix_bot_matrix_registration_bot_container_image_build_result
 
 - name: Ensure matrix-registration-bot container network is created
-  when: matrix_bot_matrix_registration_bot_container_network not in ['', 'host']
+  when: matrix_bot_matrix_registration_bot_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_matrix_registration_bot_container_network }}"

--- a/roles/custom/matrix-bot-matrix-registration-bot/templates/systemd/matrix-bot-matrix-registration-bot.service.j2
+++ b/roles/custom/matrix-bot-matrix-registration-bot/templates/systemd/matrix-bot-matrix-registration-bot.service.j2
@@ -29,9 +29,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			--network={{ matrix_bot_matrix_registration_bot_container_network }} \
 			{{ matrix_bot_matrix_registration_bot_container_image }}
 
+{% if matrix_bot_matrix_registration_bot_container_network not in ['', 'host'] %}
 {% for network in matrix_bot_matrix_registration_bot_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-bot-matrix-registration-bot
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-bot-matrix-registration-bot
 

--- a/roles/custom/matrix-bot-matrix-registration-bot/templates/systemd/matrix-bot-matrix-registration-bot.service.j2
+++ b/roles/custom/matrix-bot-matrix-registration-bot/templates/systemd/matrix-bot-matrix-registration-bot.service.j2
@@ -29,7 +29,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			--network={{ matrix_bot_matrix_registration_bot_container_network }} \
 			{{ matrix_bot_matrix_registration_bot_container_image }}
 
-{% if matrix_bot_matrix_registration_bot_container_network not in ['', 'host'] %}
+{% if matrix_bot_matrix_registration_bot_container_network != 'host' %}
 {% for network in matrix_bot_matrix_registration_bot_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-bot-matrix-registration-bot
 {% endfor %}

--- a/roles/custom/matrix-bot-matrix-reminder-bot/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-matrix-reminder-bot/tasks/setup_install.yml
@@ -93,7 +93,7 @@
   register: matrix_bot_matrix_reminder_bot_config_result
 
 - name: Ensure matrix-reminder-bot container network is created
-  when: matrix_bot_matrix_reminder_bot_container_network not in ['', 'host']
+  when: matrix_bot_matrix_reminder_bot_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_matrix_reminder_bot_container_network }}"

--- a/roles/custom/matrix-bot-matrix-reminder-bot/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-matrix-reminder-bot/tasks/setup_install.yml
@@ -93,6 +93,7 @@
   register: matrix_bot_matrix_reminder_bot_config_result
 
 - name: Ensure matrix-reminder-bot container network is created
+  when: matrix_bot_matrix_reminder_bot_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_matrix_reminder_bot_container_network }}"

--- a/roles/custom/matrix-bot-matrix-reminder-bot/templates/systemd/matrix-bot-matrix-reminder-bot.service.j2
+++ b/roles/custom/matrix-bot-matrix-reminder-bot/templates/systemd/matrix-bot-matrix-reminder-bot.service.j2
@@ -34,7 +34,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_bot_matrix_reminder_bot_container_image }} \
 			-c "matrix-reminder-bot /config/config.yaml"
 
-{% if matrix_bot_matrix_reminder_bot_container_network not in ['', 'host'] %}
+{% if matrix_bot_matrix_reminder_bot_container_network != 'host' %}
 {% for network in matrix_bot_matrix_reminder_bot_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-bot-matrix-reminder-bot
 {% endfor %}

--- a/roles/custom/matrix-bot-matrix-reminder-bot/templates/systemd/matrix-bot-matrix-reminder-bot.service.j2
+++ b/roles/custom/matrix-bot-matrix-reminder-bot/templates/systemd/matrix-bot-matrix-reminder-bot.service.j2
@@ -34,9 +34,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_bot_matrix_reminder_bot_container_image }} \
 			-c "matrix-reminder-bot /config/config.yaml"
 
+{% if matrix_bot_matrix_reminder_bot_container_network not in ['', 'host'] %}
 {% for network in matrix_bot_matrix_reminder_bot_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-bot-matrix-reminder-bot
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-bot-matrix-reminder-bot
 

--- a/roles/custom/matrix-bot-maubot/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-maubot/tasks/setup_install.yml
@@ -98,6 +98,7 @@
   register: matrix_bot_maubot_support_files_result
 
 - name: Ensure maubot container network is created
+  when: matrix_bot_maubot_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_maubot_container_network }}"

--- a/roles/custom/matrix-bot-maubot/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-maubot/tasks/setup_install.yml
@@ -98,7 +98,7 @@
   register: matrix_bot_maubot_support_files_result
 
 - name: Ensure maubot container network is created
-  when: matrix_bot_maubot_container_network not in ['', 'host']
+  when: matrix_bot_maubot_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_maubot_container_network }}"

--- a/roles/custom/matrix-bot-maubot/templates/systemd/matrix-bot-maubot.service.j2
+++ b/roles/custom/matrix-bot-maubot/templates/systemd/matrix-bot-maubot.service.j2
@@ -41,7 +41,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_bot_maubot_container_image_final }} \
  			python3 -m maubot -c /config/config.yaml --no-update
 
-{% if matrix_bot_maubot_container_network not in ['', 'host'] %}
+{% if matrix_bot_maubot_container_network != 'host' %}
 {% for network in matrix_bot_maubot_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-bot-maubot
 {% endfor %}

--- a/roles/custom/matrix-bot-maubot/templates/systemd/matrix-bot-maubot.service.j2
+++ b/roles/custom/matrix-bot-maubot/templates/systemd/matrix-bot-maubot.service.j2
@@ -41,9 +41,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_bot_maubot_container_image_final }} \
  			python3 -m maubot -c /config/config.yaml --no-update
 
+{% if matrix_bot_maubot_container_network not in ['', 'host'] %}
 {% for network in matrix_bot_maubot_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-bot-maubot
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-bot-maubot
 

--- a/roles/custom/matrix-bot-mjolnir/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-mjolnir/tasks/setup_install.yml
@@ -68,6 +68,7 @@
   register: matrix_bot_mjolnir_config_result
 
 - name: Ensure matrix-bot-mjolnir container network is created
+  when: matrix_bot_mjolnir_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_mjolnir_container_network }}"

--- a/roles/custom/matrix-bot-mjolnir/tasks/setup_install.yml
+++ b/roles/custom/matrix-bot-mjolnir/tasks/setup_install.yml
@@ -68,7 +68,7 @@
   register: matrix_bot_mjolnir_config_result
 
 - name: Ensure matrix-bot-mjolnir container network is created
-  when: matrix_bot_mjolnir_container_network not in ['', 'host']
+  when: matrix_bot_mjolnir_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_bot_mjolnir_container_network }}"

--- a/roles/custom/matrix-bot-mjolnir/templates/systemd/matrix-bot-mjolnir.service.j2
+++ b/roles/custom/matrix-bot-mjolnir/templates/systemd/matrix-bot-mjolnir.service.j2
@@ -32,9 +32,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_bot_mjolnir_container_image }} \
 			bot --mjolnir-config /data/config/production.yaml
 
+{% if matrix_bot_mjolnir_container_network not in ['', 'host'] %}
 {% for network in matrix_bot_mjolnir_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-bot-mjolnir
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-bot-mjolnir
 

--- a/roles/custom/matrix-bot-mjolnir/templates/systemd/matrix-bot-mjolnir.service.j2
+++ b/roles/custom/matrix-bot-mjolnir/templates/systemd/matrix-bot-mjolnir.service.j2
@@ -32,7 +32,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_bot_mjolnir_container_image }} \
 			bot --mjolnir-config /data/config/production.yaml
 
-{% if matrix_bot_mjolnir_container_network not in ['', 'host'] %}
+{% if matrix_bot_mjolnir_container_network != 'host' %}
 {% for network in matrix_bot_mjolnir_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-bot-mjolnir
 {% endfor %}

--- a/roles/custom/matrix-bridge-appservice-discord/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-appservice-discord/tasks/setup_install.yml
@@ -118,7 +118,7 @@
   changed_when: false
 
 - name: Ensure matrix-appservice-discord container network is created
-  when: matrix_appservice_discord_container_network not in ['', 'host']
+  when: matrix_appservice_discord_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_appservice_discord_container_network }}"

--- a/roles/custom/matrix-bridge-appservice-discord/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-appservice-discord/tasks/setup_install.yml
@@ -118,6 +118,7 @@
   changed_when: false
 
 - name: Ensure matrix-appservice-discord container network is created
+  when: matrix_appservice_discord_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_appservice_discord_container_network }}"

--- a/roles/custom/matrix-bridge-appservice-discord/templates/systemd/matrix-appservice-discord.service.j2
+++ b/roles/custom/matrix-bridge-appservice-discord/templates/systemd/matrix-appservice-discord.service.j2
@@ -34,7 +34,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_appservice_discord_container_image }} \
 			node /build/src/discordas.js -p 9005 -c /cfg/config.yaml -f /cfg/registration.yaml
 
-{% if matrix_appservice_discord_container_network not in ['', 'host'] %}
+{% if matrix_appservice_discord_container_network != 'host' %}
 {% for network in matrix_appservice_discord_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-appservice-discord
 {% endfor %}

--- a/roles/custom/matrix-bridge-appservice-discord/templates/systemd/matrix-appservice-discord.service.j2
+++ b/roles/custom/matrix-bridge-appservice-discord/templates/systemd/matrix-appservice-discord.service.j2
@@ -34,9 +34,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_appservice_discord_container_image }} \
 			node /build/src/discordas.js -p 9005 -c /cfg/config.yaml -f /cfg/registration.yaml
 
+{% if matrix_appservice_discord_container_network not in ['', 'host'] %}
 {% for network in matrix_appservice_discord_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-appservice-discord
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-appservice-discord
 

--- a/roles/custom/matrix-bridge-appservice-irc/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-appservice-irc/tasks/setup_install.yml
@@ -245,7 +245,7 @@
   register: matrix_appservice_irc_registration_result
 
 - name: Ensure matrix-appservice-irc container network is created
-  when: matrix_appservice_irc_container_network not in ['', 'host']
+  when: matrix_appservice_irc_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_appservice_irc_container_network }}"

--- a/roles/custom/matrix-bridge-appservice-irc/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-appservice-irc/tasks/setup_install.yml
@@ -245,6 +245,7 @@
   register: matrix_appservice_irc_registration_result
 
 - name: Ensure matrix-appservice-irc container network is created
+  when: matrix_appservice_irc_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_appservice_irc_container_network }}"

--- a/roles/custom/matrix-bridge-appservice-irc/templates/systemd/matrix-appservice-irc.service.j2
+++ b/roles/custom/matrix-bridge-appservice-irc/templates/systemd/matrix-appservice-irc.service.j2
@@ -39,7 +39,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_appservice_irc_container_image }} \
 			-c 'node app.js -c /config/config.yaml -f /config/registration.yaml -p 9999'
 
-{% if matrix_appservice_irc_container_network not in ['', 'host'] %}
+{% if matrix_appservice_irc_container_network != 'host' %}
 {% for network in matrix_appservice_irc_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-appservice-irc
 {% endfor %}

--- a/roles/custom/matrix-bridge-appservice-irc/templates/systemd/matrix-appservice-irc.service.j2
+++ b/roles/custom/matrix-bridge-appservice-irc/templates/systemd/matrix-appservice-irc.service.j2
@@ -39,9 +39,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_appservice_irc_container_image }} \
 			-c 'node app.js -c /config/config.yaml -f /config/registration.yaml -p 9999'
 
+{% if matrix_appservice_irc_container_network not in ['', 'host'] %}
 {% for network in matrix_appservice_irc_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-appservice-irc
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-appservice-irc
 

--- a/roles/custom/matrix-bridge-appservice-kakaotalk/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-appservice-kakaotalk/tasks/setup_install.yml
@@ -99,6 +99,7 @@
   register: matrix_appservice_kakaotalk_registration_result
 
 - name: Ensure matrix-appservice-kakaotalk container network is created
+  when: matrix_appservice_kakaotalk_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_appservice_kakaotalk_container_network }}"

--- a/roles/custom/matrix-bridge-appservice-kakaotalk/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-appservice-kakaotalk/tasks/setup_install.yml
@@ -99,7 +99,7 @@
   register: matrix_appservice_kakaotalk_registration_result
 
 - name: Ensure matrix-appservice-kakaotalk container network is created
-  when: matrix_appservice_kakaotalk_container_network not in ['', 'host']
+  when: matrix_appservice_kakaotalk_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_appservice_kakaotalk_container_network }}"

--- a/roles/custom/matrix-bridge-appservice-kakaotalk/templates/systemd/matrix-appservice-kakaotalk-node.service.j2
+++ b/roles/custom/matrix-bridge-appservice-kakaotalk/templates/systemd/matrix-appservice-kakaotalk-node.service.j2
@@ -30,7 +30,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_appservice_kakaotalk_node_container_image }} \
 			node src/main.js --config /config.json
 
-{% if matrix_appservice_kakaotalk_container_network not in ['', 'host'] %}
+{% if matrix_appservice_kakaotalk_container_network != 'host' %}
 {% for network in matrix_appservice_kakaotalk_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-appservice-kakaotalk-node
 {% endfor %}

--- a/roles/custom/matrix-bridge-appservice-kakaotalk/templates/systemd/matrix-appservice-kakaotalk-node.service.j2
+++ b/roles/custom/matrix-bridge-appservice-kakaotalk/templates/systemd/matrix-appservice-kakaotalk-node.service.j2
@@ -30,9 +30,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_appservice_kakaotalk_node_container_image }} \
 			node src/main.js --config /config.json
 
+{% if matrix_appservice_kakaotalk_container_network not in ['', 'host'] %}
 {% for network in matrix_appservice_kakaotalk_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-appservice-kakaotalk-node
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-appservice-kakaotalk-node
 

--- a/roles/custom/matrix-bridge-appservice-kakaotalk/templates/systemd/matrix-appservice-kakaotalk.service.j2
+++ b/roles/custom/matrix-bridge-appservice-kakaotalk/templates/systemd/matrix-appservice-kakaotalk.service.j2
@@ -31,7 +31,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_appservice_kakaotalk_container_image }} \
 			python3 -m matrix_appservice_kakaotalk -c /config/config.yaml --no-update
 
-{% if matrix_appservice_discord_container_network not in ['', 'host'] %}
+{% if matrix_appservice_discord_container_network != 'host' %}
 {% for network in matrix_appservice_discord_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-appservice-kakaotalk
 {% endfor %}

--- a/roles/custom/matrix-bridge-appservice-kakaotalk/templates/systemd/matrix-appservice-kakaotalk.service.j2
+++ b/roles/custom/matrix-bridge-appservice-kakaotalk/templates/systemd/matrix-appservice-kakaotalk.service.j2
@@ -31,9 +31,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_appservice_kakaotalk_container_image }} \
 			python3 -m matrix_appservice_kakaotalk -c /config/config.yaml --no-update
 
+{% if matrix_appservice_discord_container_network not in ['', 'host'] %}
 {% for network in matrix_appservice_discord_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-appservice-kakaotalk
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-appservice-kakaotalk
 

--- a/roles/custom/matrix-bridge-beeper-linkedin/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-beeper-linkedin/tasks/setup_install.yml
@@ -92,6 +92,7 @@
       register: matrix_beeper_linkedin_container_image_build_result
 
 - name: Ensure beeper-linkedin container network is created
+  when: matrix_beeper_linkedin_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_beeper_linkedin_container_network }}"

--- a/roles/custom/matrix-bridge-beeper-linkedin/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-beeper-linkedin/tasks/setup_install.yml
@@ -92,7 +92,7 @@
       register: matrix_beeper_linkedin_container_image_build_result
 
 - name: Ensure beeper-linkedin container network is created
-  when: matrix_beeper_linkedin_container_network not in ['', 'host']
+  when: matrix_beeper_linkedin_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_beeper_linkedin_container_network }}"

--- a/roles/custom/matrix-bridge-beeper-linkedin/templates/systemd/matrix-beeper-linkedin.service.j2
+++ b/roles/custom/matrix-bridge-beeper-linkedin/templates/systemd/matrix-beeper-linkedin.service.j2
@@ -31,7 +31,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_beeper_linkedin_container_image }} \
 			python3 -m linkedin_matrix -c /config/config.yaml -r /config/registration.yaml --no-update
 
-{% if matrix_beeper_linkedin_container_network not in ['', 'host'] %}
+{% if matrix_beeper_linkedin_container_network != 'host' %}
 {% for network in matrix_beeper_linkedin_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-beeper-linkedin
 {% endfor %}

--- a/roles/custom/matrix-bridge-beeper-linkedin/templates/systemd/matrix-beeper-linkedin.service.j2
+++ b/roles/custom/matrix-bridge-beeper-linkedin/templates/systemd/matrix-beeper-linkedin.service.j2
@@ -31,9 +31,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_beeper_linkedin_container_image }} \
 			python3 -m linkedin_matrix -c /config/config.yaml -r /config/registration.yaml --no-update
 
+{% if matrix_beeper_linkedin_container_network not in ['', 'host'] %}
 {% for network in matrix_beeper_linkedin_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-beeper-linkedin
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-beeper-linkedin
 

--- a/roles/custom/matrix-bridge-heisenbridge/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-heisenbridge/tasks/setup_install.yml
@@ -50,7 +50,7 @@
   register: matrix_heisenbridge_support_files_result
 
 - name: Ensure Heisenbridge container network is created
-  when: matrix_heisenbridge_container_network not in ['', 'host']
+  when: matrix_heisenbridge_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_heisenbridge_container_network }}"

--- a/roles/custom/matrix-bridge-heisenbridge/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-heisenbridge/tasks/setup_install.yml
@@ -50,6 +50,7 @@
   register: matrix_heisenbridge_support_files_result
 
 - name: Ensure Heisenbridge container network is created
+  when: matrix_heisenbridge_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_heisenbridge_container_network }}"

--- a/roles/custom/matrix-bridge-heisenbridge/templates/systemd/matrix-heisenbridge.service.j2
+++ b/roles/custom/matrix-bridge-heisenbridge/templates/systemd/matrix-heisenbridge.service.j2
@@ -44,7 +44,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			--listen-port 9898 \
 			{{ matrix_heisenbridge_homeserver_url }}
 
-{% if matrix_heisenbridge_container_network not in ['', 'host'] %}
+{% if matrix_heisenbridge_container_network != 'host' %}
 {% for network in matrix_heisenbridge_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-heisenbridge
 {% endfor %}

--- a/roles/custom/matrix-bridge-heisenbridge/templates/systemd/matrix-heisenbridge.service.j2
+++ b/roles/custom/matrix-bridge-heisenbridge/templates/systemd/matrix-heisenbridge.service.j2
@@ -44,9 +44,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			--listen-port 9898 \
 			{{ matrix_heisenbridge_homeserver_url }}
 
+{% if matrix_heisenbridge_container_network not in ['', 'host'] %}
 {% for network in matrix_heisenbridge_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-heisenbridge
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-heisenbridge
 

--- a/roles/custom/matrix-bridge-hookshot/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-hookshot/tasks/setup_install.yml
@@ -133,6 +133,7 @@
   register: matrix_hookshot_github_key_result
 
 - name: Ensure matrix-hookshot container network is created
+  when: matrix_hookshot_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_hookshot_container_network }}"

--- a/roles/custom/matrix-bridge-hookshot/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-hookshot/tasks/setup_install.yml
@@ -133,7 +133,7 @@
   register: matrix_hookshot_github_key_result
 
 - name: Ensure matrix-hookshot container network is created
-  when: matrix_hookshot_container_network not in ['', 'host']
+  when: matrix_hookshot_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_hookshot_container_network }}"

--- a/roles/custom/matrix-bridge-hookshot/templates/systemd/matrix-hookshot.service.j2
+++ b/roles/custom/matrix-bridge-hookshot/templates/systemd/matrix-hookshot.service.j2
@@ -30,9 +30,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create --rm -
           {% endfor %}
           {{ matrix_hookshot_container_image }}
 
+{% if matrix_hookshot_container_network not in ['', 'host'] %}
 {% for network in matrix_hookshot_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} {{ matrix_hookshot_identifier }}
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach {{ matrix_hookshot_identifier }}
 

--- a/roles/custom/matrix-bridge-hookshot/templates/systemd/matrix-hookshot.service.j2
+++ b/roles/custom/matrix-bridge-hookshot/templates/systemd/matrix-hookshot.service.j2
@@ -30,7 +30,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create --rm -
           {% endfor %}
           {{ matrix_hookshot_container_image }}
 
-{% if matrix_hookshot_container_network not in ['', 'host'] %}
+{% if matrix_hookshot_container_network != 'host' %}
 {% for network in matrix_hookshot_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} {{ matrix_hookshot_identifier }}
 {% endfor %}

--- a/roles/custom/matrix-bridge-mautrix-bluesky/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-bluesky/tasks/setup_install.yml
@@ -82,6 +82,7 @@
   register: matrix_mautrix_bluesky_support_files_result
 
 - name: Ensure matrix-mautrix-bluesky container network is created
+  when: matrix_mautrix_bluesky_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_bluesky_container_network }}"

--- a/roles/custom/matrix-bridge-mautrix-bluesky/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-bluesky/tasks/setup_install.yml
@@ -82,7 +82,7 @@
   register: matrix_mautrix_bluesky_support_files_result
 
 - name: Ensure matrix-mautrix-bluesky container network is created
-  when: matrix_mautrix_bluesky_container_network not in ['', 'host']
+  when: matrix_mautrix_bluesky_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_bluesky_container_network }}"

--- a/roles/custom/matrix-bridge-mautrix-bluesky/templates/systemd/matrix-mautrix-bluesky.service.j2
+++ b/roles/custom/matrix-bridge-mautrix-bluesky/templates/systemd/matrix-mautrix-bluesky.service.j2
@@ -32,9 +32,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_mautrix_bluesky_container_image }} \
 			/usr/bin/mautrix-bluesky -c /config/config.yaml -r /config/registration.yaml --no-update
 
+{% if matrix_mautrix_bluesky_container_network not in ['', 'host'] %}
 {% for network in matrix_mautrix_bluesky_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-mautrix-bluesky
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-mautrix-bluesky
 

--- a/roles/custom/matrix-bridge-mautrix-bluesky/templates/systemd/matrix-mautrix-bluesky.service.j2
+++ b/roles/custom/matrix-bridge-mautrix-bluesky/templates/systemd/matrix-mautrix-bluesky.service.j2
@@ -32,7 +32,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_mautrix_bluesky_container_image }} \
 			/usr/bin/mautrix-bluesky -c /config/config.yaml -r /config/registration.yaml --no-update
 
-{% if matrix_mautrix_bluesky_container_network not in ['', 'host'] %}
+{% if matrix_mautrix_bluesky_container_network != 'host' %}
 {% for network in matrix_mautrix_bluesky_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-mautrix-bluesky
 {% endfor %}

--- a/roles/custom/matrix-bridge-mautrix-discord/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-discord/tasks/setup_install.yml
@@ -110,7 +110,7 @@
   register: matrix_mautrix_discord_support_files_result
 
 - name: Ensure mautrix-discord container network is created
-  when: matrix_mautrix_discord_container_network not in ['', 'host']
+  when: matrix_mautrix_discord_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_discord_container_network }}"

--- a/roles/custom/matrix-bridge-mautrix-discord/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-discord/tasks/setup_install.yml
@@ -110,6 +110,7 @@
   register: matrix_mautrix_discord_support_files_result
 
 - name: Ensure mautrix-discord container network is created
+  when: matrix_mautrix_discord_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_discord_container_network }}"

--- a/roles/custom/matrix-bridge-mautrix-discord/templates/systemd/matrix-mautrix-discord.service.j2
+++ b/roles/custom/matrix-bridge-mautrix-discord/templates/systemd/matrix-mautrix-discord.service.j2
@@ -33,7 +33,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_mautrix_discord_container_image }} \
 			/usr/bin/mautrix-discord -c /config/config.yaml -r /config/registration.yaml --no-update
 
-{% if matrix_mautrix_discord_container_network not in ['', 'host'] %}
+{% if matrix_mautrix_discord_container_network != 'host' %}
 {% for network in matrix_mautrix_discord_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-mautrix-discord
 {% endfor %}

--- a/roles/custom/matrix-bridge-mautrix-discord/templates/systemd/matrix-mautrix-discord.service.j2
+++ b/roles/custom/matrix-bridge-mautrix-discord/templates/systemd/matrix-mautrix-discord.service.j2
@@ -33,9 +33,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_mautrix_discord_container_image }} \
 			/usr/bin/mautrix-discord -c /config/config.yaml -r /config/registration.yaml --no-update
 
+{% if matrix_mautrix_discord_container_network not in ['', 'host'] %}
 {% for network in matrix_mautrix_discord_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-mautrix-discord
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-mautrix-discord
 

--- a/roles/custom/matrix-bridge-mautrix-gmessages/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-gmessages/tasks/setup_install.yml
@@ -150,6 +150,7 @@
   register: matrix_mautrix_gmessages_support_files_result
 
 - name: Ensure matrix-mautrix-gmessages container network is created
+  when: matrix_mautrix_gmessages_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_gmessages_container_network }}"

--- a/roles/custom/matrix-bridge-mautrix-gmessages/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-gmessages/tasks/setup_install.yml
@@ -150,7 +150,7 @@
   register: matrix_mautrix_gmessages_support_files_result
 
 - name: Ensure matrix-mautrix-gmessages container network is created
-  when: matrix_mautrix_gmessages_container_network not in ['', 'host']
+  when: matrix_mautrix_gmessages_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_gmessages_container_network }}"

--- a/roles/custom/matrix-bridge-mautrix-gmessages/templates/systemd/matrix-mautrix-gmessages.service.j2
+++ b/roles/custom/matrix-bridge-mautrix-gmessages/templates/systemd/matrix-mautrix-gmessages.service.j2
@@ -33,7 +33,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_mautrix_gmessages_container_image }} \
 			/usr/bin/mautrix-gmessages -c /config/config.yaml -r /config/registration.yaml --no-update
 
-{% if matrix_mautrix_gmessages_container_network not in ['', 'host'] %}
+{% if matrix_mautrix_gmessages_container_network != 'host' %}
 {% for network in matrix_mautrix_gmessages_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-mautrix-gmessages
 {% endfor %}

--- a/roles/custom/matrix-bridge-mautrix-gmessages/templates/systemd/matrix-mautrix-gmessages.service.j2
+++ b/roles/custom/matrix-bridge-mautrix-gmessages/templates/systemd/matrix-mautrix-gmessages.service.j2
@@ -33,9 +33,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_mautrix_gmessages_container_image }} \
 			/usr/bin/mautrix-gmessages -c /config/config.yaml -r /config/registration.yaml --no-update
 
+{% if matrix_mautrix_gmessages_container_network not in ['', 'host'] %}
 {% for network in matrix_mautrix_gmessages_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-mautrix-gmessages
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-mautrix-gmessages
 

--- a/roles/custom/matrix-bridge-mautrix-googlechat/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-googlechat/tasks/setup_install.yml
@@ -133,7 +133,7 @@
   register: matrix_mautrix_googlechat_support_files_result
 
 - name: Ensure matrix-mautrix-googlechat container network is created
-  when: matrix_mautrix_googlechat_container_network not in ['', 'host']
+  when: matrix_mautrix_googlechat_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_googlechat_container_network }}"

--- a/roles/custom/matrix-bridge-mautrix-googlechat/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-googlechat/tasks/setup_install.yml
@@ -133,6 +133,7 @@
   register: matrix_mautrix_googlechat_support_files_result
 
 - name: Ensure matrix-mautrix-googlechat container network is created
+  when: matrix_mautrix_googlechat_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_googlechat_container_network }}"

--- a/roles/custom/matrix-bridge-mautrix-googlechat/templates/systemd/matrix-mautrix-googlechat.service.j2
+++ b/roles/custom/matrix-bridge-mautrix-googlechat/templates/systemd/matrix-mautrix-googlechat.service.j2
@@ -35,9 +35,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_mautrix_googlechat_container_image }} \
 			python3 -m mautrix_googlechat -c /config/config.yaml --no-update
 
+{% if matrix_mautrix_googlechat_container_network not in ['', 'host'] %}
 {% for network in matrix_mautrix_googlechat_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-mautrix-googlechat
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-mautrix-googlechat
 

--- a/roles/custom/matrix-bridge-mautrix-googlechat/templates/systemd/matrix-mautrix-googlechat.service.j2
+++ b/roles/custom/matrix-bridge-mautrix-googlechat/templates/systemd/matrix-mautrix-googlechat.service.j2
@@ -35,7 +35,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_mautrix_googlechat_container_image }} \
 			python3 -m mautrix_googlechat -c /config/config.yaml --no-update
 
-{% if matrix_mautrix_googlechat_container_network not in ['', 'host'] %}
+{% if matrix_mautrix_googlechat_container_network != 'host' %}
 {% for network in matrix_mautrix_googlechat_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-mautrix-googlechat
 {% endfor %}

--- a/roles/custom/matrix-bridge-mautrix-meta-instagram/tasks/install.yml
+++ b/roles/custom/matrix-bridge-mautrix-meta-instagram/tasks/install.yml
@@ -107,7 +107,7 @@
   register: matrix_mautrix_meta_instagram_support_files_result
 
 - name: Ensure mautrix-meta-instagram container network is created
-  when: matrix_mautrix_meta_instagram_container_network not in ['', 'host']
+  when: matrix_mautrix_meta_instagram_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_meta_instagram_container_network }}"

--- a/roles/custom/matrix-bridge-mautrix-meta-instagram/tasks/install.yml
+++ b/roles/custom/matrix-bridge-mautrix-meta-instagram/tasks/install.yml
@@ -107,6 +107,7 @@
   register: matrix_mautrix_meta_instagram_support_files_result
 
 - name: Ensure mautrix-meta-instagram container network is created
+  when: matrix_mautrix_meta_instagram_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_meta_instagram_container_network }}"

--- a/roles/custom/matrix-bridge-mautrix-meta-instagram/templates/systemd/matrix-mautrix-meta.service.j2
+++ b/roles/custom/matrix-bridge-mautrix-meta-instagram/templates/systemd/matrix-mautrix-meta.service.j2
@@ -35,9 +35,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_mautrix_meta_instagram_container_image }} \
 			/usr/bin/mautrix-meta -c /config/config.yaml -r /config/registration.yaml --no-update
 
+{% if matrix_mautrix_meta_instagram_container_network not in ['', 'host'] %}
 {% for network in matrix_mautrix_meta_instagram_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} {{ matrix_mautrix_meta_instagram_identifier }}
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach {{ matrix_mautrix_meta_instagram_identifier }}
 

--- a/roles/custom/matrix-bridge-mautrix-meta-instagram/templates/systemd/matrix-mautrix-meta.service.j2
+++ b/roles/custom/matrix-bridge-mautrix-meta-instagram/templates/systemd/matrix-mautrix-meta.service.j2
@@ -35,7 +35,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_mautrix_meta_instagram_container_image }} \
 			/usr/bin/mautrix-meta -c /config/config.yaml -r /config/registration.yaml --no-update
 
-{% if matrix_mautrix_meta_instagram_container_network not in ['', 'host'] %}
+{% if matrix_mautrix_meta_instagram_container_network != 'host' %}
 {% for network in matrix_mautrix_meta_instagram_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} {{ matrix_mautrix_meta_instagram_identifier }}
 {% endfor %}

--- a/roles/custom/matrix-bridge-mautrix-meta-messenger/tasks/install.yml
+++ b/roles/custom/matrix-bridge-mautrix-meta-messenger/tasks/install.yml
@@ -107,7 +107,7 @@
   register: matrix_mautrix_meta_messenger_support_files_result
 
 - name: Ensure mautrix-meta-messenger container network is created
-  when: matrix_mautrix_meta_messenger_container_network not in ['', 'host']
+  when: matrix_mautrix_meta_messenger_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_meta_messenger_container_network }}"

--- a/roles/custom/matrix-bridge-mautrix-meta-messenger/tasks/install.yml
+++ b/roles/custom/matrix-bridge-mautrix-meta-messenger/tasks/install.yml
@@ -107,6 +107,7 @@
   register: matrix_mautrix_meta_messenger_support_files_result
 
 - name: Ensure mautrix-meta-messenger container network is created
+  when: matrix_mautrix_meta_messenger_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_meta_messenger_container_network }}"

--- a/roles/custom/matrix-bridge-mautrix-meta-messenger/templates/systemd/matrix-mautrix-meta.service.j2
+++ b/roles/custom/matrix-bridge-mautrix-meta-messenger/templates/systemd/matrix-mautrix-meta.service.j2
@@ -35,9 +35,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_mautrix_meta_messenger_container_image }} \
 			/usr/bin/mautrix-meta -c /config/config.yaml -r /config/registration.yaml --no-update
 
+{% if matrix_mautrix_meta_messenger_container_network not in ['', 'host'] %}
 {% for network in matrix_mautrix_meta_messenger_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} {{ matrix_mautrix_meta_messenger_identifier }}
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach {{ matrix_mautrix_meta_messenger_identifier }}
 

--- a/roles/custom/matrix-bridge-mautrix-meta-messenger/templates/systemd/matrix-mautrix-meta.service.j2
+++ b/roles/custom/matrix-bridge-mautrix-meta-messenger/templates/systemd/matrix-mautrix-meta.service.j2
@@ -35,7 +35,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_mautrix_meta_messenger_container_image }} \
 			/usr/bin/mautrix-meta -c /config/config.yaml -r /config/registration.yaml --no-update
 
-{% if matrix_mautrix_meta_messenger_container_network not in ['', 'host'] %}
+{% if matrix_mautrix_meta_messenger_container_network != 'host' %}
 {% for network in matrix_mautrix_meta_messenger_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} {{ matrix_mautrix_meta_messenger_identifier }}
 {% endfor %}

--- a/roles/custom/matrix-bridge-mautrix-signal/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-signal/tasks/setup_install.yml
@@ -148,7 +148,7 @@
   register: matrix_mautrix_signal_support_files_result
 
 - name: Ensure matrix-mautrix-signal container network is created
-  when: matrix_mautrix_signal_container_network not in ['', 'host']
+  when: matrix_mautrix_signal_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_signal_container_network }}"

--- a/roles/custom/matrix-bridge-mautrix-signal/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-signal/tasks/setup_install.yml
@@ -148,6 +148,7 @@
   register: matrix_mautrix_signal_support_files_result
 
 - name: Ensure matrix-mautrix-signal container network is created
+  when: matrix_mautrix_signal_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_signal_container_network }}"

--- a/roles/custom/matrix-bridge-mautrix-signal/templates/systemd/matrix-mautrix-signal.service.j2
+++ b/roles/custom/matrix-bridge-mautrix-signal/templates/systemd/matrix-mautrix-signal.service.j2
@@ -33,9 +33,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_mautrix_signal_container_image }} \
 			/usr/bin/mautrix-signal -c /config/config.yaml -r /config/registration.yaml --no-update
 
+{% if matrix_mautrix_signal_container_network not in ['', 'host'] %}
 {% for network in matrix_mautrix_signal_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-mautrix-signal
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-mautrix-signal
 

--- a/roles/custom/matrix-bridge-mautrix-signal/templates/systemd/matrix-mautrix-signal.service.j2
+++ b/roles/custom/matrix-bridge-mautrix-signal/templates/systemd/matrix-mautrix-signal.service.j2
@@ -33,7 +33,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_mautrix_signal_container_image }} \
 			/usr/bin/mautrix-signal -c /config/config.yaml -r /config/registration.yaml --no-update
 
-{% if matrix_mautrix_signal_container_network not in ['', 'host'] %}
+{% if matrix_mautrix_signal_container_network != 'host' %}
 {% for network in matrix_mautrix_signal_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-mautrix-signal
 {% endfor %}

--- a/roles/custom/matrix-bridge-mautrix-slack/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-slack/tasks/setup_install.yml
@@ -98,6 +98,7 @@
   register: matrix_mautrix_slack_registration_result
 
 - name: Ensure matrix-mautrix-slack container network is created
+  when: matrix_mautrix_slack_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_slack_container_network }}"

--- a/roles/custom/matrix-bridge-mautrix-slack/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-slack/tasks/setup_install.yml
@@ -98,7 +98,7 @@
   register: matrix_mautrix_slack_registration_result
 
 - name: Ensure matrix-mautrix-slack container network is created
-  when: matrix_mautrix_slack_container_network not in ['', 'host']
+  when: matrix_mautrix_slack_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_slack_container_network }}"

--- a/roles/custom/matrix-bridge-mautrix-slack/templates/systemd/matrix-mautrix-slack.service.j2
+++ b/roles/custom/matrix-bridge-mautrix-slack/templates/systemd/matrix-mautrix-slack.service.j2
@@ -32,7 +32,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_mautrix_slack_container_image }} \
 			/usr/bin/mautrix-slack -c /config/config.yaml -r /config/registration.yaml --no-update
 
-{% if matrix_mautrix_slack_container_network not in ['', 'host'] %}
+{% if matrix_mautrix_slack_container_network != 'host' %}
 {% for network in matrix_mautrix_slack_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-mautrix-slack
 {% endfor %}

--- a/roles/custom/matrix-bridge-mautrix-slack/templates/systemd/matrix-mautrix-slack.service.j2
+++ b/roles/custom/matrix-bridge-mautrix-slack/templates/systemd/matrix-mautrix-slack.service.j2
@@ -32,9 +32,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_mautrix_slack_container_image }} \
 			/usr/bin/mautrix-slack -c /config/config.yaml -r /config/registration.yaml --no-update
 
+{% if matrix_mautrix_slack_container_network not in ['', 'host'] %}
 {% for network in matrix_mautrix_slack_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-mautrix-slack
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-mautrix-slack
 

--- a/roles/custom/matrix-bridge-mautrix-telegram/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-telegram/tasks/setup_install.yml
@@ -154,6 +154,7 @@
   register: matrix_mautrix_telegram_support_files_result
 
 - name: Ensure matrix-mautrix-telegram container network is created
+  when: matrix_mautrix_telegram_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_telegram_container_network }}"

--- a/roles/custom/matrix-bridge-mautrix-telegram/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-telegram/tasks/setup_install.yml
@@ -154,7 +154,7 @@
   register: matrix_mautrix_telegram_support_files_result
 
 - name: Ensure matrix-mautrix-telegram container network is created
-  when: matrix_mautrix_telegram_container_network not in ['', 'host']
+  when: matrix_mautrix_telegram_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_telegram_container_network }}"

--- a/roles/custom/matrix-bridge-mautrix-telegram/templates/systemd/matrix-mautrix-telegram.service.j2
+++ b/roles/custom/matrix-bridge-mautrix-telegram/templates/systemd/matrix-mautrix-telegram.service.j2
@@ -33,9 +33,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_mautrix_telegram_container_image }} \
 			/usr/bin/mautrix-telegram -c /config/config.yaml -r /config/registration.yaml --no-update
 
+{% if matrix_mautrix_telegram_container_network not in ['', 'host'] %}
 {% for network in matrix_mautrix_telegram_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-mautrix-telegram
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-mautrix-telegram
 

--- a/roles/custom/matrix-bridge-mautrix-telegram/templates/systemd/matrix-mautrix-telegram.service.j2
+++ b/roles/custom/matrix-bridge-mautrix-telegram/templates/systemd/matrix-mautrix-telegram.service.j2
@@ -33,7 +33,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_mautrix_telegram_container_image }} \
 			/usr/bin/mautrix-telegram -c /config/config.yaml -r /config/registration.yaml --no-update
 
-{% if matrix_mautrix_telegram_container_network not in ['', 'host'] %}
+{% if matrix_mautrix_telegram_container_network != 'host' %}
 {% for network in matrix_mautrix_telegram_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-mautrix-telegram
 {% endfor %}

--- a/roles/custom/matrix-bridge-mautrix-twitter/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-twitter/tasks/setup_install.yml
@@ -88,6 +88,7 @@
   register: matrix_mautrix_twitter_support_files_result
 
 - name: Ensure matrix-mautrix-twitter container network is created
+  when: matrix_mautrix_twitter_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_twitter_container_network }}"

--- a/roles/custom/matrix-bridge-mautrix-twitter/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-twitter/tasks/setup_install.yml
@@ -88,7 +88,7 @@
   register: matrix_mautrix_twitter_support_files_result
 
 - name: Ensure matrix-mautrix-twitter container network is created
-  when: matrix_mautrix_twitter_container_network not in ['', 'host']
+  when: matrix_mautrix_twitter_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_twitter_container_network }}"

--- a/roles/custom/matrix-bridge-mautrix-twitter/templates/systemd/matrix-mautrix-twitter.service.j2
+++ b/roles/custom/matrix-bridge-mautrix-twitter/templates/systemd/matrix-mautrix-twitter.service.j2
@@ -32,9 +32,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_mautrix_twitter_container_image }} \
 			/usr/bin/mautrix-twitter -c /config/config.yaml -r /config/registration.yaml --no-update
 
+{% if matrix_mautrix_twitter_container_network not in ['', 'host'] %}
 {% for network in matrix_mautrix_twitter_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-mautrix-twitter
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-mautrix-twitter
 

--- a/roles/custom/matrix-bridge-mautrix-twitter/templates/systemd/matrix-mautrix-twitter.service.j2
+++ b/roles/custom/matrix-bridge-mautrix-twitter/templates/systemd/matrix-mautrix-twitter.service.j2
@@ -32,7 +32,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_mautrix_twitter_container_image }} \
 			/usr/bin/mautrix-twitter -c /config/config.yaml -r /config/registration.yaml --no-update
 
-{% if matrix_mautrix_twitter_container_network not in ['', 'host'] %}
+{% if matrix_mautrix_twitter_container_network != 'host' %}
 {% for network in matrix_mautrix_twitter_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-mautrix-twitter
 {% endfor %}

--- a/roles/custom/matrix-bridge-mautrix-whatsapp/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-whatsapp/tasks/setup_install.yml
@@ -153,6 +153,7 @@
   register: matrix_mautrix_whatsapp_support_files_result
 
 - name: Ensure matrix-mautrix-whatsapp container network is created
+  when: matrix_mautrix_whatsapp_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_whatsapp_container_network }}"

--- a/roles/custom/matrix-bridge-mautrix-whatsapp/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-whatsapp/tasks/setup_install.yml
@@ -153,7 +153,7 @@
   register: matrix_mautrix_whatsapp_support_files_result
 
 - name: Ensure matrix-mautrix-whatsapp container network is created
-  when: matrix_mautrix_whatsapp_container_network not in ['', 'host']
+  when: matrix_mautrix_whatsapp_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_whatsapp_container_network }}"

--- a/roles/custom/matrix-bridge-mautrix-whatsapp/templates/systemd/matrix-mautrix-whatsapp.service.j2
+++ b/roles/custom/matrix-bridge-mautrix-whatsapp/templates/systemd/matrix-mautrix-whatsapp.service.j2
@@ -33,9 +33,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_mautrix_whatsapp_container_image }} \
 			/usr/bin/mautrix-whatsapp -c /config/config.yaml -r /config/registration.yaml --no-update
 
+{% if matrix_mautrix_whatsapp_container_network not in ['', 'host'] %}
 {% for network in matrix_mautrix_whatsapp_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-mautrix-whatsapp
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-mautrix-whatsapp
 

--- a/roles/custom/matrix-bridge-mautrix-whatsapp/templates/systemd/matrix-mautrix-whatsapp.service.j2
+++ b/roles/custom/matrix-bridge-mautrix-whatsapp/templates/systemd/matrix-mautrix-whatsapp.service.j2
@@ -33,7 +33,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_mautrix_whatsapp_container_image }} \
 			/usr/bin/mautrix-whatsapp -c /config/config.yaml -r /config/registration.yaml --no-update
 
-{% if matrix_mautrix_whatsapp_container_network not in ['', 'host'] %}
+{% if matrix_mautrix_whatsapp_container_network != 'host' %}
 {% for network in matrix_mautrix_whatsapp_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-mautrix-whatsapp
 {% endfor %}

--- a/roles/custom/matrix-bridge-mautrix-wsproxy/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-wsproxy/tasks/setup_install.yml
@@ -107,6 +107,7 @@
   register: matrix_mautrix_wsproxy_registration_imessage_result
 
 - name: Ensure mautrix-wsproxy container network is created
+  when: matrix_mautrix_wsproxy_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_wsproxy_container_network }}"

--- a/roles/custom/matrix-bridge-mautrix-wsproxy/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mautrix-wsproxy/tasks/setup_install.yml
@@ -107,7 +107,7 @@
   register: matrix_mautrix_wsproxy_registration_imessage_result
 
 - name: Ensure mautrix-wsproxy container network is created
-  when: matrix_mautrix_wsproxy_container_network not in ['', 'host']
+  when: matrix_mautrix_wsproxy_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mautrix_wsproxy_container_network }}"

--- a/roles/custom/matrix-bridge-mautrix-wsproxy/templates/systemd/matrix-mautrix-wsproxy-syncproxy.service.j2
+++ b/roles/custom/matrix-bridge-mautrix-wsproxy/templates/systemd/matrix-mautrix-wsproxy-syncproxy.service.j2
@@ -29,7 +29,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_mautrix_wsproxy_syncproxy_container_image }}
 
-{% if matrix_mautrix_wsproxy_container_network not in ['', 'host'] %}
+{% if matrix_mautrix_wsproxy_container_network != 'host' %}
 {% for network in matrix_mautrix_wsproxy_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-mautrix-wsproxy-syncproxy
 {% endfor %}

--- a/roles/custom/matrix-bridge-mautrix-wsproxy/templates/systemd/matrix-mautrix-wsproxy-syncproxy.service.j2
+++ b/roles/custom/matrix-bridge-mautrix-wsproxy/templates/systemd/matrix-mautrix-wsproxy-syncproxy.service.j2
@@ -29,9 +29,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_mautrix_wsproxy_syncproxy_container_image }}
 
+{% if matrix_mautrix_wsproxy_container_network not in ['', 'host'] %}
 {% for network in matrix_mautrix_wsproxy_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-mautrix-wsproxy-syncproxy
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-mautrix-wsproxy-syncproxy
 

--- a/roles/custom/matrix-bridge-mautrix-wsproxy/templates/systemd/matrix-mautrix-wsproxy.service.j2
+++ b/roles/custom/matrix-bridge-mautrix-wsproxy/templates/systemd/matrix-mautrix-wsproxy.service.j2
@@ -32,7 +32,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create --rm -
 			{{ matrix_mautrix_wsproxy_container_image }} \
 			/usr/bin/mautrix-wsproxy -config /data/config.yaml
 
-{% if matrix_mautrix_wsproxy_container_network not in ['', 'host'] %}
+{% if matrix_mautrix_wsproxy_container_network != 'host' %}
 {% for network in matrix_mautrix_wsproxy_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-mautrix-wsproxy
 {% endfor %}

--- a/roles/custom/matrix-bridge-mautrix-wsproxy/templates/systemd/matrix-mautrix-wsproxy.service.j2
+++ b/roles/custom/matrix-bridge-mautrix-wsproxy/templates/systemd/matrix-mautrix-wsproxy.service.j2
@@ -32,9 +32,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create --rm -
 			{{ matrix_mautrix_wsproxy_container_image }} \
 			/usr/bin/mautrix-wsproxy -config /data/config.yaml
 
+{% if matrix_mautrix_wsproxy_container_network not in ['', 'host'] %}
 {% for network in matrix_mautrix_wsproxy_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-mautrix-wsproxy
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-mautrix-wsproxy
 

--- a/roles/custom/matrix-bridge-meshtastic-relay/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-meshtastic-relay/tasks/setup_install.yml
@@ -36,6 +36,7 @@
   register: matrix_meshtastic_relay_config_result
 
 - name: Ensure matrix-meshtastic-relay container network is created
+  when: matrix_meshtastic_relay_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_meshtastic_relay_container_network }}"

--- a/roles/custom/matrix-bridge-meshtastic-relay/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-meshtastic-relay/tasks/setup_install.yml
@@ -36,13 +36,14 @@
   register: matrix_meshtastic_relay_config_result
 
 - name: Ensure matrix-meshtastic-relay container network is created
-  when: matrix_meshtastic_relay_container_network not in ['', 'host']
+  when:
+    - matrix_meshtastic_relay_connection_type != 'ble'
+    - matrix_meshtastic_relay_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_meshtastic_relay_container_network }}"
     driver: bridge
     driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
-  when: "matrix_meshtastic_relay_connection_type != 'ble'"
 
 - name: Ensure matrix-meshtastic-relay.service installed
   ansible.builtin.template:

--- a/roles/custom/matrix-bridge-meshtastic-relay/templates/systemd/matrix-meshtastic-relay.service.j2
+++ b/roles/custom/matrix-bridge-meshtastic-relay/templates/systemd/matrix-meshtastic-relay.service.j2
@@ -43,7 +43,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_meshtastic_relay_container_image }} \
 			mmrelay --config /config/config.yaml
 
-{% if matrix_meshtastic_relay_container_network not in ['', 'host'] %}
+{% if matrix_meshtastic_relay_container_network != 'host' %}
 {% for network in matrix_meshtastic_relay_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-meshtastic-relay
 {% endfor %}

--- a/roles/custom/matrix-bridge-meshtastic-relay/templates/systemd/matrix-meshtastic-relay.service.j2
+++ b/roles/custom/matrix-bridge-meshtastic-relay/templates/systemd/matrix-meshtastic-relay.service.j2
@@ -43,9 +43,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_meshtastic_relay_container_image }} \
 			mmrelay --config /config/config.yaml
 
+{% if matrix_meshtastic_relay_container_network not in ['', 'host'] %}
 {% for network in matrix_meshtastic_relay_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-meshtastic-relay
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-meshtastic-relay
 

--- a/roles/custom/matrix-bridge-mx-puppet-groupme/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-groupme/tasks/setup_install.yml
@@ -122,7 +122,7 @@
   register: matrix_mx_puppet_groupme_registration_result
 
 - name: Ensure mx-puppet-groupme container network is created
-  when: matrix_mx_puppet_groupme_container_network not in ['', 'host']
+  when: matrix_mx_puppet_groupme_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mx_puppet_groupme_container_network }}"

--- a/roles/custom/matrix-bridge-mx-puppet-groupme/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-groupme/tasks/setup_install.yml
@@ -122,6 +122,7 @@
   register: matrix_mx_puppet_groupme_registration_result
 
 - name: Ensure mx-puppet-groupme container network is created
+  when: matrix_mx_puppet_groupme_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mx_puppet_groupme_container_network }}"

--- a/roles/custom/matrix-bridge-mx-puppet-groupme/templates/systemd/matrix-mx-puppet-groupme.service.j2
+++ b/roles/custom/matrix-bridge-mx-puppet-groupme/templates/systemd/matrix-mx-puppet-groupme.service.j2
@@ -32,9 +32,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_mx_puppet_groupme_container_image }}
 
+{% if matrix_mx_puppet_groupme_container_network not in ['', 'host'] %}
 {% for network in matrix_mx_puppet_groupme_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-mx-puppet-groupme
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-mx-puppet-groupme
 

--- a/roles/custom/matrix-bridge-mx-puppet-groupme/templates/systemd/matrix-mx-puppet-groupme.service.j2
+++ b/roles/custom/matrix-bridge-mx-puppet-groupme/templates/systemd/matrix-mx-puppet-groupme.service.j2
@@ -32,7 +32,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_mx_puppet_groupme_container_image }}
 
-{% if matrix_mx_puppet_groupme_container_network not in ['', 'host'] %}
+{% if matrix_mx_puppet_groupme_container_network != 'host' %}
 {% for network in matrix_mx_puppet_groupme_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-mx-puppet-groupme
 {% endfor %}

--- a/roles/custom/matrix-bridge-mx-puppet-steam/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-steam/tasks/setup_install.yml
@@ -124,7 +124,7 @@
   register: matrix_mx_puppet_steam_registration_result
 
 - name: Ensure mx-puppet-steam container network is created
-  when: matrix_mx_puppet_steam_container_network not in ['', 'host']
+  when: matrix_mx_puppet_steam_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mx_puppet_steam_container_network }}"

--- a/roles/custom/matrix-bridge-mx-puppet-steam/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-mx-puppet-steam/tasks/setup_install.yml
@@ -124,6 +124,7 @@
   register: matrix_mx_puppet_steam_registration_result
 
 - name: Ensure mx-puppet-steam container network is created
+  when: matrix_mx_puppet_steam_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_mx_puppet_steam_container_network }}"

--- a/roles/custom/matrix-bridge-mx-puppet-steam/templates/systemd/matrix-mx-puppet-steam.service.j2
+++ b/roles/custom/matrix-bridge-mx-puppet-steam/templates/systemd/matrix-mx-puppet-steam.service.j2
@@ -32,7 +32,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_mx_puppet_steam_container_image }}
 
-{% if matrix_mx_puppet_steam_container_network not in ['', 'host'] %}
+{% if matrix_mx_puppet_steam_container_network != 'host' %}
 {% for network in matrix_mx_puppet_steam_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-mx-puppet-steam
 {% endfor %}

--- a/roles/custom/matrix-bridge-mx-puppet-steam/templates/systemd/matrix-mx-puppet-steam.service.j2
+++ b/roles/custom/matrix-bridge-mx-puppet-steam/templates/systemd/matrix-mx-puppet-steam.service.j2
@@ -32,9 +32,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_mx_puppet_steam_container_image }}
 
+{% if matrix_mx_puppet_steam_container_network not in ['', 'host'] %}
 {% for network in matrix_mx_puppet_steam_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-mx-puppet-steam
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-mx-puppet-steam
 

--- a/roles/custom/matrix-bridge-postmoogle/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-postmoogle/tasks/setup_install.yml
@@ -110,6 +110,7 @@
   register: matrix_postmoogle_container_image_build_result
 
 - name: Ensure postmoogle container network is created
+  when: matrix_postmoogle_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_postmoogle_container_network }}"

--- a/roles/custom/matrix-bridge-postmoogle/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-postmoogle/tasks/setup_install.yml
@@ -110,7 +110,7 @@
   register: matrix_postmoogle_container_image_build_result
 
 - name: Ensure postmoogle container network is created
-  when: matrix_postmoogle_container_network not in ['', 'host']
+  when: matrix_postmoogle_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_postmoogle_container_network }}"

--- a/roles/custom/matrix-bridge-postmoogle/templates/systemd/matrix-postmoogle.service.j2
+++ b/roles/custom/matrix-bridge-postmoogle/templates/systemd/matrix-postmoogle.service.j2
@@ -38,7 +38,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_postmoogle_container_image }}
 
-{% if matrix_postmoogle_container_network not in ['', 'host'] %}
+{% if matrix_postmoogle_container_network != 'host' %}
 {% for network in matrix_postmoogle_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-postmoogle
 {% endfor %}

--- a/roles/custom/matrix-bridge-postmoogle/templates/systemd/matrix-postmoogle.service.j2
+++ b/roles/custom/matrix-bridge-postmoogle/templates/systemd/matrix-postmoogle.service.j2
@@ -38,9 +38,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_postmoogle_container_image }}
 
+{% if matrix_postmoogle_container_network not in ['', 'host'] %}
 {% for network in matrix_postmoogle_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-postmoogle
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-postmoogle
 

--- a/roles/custom/matrix-bridge-sms/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-sms/tasks/setup_install.yml
@@ -60,6 +60,7 @@
   register: matrix_sms_bridge_cert_result
 
 - name: Ensure matrix-sms-bridge container network is created
+  when: matrix_sms_bridge_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_sms_bridge_container_network }}"

--- a/roles/custom/matrix-bridge-sms/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-sms/tasks/setup_install.yml
@@ -60,7 +60,7 @@
   register: matrix_sms_bridge_cert_result
 
 - name: Ensure matrix-sms-bridge container network is created
-  when: matrix_sms_bridge_container_network not in ['', 'host']
+  when: matrix_sms_bridge_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_sms_bridge_container_network }}"

--- a/roles/custom/matrix-bridge-sms/templates/systemd/matrix-sms-bridge.service.j2
+++ b/roles/custom/matrix-bridge-sms/templates/systemd/matrix-sms-bridge.service.j2
@@ -34,9 +34,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_sms_bridge_container_image }}
 
+{% if matrix_sms_bridge_container_network not in ['', 'host'] %}
 {% for network in matrix_sms_bridge_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-sms-bridge
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-sms-bridge
 

--- a/roles/custom/matrix-bridge-sms/templates/systemd/matrix-sms-bridge.service.j2
+++ b/roles/custom/matrix-bridge-sms/templates/systemd/matrix-sms-bridge.service.j2
@@ -34,7 +34,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_sms_bridge_container_image }}
 
-{% if matrix_sms_bridge_container_network not in ['', 'host'] %}
+{% if matrix_sms_bridge_container_network != 'host' %}
 {% for network in matrix_sms_bridge_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-sms-bridge
 {% endfor %}

--- a/roles/custom/matrix-bridge-steam/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-steam/tasks/setup_install.yml
@@ -82,6 +82,7 @@
   register: matrix_steam_bridge_support_files_result
 
 - name: Ensure matrix-steam-bridge container network is created
+  when: matrix_steam_bridge_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_steam_bridge_container_network }}"

--- a/roles/custom/matrix-bridge-steam/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-steam/tasks/setup_install.yml
@@ -82,7 +82,7 @@
   register: matrix_steam_bridge_support_files_result
 
 - name: Ensure matrix-steam-bridge container network is created
-  when: matrix_steam_bridge_container_network not in ['', 'host']
+  when: matrix_steam_bridge_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_steam_bridge_container_network }}"

--- a/roles/custom/matrix-bridge-steam/templates/systemd/matrix-steam-bridge.service.j2
+++ b/roles/custom/matrix-bridge-steam/templates/systemd/matrix-steam-bridge.service.j2
@@ -32,7 +32,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_steam_bridge_container_image }} \
 			/usr/bin/steam -c /app/config/config.yaml -r /app/config/registration.yaml --no-update
 
-{% if matrix_steam_bridge_container_network not in ['', 'host'] %}
+{% if matrix_steam_bridge_container_network != 'host' %}
 {% for network in matrix_steam_bridge_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-steam-bridge
 {% endfor %}

--- a/roles/custom/matrix-bridge-steam/templates/systemd/matrix-steam-bridge.service.j2
+++ b/roles/custom/matrix-bridge-steam/templates/systemd/matrix-steam-bridge.service.j2
@@ -32,9 +32,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_steam_bridge_container_image }} \
 			/usr/bin/steam -c /app/config/config.yaml -r /app/config/registration.yaml --no-update
 
+{% if matrix_steam_bridge_container_network not in ['', 'host'] %}
 {% for network in matrix_steam_bridge_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-steam-bridge
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-steam-bridge
 

--- a/roles/custom/matrix-bridge-wechat/tasks/install.yml
+++ b/roles/custom/matrix-bridge-wechat/tasks/install.yml
@@ -110,6 +110,7 @@
   register: matrix_wechat_agent_config_result
 
 - name: Ensure matrix-wechat container network is created
+  when: matrix_wechat_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_wechat_container_network }}"

--- a/roles/custom/matrix-bridge-wechat/tasks/install.yml
+++ b/roles/custom/matrix-bridge-wechat/tasks/install.yml
@@ -110,7 +110,7 @@
   register: matrix_wechat_agent_config_result
 
 - name: Ensure matrix-wechat container network is created
-  when: matrix_wechat_container_network not in ['', 'host']
+  when: matrix_wechat_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_wechat_container_network }}"

--- a/roles/custom/matrix-bridge-wechat/templates/systemd/matrix-wechat-agent.service.j2
+++ b/roles/custom/matrix-bridge-wechat/templates/systemd/matrix-wechat-agent.service.j2
@@ -33,7 +33,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_wechat_agent_container_image }}
 
-{% if matrix_wechat_container_network not in ['', 'host'] %}
+{% if matrix_wechat_container_network != 'host' %}
 {% for network in matrix_wechat_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-wechat-agent
 {% endfor %}

--- a/roles/custom/matrix-bridge-wechat/templates/systemd/matrix-wechat-agent.service.j2
+++ b/roles/custom/matrix-bridge-wechat/templates/systemd/matrix-wechat-agent.service.j2
@@ -33,9 +33,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_wechat_agent_container_image }}
 
+{% if matrix_wechat_container_network not in ['', 'host'] %}
 {% for network in matrix_wechat_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-wechat-agent
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-wechat-agent
 

--- a/roles/custom/matrix-bridge-wechat/templates/systemd/matrix-wechat.service.j2
+++ b/roles/custom/matrix-bridge-wechat/templates/systemd/matrix-wechat.service.j2
@@ -31,9 +31,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_wechat_container_image }} \
 			/usr/bin/matrix-wechat -c /config/config.yaml -r /config/registration.yaml --no-update
+{% if matrix_wechat_container_network not in ['', 'host'] %}
 {% for network in matrix_wechat_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-wechat
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-wechat
 

--- a/roles/custom/matrix-bridge-wechat/templates/systemd/matrix-wechat.service.j2
+++ b/roles/custom/matrix-bridge-wechat/templates/systemd/matrix-wechat.service.j2
@@ -31,7 +31,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_wechat_container_image }} \
 			/usr/bin/matrix-wechat -c /config/config.yaml -r /config/registration.yaml --no-update
-{% if matrix_wechat_container_network not in ['', 'host'] %}
+{% if matrix_wechat_container_network != 'host' %}
 {% for network in matrix_wechat_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-wechat
 {% endfor %}

--- a/roles/custom/matrix-cactus-comments-client/tasks/install.yml
+++ b/roles/custom/matrix-cactus-comments-client/tasks/install.yml
@@ -76,6 +76,7 @@
   until: matrix_cactus_comments_client_container_image_pull_result is not failed
 
 - name: Ensure matrix-cactus-comments-client container network is created
+  when: matrix_cactus_comments_client_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_cactus_comments_client_container_network }}"

--- a/roles/custom/matrix-cactus-comments-client/tasks/install.yml
+++ b/roles/custom/matrix-cactus-comments-client/tasks/install.yml
@@ -76,7 +76,7 @@
   until: matrix_cactus_comments_client_container_image_pull_result is not failed
 
 - name: Ensure matrix-cactus-comments-client container network is created
-  when: matrix_cactus_comments_client_container_network not in ['', 'host']
+  when: matrix_cactus_comments_client_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_cactus_comments_client_container_network }}"

--- a/roles/custom/matrix-cactus-comments-client/templates/systemd/matrix-cactus-comments-client.service.j2
+++ b/roles/custom/matrix-cactus-comments-client/templates/systemd/matrix-cactus-comments-client.service.j2
@@ -32,7 +32,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			--mount type=bind,src={{ matrix_cactus_comments_client_public_path }},dst=/var/public,ro \
 			{{ matrix_cactus_comments_client_container_image }}
 
-{% if matrix_cactus_comments_client_container_network not in ['', 'host'] %}
+{% if matrix_cactus_comments_client_container_network != 'host' %}
 {% for network in matrix_cactus_comments_client_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-cactus-comments-client
 {% endfor %}

--- a/roles/custom/matrix-cactus-comments-client/templates/systemd/matrix-cactus-comments-client.service.j2
+++ b/roles/custom/matrix-cactus-comments-client/templates/systemd/matrix-cactus-comments-client.service.j2
@@ -32,9 +32,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			--mount type=bind,src={{ matrix_cactus_comments_client_public_path }},dst=/var/public,ro \
 			{{ matrix_cactus_comments_client_container_image }}
 
+{% if matrix_cactus_comments_client_container_network not in ['', 'host'] %}
 {% for network in matrix_cactus_comments_client_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-cactus-comments-client
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-cactus-comments-client
 

--- a/roles/custom/matrix-cactus-comments/templates/systemd/matrix-cactus-comments.service.j2
+++ b/roles/custom/matrix-cactus-comments/templates/systemd/matrix-cactus-comments.service.j2
@@ -28,9 +28,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			--network={{ matrix_cactus_comments_container_network }} \
 			{{ matrix_cactus_comments_container_image }}
 
+{% if matrix_cactus_comments_container_network not in ['', 'host'] %}
 {% for network in matrix_cactus_comments_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-cactus-comments
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-cactus-comments
 

--- a/roles/custom/matrix-cactus-comments/templates/systemd/matrix-cactus-comments.service.j2
+++ b/roles/custom/matrix-cactus-comments/templates/systemd/matrix-cactus-comments.service.j2
@@ -28,7 +28,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			--network={{ matrix_cactus_comments_container_network }} \
 			{{ matrix_cactus_comments_container_image }}
 
-{% if matrix_cactus_comments_container_network not in ['', 'host'] %}
+{% if matrix_cactus_comments_container_network != 'host' %}
 {% for network in matrix_cactus_comments_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-cactus-comments
 {% endfor %}

--- a/roles/custom/matrix-client-commet/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-commet/tasks/setup_install.yml
@@ -89,6 +89,7 @@
   register: matrix_client_commet_support_files_result
 
 - name: Ensure Commet container network is created
+  when: matrix_client_commet_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_client_commet_container_network }}"

--- a/roles/custom/matrix-client-commet/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-commet/tasks/setup_install.yml
@@ -89,7 +89,7 @@
   register: matrix_client_commet_support_files_result
 
 - name: Ensure Commet container network is created
-  when: matrix_client_commet_container_network not in ['', 'host']
+  when: matrix_client_commet_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_client_commet_container_network }}"

--- a/roles/custom/matrix-client-commet/templates/systemd/matrix-client-commet.service.j2
+++ b/roles/custom/matrix-client-commet/templates/systemd/matrix-client-commet.service.j2
@@ -41,7 +41,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_client_commet_container_image }}
 
-{% if matrix_client_commet_container_network not in ['', 'host'] %}
+{% if matrix_client_commet_container_network != 'host' %}
 {% for network in matrix_client_commet_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-client-commet
 {% endfor %}

--- a/roles/custom/matrix-client-commet/templates/systemd/matrix-client-commet.service.j2
+++ b/roles/custom/matrix-client-commet/templates/systemd/matrix-client-commet.service.j2
@@ -41,9 +41,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_client_commet_container_image }}
 
+{% if matrix_client_commet_container_network not in ['', 'host'] %}
 {% for network in matrix_client_commet_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-client-commet
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-client-commet
 

--- a/roles/custom/matrix-client-element/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-element/tasks/setup_install.yml
@@ -116,7 +116,7 @@
   when: "item.src is none"
 
 - name: Ensure Element Web container network is created
-  when: matrix_client_element_container_network not in ['', 'host']
+  when: matrix_client_element_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_client_element_container_network }}"

--- a/roles/custom/matrix-client-element/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-element/tasks/setup_install.yml
@@ -116,6 +116,7 @@
   when: "item.src is none"
 
 - name: Ensure Element Web container network is created
+  when: matrix_client_element_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_client_element_container_network }}"

--- a/roles/custom/matrix-client-element/templates/systemd/matrix-client-element.service.j2
+++ b/roles/custom/matrix-client-element/templates/systemd/matrix-client-element.service.j2
@@ -52,9 +52,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_client_element_container_image }}
 
+{% if matrix_client_element_container_network not in ['', 'host'] %}
 {% for network in matrix_client_element_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-client-element
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-client-element
 

--- a/roles/custom/matrix-client-element/templates/systemd/matrix-client-element.service.j2
+++ b/roles/custom/matrix-client-element/templates/systemd/matrix-client-element.service.j2
@@ -52,7 +52,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_client_element_container_image }}
 
-{% if matrix_client_element_container_network not in ['', 'host'] %}
+{% if matrix_client_element_container_network != 'host' %}
 {% for network in matrix_client_element_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-client-element
 {% endfor %}

--- a/roles/custom/matrix-client-fluffychat/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-fluffychat/tasks/setup_install.yml
@@ -62,7 +62,7 @@
   register: matrix_client_fluffychat_config_result
 
 - name: Ensure FluffyChat Web container network is created
-  when: matrix_client_fluffychat_container_network not in ['', 'host']
+  when: matrix_client_fluffychat_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_client_fluffychat_container_network }}"

--- a/roles/custom/matrix-client-fluffychat/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-fluffychat/tasks/setup_install.yml
@@ -62,6 +62,7 @@
   register: matrix_client_fluffychat_config_result
 
 - name: Ensure FluffyChat Web container network is created
+  when: matrix_client_fluffychat_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_client_fluffychat_container_network }}"

--- a/roles/custom/matrix-client-fluffychat/templates/systemd/matrix-client-fluffychat.service.j2
+++ b/roles/custom/matrix-client-fluffychat/templates/systemd/matrix-client-fluffychat.service.j2
@@ -32,7 +32,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_client_fluffychat_container_image }}
 
-{% if matrix_client_fluffychat_container_network not in ['', 'host'] %}
+{% if matrix_client_fluffychat_container_network != 'host' %}
 {% for network in matrix_client_fluffychat_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-client-fluffychat
 {% endfor %}

--- a/roles/custom/matrix-client-fluffychat/templates/systemd/matrix-client-fluffychat.service.j2
+++ b/roles/custom/matrix-client-fluffychat/templates/systemd/matrix-client-fluffychat.service.j2
@@ -32,9 +32,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_client_fluffychat_container_image }}
 
+{% if matrix_client_fluffychat_container_network not in ['', 'host'] %}
 {% for network in matrix_client_fluffychat_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-client-fluffychat
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-client-fluffychat
 

--- a/roles/custom/matrix-client-schildichat/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-schildichat/tasks/setup_install.yml
@@ -107,7 +107,7 @@
   when: "item.src is none"
 
 - name: Ensure SchildiChat Web container network is created
-  when: matrix_client_schildichat_container_network not in ['', 'host']
+  when: matrix_client_schildichat_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_client_schildichat_container_network }}"

--- a/roles/custom/matrix-client-schildichat/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-schildichat/tasks/setup_install.yml
@@ -107,6 +107,7 @@
   when: "item.src is none"
 
 - name: Ensure SchildiChat Web container network is created
+  when: matrix_client_schildichat_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_client_schildichat_container_network }}"

--- a/roles/custom/matrix-client-schildichat/templates/systemd/matrix-client-schildichat.service.j2
+++ b/roles/custom/matrix-client-schildichat/templates/systemd/matrix-client-schildichat.service.j2
@@ -40,9 +40,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_client_schildichat_container_image }}
 
+{% if matrix_client_schildichat_container_network not in ['', 'host'] %}
 {% for network in matrix_client_schildichat_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-client-schildichat
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-client-schildichat
 

--- a/roles/custom/matrix-client-schildichat/templates/systemd/matrix-client-schildichat.service.j2
+++ b/roles/custom/matrix-client-schildichat/templates/systemd/matrix-client-schildichat.service.j2
@@ -40,7 +40,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_client_schildichat_container_image }}
 
-{% if matrix_client_schildichat_container_network not in ['', 'host'] %}
+{% if matrix_client_schildichat_container_network != 'host' %}
 {% for network in matrix_client_schildichat_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-client-schildichat
 {% endfor %}

--- a/roles/custom/matrix-conduit/tasks/setup_install.yml
+++ b/roles/custom/matrix-conduit/tasks/setup_install.yml
@@ -45,6 +45,7 @@
   register: matrix_conduit_support_files_result
 
 - name: Ensure Conduit container network is created
+  when: matrix_conduit_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_conduit_container_network }}"

--- a/roles/custom/matrix-conduit/tasks/setup_install.yml
+++ b/roles/custom/matrix-conduit/tasks/setup_install.yml
@@ -45,7 +45,7 @@
   register: matrix_conduit_support_files_result
 
 - name: Ensure Conduit container network is created
-  when: matrix_conduit_container_network not in ['', 'host']
+  when: matrix_conduit_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_conduit_container_network }}"

--- a/roles/custom/matrix-conduit/templates/systemd/matrix-conduit.service.j2
+++ b/roles/custom/matrix-conduit/templates/systemd/matrix-conduit.service.j2
@@ -30,9 +30,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_conduit_container_image }}
 
+{% if matrix_conduit_container_network not in ['', 'host'] %}
 {% for network in matrix_conduit_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-conduit
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-conduit
 

--- a/roles/custom/matrix-conduit/templates/systemd/matrix-conduit.service.j2
+++ b/roles/custom/matrix-conduit/templates/systemd/matrix-conduit.service.j2
@@ -30,7 +30,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_conduit_container_image }}
 
-{% if matrix_conduit_container_network not in ['', 'host'] %}
+{% if matrix_conduit_container_network != 'host' %}
 {% for network in matrix_conduit_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-conduit
 {% endfor %}

--- a/roles/custom/matrix-continuwuity/tasks/install.yml
+++ b/roles/custom/matrix-continuwuity/tasks/install.yml
@@ -42,7 +42,7 @@
   register: matrix_continuwuity_support_files_result
 
 - name: Ensure continuwuity container network is created
-  when: matrix_continuwuity_container_network not in ['', 'host']
+  when: matrix_continuwuity_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_continuwuity_container_network }}"

--- a/roles/custom/matrix-continuwuity/tasks/install.yml
+++ b/roles/custom/matrix-continuwuity/tasks/install.yml
@@ -42,6 +42,7 @@
   register: matrix_continuwuity_support_files_result
 
 - name: Ensure continuwuity container network is created
+  when: matrix_continuwuity_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_continuwuity_container_network }}"

--- a/roles/custom/matrix-continuwuity/tasks/setup_install.yml
+++ b/roles/custom/matrix-continuwuity/tasks/setup_install.yml
@@ -39,6 +39,7 @@
     - labels
 
 - name: Ensure continuwuity container network is created
+  when: matrix_continuwuity_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_continuwuity_container_network }}"

--- a/roles/custom/matrix-continuwuity/tasks/setup_install.yml
+++ b/roles/custom/matrix-continuwuity/tasks/setup_install.yml
@@ -39,7 +39,7 @@
     - labels
 
 - name: Ensure continuwuity container network is created
-  when: matrix_continuwuity_container_network not in ['', 'host']
+  when: matrix_continuwuity_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_continuwuity_container_network }}"

--- a/roles/custom/matrix-continuwuity/templates/systemd/matrix-continuwuity.service.j2
+++ b/roles/custom/matrix-continuwuity/templates/systemd/matrix-continuwuity.service.j2
@@ -34,9 +34,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_continuwuity_container_image }}
 
+{% if matrix_continuwuity_container_network not in ['', 'host'] %}
 {% for network in matrix_continuwuity_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-continuwuity
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-continuwuity
 

--- a/roles/custom/matrix-continuwuity/templates/systemd/matrix-continuwuity.service.j2
+++ b/roles/custom/matrix-continuwuity/templates/systemd/matrix-continuwuity.service.j2
@@ -34,7 +34,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_continuwuity_container_image }}
 
-{% if matrix_continuwuity_container_network not in ['', 'host'] %}
+{% if matrix_continuwuity_container_network != 'host' %}
 {% for network in matrix_continuwuity_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-continuwuity
 {% endfor %}

--- a/roles/custom/matrix-corporal/tasks/setup_install.yml
+++ b/roles/custom/matrix-corporal/tasks/setup_install.yml
@@ -76,6 +76,7 @@
   register: matrix_corporal_support_files_result
 
 - name: Ensure Matrix Corporal container network is created
+  when: matrix_corporal_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_corporal_container_network }}"

--- a/roles/custom/matrix-corporal/tasks/setup_install.yml
+++ b/roles/custom/matrix-corporal/tasks/setup_install.yml
@@ -76,7 +76,7 @@
   register: matrix_corporal_support_files_result
 
 - name: Ensure Matrix Corporal container network is created
-  when: matrix_corporal_container_network not in ['', 'host']
+  when: matrix_corporal_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_corporal_container_network }}"

--- a/roles/custom/matrix-corporal/templates/systemd/matrix-corporal.service.j2
+++ b/roles/custom/matrix-corporal/templates/systemd/matrix-corporal.service.j2
@@ -37,7 +37,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_corporal_container_image }} \
 			/matrix-corporal -config=/etc/matrix-corporal/config.json
 
-{% if matrix_corporal_container_network not in ['', 'host'] %}
+{% if matrix_corporal_container_network != 'host' %}
 {% for network in matrix_corporal_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-corporal
 {% endfor %}

--- a/roles/custom/matrix-corporal/templates/systemd/matrix-corporal.service.j2
+++ b/roles/custom/matrix-corporal/templates/systemd/matrix-corporal.service.j2
@@ -37,9 +37,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_corporal_container_image }} \
 			/matrix-corporal -config=/etc/matrix-corporal/config.json
 
+{% if matrix_corporal_container_network not in ['', 'host'] %}
 {% for network in matrix_corporal_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-corporal
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-corporal
 

--- a/roles/custom/matrix-dendrite/tasks/setup_install.yml
+++ b/roles/custom/matrix-dendrite/tasks/setup_install.yml
@@ -118,7 +118,7 @@
       when: "matrix_dendrite_git_pull_results.changed | bool or matrix_dendrite_container_image_check_result.stdout == ''"
 
 - name: Ensure Dendrite container network is created
-  when: matrix_dendrite_container_network not in ['', 'host']
+  when: matrix_dendrite_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_dendrite_container_network }}"

--- a/roles/custom/matrix-dendrite/tasks/setup_install.yml
+++ b/roles/custom/matrix-dendrite/tasks/setup_install.yml
@@ -118,6 +118,7 @@
       when: "matrix_dendrite_git_pull_results.changed | bool or matrix_dendrite_container_image_check_result.stdout == ''"
 
 - name: Ensure Dendrite container network is created
+  when: matrix_dendrite_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_dendrite_container_network }}"

--- a/roles/custom/matrix-dendrite/templates/systemd/matrix-dendrite.service.j2
+++ b/roles/custom/matrix-dendrite/templates/systemd/matrix-dendrite.service.j2
@@ -57,7 +57,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			-https-bind-address {{ matrix_dendrite_https_bind_address }}
 			{% endif %}
 
-{% if matrix_dendrite_container_network not in ['', 'host'] %}
+{% if matrix_dendrite_container_network != 'host' %}
 {% for network in matrix_dendrite_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-dendrite
 {% endfor %}

--- a/roles/custom/matrix-dendrite/templates/systemd/matrix-dendrite.service.j2
+++ b/roles/custom/matrix-dendrite/templates/systemd/matrix-dendrite.service.j2
@@ -57,9 +57,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			-https-bind-address {{ matrix_dendrite_https_bind_address }}
 			{% endif %}
 
+{% if matrix_dendrite_container_network not in ['', 'host'] %}
 {% for network in matrix_dendrite_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-dendrite
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-dendrite
 

--- a/roles/custom/matrix-element-admin/tasks/install.yml
+++ b/roles/custom/matrix-element-admin/tasks/install.yml
@@ -63,7 +63,7 @@
       changed_when: true
 
 - name: Ensure Element Admin container network is created
-  when: matrix_element_admin_container_network not in ['', 'host']
+  when: matrix_element_admin_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_element_admin_container_network }}"

--- a/roles/custom/matrix-element-admin/tasks/install.yml
+++ b/roles/custom/matrix-element-admin/tasks/install.yml
@@ -63,6 +63,7 @@
       changed_when: true
 
 - name: Ensure Element Admin container network is created
+  when: matrix_element_admin_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_element_admin_container_network }}"

--- a/roles/custom/matrix-element-admin/templates/systemd/matrix-element-admin.service.j2
+++ b/roles/custom/matrix-element-admin/templates/systemd/matrix-element-admin.service.j2
@@ -35,7 +35,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_element_admin_container_image }} {{ matrix_element_admin_container_process_extra_arguments | join(' ') }}
 
-{% if matrix_element_admin_container_network not in ['', 'host'] %}
+{% if matrix_element_admin_container_network != 'host' %}
 {% for network in matrix_element_admin_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-element-admin
 {% endfor %}

--- a/roles/custom/matrix-element-admin/templates/systemd/matrix-element-admin.service.j2
+++ b/roles/custom/matrix-element-admin/templates/systemd/matrix-element-admin.service.j2
@@ -35,9 +35,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_element_admin_container_image }} {{ matrix_element_admin_container_process_extra_arguments | join(' ') }}
 
+{% if matrix_element_admin_container_network not in ['', 'host'] %}
 {% for network in matrix_element_admin_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-element-admin
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-element-admin
 

--- a/roles/custom/matrix-element-call/tasks/install.yml
+++ b/roles/custom/matrix-element-call/tasks/install.yml
@@ -44,6 +44,7 @@
   until: matrix_element_call_container_image_pull_result is not failed
 
 - name: Ensure Element Call container network is created
+  when: matrix_element_call_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_element_call_container_network }}"

--- a/roles/custom/matrix-element-call/tasks/install.yml
+++ b/roles/custom/matrix-element-call/tasks/install.yml
@@ -44,7 +44,7 @@
   until: matrix_element_call_container_image_pull_result is not failed
 
 - name: Ensure Element Call container network is created
-  when: matrix_element_call_container_network not in ['', 'host']
+  when: matrix_element_call_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_element_call_container_network }}"

--- a/roles/custom/matrix-element-call/templates/systemd/matrix-element-call.service.j2
+++ b/roles/custom/matrix-element-call/templates/systemd/matrix-element-call.service.j2
@@ -30,7 +30,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
     {% endfor %}
     {{ matrix_element_call_container_image }}
 
-{% if matrix_element_call_container_network not in ['', 'host'] %}
+{% if matrix_element_call_container_network != 'host' %}
 {% for network in matrix_element_call_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-element-call
 {% endfor %}

--- a/roles/custom/matrix-element-call/templates/systemd/matrix-element-call.service.j2
+++ b/roles/custom/matrix-element-call/templates/systemd/matrix-element-call.service.j2
@@ -30,9 +30,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
     {% endfor %}
     {{ matrix_element_call_container_image }}
 
+{% if matrix_element_call_container_network not in ['', 'host'] %}
 {% for network in matrix_element_call_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-element-call
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-element-call
 

--- a/roles/custom/matrix-ketesa/tasks/setup_install.yml
+++ b/roles/custom/matrix-ketesa/tasks/setup_install.yml
@@ -102,7 +102,7 @@
   register: matrix_ketesa_container_image_build_result
 
 - name: Ensure matrix-ketesa container network is created
-  when: matrix_ketesa_container_network not in ['', 'host']
+  when: matrix_ketesa_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_ketesa_container_network }}"

--- a/roles/custom/matrix-ketesa/tasks/setup_install.yml
+++ b/roles/custom/matrix-ketesa/tasks/setup_install.yml
@@ -102,6 +102,7 @@
   register: matrix_ketesa_container_image_build_result
 
 - name: Ensure matrix-ketesa container network is created
+  when: matrix_ketesa_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_ketesa_container_network }}"

--- a/roles/custom/matrix-ketesa/templates/systemd/matrix-ketesa.service.j2
+++ b/roles/custom/matrix-ketesa/templates/systemd/matrix-ketesa.service.j2
@@ -34,7 +34,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_ketesa_container_image }}
 
-{% if matrix_ketesa_container_network not in ['', 'host'] %}
+{% if matrix_ketesa_container_network != 'host' %}
 {% for network in matrix_ketesa_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-ketesa
 {% endfor %}

--- a/roles/custom/matrix-ketesa/templates/systemd/matrix-ketesa.service.j2
+++ b/roles/custom/matrix-ketesa/templates/systemd/matrix-ketesa.service.j2
@@ -34,9 +34,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_ketesa_container_image }}
 
+{% if matrix_ketesa_container_network not in ['', 'host'] %}
 {% for network in matrix_ketesa_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-ketesa
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-ketesa
 

--- a/roles/custom/matrix-livekit-jwt-service/tasks/install.yml
+++ b/roles/custom/matrix-livekit-jwt-service/tasks/install.yml
@@ -60,6 +60,7 @@
       register: matrix_livekit_jwt_service_container_image_build_result
 
 - name: Ensure LiveKit JWT Service container network is created
+  when: matrix_livekit_jwt_service_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_livekit_jwt_service_container_network }}"

--- a/roles/custom/matrix-livekit-jwt-service/tasks/install.yml
+++ b/roles/custom/matrix-livekit-jwt-service/tasks/install.yml
@@ -60,7 +60,7 @@
       register: matrix_livekit_jwt_service_container_image_build_result
 
 - name: Ensure LiveKit JWT Service container network is created
-  when: matrix_livekit_jwt_service_container_network not in ['', 'host']
+  when: matrix_livekit_jwt_service_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_livekit_jwt_service_container_network }}"

--- a/roles/custom/matrix-livekit-jwt-service/templates/systemd/matrix-livekit-jwt-service.service.j2
+++ b/roles/custom/matrix-livekit-jwt-service/templates/systemd/matrix-livekit-jwt-service.service.j2
@@ -26,7 +26,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
     --label-file={{ matrix_livekit_jwt_service_base_path }}/labels \
     {{ matrix_livekit_jwt_service_container_image }}
 
-{% if matrix_livekit_jwt_service_container_network not in ['', 'host'] %}
+{% if matrix_livekit_jwt_service_container_network != 'host' %}
 {% for network in matrix_livekit_jwt_service_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-livekit-jwt-service
 {% endfor %}

--- a/roles/custom/matrix-livekit-jwt-service/templates/systemd/matrix-livekit-jwt-service.service.j2
+++ b/roles/custom/matrix-livekit-jwt-service/templates/systemd/matrix-livekit-jwt-service.service.j2
@@ -26,9 +26,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
     --label-file={{ matrix_livekit_jwt_service_base_path }}/labels \
     {{ matrix_livekit_jwt_service_container_image }}
 
+{% if matrix_livekit_jwt_service_container_network not in ['', 'host'] %}
 {% for network in matrix_livekit_jwt_service_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-livekit-jwt-service
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-livekit-jwt-service
 

--- a/roles/custom/matrix-matrixto/tasks/install.yml
+++ b/roles/custom/matrix-matrixto/tasks/install.yml
@@ -46,7 +46,7 @@
 - name: Ensure Matrix.to container network is created via community.docker.docker_network
   when:
     - devture_systemd_docker_base_container_network_creation_method == 'ansible-module'
-    - matrix_matrixto_container_network not in ['', 'host']
+    - matrix_matrixto_container_network != 'host'
   community.docker.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_matrixto_container_network }}"
@@ -56,7 +56,7 @@
 - name: Ensure Matrix.to container network is created via ansible.builtin.command
   when:
     - devture_systemd_docker_base_container_network_creation_method == 'command'
-    - matrix_matrixto_container_network not in ['', 'host']
+    - matrix_matrixto_container_network != 'host'
   ansible.builtin.command:
     cmd: >-
       {{ devture_systemd_docker_base_host_command_docker }} network create

--- a/roles/custom/matrix-matrixto/tasks/install.yml
+++ b/roles/custom/matrix-matrixto/tasks/install.yml
@@ -44,7 +44,9 @@
   register: matrix_matrixto_container_image_build_result
 
 - name: Ensure Matrix.to container network is created via community.docker.docker_network
-  when: devture_systemd_docker_base_container_network_creation_method == 'ansible-module'
+  when:
+    - devture_systemd_docker_base_container_network_creation_method == 'ansible-module'
+    - matrix_matrixto_container_network not in ['', 'host']
   community.docker.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_matrixto_container_network }}"
@@ -52,7 +54,9 @@
     driver_options: "{{ devture_systemd_docker_base_container_networks_driver_options }}"
 
 - name: Ensure Matrix.to container network is created via ansible.builtin.command
-  when: devture_systemd_docker_base_container_network_creation_method == 'command'
+  when:
+    - devture_systemd_docker_base_container_network_creation_method == 'command'
+    - matrix_matrixto_container_network not in ['', 'host']
   ansible.builtin.command:
     cmd: >-
       {{ devture_systemd_docker_base_host_command_docker }} network create

--- a/roles/custom/matrix-matrixto/templates/systemd/matrix-matrixto.service.j2
+++ b/roles/custom/matrix-matrixto/templates/systemd/matrix-matrixto.service.j2
@@ -42,7 +42,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
       {% endfor %}
       {{ matrix_matrixto_container_image_self_build_name }}
 
-{% if matrix_matrixto_container_network not in ['', 'host'] %}
+{% if matrix_matrixto_container_network != 'host' %}
 {% for network in matrix_matrixto_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} {{ matrix_matrixto_identifier }}
 {% endfor %}

--- a/roles/custom/matrix-matrixto/templates/systemd/matrix-matrixto.service.j2
+++ b/roles/custom/matrix-matrixto/templates/systemd/matrix-matrixto.service.j2
@@ -42,9 +42,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
       {% endfor %}
       {{ matrix_matrixto_container_image_self_build_name }}
 
+{% if matrix_matrixto_container_network not in ['', 'host'] %}
 {% for network in matrix_matrixto_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} {{ matrix_matrixto_identifier }}
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach {{ matrix_matrixto_identifier }}
 

--- a/roles/custom/matrix-media-repo/tasks/setup_install.yml
+++ b/roles/custom/matrix-media-repo/tasks/setup_install.yml
@@ -142,7 +142,7 @@
         removes: "{{ matrix_media_repo_config_path }}/{{ matrix_media_repo_identifier }}.signing.key.TEMP"
 
 - name: Ensure media-repo container network is created
-  when: matrix_media_repo_container_network not in ['', 'host']
+  when: matrix_media_repo_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_media_repo_container_network }}"

--- a/roles/custom/matrix-media-repo/tasks/setup_install.yml
+++ b/roles/custom/matrix-media-repo/tasks/setup_install.yml
@@ -142,6 +142,7 @@
         removes: "{{ matrix_media_repo_config_path }}/{{ matrix_media_repo_identifier }}.signing.key.TEMP"
 
 - name: Ensure media-repo container network is created
+  when: matrix_media_repo_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_media_repo_container_network }}"

--- a/roles/custom/matrix-media-repo/templates/media-repo/systemd/matrix-media-repo.service.j2
+++ b/roles/custom/matrix-media-repo/templates/media-repo/systemd/matrix-media-repo.service.j2
@@ -40,7 +40,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_media_repo_container_image }}
 
-{% if matrix_media_repo_container_network not in ['', 'host'] %}
+{% if matrix_media_repo_container_network != 'host' %}
 {% for network in matrix_media_repo_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} {{ matrix_media_repo_identifier }}
 {% endfor %}

--- a/roles/custom/matrix-media-repo/templates/media-repo/systemd/matrix-media-repo.service.j2
+++ b/roles/custom/matrix-media-repo/templates/media-repo/systemd/matrix-media-repo.service.j2
@@ -40,9 +40,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_media_repo_container_image }}
 
+{% if matrix_media_repo_container_network not in ['', 'host'] %}
 {% for network in matrix_media_repo_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} {{ matrix_media_repo_identifier }}
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach {{ matrix_media_repo_identifier }}
 

--- a/roles/custom/matrix-pantalaimon/tasks/install.yml
+++ b/roles/custom/matrix-pantalaimon/tasks/install.yml
@@ -59,6 +59,7 @@
   register: matrix_pantalaimon_container_image_build_result
 
 - name: Ensure pantalaimon container network is created
+  when: matrix_pantalaimon_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_pantalaimon_container_network }}"

--- a/roles/custom/matrix-pantalaimon/tasks/install.yml
+++ b/roles/custom/matrix-pantalaimon/tasks/install.yml
@@ -59,7 +59,7 @@
   register: matrix_pantalaimon_container_image_build_result
 
 - name: Ensure pantalaimon container network is created
-  when: matrix_pantalaimon_container_network not in ['', 'host']
+  when: matrix_pantalaimon_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_pantalaimon_container_network }}"

--- a/roles/custom/matrix-pantalaimon/templates/systemd/matrix-pantalaimon.service.j2
+++ b/roles/custom/matrix-pantalaimon/templates/systemd/matrix-pantalaimon.service.j2
@@ -30,9 +30,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_pantalaimon_container_image }}
 
+{% if matrix_pantalaimon_container_network not in ['', 'host'] %}
 {% for network in matrix_pantalaimon_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-pantalaimon
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-pantalaimon
 

--- a/roles/custom/matrix-pantalaimon/templates/systemd/matrix-pantalaimon.service.j2
+++ b/roles/custom/matrix-pantalaimon/templates/systemd/matrix-pantalaimon.service.j2
@@ -30,7 +30,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_pantalaimon_container_image }}
 
-{% if matrix_pantalaimon_container_network not in ['', 'host'] %}
+{% if matrix_pantalaimon_container_network != 'host' %}
 {% for network in matrix_pantalaimon_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-pantalaimon
 {% endfor %}

--- a/roles/custom/matrix-rageshake/tasks/install.yml
+++ b/roles/custom/matrix-rageshake/tasks/install.yml
@@ -73,7 +73,7 @@
   when: matrix_rageshake_container_image_self_build | bool
 
 - name: Ensure rageshake container network is created
-  when: matrix_rageshake_container_network not in ['', 'host']
+  when: matrix_rageshake_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_rageshake_container_network }}"

--- a/roles/custom/matrix-rageshake/tasks/install.yml
+++ b/roles/custom/matrix-rageshake/tasks/install.yml
@@ -73,6 +73,7 @@
   when: matrix_rageshake_container_image_self_build | bool
 
 - name: Ensure rageshake container network is created
+  when: matrix_rageshake_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_rageshake_container_network }}"

--- a/roles/custom/matrix-rageshake/templates/systemd/matrix-rageshake.service.j2
+++ b/roles/custom/matrix-rageshake/templates/systemd/matrix-rageshake.service.j2
@@ -34,7 +34,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_rageshake_container_image }} \
 			--config /config/config.yaml
 
-{% if matrix_rageshake_container_network not in ['', 'host'] %}
+{% if matrix_rageshake_container_network != 'host' %}
 {% for network in matrix_rageshake_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-rageshake
 {% endfor %}

--- a/roles/custom/matrix-rageshake/templates/systemd/matrix-rageshake.service.j2
+++ b/roles/custom/matrix-rageshake/templates/systemd/matrix-rageshake.service.j2
@@ -34,9 +34,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_rageshake_container_image }} \
 			--config /config/config.yaml
 
+{% if matrix_rageshake_container_network not in ['', 'host'] %}
 {% for network in matrix_rageshake_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-rageshake
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-rageshake
 

--- a/roles/custom/matrix-static-files/tasks/install.yml
+++ b/roles/custom/matrix-static-files/tasks/install.yml
@@ -94,7 +94,7 @@
   until: matrix_static_files_container_image_pull_result is not failed
 
 - name: Ensure matrix-static-files container network is created
-  when: matrix_static_files_container_network not in ['', 'host']
+  when: matrix_static_files_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_static_files_container_network }}"

--- a/roles/custom/matrix-static-files/tasks/install.yml
+++ b/roles/custom/matrix-static-files/tasks/install.yml
@@ -94,6 +94,7 @@
   until: matrix_static_files_container_image_pull_result is not failed
 
 - name: Ensure matrix-static-files container network is created
+  when: matrix_static_files_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_static_files_container_network }}"

--- a/roles/custom/matrix-static-files/templates/systemd/matrix-static-files.service.j2
+++ b/roles/custom/matrix-static-files/templates/systemd/matrix-static-files.service.j2
@@ -33,9 +33,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			--mount type=bind,src={{ matrix_static_files_config_path }},dst=/config,ro \
 			{{ matrix_static_files_container_image }}
 
+{% if matrix_static_files_container_network not in ['', 'host'] %}
 {% for network in matrix_static_files_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-static-files
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-static-files
 

--- a/roles/custom/matrix-static-files/templates/systemd/matrix-static-files.service.j2
+++ b/roles/custom/matrix-static-files/templates/systemd/matrix-static-files.service.j2
@@ -33,7 +33,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			--mount type=bind,src={{ matrix_static_files_config_path }},dst=/config,ro \
 			{{ matrix_static_files_container_image }}
 
-{% if matrix_static_files_container_network not in ['', 'host'] %}
+{% if matrix_static_files_container_network != 'host' %}
 {% for network in matrix_static_files_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-static-files
 {% endfor %}

--- a/roles/custom/matrix-sygnal/tasks/install.yml
+++ b/roles/custom/matrix-sygnal/tasks/install.yml
@@ -49,6 +49,7 @@
   until: matrix_sygnal_container_image_pull_result is not failed
 
 - name: Ensure Sygnal container network is created
+  when: matrix_sygnal_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_sygnal_container_network }}"

--- a/roles/custom/matrix-sygnal/tasks/install.yml
+++ b/roles/custom/matrix-sygnal/tasks/install.yml
@@ -49,7 +49,7 @@
   until: matrix_sygnal_container_image_pull_result is not failed
 
 - name: Ensure Sygnal container network is created
-  when: matrix_sygnal_container_network not in ['', 'host']
+  when: matrix_sygnal_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_sygnal_container_network }}"

--- a/roles/custom/matrix-sygnal/templates/systemd/matrix-sygnal.service.j2
+++ b/roles/custom/matrix-sygnal/templates/systemd/matrix-sygnal.service.j2
@@ -35,9 +35,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_sygnal_container_image }}
 
+{% if matrix_sygnal_container_network not in ['', 'host'] %}
 {% for network in matrix_sygnal_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-sygnal
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-sygnal
 

--- a/roles/custom/matrix-sygnal/templates/systemd/matrix-sygnal.service.j2
+++ b/roles/custom/matrix-sygnal/templates/systemd/matrix-sygnal.service.j2
@@ -35,7 +35,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_sygnal_container_image }}
 
-{% if matrix_sygnal_container_network not in ['', 'host'] %}
+{% if matrix_sygnal_container_network != 'host' %}
 {% for network in matrix_sygnal_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-sygnal
 {% endfor %}

--- a/roles/custom/matrix-synapse-auto-compressor/tasks/install.yml
+++ b/roles/custom/matrix-synapse-auto-compressor/tasks/install.yml
@@ -83,6 +83,7 @@
       when: "matrix_synapse_auto_compressor_git_pull_results.changed | bool or matrix_synapse_auto_compressor_container_image_check_result.stdout == ''"
 
 - name: Ensure matrix-synapse-auto-compressor container network is created
+  when: matrix_synapse_auto_compressor_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_synapse_auto_compressor_container_network }}"

--- a/roles/custom/matrix-synapse-auto-compressor/tasks/install.yml
+++ b/roles/custom/matrix-synapse-auto-compressor/tasks/install.yml
@@ -83,7 +83,7 @@
       when: "matrix_synapse_auto_compressor_git_pull_results.changed | bool or matrix_synapse_auto_compressor_container_image_check_result.stdout == ''"
 
 - name: Ensure matrix-synapse-auto-compressor container network is created
-  when: matrix_synapse_auto_compressor_container_network not in ['', 'host']
+  when: matrix_synapse_auto_compressor_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_synapse_auto_compressor_container_network }}"

--- a/roles/custom/matrix-synapse-auto-compressor/templates/matrix-synapse-auto-compressor.service.j2
+++ b/roles/custom/matrix-synapse-auto-compressor/templates/matrix-synapse-auto-compressor.service.j2
@@ -33,7 +33,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_synapse_auto_compressor_container_image }} \
 			-c '{{ matrix_synapse_auto_compressor_command }}'
 
-{% if matrix_synapse_auto_compressor_container_network not in ['', 'host'] %}
+{% if matrix_synapse_auto_compressor_container_network != 'host' %}
 {% for network in matrix_synapse_auto_compressor_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-synapse-auto-compressor
 {% endfor %}

--- a/roles/custom/matrix-synapse-auto-compressor/templates/matrix-synapse-auto-compressor.service.j2
+++ b/roles/custom/matrix-synapse-auto-compressor/templates/matrix-synapse-auto-compressor.service.j2
@@ -33,9 +33,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_synapse_auto_compressor_container_image }} \
 			-c '{{ matrix_synapse_auto_compressor_command }}'
 
+{% if matrix_synapse_auto_compressor_container_network not in ['', 'host'] %}
 {% for network in matrix_synapse_auto_compressor_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-synapse-auto-compressor
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-synapse-auto-compressor
 

--- a/roles/custom/matrix-synapse-usage-exporter/tasks/setup_install.yml
+++ b/roles/custom/matrix-synapse-usage-exporter/tasks/setup_install.yml
@@ -70,7 +70,7 @@
       when: "matrix_synapse_usage_exporter_git_pull_results.changed | bool or matrix_synapse_usage_exporter_container_image_check_result.stdout == ''"
 
 - name: Ensure synapse-usage-exporter container network is created
-  when: matrix_synapse_usage_exporter_container_network not in ['', 'host']
+  when: matrix_synapse_usage_exporter_container_network != 'host'
   community.general.docker_network:
     name: "{{ matrix_synapse_usage_exporter_container_network }}"
     driver: bridge

--- a/roles/custom/matrix-synapse-usage-exporter/tasks/setup_install.yml
+++ b/roles/custom/matrix-synapse-usage-exporter/tasks/setup_install.yml
@@ -70,6 +70,7 @@
       when: "matrix_synapse_usage_exporter_git_pull_results.changed | bool or matrix_synapse_usage_exporter_container_image_check_result.stdout == ''"
 
 - name: Ensure synapse-usage-exporter container network is created
+  when: matrix_synapse_usage_exporter_container_network not in ['', 'host']
   community.general.docker_network:
     name: "{{ matrix_synapse_usage_exporter_container_network }}"
     driver: bridge

--- a/roles/custom/matrix-synapse-usage-exporter/templates/systemd/matrix-synapse-usage-exporter.service.j2
+++ b/roles/custom/matrix-synapse-usage-exporter/templates/systemd/matrix-synapse-usage-exporter.service.j2
@@ -30,9 +30,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_synapse_usage_exporter_container_image }}
 
+{% if matrix_synapse_usage_exporter_container_network not in ['', 'host'] %}
 {% for network in matrix_synapse_usage_exporter_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} {{ matrix_synapse_usage_exporter_identifier }}
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach {{ matrix_synapse_usage_exporter_identifier }}
 

--- a/roles/custom/matrix-synapse-usage-exporter/templates/systemd/matrix-synapse-usage-exporter.service.j2
+++ b/roles/custom/matrix-synapse-usage-exporter/templates/systemd/matrix-synapse-usage-exporter.service.j2
@@ -30,7 +30,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_synapse_usage_exporter_container_image }}
 
-{% if matrix_synapse_usage_exporter_container_network not in ['', 'host'] %}
+{% if matrix_synapse_usage_exporter_container_network != 'host' %}
 {% for network in matrix_synapse_usage_exporter_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} {{ matrix_synapse_usage_exporter_identifier }}
 {% endfor %}

--- a/roles/custom/matrix-synapse/tasks/reverse_proxy_companion/setup_install.yml
+++ b/roles/custom/matrix-synapse/tasks/reverse_proxy_companion/setup_install.yml
@@ -61,7 +61,7 @@
   until: matrix_synapse_reverse_proxy_companion_container_image_pull_result is not failed
 
 - name: Ensure matrix-synapse-reverse-proxy-companion container network is created
-  when: matrix_synapse_reverse_proxy_companion_container_network not in ['', 'host']
+  when: matrix_synapse_reverse_proxy_companion_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_synapse_reverse_proxy_companion_container_network }}"

--- a/roles/custom/matrix-synapse/tasks/reverse_proxy_companion/setup_install.yml
+++ b/roles/custom/matrix-synapse/tasks/reverse_proxy_companion/setup_install.yml
@@ -61,6 +61,7 @@
   until: matrix_synapse_reverse_proxy_companion_container_image_pull_result is not failed
 
 - name: Ensure matrix-synapse-reverse-proxy-companion container network is created
+  when: matrix_synapse_reverse_proxy_companion_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_synapse_reverse_proxy_companion_container_network }}"

--- a/roles/custom/matrix-synapse/tasks/synapse/setup_install.yml
+++ b/roles/custom/matrix-synapse/tasks/synapse/setup_install.yml
@@ -129,7 +129,7 @@
     group: "{{ matrix_synapse_gid }}"
 
 - name: Ensure Synapse container network is created
-  when: matrix_synapse_container_network not in ['', 'host']
+  when: matrix_synapse_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_synapse_container_network }}"

--- a/roles/custom/matrix-synapse/tasks/synapse/setup_install.yml
+++ b/roles/custom/matrix-synapse/tasks/synapse/setup_install.yml
@@ -129,6 +129,7 @@
     group: "{{ matrix_synapse_gid }}"
 
 - name: Ensure Synapse container network is created
+  when: matrix_synapse_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_synapse_container_network }}"

--- a/roles/custom/matrix-synapse/templates/reverse_proxy_companion/systemd/matrix-synapse-reverse-proxy-companion.service.j2
+++ b/roles/custom/matrix-synapse/templates/reverse_proxy_companion/systemd/matrix-synapse-reverse-proxy-companion.service.j2
@@ -45,7 +45,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_synapse_reverse_proxy_companion_container_image }}
 
-{% if matrix_synapse_reverse_proxy_companion_container_network not in ['', 'host'] %}
+{% if matrix_synapse_reverse_proxy_companion_container_network != 'host' %}
 {% for network in matrix_synapse_reverse_proxy_companion_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-synapse-reverse-proxy-companion
 {% endfor %}

--- a/roles/custom/matrix-synapse/templates/reverse_proxy_companion/systemd/matrix-synapse-reverse-proxy-companion.service.j2
+++ b/roles/custom/matrix-synapse/templates/reverse_proxy_companion/systemd/matrix-synapse-reverse-proxy-companion.service.j2
@@ -45,9 +45,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_synapse_reverse_proxy_companion_container_image }}
 
+{% if matrix_synapse_reverse_proxy_companion_container_network not in ['', 'host'] %}
 {% for network in matrix_synapse_reverse_proxy_companion_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-synapse-reverse-proxy-companion
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-synapse-reverse-proxy-companion
 

--- a/roles/custom/matrix-synapse/templates/synapse/systemd/matrix-synapse-worker.service.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/systemd/matrix-synapse-worker.service.j2
@@ -83,7 +83,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_synapse_container_image_final }} \
 			run -m synapse.app.{{ matrix_synapse_worker_details.app }} -c /data/homeserver.yaml -c /data/{{ matrix_synapse_worker_config_file_name }}
 
-{% if matrix_synapse_container_network not in ['', 'host'] %}
+{% if matrix_synapse_container_network != 'host' %}
 {% for network in matrix_synapse_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} {{ matrix_synapse_worker_container_name }}
 {% endfor %}

--- a/roles/custom/matrix-synapse/templates/synapse/systemd/matrix-synapse-worker.service.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/systemd/matrix-synapse-worker.service.j2
@@ -83,9 +83,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_synapse_container_image_final }} \
 			run -m synapse.app.{{ matrix_synapse_worker_details.app }} -c /data/homeserver.yaml -c /data/{{ matrix_synapse_worker_config_file_name }}
 
+{% if matrix_synapse_container_network not in ['', 'host'] %}
 {% for network in matrix_synapse_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} {{ matrix_synapse_worker_container_name }}
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach {{ matrix_synapse_worker_container_name }}
 

--- a/roles/custom/matrix-synapse/templates/synapse/systemd/matrix-synapse.service.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/systemd/matrix-synapse.service.j2
@@ -70,7 +70,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_synapse_container_image_final }} \
 			run -m synapse.app.homeserver -c /data/homeserver.yaml
 
-{% if matrix_synapse_container_network not in ['', 'host'] %}
+{% if matrix_synapse_container_network != 'host' %}
 {% for network in matrix_synapse_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-synapse
 {% endfor %}

--- a/roles/custom/matrix-synapse/templates/synapse/systemd/matrix-synapse.service.j2
+++ b/roles/custom/matrix-synapse/templates/synapse/systemd/matrix-synapse.service.j2
@@ -70,9 +70,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{{ matrix_synapse_container_image_final }} \
 			run -m synapse.app.homeserver -c /data/homeserver.yaml
 
+{% if matrix_synapse_container_network not in ['', 'host'] %}
 {% for network in matrix_synapse_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-synapse
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-synapse
 

--- a/roles/custom/matrix-tuwunel/tasks/install.yml
+++ b/roles/custom/matrix-tuwunel/tasks/install.yml
@@ -43,7 +43,7 @@
   register: matrix_tuwunel_support_files_result
 
 - name: Ensure tuwunel container network is created
-  when: matrix_tuwunel_container_network not in ['', 'host']
+  when: matrix_tuwunel_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_tuwunel_container_network }}"

--- a/roles/custom/matrix-tuwunel/tasks/install.yml
+++ b/roles/custom/matrix-tuwunel/tasks/install.yml
@@ -43,6 +43,7 @@
   register: matrix_tuwunel_support_files_result
 
 - name: Ensure tuwunel container network is created
+  when: matrix_tuwunel_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_tuwunel_container_network }}"

--- a/roles/custom/matrix-tuwunel/templates/systemd/matrix-tuwunel.service.j2
+++ b/roles/custom/matrix-tuwunel/templates/systemd/matrix-tuwunel.service.j2
@@ -34,7 +34,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_tuwunel_container_image }}
 
-{% if matrix_tuwunel_container_network not in ['', 'host'] %}
+{% if matrix_tuwunel_container_network != 'host' %}
 {% for network in matrix_tuwunel_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-tuwunel
 {% endfor %}

--- a/roles/custom/matrix-tuwunel/templates/systemd/matrix-tuwunel.service.j2
+++ b/roles/custom/matrix-tuwunel/templates/systemd/matrix-tuwunel.service.j2
@@ -34,9 +34,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_tuwunel_container_image }}
 
+{% if matrix_tuwunel_container_network not in ['', 'host'] %}
 {% for network in matrix_tuwunel_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} matrix-tuwunel
 {% endfor %}
+{% endif %}
 
 ExecStart={{ devture_systemd_docker_base_host_command_docker }} start --attach matrix-tuwunel
 

--- a/roles/custom/matrix-user-verification-service/tasks/setup_install.yml
+++ b/roles/custom/matrix-user-verification-service/tasks/setup_install.yml
@@ -59,7 +59,7 @@
   register: matrix_user_verification_service_config_result
 
 - name: Ensure matrix-user-verification-service container network is created
-  when: matrix_user_verification_service_container_network not in ['', 'host']
+  when: matrix_user_verification_service_container_network != 'host'
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_user_verification_service_container_network }}"

--- a/roles/custom/matrix-user-verification-service/tasks/setup_install.yml
+++ b/roles/custom/matrix-user-verification-service/tasks/setup_install.yml
@@ -59,6 +59,7 @@
   register: matrix_user_verification_service_config_result
 
 - name: Ensure matrix-user-verification-service container network is created
+  when: matrix_user_verification_service_container_network not in ['', 'host']
   community.general.docker_network:
     enable_ipv6: "{{ devture_systemd_docker_base_ipv6_enabled }}"
     name: "{{ matrix_user_verification_service_container_network }}"

--- a/roles/custom/matrix-user-verification-service/templates/systemd/matrix-user-verification-service.service.j2
+++ b/roles/custom/matrix-user-verification-service/templates/systemd/matrix-user-verification-service.service.j2
@@ -35,7 +35,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_user_verification_service_container_image }}
 
-{% if matrix_user_verification_service_container_network not in ['', 'host'] %}
+{% if matrix_user_verification_service_container_network != 'host' %}
 {% for network in matrix_user_verification_service_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} {{ matrix_user_verification_service_container_name }}
 {% endfor %}

--- a/roles/custom/matrix-user-verification-service/templates/systemd/matrix-user-verification-service.service.j2
+++ b/roles/custom/matrix-user-verification-service/templates/systemd/matrix-user-verification-service.service.j2
@@ -35,9 +35,11 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 			{% endfor %}
 			{{ matrix_user_verification_service_container_image }}
 
+{% if matrix_user_verification_service_container_network not in ['', 'host'] %}
 {% for network in matrix_user_verification_service_container_additional_networks %}
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} network connect {{ network }} {{ matrix_user_verification_service_container_name }}
 {% endfor %}
+{% endif %}
 ExecStart=/usr/bin/env docker start --attach matrix-user-verification-service
 
 ExecStop=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} stop -t {{ devture_systemd_docker_base_container_stop_grace_time_seconds }} {{ matrix_user_verification_service_container_name }} 2>/dev/null'


### PR DESCRIPTION
## Summary

Adds support for running every MDAD-managed container with `--network=host`,
so the entire Matrix stack can share a single network namespace instead of
requiring per-service docker networks.

Two guards are added across the playbook:

1. **`docker_network` tasks** are now skipped when the corresponding
   `*_container_network` variable is unset or `host` — there is nothing to
   create when containers share the host namespace.
   (62 tasks touched.)
2. **systemd unit templates** wrap their `--network <name>` and `--ip <addr>`
   flags in `{% if %}` guards so units don't reference a non-existent
   docker network at start time.
   (66 templates touched.)

No behavior changes for the default bridge-network setup — only the new
`host`/empty case is gated.

## Why — Infinito.Nexus DiD integration

This fork is consumed by the Infinito.Nexus `web-app-matrix` role:
https://github.com/infinito-nexus/core/tree/main/roles/web-app-matrix

Infinito.Nexus runs every application as a compose service on a shared
host, with central postgres / OpenLDAP / coturn / Keycloak. To bolt
upstream MDAD into that model without spawning a parallel set of docker
networks (and without the MDAD-managed containers losing access to the
central postgres + LDAP networks), the role wraps the full MDAD playbook
in a privileged systemd-in-container runner with a bundled docker daemon
— **Docker-in-Docker**.

That outer `matrix-mdad` container joins the Infinito.Nexus `postgres`
and `openldap` overlay networks. Every MDAD-managed inner container
(synapse, element, coturn, bridges, jitsi, livekit, …) is then started
with `--network=host` so it shares the runner's NS, transparently
inheriting both the central-service reachability and the published port
forwards on the outer compose stack.

For that pattern to work upstream MDAD must (a) skip its own
docker-network bootstrap when the network is `host` and (b) not bake
`--network <name>` into the generated systemd units. Hence this PR.

## Test plan

- [x] Three-variant `full_cycle` reinstall of `web-app-matrix` in
      Infinito.Nexus on top of this fork: V1 (ansible all-on),
      V2 (ansible no-auth), V3 (compose all-on) — all green
- [x] Final canonical `full_cycle` reinstall across all three variants:
      6 PLAY RECAPs, `failed=0`, 20/20 Playwright matrix tests pass
      (OIDC login, native login, DM, Element Call, bridge roster)
- [x] Default bridge-network deployments untouched — guards are
      no-ops when `*_container_network` is set to a real network name
      
 E2E tested here: https://github.com/kevinveenbirkenbach/infinito-nexus-core/actions/runs/27239821968