### PR TITLE
Add flake.lock to be the list of items for automerge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,6 +32,12 @@
 				"dock.mau.dev/mautrix/**"
 			],
 			"allowedVersions": "/^v0\\./"
+		},
+		{
+			"matchFileNames": [
+				"flake.lock"
+			],
+			"automerge": true
 		}
 	],
 	"pre-commit": {


### PR DESCRIPTION
This enables [automerge](https://docs.renovatebot.com/key-concepts/automerge/) of PRs like https://github.com/spantaleev/matrix-docker-ansible-deploy/pull/5416 per the default settings at Renovate ([`automergeSchedule`](https://docs.renovatebot.com/configuration-options/#automergeschedule)).