### PR TITLE
Update readme for NPM

### DIFF
--- a/examples/reverse-proxies/nginx-proxy-manager/README.md
+++ b/examples/reverse-proxies/nginx-proxy-manager/README.md
@@ -44,27 +44,19 @@ Custom Nginx Configuration:
 	client_max_body_size 50M;
 ```
 
-Again, under the 'Proxy Hosts' page select `Add Proxy Host`, this time for your federation traffic. Apply the proxy's configuration like this:
+Then, under the 'Streams' page select `Add Stream`, this time for your federation traffic. Apply the configuration like this:
 
 ```md
 # Details
 # Matrix Federation proxy config
-Domain Names: matrix.example.com:8448
-Scheme: http
-Forward Hostname/IP: IP-ADDRESS-OF-YOUR-MATRIX
+Incoming Port: 8448
+Forward Host/IP: IP-ADDRESS-OF-YOUR-MATRIX
 Forward Port: 8449
+Protocols: TCP
 
 # SSL
 # Either 'Request a new certificate' or select an existing one
 SSL Certificate: matrix.example.com or *.example.com
-Force SSL: true
-HTTP/2 Support: true
-
-# Advanced
-# Allows NPM to listen on the federation port
-Custom Nginx Configuration:
-	listen 8448 ssl http2;
-	client_max_body_size 50M;
 ```
 
 Also note, NPM would need to be configured for whatever other services you are using. For example, you would need to create additional proxy hosts for `element.example.com` or `jitsi.example.com`, which would use the forwarding port `81`.


### PR DESCRIPTION
NPM "Proxy Hosts" page is only for http/https 80/443 - it is not possible to add a name such as "matrix.example.com:port".

Instead, the Streams page might work for what is intended here (federation traffic) - to proxy stream anything on 8448 to 8449.

Note: I'm on version v2.14.0, but if I am remembering correctly, the Streams page has been around for at least 2 years on NPM.

Edit: Supporting photos:
Proxy Hosts does not support port numbers in the name:
<img width="521" height="261" alt="image" src="https://github.com/user-attachments/assets/bbae4857-92ce-48b3-ab2d-6a0d4fa9ea1b" />

Streams (which does support arbitrary port to port mapping):
<img width="1113" height="181" alt="image" src="https://github.com/user-attachments/assets/6924a171-b6c2-4e52-9179-21fd6d942893" />

