### PR TITLE
update go module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
         pkgs = import nixpkgs {
           inherit system;
         };
-        agru = pkgs.buildGo125Module {
+        agru = pkgs.buildGo126Module {
           pname = "agru";
           version = "0.2.1";
           src = agru-src;


### PR DESCRIPTION
Fix error: Cannot build '/nix/store/…-agru-0.2.1.drv'.
       Reason: builder failed with exit code 1.
	…
       > go: go.mod requires go >= 1.26 (running go 1.25.14; GOTOOLCHAIN=local)