### PR TITLE
matrix-rustpush-brigdge: Add renovate and bump version

### DIFF
--- a/roles/custom/matrix-bridge-rustpush/defaults/main.yml
+++ b/roles/custom/matrix-bridge-rustpush/defaults/main.yml
@@ -13,8 +13,8 @@ matrix_rustpush_bridge_container_image_self_build: false
 matrix_rustpush_bridge_container_image_self_build_repo: "https://github.com/jasonlaguidice/imessage.git"
 matrix_rustpush_bridge_container_image_self_build_repo_version: "{{ 'master' if matrix_rustpush_bridge_version == 'latest' else matrix_rustpush_bridge_version }}"
 
-# Adjust to pin to releases
-matrix_rustpush_bridge_version: v0.0.1
+# renovate: datasource=docker depName=ghcr.io/jasonlaguidice/imessage
+matrix_rustpush_bridge_version: v0.0.2
 matrix_rustpush_bridge_container_image: "{{ matrix_rustpush_bridge_container_image_registry_prefix }}jasonlaguidice/imessage:{{ matrix_rustpush_bridge_version }}"
 matrix_rustpush_bridge_container_image_registry_prefix: "{{ 'localhost/' if matrix_rustpush_bridge_container_image_self_build else matrix_rustpush_bridge_container_image_registry_prefix_upstream }}"
 matrix_rustpush_bridge_container_image_registry_prefix_upstream: "{{ matrix_rustpush_bridge_container_image_registry_prefix_upstream_default }}"


### PR DESCRIPTION
I totally forgot to replace the commented line with one for renovate to notify when new versions were available. Apologies!

🙃