### PR TITLE
Fix Dockerfile path when self building Element Web container image

### DIFF
--- a/roles/custom/matrix-client-element/defaults/main.yml
+++ b/roles/custom/matrix-client-element/defaults/main.yml
@@ -38,6 +38,7 @@ matrix_client_element_container_image_registry_prefix_upstream_default: ghcr.io/
 
 matrix_client_element_data_path: "{{ matrix_base_data_path }}/client-element"
 matrix_client_element_container_src_files_path: "{{ matrix_client_element_data_path }}/docker-src"
+matrix_client_element_container_src_dockerfile_path: "{{ matrix_client_element_container_src_files_path }}/apps/web/Dockerfile"
 
 # The base container network
 matrix_client_element_container_network: ''

--- a/roles/custom/matrix-client-element/tasks/setup_install.yml
+++ b/roles/custom/matrix-client-element/tasks/setup_install.yml
@@ -63,7 +63,7 @@
     cmd: |-
       {{ devture_systemd_docker_base_host_command_docker }} buildx build
       --tag={{ matrix_client_element_container_image }}
-      --file={{ matrix_client_element_container_src_files_path }}/Dockerfile
+      --file={{ matrix_client_element_container_src_dockerfile_path }}
       {{ matrix_client_element_container_src_files_path }}
   changed_when: true
   when: matrix_client_element_container_image_self_build | bool


### PR DESCRIPTION
Since commit element-hq/element-web@91a3cb03c16bed2857538f143fd1a911f0177eb0 (part of release `v1.12.21`) the `Dockerfile` location has moved from the root directory of the projects to `apps/web/Dockerfile` 