### PR TITLE
ntfy: protect exposed metrics with global basic auth

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -4407,6 +4407,8 @@ ntfy_container_labels_traefik_enabled: "{{ matrix_playbook_traefik_labels_enable
 ntfy_container_labels_traefik_docker_network: "{{ matrix_playbook_reverse_proxyable_services_additional_network }}"
 ntfy_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
 ntfy_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
+ntfy_container_labels_traefik_metrics_middleware_basic_auth_enabled: "{{ matrix_metrics_exposure_http_basic_auth_enabled }}"
+ntfy_container_labels_traefik_metrics_middleware_basic_auth_users: "{{ matrix_metrics_exposure_http_basic_auth_users }}"
 
 ntfy_visitor_request_limit_exempt_hosts_hostnames_auto: |
   {{


### PR DESCRIPTION
Closes #5468.

Ntfy's metrics router supports its own Traefik basic-auth middleware, but the playbook did not forward the global metrics exposure credentials to the external ntfy role. As a result, enabling `matrix_metrics_exposure_http_basic_auth_enabled` protected other metrics endpoints while leaving ntfy's endpoint unauthenticated.

This forwards:

- `matrix_metrics_exposure_http_basic_auth_enabled` → `ntfy_container_labels_traefik_metrics_middleware_basic_auth_enabled`
- `matrix_metrics_exposure_http_basic_auth_users` → `ntfy_container_labels_traefik_metrics_middleware_basic_auth_users`

The variable names and generated `ntfy-metrics-basic-auth` middleware were verified against the exact pinned ntfy role release (`v2.26.3-0`). The mapping follows the same global metrics-auth pattern already used by the other services in `group_vars/matrix_servers`.

Validation:

- All project pre-commit hooks pass for the changed file, including codespell, REUSE, and ansible-lint.
- The full `group_vars/matrix_servers` YAML parses successfully.
- Jinja rendering assertions confirm both ntfy variables resolve to their respective global values.
- No default behavior changes when global metrics basic authentication is disabled.
