### PR TITLE
Fix: Remove old deprecation warning preventing Rustpush bridge deployment

### DIFF
--- a/roles/custom/matrix-bridge-rustpush/tasks/validate_config.yml
+++ b/roles/custom/matrix-bridge-rustpush/tasks/validate_config.yml
@@ -24,10 +24,6 @@
     - {'old': 'matrix_bridge_rustpush_container_labels_metrics_traefik_tls_certResolver', 'new': '<removed> (the rustpush bridge does not support metrics)'}
     - {'old': 'matrix_bridge_rustpush_container_labels_metrics_middleware_basic_auth_enabled', 'new': '<removed> (the rustpush bridge does not support metrics)'}
     - {'old': 'matrix_bridge_rustpush_container_labels_metrics_middleware_basic_auth_users', 'new': '<removed> (the rustpush bridge does not support metrics)'}
-    - {'old': 'matrix_bridge_rustpush_container_labels_traefik_enabled', 'new': '<removed> (the bridge exposes nothing via Traefik)'}
-    - {'old': 'matrix_bridge_rustpush_container_labels_traefik_docker_network', 'new': '<removed> (the bridge exposes nothing via Traefik)'}
-    - {'old': 'matrix_bridge_rustpush_container_labels_traefik_entrypoints', 'new': '<removed> (the bridge exposes nothing via Traefik)'}
-    - {'old': 'matrix_bridge_rustpush_container_labels_traefik_tls_certResolver', 'new': '<removed> (the bridge exposes nothing via Traefik)'}
 
 - name: Fail if required RustPush settings not defined
   ansible.builtin.fail:


### PR DESCRIPTION
The Rustpush and Steam bridges both do support the provisioning API (if I do use the right name :) ...) and that should have labels in order to expose them so mautrix manager can find them (and you can setup fun stuff like Uptime Kuma to monitor if you have been logged out of your account).

I went to re-deploy and noticed we forgot to remove the deprecation warning for the removed labels. The labels _should_ be there in this case so it should be safe to remove the deprecation warning.