### PR TITLE
[Element] Fix missing background URL on welcome, login & register pages

### DIFF
--- a/roles/custom/matrix-client-element/defaults/main.yml
+++ b/roles/custom/matrix-client-element/defaults/main.yml
@@ -206,7 +206,7 @@ matrix_client_element_branding_auth_footer_links: ~  # noqa var-naming
 matrix_client_element_branding_auth_header_logo_url: "{{ matrix_client_element_welcome_logo }}"  # noqa var-naming
 
 # URL to Wallpaper, shown in background of welcome page
-matrix_client_element_branding_welcome_background_url: ~  # noqa var-naming
+matrix_client_element_branding_welcome_background_url: "themes/element/img/backgrounds/lake.jpg"
 
 # Controls the `features` section of the Element Web configuration.
 matrix_client_element_features: "{{ matrix_client_element_features_default | combine(matrix_client_element_features_auto, recursive=True) | combine(matrix_client_element_features_custom, recursive=True) }}"


### PR DESCRIPTION
- Updated `welcome_background_url` to upstream default *lake.jpg* for the official Matrix Client Element.
- Provoked by: [Convert welcome.html to React component](https://github.com/element-hq/element-web/commit/4b4289e211c12ea0ebb885d570cfa6b7c29dac86)