### PR TITLE
Enable sticky events by default if MatrixRTC is enabled

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -4945,6 +4945,8 @@ matrix_synapse_experimental_features_msc4143_enabled: "{{ matrix_rtc_enabled }}"
 
 matrix_synapse_experimental_features_msc4222_enabled: "{{ matrix_rtc_enabled }}"
 
+matrix_synapse_experimental_features_msc4354_enabled: "{{ matrix_rtc_enabled }}"
+
 # Disable password authentication when delegating authentication to Matrix Authentication Service.
 # Unless this is done, Synapse fails on startup with:
 # > Error in configuration at 'password_config.enabled':


### PR DESCRIPTION
We already enable delayed events, etc. when MatrixRTC is enabled, I think we should also enable sticky events.