### PR TITLE
Add the restrict_room_creation module from intevation

### DIFF
--- a/roles/custom/matrix-synapse/defaults/main.yml
+++ b/roles/custom/matrix-synapse/defaults/main.yml
@@ -1636,6 +1636,10 @@ matrix_synapse_ext_spam_checker_mjolnir_antispam_config:
   ban_lists: "{{ matrix_synapse_ext_spam_checker_mjolnir_antispam_config_ban_lists }}"
   message_max_length: "{{ matrix_synapse_ext_spam_checker_mjolnir_antispam_config_message_max_length }}"
 
+# Enable this to activate the synapse-restrict-room-creation module.
+matrix_synapse_ext_synapse_restrict_room_creation_enabled: false
+matrix_synapse_ext_synapse_restrict_room_creation_git_repository_url: "https://heptapod.host/intevation/fac/synapse-modules.git"
+
 # Enable this to activate the synapse-http-antispam module.
 # See: github.com/maunium/synapse-http-antispam
 matrix_synapse_ext_synapse_http_antispam_enabled: false

--- a/roles/custom/matrix-synapse/tasks/ext/setup_install.yml
+++ b/roles/custom/matrix-synapse/tasks/ext/setup_install.yml
@@ -46,6 +46,16 @@
     - when: matrix_synapse_ext_password_provider_ldap_enabled | bool
       ansible.builtin.include_tasks: "{{ role_path }}/tasks/ext/ldap-auth/setup_install.yml"
 
+# synapse_restrict_room_creation
+- tags:
+    - setup-all
+    - setup-synapse
+    - install-all
+    - install-synapse
+  block:
+    - when: matrix_synapse_ext_synapse_restrict_room_creation_enabled | bool
+      ansible.builtin.include_tasks: "{{ role_path }}/tasks/ext/synapse-restrict-room-creation/setup_install.yml"
+
 # synapse-simple-antispam
 - tags:
     - setup-all

--- a/roles/custom/matrix-synapse/tasks/ext/setup_uninstall.yml
+++ b/roles/custom/matrix-synapse/tasks/ext/setup_uninstall.yml
@@ -30,6 +30,13 @@
 
 # ldap-auth has no uninstall tasks
 
+# synapse_restrict_room_creation
+- tags:
+    - setup-all
+    - setup-synapse
+  block:
+    - when: not matrix_synapse_ext_synapse_restrict_room_creation_enabled | bool
+      ansible.builtin.include_tasks: "{{ role_path }}/tasks/ext/synapse-restrict-room-creation/setup_uninstall.yml"
 
 # synapse-simple-antispam
 - tags:

--- a/roles/custom/matrix-synapse/tasks/ext/synapse-restrict-room-creation/setup_install.yml
+++ b/roles/custom/matrix-synapse/tasks/ext/synapse-restrict-room-creation/setup_install.yml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2025 MDAD project contributors
+# SPDX-FileCopyrightText: 2025 Catalan Lover <catalanlover@protonmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+---
+
+- name: Ensure git installed
+  ansible.builtin.package:
+    name: git
+    state: present
+
+- name: Clone synapse-modules synapse_restrict_room_creation_git repository
+  ansible.builtin.git:
+    repo: "{{ matrix_synapse_ext_synapse_restrict_room_creation_git_repository_url }}"
+    dest: "{{ matrix_synapse_ext_path }}/synapse-restrict-room-creation"
+  become: true
+  become_user: "{{ matrix_synapse_username }}"
+
+- ansible.builtin.set_fact:
+    matrix_synapse_modules: >
+      {{
+        matrix_synapse_modules | default([])
+        +
+        [{
+          "config": {
+            "error_message_top_rooms": "Only server admins can create new spaces and rooms in Home."
+          },
+          "module": "restrict_room_creation.RestrictRoomCreation"
+        }]
+        +
+        [{
+          "module": "restrict_room_creation.RestrictJoinRules"
+        }]
+      }}
+
+    matrix_synapse_container_extra_arguments: >
+      {{
+        matrix_synapse_container_extra_arguments | default([])
+        +
+        ["--mount type=bind,src=" + matrix_synapse_ext_path + "/synapse-restrict-room-creation/synapse_modules/restrict_room_creation,dst=" + matrix_synapse_in_container_python_packages_path + "/restrict_room_creation,ro"]
+      }}

--- a/roles/custom/matrix-synapse/tasks/ext/synapse-restrict-room-creation/setup_uninstall.yml
+++ b/roles/custom/matrix-synapse/tasks/ext/synapse-restrict-room-creation/setup_uninstall.yml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2025 MDAD project contributors
+# SPDX-FileCopyrightText: 2025 Catalan Lover <catalanlover@protonmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+---
+
+- name: Ensure synapse-restrict-room-creation doesn't exist
+  ansible.builtin.file:
+    path: "{{ matrix_synapse_ext_path }}/synapse-restrict-room-creation"
+    state: absent


### PR DESCRIPTION
I did not write the modules, but I tested the restrict_room_creation one and find it useful and would like to see it included :) https://heptapod.host/intevation/fac/synapse-modules/-/tree/master