### PR TITLE
Support additional container arguments for matrix-livekit-jwt

### DIFF
--- a/roles/custom/matrix-livekit-jwt-service/defaults/main.yml
+++ b/roles/custom/matrix-livekit-jwt-service/defaults/main.yml
@@ -125,3 +125,6 @@ matrix_livekit_jwt_service_systemd_required_services_list_custom: []
 # The default of `false` means "no restart needed" — appropriate when the role's
 # installation tasks haven't run (e.g., due to --tags skipping them).
 matrix_livekit_jwt_service_restart_necessary: false
+
+# Support additional container arguments for the LiveKit JWT service
+matrix_livekit_jwt_service_container_additional_arguments: []

--- a/roles/custom/matrix-livekit-jwt-service/templates/systemd/matrix-livekit-jwt-service.service.j2
+++ b/roles/custom/matrix-livekit-jwt-service/templates/systemd/matrix-livekit-jwt-service.service.j2
@@ -22,6 +22,9 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
     {% if matrix_livekit_jwt_service_container_http_host_bind_port %}
     -p {{ matrix_livekit_jwt_service_container_http_host_bind_port }}:{{ matrix_livekit_jwt_service_container_port }} \
     {% endif %}
+    {% for arg in matrix_livekit_jwt_service_container_additional_arguments %}
+    {{ arg }} \
+    {% endfor %}
     --env-file={{ matrix_livekit_jwt_service_base_path }}/env \
     --label-file={{ matrix_livekit_jwt_service_base_path }}/labels \
     {{ matrix_livekit_jwt_service_container_image }}


### PR DESCRIPTION
Hit an issue when testing Element Call with self-signed certificates where livekit wouldn't be able to reach the Matrix API due to untrusted certificates. This patch allows configuring JWT to accept additional container arguments which allowed the pass through of certificates (among other uses).

```
matrix_livekit_jwt_service_container_additional_arguments:
  - "--volume=<cert_path>/cert.pem:/ca.crt:ro"
```