### PR TITLE
Update changelog version

### DIFF
--- a/examples/vars.yml
+++ b/examples/vars.yml
@@ -2,7 +2,7 @@
 # This variable acknowledges that you've reviewed breaking changes up to this version.
 # The playbook will fail if this is outdated, guiding you through what changed.
 # See the changelog: https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/CHANGELOG.md
-matrix_playbook_migration_validated_version: v2026.05.18.0
+matrix_playbook_migration_validated_version: v2026.07.19.0
 
 # The bare domain name which represents your Matrix identity.
 # Matrix user IDs for your server will be of the form (`@alice:example.com`).

--- a/roles/custom/matrix_playbook_migration/defaults/main.yml
+++ b/roles/custom/matrix_playbook_migration/defaults/main.yml
@@ -14,11 +14,11 @@ matrix_playbook_migration_validated_version: ''
 # The version that the playbook expects the user to have validated against.
 # This is bumped whenever a breaking change is introduced.
 # The value configured here needs to exist in `matrix_playbook_migration_breaking_changes` as well.
-matrix_playbook_migration_expected_version: "v2026.05.18.0"
+matrix_playbook_migration_expected_version: "v2026.07.19.0"
 
 # A list of breaking changes, used to inform users what changed between their validated version and the expected version.
 matrix_playbook_migration_breaking_changes:
-  - version: "v2026.05.18.0"
+  - version: "v2026.07.19.0"
     summary: "LiveKit Server has been upgraded to v1.12.0 — TURN no longer relays to restricted peer CIDRs (loopback, link-local, multicast, private, unspecified) by default; TURN credentials now carry a TTL (300s)"
     changelog_url: "https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/CHANGELOG.md#2026-05-18"
   - version: "v2026.04.24.0"


### PR DESCRIPTION
Changelog version is still on month May, effectively bypassing this feature. With this PR I'd like to update it to the current date from CHANGELOG.md.
