### PR TITLE
fix: Add mautrix-go API exposure for Steam & Rushpush bridges

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -1532,8 +1532,15 @@ matrix_bridge_rustpush_container_additional_networks_auto: |-
       ([] if matrix_addons_homeserver_container_network == '' else [matrix_addons_homeserver_container_network])
       +
       ([postgres_container_network] if (postgres_enabled and matrix_bridge_rustpush_database_hostname == postgres_connection_hostname and matrix_bridge_rustpush_container_network != postgres_container_network) else [])
+      +
+      ([matrix_playbook_reverse_proxyable_services_additional_network] if matrix_playbook_reverse_proxyable_services_additional_network and matrix_bridge_rustpush_container_labels_traefik_enabled else [])
     ) | unique
   }}
+
+matrix_bridge_rustpush_container_labels_traefik_enabled: "{{ matrix_playbook_reverse_proxy_type in ['playbook-managed-traefik', 'other-traefik-container'] }}"
+matrix_bridge_rustpush_container_labels_traefik_docker_network: "{{ matrix_playbook_reverse_proxyable_services_additional_network }}"
+matrix_bridge_rustpush_container_labels_traefik_entrypoints: "{{ traefik_entrypoint_primary }}"
+matrix_bridge_rustpush_container_labels_traefik_tls_certResolver: "{{ traefik_certResolver_primary }}"
 
 matrix_bridge_rustpush_appservice_token: "{{ (matrix_homeserver_generic_secret_key + ':imsg.as.token') | hash('sha512') | to_uuid }}"
 
@@ -1543,6 +1550,10 @@ matrix_bridge_rustpush_homeserver_token: "{{ (matrix_homeserver_generic_secret_k
 matrix_bridge_rustpush_homeserver_async_media: "{{ matrix_homeserver_implementation in ['synapse'] }}"
 
 matrix_bridge_rustpush_provisioning_shared_secret: "{{ (matrix_homeserver_generic_secret_key + ':mau.imsg.prov') | hash('sha512') | to_uuid }}"
+
+matrix_bridge_rustpush_exposure_enabled: "{{ matrix_bridges_exposure_enabled }}"
+matrix_bridge_rustpush_exposure_hostname: "{{ matrix_bridges_exposure_hostname }}"
+matrix_bridge_rustpush_exposure_path_prefix: "{{ matrix_bridges_exposure_path_prefix }}/imessage"
 
 matrix_bridge_rustpush_double_puppet_secrets_auto: |-
   {{
@@ -2964,6 +2975,10 @@ matrix_bridge_steam_homeserver_async_media: "{{ matrix_homeserver_implementation
 matrix_bridge_steam_public_media_signing_key: "{{ ((matrix_homeserver_generic_secret_key + ':steam.pub.key') | hash('sha512') | to_uuid) if matrix_bridge_steam_public_media_enabled else '' }}"
 
 matrix_bridge_steam_provisioning_shared_secret: "{{ (matrix_homeserver_generic_secret_key + ':steam.prov') | hash('sha512') | to_uuid }}"
+
+matrix_bridge_steam_exposure_enabled: "{{ matrix_bridges_exposure_enabled }}"
+matrix_bridge_steam_exposure_hostname: "{{ matrix_bridges_exposure_hostname }}"
+matrix_bridge_steam_exposure_path_prefix: "{{ matrix_bridges_exposure_path_prefix }}/steam"
 
 matrix_bridge_steam_double_puppet_secrets_auto: |-
   {{

--- a/roles/custom/matrix-bridge-rustpush/defaults/main.yml
+++ b/roles/custom/matrix-bridge-rustpush/defaults/main.yml
@@ -68,6 +68,31 @@ matrix_bridge_rustpush_container_additional_networks: "{{ matrix_bridge_rustpush
 matrix_bridge_rustpush_container_additional_networks_auto: []
 matrix_bridge_rustpush_container_additional_networks_custom: []
 
+# matrix_bridge_rustpush_container_labels_traefik_enabled controls whether labels to assist a Traefik reverse-proxy will be attached to the container.
+# See `../templates/labels.j2` for details.
+#
+# To inject your own other container labels, see `matrix_bridge_rustpush_container_labels_additional_labels`.
+matrix_bridge_rustpush_container_labels_traefik_enabled: true
+matrix_bridge_rustpush_container_labels_traefik_docker_network: "{{ matrix_bridge_rustpush_container_network }}"
+matrix_bridge_rustpush_container_labels_traefik_entrypoints: web-secure
+matrix_bridge_rustpush_container_labels_traefik_tls: "{{ matrix_bridge_rustpush_container_labels_traefik_entrypoints != 'web' }}"
+matrix_bridge_rustpush_container_labels_traefik_tls_certResolver: default  # noqa var-naming
+
+# Whether this bridge's HTTP API (including the provisioning API) is exposed at a
+# public path via Traefik. Disabled by default. When enabled, requests to
+# https://<matrix_bridge_rustpush_exposure_hostname><matrix_bridge_rustpush_exposure_path_prefix>/...
+# are forwarded to the bridge with that path prefix stripped.
+matrix_bridge_rustpush_exposure_enabled: false
+matrix_bridge_rustpush_exposure_hostname: ''
+matrix_bridge_rustpush_exposure_path_prefix: ''
+
+matrix_bridge_rustpush_container_labels_exposure_enabled: "{{ matrix_bridge_rustpush_exposure_enabled }}"
+matrix_bridge_rustpush_container_labels_exposure_traefik_rule: "Host(`{{ matrix_bridge_rustpush_exposure_hostname }}`) && PathPrefix(`{{ matrix_bridge_rustpush_exposure_path_prefix }}`)"
+matrix_bridge_rustpush_container_labels_exposure_traefik_priority: 0
+matrix_bridge_rustpush_container_labels_exposure_traefik_entrypoints: "{{ matrix_bridge_rustpush_container_labels_traefik_entrypoints }}"
+matrix_bridge_rustpush_container_labels_exposure_traefik_tls: "{{ matrix_bridge_rustpush_container_labels_exposure_traefik_entrypoints != 'web' }}"
+matrix_bridge_rustpush_container_labels_exposure_traefik_tls_certResolver: "{{ matrix_bridge_rustpush_container_labels_traefik_tls_certResolver }}"  # noqa var-naming
+
 # matrix_bridge_rustpush_container_labels_additional_labels contains a multiline string with additional labels to add to the container label file.
 # See `../templates/labels.j2` for details.
 #

--- a/roles/custom/matrix-bridge-rustpush/templates/labels.j2
+++ b/roles/custom/matrix-bridge-rustpush/templates/labels.j2
@@ -5,4 +5,47 @@ SPDX-FileCopyrightText: 2026 Jason LaGuidice
 SPDX-License-Identifier: AGPL-3.0-or-later
 #}
 
+{% if matrix_bridge_rustpush_container_labels_traefik_enabled %}
+traefik.enable=true
+
+{% if matrix_bridge_rustpush_container_labels_traefik_docker_network %}
+traefik.docker.network={{ matrix_bridge_rustpush_container_labels_traefik_docker_network }}
+{% endif %}
+
+traefik.http.services.matrix-rustpush-bridge.loadbalancer.server.port=8081
+
+{% if matrix_bridge_rustpush_container_labels_exposure_enabled %}
+############################################################
+#                                                          #
+# Bridge API exposure                                      #
+#                                                          #
+############################################################
+
+traefik.http.middlewares.matrix-rustpush-bridge-exposure-strip-prefix.stripprefix.prefixes={{ matrix_bridge_rustpush_exposure_path_prefix }}
+traefik.http.routers.matrix-rustpush-bridge-exposure.middlewares=matrix-rustpush-bridge-exposure-strip-prefix
+
+traefik.http.routers.matrix-rustpush-bridge-exposure.rule={{ matrix_bridge_rustpush_container_labels_exposure_traefik_rule }}
+
+{% if matrix_bridge_rustpush_container_labels_exposure_traefik_priority | int > 0 %}
+traefik.http.routers.matrix-rustpush-bridge-exposure.priority={{ matrix_bridge_rustpush_container_labels_exposure_traefik_priority }}
+{% endif %}
+
+traefik.http.routers.matrix-rustpush-bridge-exposure.service=matrix-rustpush-bridge
+traefik.http.routers.matrix-rustpush-bridge-exposure.entrypoints={{ matrix_bridge_rustpush_container_labels_exposure_traefik_entrypoints }}
+
+traefik.http.routers.matrix-rustpush-bridge-exposure.tls={{ matrix_bridge_rustpush_container_labels_exposure_traefik_tls | to_json }}
+{% if matrix_bridge_rustpush_container_labels_exposure_traefik_tls %}
+traefik.http.routers.matrix-rustpush-bridge-exposure.tls.certResolver={{ matrix_bridge_rustpush_container_labels_exposure_traefik_tls_certResolver }}
+{% endif %}
+
+############################################################
+#                                                          #
+# /Bridge API exposure                                     #
+#                                                          #
+############################################################
+{% endif %}
+
+
+{% endif %}
+
 {{ matrix_bridge_rustpush_container_labels_additional_labels }}

--- a/roles/custom/matrix-bridge-steam/defaults/main.yml
+++ b/roles/custom/matrix-bridge-steam/defaults/main.yml
@@ -94,6 +94,21 @@ matrix_bridge_steam_container_labels_traefik_entrypoints: web-secure
 matrix_bridge_steam_container_labels_traefik_tls: "{{ matrix_bridge_steam_container_labels_traefik_entrypoints != 'web' }}"
 matrix_bridge_steam_container_labels_traefik_tls_certResolver: default  # noqa var-naming
 
+# Whether this bridge's HTTP API (including the provisioning API) is exposed at a
+# public path via Traefik. Disabled by default. When enabled, requests to
+# https://<matrix_bridge_steam_exposure_hostname><matrix_bridge_steam_exposure_path_prefix>/...
+# are forwarded to the bridge with that path prefix stripped.
+matrix_bridge_steam_exposure_enabled: false
+matrix_bridge_steam_exposure_hostname: ''
+matrix_bridge_steam_exposure_path_prefix: ''
+
+matrix_bridge_steam_container_labels_exposure_enabled: "{{ matrix_bridge_steam_exposure_enabled }}"
+matrix_bridge_steam_container_labels_exposure_traefik_rule: "Host(`{{ matrix_bridge_steam_exposure_hostname }}`) && PathPrefix(`{{ matrix_bridge_steam_exposure_path_prefix }}`)"
+matrix_bridge_steam_container_labels_exposure_traefik_priority: 0
+matrix_bridge_steam_container_labels_exposure_traefik_entrypoints: "{{ matrix_bridge_steam_container_labels_traefik_entrypoints }}"
+matrix_bridge_steam_container_labels_exposure_traefik_tls: "{{ matrix_bridge_steam_container_labels_exposure_traefik_entrypoints != 'web' }}"
+matrix_bridge_steam_container_labels_exposure_traefik_tls_certResolver: "{{ matrix_bridge_steam_container_labels_traefik_tls_certResolver }}"  # noqa var-naming
+
 # matrix_bridge_steam_container_labels_additional_labels contains a multiline string with additional labels to add to the container label file.
 # See `../templates/labels.j2` for details.
 #

--- a/roles/custom/matrix-bridge-steam/templates/labels.j2
+++ b/roles/custom/matrix-bridge-steam/templates/labels.j2
@@ -37,6 +37,37 @@ traefik.http.routers.matrix-steam-bridge-public-media.tls.certResolver={{ matrix
 ############################################################
 {% endif %}
 
+{% if matrix_bridge_steam_container_labels_exposure_enabled %}
+############################################################
+#                                                          #
+# Bridge API exposure                                      #
+#                                                          #
+############################################################
+
+traefik.http.middlewares.matrix-steam-bridge-exposure-strip-prefix.stripprefix.prefixes={{ matrix_bridge_steam_exposure_path_prefix }}
+traefik.http.routers.matrix-steam-bridge-exposure.middlewares=matrix-steam-bridge-exposure-strip-prefix
+
+traefik.http.routers.matrix-steam-bridge-exposure.rule={{ matrix_bridge_steam_container_labels_exposure_traefik_rule }}
+
+{% if matrix_bridge_steam_container_labels_exposure_traefik_priority | int > 0 %}
+traefik.http.routers.matrix-steam-bridge-exposure.priority={{ matrix_bridge_steam_container_labels_exposure_traefik_priority }}
+{% endif %}
+
+traefik.http.routers.matrix-steam-bridge-exposure.service=matrix-steam-bridge
+traefik.http.routers.matrix-steam-bridge-exposure.entrypoints={{ matrix_bridge_steam_container_labels_exposure_traefik_entrypoints }}
+
+traefik.http.routers.matrix-steam-bridge-exposure.tls={{ matrix_bridge_steam_container_labels_exposure_traefik_tls | to_json }}
+{% if matrix_bridge_steam_container_labels_exposure_traefik_tls %}
+traefik.http.routers.matrix-steam-bridge-exposure.tls.certResolver={{ matrix_bridge_steam_container_labels_exposure_traefik_tls_certResolver }}
+{% endif %}
+
+############################################################
+#                                                          #
+# /Bridge API exposure                                     #
+#                                                          #
+############################################################
+{% endif %}
+
 
 {% endif %}
 


### PR DESCRIPTION
I noticed all of the rest of the mautrix bridges show up in mautrix manager - and you can poll their status. I never added labels to my bridges... but I should have!

This takes care of that.