### PR TITLE
feat: public client root redirection URL from enabled client hostnames

### DIFF
--- a/group_vars/matrix_servers
+++ b/group_vars/matrix_servers
@@ -4924,7 +4924,36 @@ matrix_synapse_container_labels_traefik_compression_middleware_name: "{{ matrix_
 matrix_synapse_container_labels_matrix_labels_enabled: "{{ not matrix_synapse_workers_enabled }}"
 
 matrix_synapse_container_labels_public_client_root_redirection_enabled: "{{ matrix_synapse_container_labels_public_client_root_redirection_url != '' }}"
-matrix_synapse_container_labels_public_client_root_redirection_url: "{{ (('https://' if matrix_playbook_ssl_enabled else 'http://') + matrix_server_fqn_element) if matrix_client_element_enabled else '' }}"
+matrix_synapse_container_labels_public_client_root_redirection_url: |-
+  {{
+    (
+      ('https://' if matrix_playbook_ssl_enabled else 'http://')
+      +
+      (
+        (
+          ([matrix_server_fqn_element] if matrix_client_element_enabled else [])
+          + ([cinny_hostname] if cinny_enabled else [])
+          + ([sable_hostname] if sable_enabled else [])
+          + ([hydrogen_hostname] if hydrogen_enabled else [])
+          + ([matrix_client_schildichat_hostname] if matrix_client_schildichat_enabled else [])
+          + ([matrix_client_commet_hostname] if matrix_client_commet_enabled else [])
+          + ([matrix_client_fluffychat_hostname] if matrix_client_fluffychat_enabled else [])
+        )[0]
+        if (
+          (
+            ([matrix_server_fqn_element] if matrix_client_element_enabled else [])
+            + ([cinny_hostname] if cinny_enabled else [])
+            + ([sable_hostname] if sable_enabled else [])
+            + ([hydrogen_hostname] if hydrogen_enabled else [])
+            + ([matrix_client_schildichat_hostname] if matrix_client_schildichat_enabled else [])
+            + ([matrix_client_commet_hostname] if matrix_client_commet_enabled else [])
+            + ([matrix_client_fluffychat_hostname] if matrix_client_fluffychat_enabled else [])
+          ) | length == 1
+        )
+        else ''
+      )
+    )
+  }}
 
 matrix_synapse_container_labels_public_client_synapse_admin_api_enabled: "{{ matrix_ketesa_enabled or matrix_element_admin_enabled }}"
 matrix_synapse_container_labels_internal_client_synapse_admin_api_enabled: "{{ (matrix_bot_draupnir_enabled and matrix_bot_draupnir_admin_api_enabled) }}"


### PR DESCRIPTION
We used to redirect matrix fnq > element fnq if element-web installed. Do the same if any other client is installed, default to none if multiple are installed.