### PR TITLE
Add `helpers:pinGitHubActionDigests` to renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,8 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": [
-		"config:recommended"
+		"config:recommended",
+		"helpers:pinGitHubActionDigests"
 	],
 	"labels": [
 		"dependencies"


### PR DESCRIPTION
The preset will pin third-party GitHub Actions to a full-length commit SHA. This is recommended by Renovate at https://docs.renovatebot.com/upgrade-best-practices/#extends-helperspingithubactiondigests.

Renovate should update them in the similar way as https://github.com/mother-of-all-self-hosting/mash-playbook/commit/7f8b4df97d07e0c694175131fd3bf9532744d832.