### PR TITLE
matrix-tuwunel: expose the /_synapse/admin and /_tuwunel API paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 2026-07-19
+
+## Tuwunel now exposes its administration and /_tuwunel API paths
+
+The [Tuwunel](docs/configuring-playbook-tuwunel.md) role previously routed only the `/_matrix` path through the reverse proxy. It now also exposes the two other API paths that Tuwunel serves.
+
+The Synapse-compatible administration API (`/_synapse/admin`) powers administration dashboards and moderation bots. As with Synapse and Dendrite, the playbook now exposes it automatically when such a tool is installed: publicly for [Ketesa](docs/configuring-playbook-ketesa.md) or [Element Admin](docs/configuring-playbook-element-admin.md), and on the internal entrypoint for [Draupnir](docs/configuring-playbook-bot-draupnir.md). To expose it yourself, set `matrix_tuwunel_container_labels_public_client_synapse_admin_api_enabled: true` (or the `internal_` variant).
+
+Tuwunel also serves first-party routes under `/_tuwunel`, including its native OpenID Connect provider endpoints, which the reverse proxy must route for OIDC login to work. This path is now routed on the public entrypoint by default. To keep it off the public entrypoint, set `matrix_tuwunel_container_labels_public_tuwunel_api_enabled: false`.
+
+
 # 2026-07-18
 
 ## LiveKit Server port configuration must be unambiguous now

--- a/docs/configuring-playbook-ketesa.md
+++ b/docs/configuring-playbook-ketesa.md
@@ -41,6 +41,7 @@ matrix_ketesa_enabled: true
 
 - for [Synapse](./configuring-playbook-synapse.md) (our default homeserver implementation): `matrix_synapse_container_labels_public_client_synapse_admin_api_enabled: true`
 - for [Dendrite](./configuring-playbook-dendrite.md): `matrix_dendrite_container_labels_public_client_synapse_admin_api_enabled: true`
+- for [Tuwunel](./configuring-playbook-tuwunel.md): `matrix_tuwunel_container_labels_public_client_synapse_admin_api_enabled: true`
 
 By default, Ketesa installation will be [restricted to only work with one homeserver](https://github.com/etkecc/ketesa/blob/main/README.md#restricting-available-homeserver) — the one managed by the playbook. To adjust these restrictions, tweak the `matrix_ketesa_config_restrictBaseUrl` variable.
 

--- a/docs/configuring-playbook-tuwunel.md
+++ b/docs/configuring-playbook-tuwunel.md
@@ -180,6 +180,22 @@ When enabled, rooms with a valid `m.room.policy` state event have outgoing event
 
 The role sets `default_room_version: '12'`, so newly created rooms default to Matrix [room version 12](https://github.com/matrix-org/matrix-spec-proposals/pull/4289) ("Hydra"). Override `matrix_tuwunel_config_default_room_version` if you need an earlier version for client compatibility.
 
+### Exposing the Administration API
+
+Tuwunel serves a Synapse-compatible Administration API under the `/_synapse/admin` path, so administration dashboards (such as synapse-admin and ketesa) and moderation bots (such as Draupnir and Meowlnir) work against it. The served endpoints are listed on the [Tuwunel Synapse Admin API page](https://matrix-construct.github.io/tuwunel/development/compliance/synapse-admin.html).
+
+The API is not routed through the reverse proxy by default. Every endpoint requires an administrator access token, but you may still prefer to keep it off the public entrypoint. To reach it only from trusted networks, expose it on the internal Traefik entrypoint:
+
+```yaml
+matrix_tuwunel_container_labels_internal_client_synapse_admin_api_enabled: true
+```
+
+To expose it publicly instead (for example, when a dashboard runs in the browser), set:
+
+```yaml
+matrix_tuwunel_container_labels_public_client_synapse_admin_api_enabled: true
+```
+
 ## Creating the first user account
 
 Unlike Synapse and Dendrite, Tuwunel does not register users from the command line or via the playbook. On first startup it logs a one-time-use registration token to its journal:

--- a/docs/configuring-playbook-tuwunel.md
+++ b/docs/configuring-playbook-tuwunel.md
@@ -180,6 +180,17 @@ When enabled, rooms with a valid `m.room.policy` state event have outgoing event
 
 The role sets `default_room_version: '12'`, so newly created rooms default to Matrix [room version 12](https://github.com/matrix-org/matrix-spec-proposals/pull/4289) ("Hydra"). Override `matrix_tuwunel_config_default_room_version` if you need an earlier version for client compatibility.
 
+### The `/_tuwunel` API path
+
+Besides `/_matrix`, Tuwunel serves its own first-party routes under `/_tuwunel`. This namespace carries ad-hoc endpoints such as `/_tuwunel/server_version` and `/_tuwunel/local_user_count`, and the [native OpenID Connect provider](https://matrix-construct.github.io/tuwunel/authentication/oidc-server.html) endpoints (`/_tuwunel/oidc/...`) that clients use when Tuwunel handles OIDC login itself, rather than delegating to an upstream provider as described above. The role routes `/_tuwunel` on the public entrypoint by default so these features work out of the box.
+
+To keep this namespace off the public entrypoint and expose it only on the internal one, set:
+
+```yaml
+matrix_tuwunel_container_labels_public_tuwunel_api_enabled: false
+matrix_tuwunel_container_labels_internal_tuwunel_api_enabled: true
+```
+
 ### Exposing the Administration API
 
 Tuwunel serves a Synapse-compatible Administration API under the `/_synapse/admin` path, so administration dashboards (such as synapse-admin and ketesa) and moderation bots (such as Draupnir and Meowlnir) work against it. The served endpoints are listed on the [Tuwunel Synapse Admin API page](https://matrix-construct.github.io/tuwunel/development/compliance/synapse-admin.html).

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -5829,6 +5829,7 @@ matrix_tuwunel_container_labels_public_federation_api_traefik_tls: "{{ matrix_fe
 
 matrix_tuwunel_container_labels_internal_client_api_enabled: "{{ matrix_playbook_internal_matrix_client_api_traefik_entrypoint_enabled }}"
 matrix_tuwunel_container_labels_internal_client_api_traefik_entrypoints: "{{ matrix_playbook_internal_matrix_client_api_traefik_entrypoint_name }}"
+matrix_tuwunel_container_labels_internal_tuwunel_api_traefik_entrypoints: "{{ matrix_playbook_internal_matrix_client_api_traefik_entrypoint_name }}"
 
 matrix_tuwunel_config_well_known_livekit_url: "{{ matrix_livekit_jwt_service_public_url if matrix_livekit_jwt_service_enabled else '' }}"
 

--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -5819,6 +5819,10 @@ matrix_tuwunel_container_labels_traefik_tls_certResolver: "{{ traefik_certResolv
 matrix_tuwunel_container_labels_public_client_root_redirection_enabled: "{{ matrix_tuwunel_container_labels_public_client_root_redirection_url != '' }}"
 matrix_tuwunel_container_labels_public_client_root_redirection_url: "{{ (('https://' if matrix_playbook_ssl_enabled else 'http://') + matrix_server_fqn_element) if matrix_client_element_enabled else '' }}"
 
+matrix_tuwunel_container_labels_public_client_synapse_admin_api_enabled: "{{ matrix_ketesa_enabled or matrix_element_admin_enabled }}"
+matrix_tuwunel_container_labels_internal_client_synapse_admin_api_enabled: "{{ (matrix_bot_draupnir_enabled and matrix_bot_draupnir_admin_api_enabled) }}"
+matrix_tuwunel_container_labels_internal_client_synapse_admin_api_traefik_entrypoints: "{{ matrix_playbook_internal_matrix_client_api_traefik_entrypoint_name }}"
+
 matrix_tuwunel_container_labels_public_federation_api_traefik_hostname: "{{ matrix_server_fqn_matrix_federation }}"
 matrix_tuwunel_container_labels_public_federation_api_traefik_entrypoints: "{{ matrix_federation_traefik_entrypoint_name }}"
 matrix_tuwunel_container_labels_public_federation_api_traefik_tls: "{{ matrix_federation_traefik_entrypoint_tls }}"

--- a/roles/custom/matrix-tuwunel/defaults/main.yml
+++ b/roles/custom/matrix-tuwunel/defaults/main.yml
@@ -106,6 +106,25 @@ matrix_tuwunel_container_labels_public_federation_api_traefik_entrypoints: ''
 matrix_tuwunel_container_labels_public_federation_api_traefik_tls: true
 matrix_tuwunel_container_labels_public_federation_api_traefik_tls_certResolver: "{{ matrix_tuwunel_container_labels_traefik_tls_certResolver }}"  # noqa var-naming
 
+# Controls whether labels will be added that expose the Synapse-compatible Administration API (`/_synapse/admin`) on a public Traefik entrypoint.
+# Tuwunel serves this API so that administration dashboards (synapse-admin, ketesa) and moderation bots (Draupnir, Meowlnir) work against it.
+# Every endpoint requires an administrator access token. It is disabled by default; you may prefer to expose it only on the internal entrypoint below.
+matrix_tuwunel_container_labels_public_client_synapse_admin_api_enabled: false
+matrix_tuwunel_container_labels_public_client_synapse_admin_api_traefik_hostname: "{{ matrix_tuwunel_hostname }}"
+matrix_tuwunel_container_labels_public_client_synapse_admin_api_traefik_path_prefix: /_synapse/admin
+matrix_tuwunel_container_labels_public_client_synapse_admin_api_traefik_rule: "Host(`{{ matrix_tuwunel_container_labels_public_client_synapse_admin_api_traefik_hostname }}`) && PathPrefix(`{{ matrix_tuwunel_container_labels_public_client_synapse_admin_api_traefik_path_prefix }}`)"
+matrix_tuwunel_container_labels_public_client_synapse_admin_api_traefik_priority: 0
+matrix_tuwunel_container_labels_public_client_synapse_admin_api_traefik_entrypoints: "{{ matrix_tuwunel_container_labels_traefik_entrypoints }}"
+matrix_tuwunel_container_labels_public_client_synapse_admin_api_traefik_tls: "{{ matrix_tuwunel_container_labels_public_client_synapse_admin_api_traefik_entrypoints != 'web' }}"
+matrix_tuwunel_container_labels_public_client_synapse_admin_api_traefik_tls_certResolver: "{{ matrix_tuwunel_container_labels_traefik_tls_certResolver }}"  # noqa var-naming
+
+# Controls whether labels will be added that expose the Synapse-compatible Administration API (`/_synapse/admin`) on the internal Traefik entrypoint.
+matrix_tuwunel_container_labels_internal_client_synapse_admin_api_enabled: false
+matrix_tuwunel_container_labels_internal_client_synapse_admin_api_traefik_path_prefix: /_synapse/admin
+matrix_tuwunel_container_labels_internal_client_synapse_admin_api_traefik_rule: "PathPrefix(`{{ matrix_tuwunel_container_labels_internal_client_synapse_admin_api_traefik_path_prefix }}`)"
+matrix_tuwunel_container_labels_internal_client_synapse_admin_api_traefik_priority: 0
+matrix_tuwunel_container_labels_internal_client_synapse_admin_api_traefik_entrypoints: ""
+
 # Additional Docker container labels (multiline string) appended verbatim to the label file.
 # See `../templates/labels.j2`.
 matrix_tuwunel_container_labels_additional_labels: ''

--- a/roles/custom/matrix-tuwunel/defaults/main.yml
+++ b/roles/custom/matrix-tuwunel/defaults/main.yml
@@ -106,6 +106,26 @@ matrix_tuwunel_container_labels_public_federation_api_traefik_entrypoints: ''
 matrix_tuwunel_container_labels_public_federation_api_traefik_tls: true
 matrix_tuwunel_container_labels_public_federation_api_traefik_tls_certResolver: "{{ matrix_tuwunel_container_labels_traefik_tls_certResolver }}"  # noqa var-naming
 
+# Controls whether labels will be added that expose Tuwunel's first-party API (`/_tuwunel`) on a public Traefik entrypoint.
+# This namespace carries ad-hoc routes such as `/_tuwunel/server_version` and `/_tuwunel/local_user_count`, as well as the
+# native OpenID Connect provider endpoints (`/_tuwunel/oidc/...`) that clients use when Tuwunel performs OIDC login itself.
+# It is enabled by default because the reverse proxy must route it for those features to work.
+matrix_tuwunel_container_labels_public_tuwunel_api_enabled: true
+matrix_tuwunel_container_labels_public_tuwunel_api_traefik_hostname: "{{ matrix_tuwunel_hostname }}"
+matrix_tuwunel_container_labels_public_tuwunel_api_traefik_path_prefix: /_tuwunel
+matrix_tuwunel_container_labels_public_tuwunel_api_traefik_rule: "Host(`{{ matrix_tuwunel_container_labels_public_tuwunel_api_traefik_hostname }}`) && PathPrefix(`{{ matrix_tuwunel_container_labels_public_tuwunel_api_traefik_path_prefix }}`)"
+matrix_tuwunel_container_labels_public_tuwunel_api_traefik_priority: 0
+matrix_tuwunel_container_labels_public_tuwunel_api_traefik_entrypoints: "{{ matrix_tuwunel_container_labels_traefik_entrypoints }}"
+matrix_tuwunel_container_labels_public_tuwunel_api_traefik_tls: "{{ matrix_tuwunel_container_labels_public_tuwunel_api_traefik_entrypoints != 'web' }}"
+matrix_tuwunel_container_labels_public_tuwunel_api_traefik_tls_certResolver: "{{ matrix_tuwunel_container_labels_traefik_tls_certResolver }}"  # noqa var-naming
+
+# Controls whether labels will be added that expose Tuwunel's first-party API (`/_tuwunel`) on the internal Traefik entrypoint.
+matrix_tuwunel_container_labels_internal_tuwunel_api_enabled: false
+matrix_tuwunel_container_labels_internal_tuwunel_api_traefik_path_prefix: /_tuwunel
+matrix_tuwunel_container_labels_internal_tuwunel_api_traefik_rule: "PathPrefix(`{{ matrix_tuwunel_container_labels_internal_tuwunel_api_traefik_path_prefix }}`)"
+matrix_tuwunel_container_labels_internal_tuwunel_api_traefik_priority: 0
+matrix_tuwunel_container_labels_internal_tuwunel_api_traefik_entrypoints: ""
+
 # Controls whether labels will be added that expose the Synapse-compatible Administration API (`/_synapse/admin`) on a public Traefik entrypoint.
 # Tuwunel serves this API so that administration dashboards (synapse-admin, ketesa) and moderation bots (Draupnir, Meowlnir) work against it.
 # Every endpoint requires an administrator access token. It is disabled by default; you may prefer to expose it only on the internal entrypoint below.

--- a/roles/custom/matrix-tuwunel/templates/labels.j2
+++ b/roles/custom/matrix-tuwunel/templates/labels.j2
@@ -136,6 +136,59 @@ traefik.http.routers.matrix-tuwunel-public-federation-api.tls.certResolver={{ ma
 {% endif %}
 
 
+{% if matrix_tuwunel_container_labels_public_tuwunel_api_enabled %}
+############################################################
+#                                                          #
+# Public Tuwunel API (/_tuwunel)                           #
+#                                                          #
+############################################################
+
+traefik.http.routers.matrix-tuwunel-public-tuwunel-api.rule={{ matrix_tuwunel_container_labels_public_tuwunel_api_traefik_rule }}
+
+{% if matrix_tuwunel_container_labels_public_tuwunel_api_traefik_priority | int > 0 %}
+traefik.http.routers.matrix-tuwunel-public-tuwunel-api.priority={{ matrix_tuwunel_container_labels_public_tuwunel_api_traefik_priority }}
+{% endif %}
+
+traefik.http.routers.matrix-tuwunel-public-tuwunel-api.service=matrix-tuwunel
+traefik.http.routers.matrix-tuwunel-public-tuwunel-api.entrypoints={{ matrix_tuwunel_container_labels_public_tuwunel_api_traefik_entrypoints }}
+
+traefik.http.routers.matrix-tuwunel-public-tuwunel-api.tls={{ matrix_tuwunel_container_labels_public_tuwunel_api_traefik_tls | to_json }}
+{% if matrix_tuwunel_container_labels_public_tuwunel_api_traefik_tls %}
+traefik.http.routers.matrix-tuwunel-public-tuwunel-api.tls.certResolver={{ matrix_tuwunel_container_labels_public_tuwunel_api_traefik_tls_certResolver }}
+{% endif %}
+
+############################################################
+#                                                          #
+# /Public Tuwunel API (/_tuwunel)                          #
+#                                                          #
+############################################################
+{% endif %}
+
+
+{% if matrix_tuwunel_container_labels_internal_tuwunel_api_enabled %}
+############################################################
+#                                                          #
+# Internal Tuwunel API (/_tuwunel)                         #
+#                                                          #
+############################################################
+
+traefik.http.routers.matrix-tuwunel-internal-tuwunel-api.rule={{ matrix_tuwunel_container_labels_internal_tuwunel_api_traefik_rule }}
+
+{% if matrix_tuwunel_container_labels_internal_tuwunel_api_traefik_priority | int > 0 %}
+traefik.http.routers.matrix-tuwunel-internal-tuwunel-api.priority={{ matrix_tuwunel_container_labels_internal_tuwunel_api_traefik_priority }}
+{% endif %}
+
+traefik.http.routers.matrix-tuwunel-internal-tuwunel-api.service=matrix-tuwunel
+traefik.http.routers.matrix-tuwunel-internal-tuwunel-api.entrypoints={{ matrix_tuwunel_container_labels_internal_tuwunel_api_traefik_entrypoints }}
+
+############################################################
+#                                                          #
+# /Internal Tuwunel API (/_tuwunel)                        #
+#                                                          #
+############################################################
+{% endif %}
+
+
 {% if matrix_tuwunel_container_labels_public_client_synapse_admin_api_enabled %}
 ############################################################
 #                                                          #

--- a/roles/custom/matrix-tuwunel/templates/labels.j2
+++ b/roles/custom/matrix-tuwunel/templates/labels.j2
@@ -136,6 +136,59 @@ traefik.http.routers.matrix-tuwunel-public-federation-api.tls.certResolver={{ ma
 {% endif %}
 
 
+{% if matrix_tuwunel_container_labels_public_client_synapse_admin_api_enabled %}
+############################################################
+#                                                          #
+# Public Synapse Admin API (/_synapse/admin)               #
+#                                                          #
+############################################################
+
+traefik.http.routers.matrix-tuwunel-public-client-synapse-admin-api.rule={{ matrix_tuwunel_container_labels_public_client_synapse_admin_api_traefik_rule }}
+
+{% if matrix_tuwunel_container_labels_public_client_synapse_admin_api_traefik_priority | int > 0 %}
+traefik.http.routers.matrix-tuwunel-public-client-synapse-admin-api.priority={{ matrix_tuwunel_container_labels_public_client_synapse_admin_api_traefik_priority }}
+{% endif %}
+
+traefik.http.routers.matrix-tuwunel-public-client-synapse-admin-api.service=matrix-tuwunel
+traefik.http.routers.matrix-tuwunel-public-client-synapse-admin-api.entrypoints={{ matrix_tuwunel_container_labels_public_client_synapse_admin_api_traefik_entrypoints }}
+
+traefik.http.routers.matrix-tuwunel-public-client-synapse-admin-api.tls={{ matrix_tuwunel_container_labels_public_client_synapse_admin_api_traefik_tls | to_json }}
+{% if matrix_tuwunel_container_labels_public_client_synapse_admin_api_traefik_tls %}
+traefik.http.routers.matrix-tuwunel-public-client-synapse-admin-api.tls.certResolver={{ matrix_tuwunel_container_labels_public_client_synapse_admin_api_traefik_tls_certResolver }}
+{% endif %}
+
+############################################################
+#                                                          #
+# /Public Synapse Admin API (/_synapse/admin)              #
+#                                                          #
+############################################################
+{% endif %}
+
+
+{% if matrix_tuwunel_container_labels_internal_client_synapse_admin_api_enabled %}
+############################################################
+#                                                          #
+# Internal Synapse Admin API (/_synapse/admin)             #
+#                                                          #
+############################################################
+
+traefik.http.routers.matrix-tuwunel-internal-client-synapse-admin-api.rule={{ matrix_tuwunel_container_labels_internal_client_synapse_admin_api_traefik_rule }}
+
+{% if matrix_tuwunel_container_labels_internal_client_synapse_admin_api_traefik_priority | int > 0 %}
+traefik.http.routers.matrix-tuwunel-internal-client-synapse-admin-api.priority={{ matrix_tuwunel_container_labels_internal_client_synapse_admin_api_traefik_priority }}
+{% endif %}
+
+traefik.http.routers.matrix-tuwunel-internal-client-synapse-admin-api.service=matrix-tuwunel
+traefik.http.routers.matrix-tuwunel-internal-client-synapse-admin-api.entrypoints={{ matrix_tuwunel_container_labels_internal_client_synapse_admin_api_traefik_entrypoints }}
+
+############################################################
+#                                                          #
+# /Internal Synapse Admin API (/_synapse/admin)            #
+#                                                          #
+############################################################
+{% endif %}
+
+
 {% endif %}
 
 {{ matrix_tuwunel_container_labels_additional_labels }}


### PR DESCRIPTION
This follows up on #5200, which introduced the `matrix-tuwunel` role. That role routed only `/_matrix` through Traefik, but Tuwunel serves two other first-party API paths that a reverse proxy must carry. This adds Traefik label groups for both, wired into the playbook the same way the `matrix-synapse` role wires its equivalents.

## `/_synapse/admin` (Synapse-compatible administration API)

Tuwunel serves the Synapse admin API, so administration dashboards (synapse-admin, Ketesa) and moderation bots (Draupnir, Meowlnir) work against it. New public and internal label groups mirror `matrix_synapse_container_labels_*_client_synapse_admin_api_*`, and `group_vars/matrix_servers` enables them automatically when Ketesa or Element Admin (public entrypoint) or Draupnir (internal entrypoint) is installed, matching the Synapse and Dendrite behavior the Ketesa guide already documents.

## `/_tuwunel` (first-party routes and native OIDC provider)

The `/_tuwunel` namespace carries `server_version`, `local_user_count`, and Tuwunel's native OpenID Connect provider endpoints (`/_tuwunel/oidc/...`), which the reverse proxy must route for OIDC login to work. It is exposed on the public entrypoint by default, like the client API; Tuwunel's reverse-proxy guide lists it as a required path. A CHANGELOG entry documents this default and its one-line opt-out.

## Notes

- New role variables follow the `matrix-synapse` naming: `matrix_tuwunel_container_labels_public_client_synapse_admin_api_enabled` (plus the `internal_` variant) and `matrix_tuwunel_container_labels_public_tuwunel_api_enabled` (plus the `internal_` variant).
- The internal recipes are pre-wired to the internal client-API entrypoint in `group_vars`, so enabling either is a one-line change.
- `docs/configuring-playbook-tuwunel.md` gains "The `/_tuwunel` API path" and "Exposing the Administration API" sections; the Ketesa guide lists Tuwunel alongside Synapse and Dendrite.
- Validation: `yamllint` (no new findings) and `ansible-lint --offline` (production profile, clean) on the role, plus a Jinja render of every label group.
