### PR TITLE
lint: align yamllint and quote RustPush modes

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,5 +1,16 @@
 ---
 extends: default
 
+# Keep this custom configuration compatible with ansible-lint's `yaml` rule.
+# See https://docs.ansible.com/projects/lint/rules/yaml/#yamllint-configuration
 rules:
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 1
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: false
   line-length: disable
+  octal-values:
+    forbid-explicit-octal: true
+    forbid-implicit-octal: true

--- a/roles/custom/matrix-bridge-rustpush/tasks/setup_install.yml
+++ b/roles/custom/matrix-bridge-rustpush/tasks/setup_install.yml
@@ -9,7 +9,7 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
-    mode: 0750
+    mode: "0750"
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -58,7 +58,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_rustpush_bridge_configuration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_rustpush_bridge_config_path }}/config.yaml"
-    mode: 0644
+    mode: "0644"
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_rustpush_bridge_config_result
@@ -67,7 +67,7 @@
   ansible.builtin.copy:
     content: "{{ matrix_rustpush_bridge_registration | to_nice_yaml(indent=2, width=999999) }}"
     dest: "{{ matrix_rustpush_bridge_config_path }}/registration.yaml"
-    mode: 0644
+    mode: "0644"
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   register: matrix_rustpush_bridge_registration_result
@@ -76,7 +76,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/{{ item }}.j2"
     dest: "{{ matrix_rustpush_bridge_base_path }}/{{ item }}"
-    mode: 0640
+    mode: "0640"
     owner: "{{ matrix_user_name }}"
     group: "{{ matrix_group_name }}"
   with_items:
@@ -94,7 +94,7 @@
   ansible.builtin.template:
     src: "{{ role_path }}/templates/systemd/matrix-rustpush-bridge.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/matrix-rustpush-bridge.service"
-    mode: 0644
+    mode: "0644"
   register: matrix_rustpush_bridge_systemd_service_result
 
 - name: Determine whether matrix-rustpush-bridge needs a restart


### PR DESCRIPTION
Align the repository's `.yamllint` configuration with the compatibility requirements of ansible-lint's built-in `yaml` rule and correct the existing RustPush violations exposed by enabling strict octal-value detection.